### PR TITLE
feat(copilot): Copilot coding agent + CI fail issue workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,58 @@
+# GitHub Copilot Instructions — ansible-proxmox-apps
+
+## Repository Purpose
+
+Ansible playbooks and roles for configuring applications on Proxmox VMs/containers.
+Manages: Cribl Edge, Cribl Stream, HAProxy, Technitium DNS, apt-cacher-ng, Mailpit, ntfy.
+Does NOT manage Splunk (see ansible-splunk repo).
+
+## Build & Validate
+
+```bash
+ansible-lint                    # lint all playbooks/roles
+yamllint .                     # YAML formatting
+molecule test                  # role integration tests (where available)
+```
+
+CI (`Ansible Lint` workflow) runs ansible-lint on all PRs. Fix all errors before merging.
+
+## Ansible Conventions
+
+- **Fully qualified collection names required** — always use fully qualified collection names:
+  - `ansible.builtin.copy` not `copy`
+  - `ansible.builtin.template` not `template`
+  - `community.general.ini_file` not `ini_file`
+- **Idempotency** — all tasks must be idempotent (safe to run multiple times)
+- **No bare variables** — quote variables: `"{{ variable }}"` not `{{ variable }}`
+- **Tags** — add meaningful tags to tasks and plays
+
+## Role Structure
+
+```text
+roles/<name>/
+  tasks/main.yml       # main task file
+  handlers/main.yml    # handlers (restart services etc.)
+  defaults/main.yml    # default variable values
+  vars/main.yml        # role-specific variables
+  templates/           # Jinja2 templates
+  files/               # static files
+```
+
+## Secrets & Inventory
+
+- Secrets via Doppler (environment variables at runtime)
+- Inventory in `inventory/` — hosts organized by service group
+- Service ports documented in `docs/` and CLAUDE.md
+
+## Common Patterns
+
+```yaml
+- name: Copy configuration file
+  ansible.builtin.template:
+    src: config.j2
+    dest: /etc/service/config.yml
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart service
+```

--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -1,0 +1,21 @@
+---
+name: CI Fail Issue
+
+on:
+  workflow_run:
+    workflows: ["Ansible Lint"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+jobs:
+  handle-failure:
+    if: github.event.workflow_run.conclusion == 'failure'
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fail-issue.yml@v0.6.0
+    with:
+      workflow_name: "Ansible Lint"
+    secrets: inherit

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,14 @@
+---
+name: Copilot Setup Steps
+
+on:
+  workflow_call:
+
+jobs:
+  copilot-setup-steps:
+    name: Copilot Setup Steps
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install ansible tools
+        run: pip install ansible-core ansible-lint


### PR DESCRIPTION
## Summary

- Add `.github/copilot-instructions.md` for Copilot agent context (ansible-lint, fully qualified collection names, role structure, idempotency)
- Add `copilot-setup-steps.yml` — ansible-core + ansible-lint environment setup for Copilot
- Add `ci-fail-issue.yml` — creates GitHub issue when Ansible Lint fails on main, assigned to Copilot

## Behavior

When Ansible Lint fails on a commit to main, a GitHub issue is created with failure logs and assigned to Copilot, which opens a fix PR.

5 safety gates prevent loops/spam: bot-author detection, SHA dedup, 3/24h daily limit.

> **Note**: Requires ai-workflows v0.6.0 to be released (PR [JacobPEvans/ai-workflows#60](https://github.com/JacobPEvans/ai-workflows/pull/60))

## Test plan

- [ ] After ai-workflows v0.6.0 is released and this merges: trigger Ansible Lint failure -> verify issue created

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces Copilot coding agent instructions and CI fail issue workflow to handle Ansible Lint failures with GitHub issues.
> 
>   - **Behavior**:
>     - Adds `.github/copilot-instructions.md` for Copilot agent context, detailing Ansible conventions and role structure.
>     - Adds `ci-fail-issue.yml` to create GitHub issues on Ansible Lint failure on `main`, assigned to Copilot.
>     - Implements 5 safety gates in `ci-fail-issue.yml` to prevent spam: bot-author detection, SHA deduplication, and a 3/24h daily limit.
>   - **Workflows**:
>     - Adds `copilot-setup-steps.yml` to set up an Ansible environment for Copilot using `ansible-core` and `ansible-lint`.
>     - `ci-fail-issue.yml` uses `JacobPEvans/ai-workflows` to handle failures.
>   - **Misc**:
>     - Requires `ai-workflows` v0.6.0 for full functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-proxmox-apps&utm_source=github&utm_medium=referral)<sup> for 496235ba3f8663b38c77747b08a4d24b83c94bd7. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->