### PR TITLE
fix(inventory): add haproxy_group and cribl_edge dynamic groups

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,8 @@ repos:
       - id: check-yaml
       - id: check-json
 
-  - repo: local
+  - repo: https://github.com/ansible/ansible-lint
+    rev: v26.1.1
     hooks:
       - id: ansible-lint
-        name: Ansible-lint
-        description: Run ansible-lint on Ansible files
-        entry: uv tool run ansible-lint
-        language: system
         files: \.(yaml|yml)$
-        pass_filenames: false


### PR DESCRIPTION
Add tag-based dynamic group definitions to load_terraform.yml so
playbooks can target HAProxy and Cribl Edge containers by group name
instead of individual host references.

Includes portable pre-commit fix from fix/pre-commit-portable-path.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add dynamic group definitions for HAProxy and Cribl Edge in `load_terraform.yml` and update pre-commit configuration for `ansible-lint`.
> 
>   - **Inventory Management**:
>     - In `load_terraform.yml`, add dynamic groups `haproxy_group` and `cribl_edge` based on tags `loadbalancer` and `cribl`/`edge` respectively.
>     - Ensures LXC containers are added to these groups if tags are present.
>   - **Pre-commit Configuration**:
>     - Update `.pre-commit-config.yaml` to include a portable path fix for `ansible-lint` hook.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-proxmox-apps&utm_source=github&utm_medium=referral)<sup> for 1a8678b89f76ccbe6214224073a14d7ae3dc5472. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->