### PR TITLE
fix: bump ai-workflows callers to v0.2.9 and add OIDC permissions

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   recommend:
-    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.2.9
     secrets: inherit

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -22,7 +22,7 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.head_branch != 'main'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.2.6
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.2.9
     with:
       repo_context: "Ansible playbooks and roles for applications on Proxmox VMs/containers"
       ci_structure: "ansible-lint.yml (ansible-lint + ansible-playbook --syntax-check)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.2.6
+    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.2.9
     with:
       review_prompt: "Focus on Ansible FQCN usage, idempotency patterns, role structure"
     secrets: inherit

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   simplify:
-    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.2.9
     secrets: inherit

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -16,5 +16,5 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.2.6
+    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.2.9
     secrets: inherit

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   hygiene:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.2.9
     secrets: inherit

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   sweep:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.2.9
     secrets: inherit

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -7,9 +7,10 @@ on:
 
 permissions:
   contents: read
+  id-token: write
   issues: write
 
 jobs:
   triage:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.2.9
     secrets: inherit

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   analyze:
-    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.2.9
     secrets: inherit

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.2.9
     secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.2.9
     secrets: inherit


### PR DESCRIPTION
## Summary
- Bump all `JacobPEvans/ai-workflows` reusable workflow references from `@v0.2.3`/`@v0.2.6` to `@v0.2.9` across 11 thin caller workflow files
- Add `id-token: write` permission to `issue-triage.yml` for OIDC token exchange (required by claude-code-action@v1)

## Files changed
All `.github/workflows/*.yml` files that reference `JacobPEvans/ai-workflows`:
- best-practices.yml, ci-fix.yml, claude-review.yml, code-simplifier.yml
- final-pr-review.yml, issue-hygiene.yml, issue-sweeper.yml, issue-triage.yml
- next-steps.yml, post-merge-docs-review.yml, post-merge-tests.yml

## Test plan
- [ ] CI checks pass on this PR
- [ ] Verify workflow references resolve to valid reusable workflows at v0.2.9
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `ai-workflows` references to `v0.2.9` and add OIDC permissions in `issue-triage.yml`.
> 
>   - **Workflows**:
>     - Bump `JacobPEvans/ai-workflows` references from `@v0.2.3`/`@v0.2.6` to `@v0.2.9` in 11 workflow files including `best-practices.yml`, `ci-fix.yml`, and `claude-review.yml`.
>     - Add `id-token: write` permission to `issue-triage.yml` for OIDC token exchange.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-proxmox-apps&utm_source=github&utm_medium=referral)<sup> for 073e73ab24095d0d33b9504df1c28bb20fae1779. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->