### PR TITLE
chore: bump ai-workflows to v0.7.0

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -14,5 +14,5 @@ permissions:
 
 jobs:
   recommend:
-    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.7.0
     secrets: inherit

--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   handle-failure:
     if: github.event.workflow_run.conclusion == 'failure'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fail-issue.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fail-issue.yml@v0.7.0
     with:
       workflow_name: "Ansible Lint"
     secrets: inherit

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -22,7 +22,7 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.head_branch != 'main'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.7.0
     with:
       repo_context: "Ansible playbooks and roles for applications on Proxmox VMs/containers"
       ci_structure: "ansible-lint.yml (ansible-lint + ansible-playbook --syntax-check)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.7.0
     with:
       review_prompt: "Focus on Ansible FQCN usage, idempotency patterns, role structure"
     secrets: inherit

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   simplify:
-    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.7.0
     secrets: inherit

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -16,5 +16,5 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.7.0
     secrets: inherit

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -65,7 +65,7 @@ jobs:
 
   run-triage:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.7.0
     secrets: inherit
     with:
       issue_number: ${{ inputs.issue_number }}
@@ -76,7 +76,7 @@ jobs:
       always() &&
       github.event_name == 'workflow_dispatch' &&
       (needs.run-triage.result == 'success' || needs.run-triage.result == 'skipped')
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.7.0
     secrets: inherit
     with:
       repo_context: "Ansible Proxmox application configuration"

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -14,9 +14,9 @@ permissions:
 
 jobs:
   sweep:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.7.0
     secrets: inherit
 
   hygiene:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.7.0
     secrets: inherit

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -14,5 +14,5 @@ permissions:
 
 jobs:
   analyze:
-    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.7.0
     secrets: inherit

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -38,7 +38,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.7.0
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -38,7 +38,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.7.0
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit


### PR DESCRIPTION
Dependency bot workflows (renovate, dependabot) will now show as skipped instead of failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `ai-workflows` to v0.7.0 in multiple GitHub Actions workflows to show dependency bot workflows as skipped instead of failed.
> 
>   - **Workflows Updated**:
>     - Bump `ai-workflows` version from `v0.6.1` to `v0.7.0` in `.github/workflows/best-practices.yml`, `.github/workflows/ci-fail-issue.yml`, and `.github/workflows/ci-fix.yml`.
>     - Update version in `.github/workflows/claude-review.yml`, `.github/workflows/code-simplifier.yml`, and `.github/workflows/final-pr-review.yml`.
>     - Change version in `.github/workflows/issue-auto-resolve.yml`, `.github/workflows/issue-sweeper.yml`, and `.github/workflows/next-steps.yml`.
>     - Modify version in `.github/workflows/post-merge-docs-review.yml` and `.github/workflows/post-merge-tests.yml`.
>   - **Behavior**:
>     - Dependency bot workflows (renovate, dependabot) will now show as skipped instead of failed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-proxmox-apps&utm_source=github&utm_medium=referral)<sup> for 19fa0ffcef4382701d20595c3bd3ee9b75a0a6fd. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->