### PR TITLE
chore: fix license references from MIT to Apache 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,4 +246,4 @@ Fix common issues automatically:
 
 ## License
 
-MIT
+Apache License 2.0 - see [LICENSE](LICENSE) for details.

--- a/roles/apt_cacher_ng/README.md
+++ b/roles/apt_cacher_ng/README.md
@@ -71,4 +71,4 @@ None.
 
 ## License
 
-MIT
+Apache License 2.0


### PR DESCRIPTION
## Summary
- Update README.md license section from "MIT" to "Apache License 2.0" with link to LICENSE file
- Update roles/apt_cacher_ng/README.md license section from "MIT" to "Apache License 2.0"
- The LICENSE file already contains the correct Apache 2.0 text; only the README references were stale

## Test plan
- [x] Verify README.md license section is correct
- [x] Verify roles/apt_cacher_ng/README.md license section is correct
- [x] Pre-commit hooks pass (ansible-lint, yaml checks)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update license references from MIT to Apache 2.0 in README files.
> 
>   - **License Update**:
>     - Change license reference from "MIT" to "Apache License 2.0" in `README.md` and `roles/apt_cacher_ng/README.md`.
>     - Add link to `LICENSE` file in `README.md` for details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-proxmox-apps&utm_source=github&utm_medium=referral)<sup> for e1dd36acf4a00c1e71dccd5942534c4b0c30bb5a. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->