### PR TITLE
docs: add pipeline testing documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: ansible-lint
         name: Ansible-lint
         description: Run ansible-lint on Ansible files
-        entry: uv tool run ansible-lint
+        entry: ansible-lint
         language: system
         files: \.(yaml|yml)$
         pass_filenames: false


### PR DESCRIPTION
## Summary
- Add `docs/TESTING.md` with comprehensive pipeline testing documentation
- Covers automated validation playbooks, hop-by-hop diagnostics, manual quick tests, and troubleshooting
- All port/IP references use `terraform_data.constants` per `ip-addressing.md` rule (no hardcoded values)
- Uses `SPLUNK_PASSWORD` consistently (not `SPLUNK_ADMIN_PASSWORD`)
- Includes portable pre-commit fix (PR #34) to unblock commits

## Context
Salvaged from closed PR #32 (`docs/testing-framework-and-ip-placeholders`). The testing methodology and documentation structure were valuable, but all hardcoded IPs/ports were replaced with terraform_data.constants references.

## Test plan
- [ ] Verify no hardcoded IPs or ports in `docs/TESTING.md`
- [ ] Confirm all terraform_data.constants references match inventory structure
- [ ] ansible-lint passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds comprehensive pipeline testing documentation in `docs/TESTING.md` and updates `.pre-commit-config.yaml` to simplify `ansible-lint` hook entry.
> 
>   - **Documentation**:
>     - Adds `docs/TESTING.md` with detailed pipeline testing documentation.
>     - Covers automated validation playbooks, hop-by-hop diagnostics, manual quick tests, and troubleshooting.
>     - Ensures all IP/port references use `terraform_data.constants`.
>   - **Configuration**:
>     - Updates `.pre-commit-config.yaml` to simplify `ansible-lint` hook entry by removing `nix` shell dependency.
>   - **Environment Variables**:
>     - Uses `SPLUNK_PASSWORD` consistently instead of `SPLUNK_ADMIN_PASSWORD`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-proxmox-apps&utm_source=github&utm_medium=referral)<sup> for 9c5507c2b75ef0ad479c527d7571cede74cc15d2. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->