### PR TITLE
fix: use portable PATH lookup for ansible-lint in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,11 +12,8 @@ repos:
     hooks:
       - id: ansible-lint
         name: Ansible-lint
-        description: Run ansible-lint via nix shell
-        entry: >-
-          bash -c 'nix develop
-          /Users/jevans/git/nix-config/main/shells/infrastructure-automation
-          --command ansible-lint'
+        description: Run ansible-lint on Ansible files
+        entry: uv tool run ansible-lint
         language: system
         files: \.(yaml|yml)$
         pass_filenames: false


### PR DESCRIPTION
## Summary
- Replace hardcoded `/Users/jevans/.../nix-config/main/shells/infrastructure-automation` absolute path in `.pre-commit-config.yaml` with portable `uv tool run ansible-lint` invocation
- Removes the `bash -c 'nix develop ...'` wrapper that contained a user-specific absolute path
- Uses `uv tool run` which is available system-wide via Nix PATH, making the hook portable across machines

## Test plan
- [x] Verified `pre-commit run ansible-lint --all-files` passes
- [x] Verified all pre-commit hooks pass during commit (trailing-whitespace, end-of-file-fixer, check-yaml, check-json, ansible-lint)
- [x] Verified `uv tool run ansible-lint` produces 0 failures and 0 warnings across all 67 linted files

## Notes
This change enforces the portable path rules from CLAUDE.md: "NEVER commit absolute user paths in git-tracked files." The previous `entry` used a hardcoded path to a nix shell (`/Users/jevans/git/nix-config/main/shells/infrastructure-automation`) which would fail for any other developer or CI environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces hardcoded path with portable `uv tool run ansible-lint` in `.pre-commit-config.yaml` for `ansible-lint` hook.
> 
>   - **Behavior**:
>     - Replaces hardcoded path in `.pre-commit-config.yaml` with `uv tool run ansible-lint` for `ansible-lint` hook.
>     - Removes `bash -c 'nix develop ...'` wrapper with user-specific path.
>     - Ensures portability across different machines by using Nix PATH.
>   - **Testing**:
>     - Verified `pre-commit run ansible-lint --all-files` passes.
>     - Verified all pre-commit hooks pass during commit.
>     - Verified `uv tool run ansible-lint` produces 0 failures and warnings across 67 files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-proxmox-apps&utm_source=github&utm_medium=referral)<sup> for b02293b501531f819ce165c850b0d5f0aa42eab5. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->