### PR TITLE
chore: add flake.lock for reproducible devshell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772173633,
+        "narHash": "sha256-MOH58F4AIbCkh6qlQcwMycyk5SWvsqnS/TCfnqDlpj4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c0f3d81a7ddbc2b1332be0d8481a672b4f6004d6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}


### PR DESCRIPTION
## Summary

- Adds `flake.lock` generated by `nix flake lock`
- Pins `nixpkgs` to `github:nixos/nixpkgs/c0f3d81a7ddbc2b1332be0d8481a672b4f6004d6` (2026-02-27)
- Without a lockfile, `nix develop` regenerates inputs on first run, making the devshell non-reproducible

## Test plan

- [ ] Run `nix develop` in the repo — should use pinned nixpkgs without generating a new lockfile
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `flake.lock` to pin `nixpkgs` for reproducible devshell setup.
> 
>   - **Behavior**:
>     - Adds `flake.lock` to pin `nixpkgs` to `github:nixos/nixpkgs/c0f3d81a7ddbc2b1332be0d8481a672b4f6004d6`.
>     - Ensures `nix develop` uses pinned `nixpkgs` without regenerating inputs, making the devshell reproducible.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-proxmox-apps&utm_source=github&utm_medium=referral)<sup> for 2ba54a11e4035dd981ea09f577b06c9545ffc2c7. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->