### PR TITLE
fix: Remove ipaddr filter from terraform inventory loader

### DIFF
--- a/inventory/load_terraform.yml
+++ b/inventory/load_terraform.yml
@@ -24,7 +24,7 @@
           - lxc_containers
           - all
         ansible_pct_vmid: "{{ item.value.vmid }}"
-        ansible_host: "{{ item.value.ip | ansible.netcommon.ipaddr('address') }}"
+        ansible_host: "{{ item.value.ip }}"
         ansible_connection: "{{ item.value.ansible_connection }}"
         ansible_pct_host: "{{ lookup('env', 'PROXMOX_VE_HOSTNAME') }}"
         ansible_pct_user: root


### PR DESCRIPTION
## Summary
- Remove `ansible.netcommon.ipaddr` filter from terraform inventory loader
- Terraform already provides plain IP addresses, no transformation needed

## Problem
The `ansible.netcommon` collection was not installed, causing playbook failures:
```
No filter named 'ansible.netcommon.ipaddr'
```

## Solution
Use the IP directly since `item.value.ip` is already a plain IP address (e.g., "10.0.1.180").

## Test plan
- [ ] Run `ansible-playbook playbooks/site.yml --tags splunk_docker`
- [ ] Verify playbook completes without ipaddr filter errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unnecessary `ipaddr` filter from `ansible_host` in `load_terraform.yml` to fix playbook failures.
> 
>   - **Behavior**:
>     - Remove `ansible.netcommon.ipaddr` filter from `ansible_host` in `load_terraform.yml`.
>     - Use `item.value.ip` directly as it is already a plain IP address.
>   - **Problem**:
>     - Playbook failures due to missing `ansible.netcommon` collection.
>   - **Solution**:
>     - Directly use IP from Terraform output without transformation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-proxmox-apps&utm_source=github&utm_medium=referral)<sup> for f2168c362cf66630465bee8a242f7ca25b2dd6f4. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->