### PR TITLE
chore: bump ai-workflows to v0.5.1

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -14,5 +14,5 @@ permissions:
 
 jobs:
   recommend:
-    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.5.1
     secrets: inherit

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -22,7 +22,7 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.head_branch != 'main'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.5.1
     with:
       repo_context: "Ansible playbooks and roles for applications on Proxmox VMs/containers"
       ci_structure: "ansible-lint.yml (ansible-lint + ansible-playbook --syntax-check)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.5.1
     with:
       review_prompt: "Focus on Ansible FQCN usage, idempotency patterns, role structure"
     secrets: inherit

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   simplify:
-    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.5.1
     secrets: inherit

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -16,5 +16,5 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.5.1
     secrets: inherit

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -54,7 +54,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' &&
       inputs.skip_triage != 'true'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.5.1
     secrets: inherit
     with:
       issue_number: ${{ inputs.issue_number }}
@@ -65,7 +65,7 @@ jobs:
       always() &&
       github.event_name == 'workflow_dispatch' &&
       (needs.run-triage.result == 'success' || needs.run-triage.result == 'skipped')
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.5.1
     secrets: inherit
     with:
       repo_context: "Ansible playbooks and roles for applications on Proxmox VMs/containers"

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -14,9 +14,9 @@ permissions:
 
 jobs:
   sweep:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.5.1
     secrets: inherit
 
   hygiene:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.5.1
     secrets: inherit

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -14,5 +14,5 @@ permissions:
 
 jobs:
   analyze:
-    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.5.1
     secrets: inherit

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -38,7 +38,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.5.1
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -38,7 +38,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.5.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.5.1
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,12 +15,14 @@ repos:
       - id: yamllint
         args: [-c, .yamllint]
 
-  - repo: https://github.com/ansible/ansible-lint
-    rev: v26.2.0
+  - repo: local
     hooks:
       - id: ansible-lint
+        name: ansible-lint
+        language: system
+        entry: ansible-lint
         files: \.(yaml|yml)$
-        language_version: python3.12
+        pass_filenames: false
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.47.0


### PR DESCRIPTION
Bump all ai-workflows reusable workflow references from @v0.5.0 to @v0.5.1.

Also fixes ansible-lint pre-commit hook: switch from git-sourced install (broken data/ directory) to system-installed ansible-lint via `language: system`.

## Changes in v0.5.1
- Fix claude-review self-cancellation loop (concurrency group collision between `pull_request` and `issue_comment` events)
- Add `max_reviews` input to prevent re-reviewing on subsequent pushes
- Add `model` input for token efficiency control

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump ai-workflows to v0.5.1 in GitHub Actions workflows and fix ansible-lint pre-commit hook installation.
> 
>   - **Workflows Update**:
>     - Bump ai-workflows references from `@v0.5.0` to `@v0.5.1` in `best-practices.yml`, `ci-fix.yml`, and `claude-review.yml`.
>     - Update `code-simplifier.yml`, `final-pr-review.yml`, and `issue-auto-resolve.yml` to use `@v0.5.1`.
>     - Modify `issue-sweeper.yml`, `next-steps.yml`, and `post-merge-docs-review.yml` to reference `@v0.5.1`.
>     - Change `post-merge-tests.yml` to use `@v0.5.1`.
>   - **Pre-commit Hook**:
>     - Switch `ansible-lint` pre-commit hook from git-sourced to system-installed in `.pre-commit-config.yaml` using `language: system` and `entry: ansible-lint`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-proxmox-apps&utm_source=github&utm_medium=referral)<sup> for 0a00d93ea0271f938e151d8c7e0adb4dc57d0dc6. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->