### PR TITLE
ci: migrate to centralized release-please reusable workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,16 +5,10 @@ on:
   push:
     branches: [main]
 
-permissions: {}
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: googleapis/release-please-action@v4
-        with:
-          config-file: release-please-config.json
-          manifest-file: .release-please-manifest.json
+    uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main


### PR DESCRIPTION
## Summary
- Replace inline release-please action with call to centralized reusable workflow in JacobPEvans/.github
- Config is now fetched from central source at runtime, preventing per-repo drift
- Future config changes (e.g., versioning strategy) only need updating in one place

## Notes
- Depends on JacobPEvans/.github PR being merged first (central config must exist on .github/main)
- Per-repo release-please-config.json is overwritten at runtime — no deletion needed

## Test plan
- [ ] release-please.yml calls the reusable workflow correctly
- [ ] No inline action steps remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)