### PR TITLE
feat: configure Cribl Edge syslog listeners for all ports

### DIFF
--- a/roles/cribl_edge/defaults/main.yml
+++ b/roles/cribl_edge/defaults/main.yml
@@ -9,7 +9,7 @@ cribl_edge_container_name: cribl-edge
 cribl_edge_mode: edge  # edge or worker
 
 # Network configuration - syslog listeners (per port assignment)
-# 1514: UniFi, 1515: Palo Alto, 1516: Cisco, 1517: Linux, 1518: Windows
+# 1514: UniFi, 1515: Palo Alto, 1516: Cisco ASA, 1517: Linux, 1518: Windows
 cribl_edge_syslog_ports:
   - port: 1514
     name: unifi
@@ -18,10 +18,10 @@ cribl_edge_syslog_ports:
     name: unifi_udp
     protocol: udp
   - port: 1515
-    name: paloalto
+    name: palo_alto
     protocol: tcp
   - port: 1515
-    name: paloalto_udp
+    name: palo_alto_udp
     protocol: udp
   - port: 1516
     name: cisco

--- a/roles/cribl_edge/tasks/main.yml
+++ b/roles/cribl_edge/tasks/main.yml
@@ -36,6 +36,15 @@
   notify: restart cribl edge
   when: cribl_edge_hec_token != ''
 
+- name: Deploy syslog inputs configuration
+  ansible.builtin.template:
+    src: inputs.yml.j2
+    dest: /etc/cribl/default/inputs.yml
+    owner: "{{ cribl_edge_user }}"
+    group: "{{ cribl_edge_group }}"
+    mode: '0644'
+  notify: restart cribl edge
+
 - name: Start Cribl Edge service
   ansible.builtin.systemd:
     name: "{{ cribl_edge_service_name }}"

--- a/roles/cribl_edge/templates/inputs.yml.j2
+++ b/roles/cribl_edge/templates/inputs.yml.j2
@@ -17,15 +17,15 @@ inputs:
 {% else %}
     tls:
       disabled: true
-{% endif %}
     maxActiveCxn: 100
+{% endif %}
     enableProxyHeader: false
     captureHeaders: false
     activityLogSampleRate: 100
     enableMultiline: false
     metadata:
       - name: source_type
-        value: "{{ listener.name }}"
+        value: "{{ listener.name | regex_replace('_udp$', '') }}"
     pqEnabled: true
 
 {% endfor %}


### PR DESCRIPTION
## Summary
- Configure syslog listeners for ports 1514-1518 (UDP and TCP)
- Add source type metadata for each listener
- Enable persistent queuing on all listeners

## Port Assignments
| Port | Source |
| ---- | ------ |
| 1514 | UniFi |
| 1515 | Palo Alto |
| 1516 | Cisco ASA |
| 1517 | Linux hosts |
| 1518 | Windows hosts |

## Test plan
- [ ] Verify Cribl Edge listeners are created after deploy
- [ ] Test syslog delivery: `logger -n <host> -P 1514 "test"`
- [ ] Verify source_type metadata is populated

Closes #6

Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Configure Cribl Edge syslog listeners for ports 1514-1518 with metadata and persistent queuing.
> 
>   - **Syslog Listeners Configuration**:
>     - Configure syslog listeners for ports 1514-1518 (UDP and TCP) in `main.yml`.
>     - Add source type metadata for each listener in `inputs.yml.j2`.
>     - Enable persistent queuing on all listeners in `inputs.yml.j2`.
>   - **Files Modified**:
>     - `main.yml`: Define syslog ports and protocols.
>     - `tasks/main.yml`: Deploy syslog inputs configuration.
>     - `inputs.yml.j2`: Template for syslog listener configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-proxmox-apps&utm_source=github&utm_medium=referral)<sup> for 6d3178b2ee5192971dd44432b4462f9c8f0b6d98. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->