### PR TITLE
fix: Remove broken tag-based role conditions from playbooks

### DIFF
--- a/inventory/load_terraform.yml
+++ b/inventory/load_terraform.yml
@@ -31,7 +31,7 @@
         ansible_pct_private_key_file: "{{ lookup('env', 'PROXMOX_SSH_KEY_PATH') }}"
         hostname: "{{ item.value.hostname }}"
         ansible_pct_node: "{{ item.value.node }}"
-        tags: "{{ item.value.tags | default([]) }}"
+        host_tags: "{{ item.value.tags | default([]) }}"
       loop: "{{ terraform_data.ansible_inventory.containers | dict2items }}"
       when:
         - terraform_data.ansible_inventory.containers is defined
@@ -47,7 +47,7 @@
         ansible_connection: "{{ item.value.ansible_connection }}"
         ansible_user: debian
         hostname: "{{ item.value.hostname }}"
-        tags: "{{ item.value.tags | default([]) }}"
+        host_tags: "{{ item.value.tags | default([]) }}"
       loop: "{{ terraform_data.ansible_inventory.vms | dict2items }}"
       when:
         - terraform_data.ansible_inventory.vms is defined

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -16,14 +16,8 @@
   tags:
     - splunk_docker
 
-  pre_tasks:
-    - name: Check if host should run splunk_docker role
-      ansible.builtin.set_fact:
-        run_splunk_docker: "{{ 'splunk_docker' in (tags | default([])) }}"
-
   roles:
     - role: splunk_docker
-      when: run_splunk_docker | default(false)
 
 - name: Configure Cribl Edge nodes
   hosts: cribl_edge
@@ -36,19 +30,14 @@
     - role: cribl_edge
 
 - name: Configure Cribl Stream
-  hosts: vms
+  hosts: cribl_stream_group
   become: true
+  gather_facts: false
   tags:
     - cribl_stream
 
-  pre_tasks:
-    - name: Check if host should run cribl_stream role
-      ansible.builtin.set_fact:
-        run_cribl_stream: "{{ 'cribl_stream' in (tags | default([])) }}"
-
   roles:
     - role: cribl_stream
-      when: run_cribl_stream | default(false)
 
 - name: Configure HAProxy load balancer
   hosts: haproxy_group


### PR DESCRIPTION
## Summary
- Remove pre_tasks that incorrectly checked host tags to decide role execution
- The Ansible play-level `tags:` already handles filtering via `--tags`
- Change cribl_stream hosts from 'vms' to 'cribl_stream_group' for correct targeting
- Rename 'tags' variable to 'host_tags' to avoid Ansible reserved name warning

## Problem
The playbook had pre_tasks that set `run_splunk_docker` based on checking if `'splunk_docker'` was in the host's `tags` variable. This was checking Terraform metadata tags, not the Ansible `--tags` argument, causing all tasks to be skipped.

## Test plan
- [ ] Run `ansible-playbook playbooks/site.yml --tags splunk_docker`
- [ ] Verify splunk_docker tasks actually execute instead of being skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove broken tag-based role conditions in `site.yml` and rename `tags` to `host_tags` in `load_terraform.yml`.
> 
>   - **Behavior**:
>     - Remove `pre_tasks` in `site.yml` that checked host tags for role execution, relying on Ansible `--tags` instead.
>     - Change Cribl Stream hosts from `vms` to `cribl_stream_group` in `site.yml`.
>   - **Variables**:
>     - Rename `tags` to `host_tags` in `load_terraform.yml` to avoid Ansible reserved name warning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-proxmox-apps&utm_source=github&utm_medium=referral)<sup> for d9ee372ec7a40b3037320a7c4d83685fb02d4ecd. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->