### PR TITLE
feat(renovate): extend shared preset, remove duplicated rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,24 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "local>JacobPEvans/.github:renovate-presets"
   ],
   "packageRules": [
-    {
-      "description": "Auto-merge official GitHub Actions (including major versions)",
-      "matchDatasources": ["github-actions"],
-      "matchPackagePrefixes": ["actions/"],
-      "automerge": true,
-      "automergeType": "squash",
-      "minimumReleaseAge": "3 days"
-    },
-    {
-      "description": "Auto-merge pre-commit hooks minor and patch updates",
-      "matchManagers": ["pre-commit"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true,
-      "automergeType": "squash"
-    },
     {
       "description": "Group Ansible collection updates",
       "matchManagers": ["ansible-galaxy"],


### PR DESCRIPTION
## Summary

- Extends `local>JacobPEvans/.github:renovate-presets` to inherit org-wide auto-merge rules
- Removes local `actions/` and `pre-commit` package rules now covered by the shared preset
- Retains Ansible-specific: ansible-galaxy collection grouping and manager enablement

## Why

Centralizes Renovate auto-merge configuration in the `.github` repo preset, eliminating duplication.

## Test plan

- [ ] Merge `.github` PR #69 first (preset must be on main before Renovate runs)
- [ ] Verify next Renovate PR gets auto-merge enabled at creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Extends `renovate.json` with shared preset and removes redundant local rules, retaining Ansible-specific configurations.
> 
>   - **Configuration**:
>     - Extends `renovate.json` with `local>JacobPEvans/.github:renovate-presets` to inherit org-wide auto-merge rules.
>     - Removes local `actions/` and `pre-commit` package rules now covered by the shared preset.
>   - **Ansible**:
>     - Retains Ansible-specific configurations: `ansible-galaxy` collection grouping and manager enablement in `renovate.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-proxmox-apps&utm_source=github&utm_medium=referral)<sup> for 2e7504229b882a99c0e557fdf63754828b5f9cd1. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->