### PR TITLE
fix: Add 'always' tag to terraform inventory loader

### DIFF
--- a/inventory/load_terraform.yml
+++ b/inventory/load_terraform.yml
@@ -9,6 +9,7 @@
 - name: Load Terraform Infrastructure Inventory
   hosts: localhost
   gather_facts: false
+  tags: always
 
   tasks:
     - name: Load Terraform inventory JSON


### PR DESCRIPTION
## Summary
- Add `tags: always` to the Load Terraform Infrastructure Inventory play
- Ensures dynamic inventory is loaded regardless of which `--tags` are specified

## Problem
When running playbooks with `--tags splunk_docker`, the terraform inventory loader tasks were being skipped because they weren't tagged. This caused "no hosts matched" errors since the dynamic `splunk_vms` group was never populated.

## Test plan
- [ ] Run `ansible-playbook playbooks/site.yml --tags splunk_docker --list-hosts`
- [ ] Verify `splunk_vms` group shows 1 host (splunk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `tags: always` to ensure Terraform inventory loader runs regardless of specified tags.
> 
>   - **Behavior**:
>     - Add `tags: always` to the `Load Terraform Infrastructure Inventory` play in `inventory/load_terraform.yml`.
>     - Ensures the play runs regardless of specified `--tags`, preventing skipped tasks and "no hosts matched" errors.
>   - **Problem**:
>     - Previously, running playbooks with `--tags splunk_docker` skipped the inventory loader, causing errors due to unpopulated `splunk_vms` group.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-proxmox-apps&utm_source=github&utm_medium=referral)<sup> for e9c1048286fb410e8db7c19c2bed027a40fec2ca. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->