### PR TITLE
fix: bump ai-workflows to v0.2.6 and add id-token:write

### DIFF
--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -7,10 +7,11 @@ on:
     types: [completed]
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
   actions: read
+  contents: write
+  id-token: write
+  issues: write
+  pull-requests: write
 
 concurrency:
   group: ci-fix-${{ github.event.workflow_run.head_branch }}
@@ -21,7 +22,7 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.head_branch != 'main'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.2.6
     with:
       repo_context: "Ansible playbooks and roles for applications on Proxmox VMs/containers"
       ci_structure: "ansible-lint.yml (ansible-lint + ansible-playbook --syntax-check)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.2.6
     with:
       review_prompt: "Focus on Ansible FQCN usage, idempotency patterns, role structure"
     secrets: inherit

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -10,10 +10,11 @@ on:
 permissions:
   checks: read
   contents: read
+  id-token: write
   issues: write
   pull-requests: write
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.2.6
     secrets: inherit


### PR DESCRIPTION
## Summary

- Bump all ai-workflows caller references to `@v0.2.6`
- Add `id-token: write` permission to ci-fix and final-pr-review callers (required for OIDC token exchange in `claude-code-action@v1`)
- `claude-review.yml` already had `id-token: write` — only version bump needed

## Context

ai-workflows v0.2.6 migrates from deprecated `claude-code-action` inputs (`direct_prompt`, `allowed_tools`, `model`) to the current API (`prompt`, `claude_args`), and uses OIDC for git push auth instead of explicit token checkout.

## Test plan

- [ ] Verify ci-fix and final-pr-review callers work after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update ai-workflows to v0.2.6 and add id-token:write permission for OIDC token exchange in workflows.
> 
>   - **Version Update**:
>     - Bump `ai-workflows` version to `v0.2.6` in `ci-fix.yml`, `claude-review.yml`, and `final-pr-review.yml`.
>   - **Permissions**:
>     - Add `id-token: write` permission to `ci-fix.yml` and `final-pr-review.yml` for OIDC token exchange.
>     - `claude-review.yml` already had `id-token: write` permission.
>   - **Context**:
>     - `ai-workflows` v0.2.6 uses OIDC for git push auth and updates API inputs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-proxmox-apps&utm_source=github&utm_medium=referral)<sup> for 17a7c483d781b78d1af3cc5d9acf5ea52aba6858. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->