### PR TITLE
fix: add SSH key to VM inventory and gitignore terraform_inventory.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ env/
 *.retry
 .ansible_cache/
 /roles/requirements/
+inventory/terraform_inventory.json
 
 # Environment files (secrets)
 .env

--- a/inventory/load_terraform.yml
+++ b/inventory/load_terraform.yml
@@ -46,6 +46,7 @@
         ansible_host: "{{ item.value.ip }}"
         ansible_connection: "{{ item.value.ansible_connection }}"
         ansible_user: debian
+        ansible_ssh_private_key_file: "{{ lookup('env', 'PROXMOX_SSH_KEY_PATH') }}"
         hostname: "{{ item.value.hostname }}"
         host_tags: "{{ item.value.tags | default([]) }}"
       loop: "{{ terraform_data.ansible_inventory.vms | dict2items }}"
@@ -62,6 +63,7 @@
         ansible_host: "{{ terraform_data.ansible_inventory.splunk_vm.splunk.ip }}"
         ansible_connection: "{{ terraform_data.ansible_inventory.splunk_vm.splunk.ansible_connection }}"
         ansible_user: debian
+        ansible_ssh_private_key_file: "{{ lookup('env', 'PROXMOX_SSH_KEY_PATH') }}"
         hostname: "{{ terraform_data.ansible_inventory.splunk_vm.splunk.hostname }}"
         vmid: "{{ terraform_data.ansible_inventory.splunk_vm.splunk.vmid }}"
       when: terraform_data.ansible_inventory.splunk_vm.splunk is defined


### PR DESCRIPTION
## Summary
- Add `ansible_ssh_private_key_file` to VMs and Splunk VM in `load_terraform.yml`
- Gitignore `inventory/terraform_inventory.json` as it contains environment-specific data

## Context
During Splunk deployment testing, the playbook failed to connect to VMs because the SSH private key wasn't specified. This fix adds the key path from `PROXMOX_SSH_KEY_PATH` environment variable.

The `terraform_inventory.json` file is now properly gitignored since it contains real IP addresses and VM IDs that are generated from Terraform outputs.

## Test plan
- [x] Verified SSH connection works with the key
- [x] Confirmed Ansible playbook can connect to VMs
- [x] Validated terraform_inventory.json is excluded from git

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add SSH key to Ansible inventory and gitignore `terraform_inventory.json` to fix connection issues and prevent sensitive data tracking.
> 
>   - **Behavior**:
>     - Add `ansible_ssh_private_key_file` to VMs and Splunk VM in `load_terraform.yml` using `PROXMOX_SSH_KEY_PATH` environment variable.
>     - Gitignore `terraform_inventory.json` to prevent committing environment-specific data.
>   - **Context**:
>     - Fixes SSH connection issue during Splunk deployment by specifying the SSH key.
>     - Ensures sensitive data in `terraform_inventory.json` is not tracked by git.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-proxmox-apps&utm_source=github&utm_medium=referral)<sup> for 802e444a7fa137f31bdea6bc9233fc8942130919. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->