### PR TITLE
chore: stagger AI workflow schedules

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -3,7 +3,7 @@ name: Best Practices Recommender
 
 on:
   schedule:
-    - cron: "0 3 * * 3"
+    - cron: "0 3 * * 2,5"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -3,7 +3,7 @@ name: Code Simplifier
 
 on:
   schedule:
-    - cron: "0 4 * * 1"
+    - cron: "0 4 * * 0,3,6"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -3,7 +3,7 @@ name: Next Steps
 
 on:
   schedule:
-    - cron: "0 5 * * 1"
+    - cron: "0 5 * * 1,4"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Stagger AI cron schedules across these three workflows to avoid concurrent runs
- code-simplifier: Sun/Wed/Sat at 4am UTC
- next-steps: Mon/Thu at 5am UTC
- best-practices: Tue/Fri at 3am UTC

Note: Other scheduled workflows (issue-sweeper, issue-hygiene, etc.) are unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)