### PR TITLE
feat: disable automatic triggers on Claude-executing workflows

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -2,9 +2,11 @@
 name: Best Practices Recommender
 
 on:
-  schedule:
-    - cron: "0 3 * * 2,5"
   workflow_dispatch:
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # schedule:
+  #   - cron: "0 3 * * 2,5"
+  # --- END DISABLED ---
 
 permissions:
   contents: read

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -2,9 +2,12 @@
 name: CI Fix (Claude)
 
 on:
-  workflow_run:
-    workflows: ["Ansible Lint"]
-    types: [completed]
+  workflow_dispatch:
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # workflow_run:
+  #   workflows: ["Ansible Lint"]
+  #   types: [completed]
+  # --- END DISABLED ---
 
 permissions:
   actions: read
@@ -13,15 +16,19 @@ permissions:
   issues: write
   pull-requests: write
 
-concurrency:
-  group: ci-fix-${{ github.event.workflow_run.head_branch }}
-  cancel-in-progress: true
+# --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+# concurrency:
+#   group: ci-fix-${{ github.event.workflow_run.head_branch }}
+#   cancel-in-progress: true
+# --- END DISABLED ---
 
 jobs:
   fix:
-    if: >-
-      github.event.workflow_run.conclusion == 'failure' &&
-      github.event.workflow_run.head_branch != 'main'
+    # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+    # if: >-
+    #   github.event.workflow_run.conclusion == 'failure' &&
+    #   github.event.workflow_run.head_branch != 'main'
+    # --- END DISABLED ---
     uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.9.4
     with:
       repo_context: "Ansible playbooks and roles for applications on Proxmox VMs/containers"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,10 +2,13 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-  issue_comment:
-    types: [created]
+  workflow_dispatch:
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # pull_request:
+  #   types: [opened, synchronize]
+  # issue_comment:
+  #   types: [created]
+  # --- END DISABLED ---
 
 permissions:
   actions: read

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -2,9 +2,11 @@
 name: Code Simplifier
 
 on:
-  schedule:
-    - cron: "0 4 * * 0,3,6"
   workflow_dispatch:
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # schedule:
+  #   - cron: "0 4 * * 0,3,6"
+  # --- END DISABLED ---
 
 permissions:
   contents: write

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -2,10 +2,13 @@
 name: Final PR Review
 
 on:
-  pull_request_review:
-    types: [submitted]
-  check_suite:
-    types: [completed]
+  workflow_dispatch:
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # pull_request_review:
+  #   types: [submitted]
+  # check_suite:
+  #   types: [completed]
+  # --- END DISABLED ---
 
 permissions:
   checks: read

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -2,8 +2,10 @@
 name: Issue Auto-Resolve
 
 on:
-  issues:
-    types: [opened, labeled]
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # issues:
+  #   types: [opened, labeled]
+  # --- END DISABLED ---
   workflow_dispatch:
     inputs:
       issue_number:
@@ -19,49 +21,51 @@ permissions:
   pull-requests: write
 
 jobs:
-  dispatch:
-    if: github.event_name == 'issues'
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      issues: write
-    steps:
-      - name: Dispatch as workflow_dispatch
-        env:
-          GH_TOKEN: ${{ github.token }}
-          WORKFLOW_NAME: ${{ github.workflow }}
-          REPO: ${{ github.repository }}
-          ISSUE_NUM: ${{ github.event.issue.number }}
-          EVENT_ACTION: ${{ github.event.action }}
-          LABEL_NAME: ${{ github.event.label.name }}
-        run: |
-          # Filter labeled events to only ai:ready
-          if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" != "ai:ready" ]]; then
-            echo "Label '$LABEL_NAME' is not ai:ready — skipping"
-            exit 0
-          fi
-
-          # Daily dispatch limit (cost control safety valve)
-          TODAY=$(date -u +%Y-%m-%d)
-          COUNT=$(gh run list \
-            --workflow "$WORKFLOW_NAME" \
-            --repo "$REPO" \
-            --event workflow_dispatch \
-            --created ">=$TODAY" \
-            --json databaseId --jq 'length')
-          if [[ "$COUNT" -ge 5 ]]; then
-            echo "Daily dispatch limit reached ($COUNT/5) — skipping"
-            exit 0
-          fi
-
-          # Remove ai:ready label so it can be re-applied to re-trigger
-          if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" == "ai:ready" ]]; then
-            gh issue edit "$ISSUE_NUM" --repo "$REPO" --remove-label "ai:ready" || true
-          fi
-
-          gh workflow run "$WORKFLOW_NAME" \
-            --repo "$REPO" \
-            -f issue_number="$ISSUE_NUM"
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # dispatch:
+  #   if: github.event_name == 'issues'
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: write
+  #     issues: write
+  #   steps:
+  #     - name: Dispatch as workflow_dispatch
+  #       env:
+  #         GH_TOKEN: ${{ github.token }}
+  #         WORKFLOW_NAME: ${{ github.workflow }}
+  #         REPO: ${{ github.repository }}
+  #         ISSUE_NUM: ${{ github.event.issue.number }}
+  #         EVENT_ACTION: ${{ github.event.action }}
+  #         LABEL_NAME: ${{ github.event.label.name }}
+  #       run: |
+  #         # Filter labeled events to only ai:ready
+  #         if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" != "ai:ready" ]]; then
+  #           echo "Label '$LABEL_NAME' is not ai:ready — skipping"
+  #           exit 0
+  #         fi
+  #
+  #         # Daily dispatch limit (cost control safety valve)
+  #         TODAY=$(date -u +%Y-%m-%d)
+  #         COUNT=$(gh run list \
+  #           --workflow "$WORKFLOW_NAME" \
+  #           --repo "$REPO" \
+  #           --event workflow_dispatch \
+  #           --created ">=$TODAY" \
+  #           --json databaseId --jq 'length')
+  #         if [[ "$COUNT" -ge 5 ]]; then
+  #           echo "Daily dispatch limit reached ($COUNT/5) — skipping"
+  #           exit 0
+  #         fi
+  #
+  #         # Remove ai:ready label so it can be re-applied to re-trigger
+  #         if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" == "ai:ready" ]]; then
+  #           gh issue edit "$ISSUE_NUM" --repo "$REPO" --remove-label "ai:ready" || true
+  #         fi
+  #
+  #         gh workflow run "$WORKFLOW_NAME" \
+  #           --repo "$REPO" \
+  #           -f issue_number="$ISSUE_NUM"
+  # --- END DISABLED ---
 
   run-triage:
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -2,9 +2,11 @@
 name: Issue Maintenance
 
 on:
-  schedule:
-    - cron: "0 6 * * 1"
   workflow_dispatch:
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # schedule:
+  #   - cron: "0 6 * * 1"
+  # --- END DISABLED ---
 
 permissions:
   contents: read

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -2,9 +2,11 @@
 name: Next Steps
 
 on:
-  schedule:
-    - cron: "0 5 * * 1,4"
   workflow_dispatch:
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # schedule:
+  #   - cron: "0 5 * * 1,4"
+  # --- END DISABLED ---
 
 permissions:
   contents: write

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -2,8 +2,10 @@
 name: Post-Merge Docs Review
 
 on:
-  push:
-    branches: [main]
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # push:
+  #   branches: [main]
+  # --- END DISABLED ---
   workflow_dispatch:
     inputs:
       commit_sha:
@@ -20,21 +22,23 @@ permissions:
   pull-requests: write
 
 jobs:
-  dispatch:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - name: Re-trigger as workflow_dispatch
-        env:
-          WORKFLOW_NAME: ${{ github.workflow }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh workflow run "$WORKFLOW_NAME" \
-            --repo "${{ github.repository }}" \
-            --ref main \
-            -f commit_sha="${{ github.sha }}"
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # dispatch:
+  #   if: github.event_name == 'push'
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: write
+  #   steps:
+  #     - name: Re-trigger as workflow_dispatch
+  #       env:
+  #         WORKFLOW_NAME: ${{ github.workflow }}
+  #         GH_TOKEN: ${{ github.token }}
+  #       run: |
+  #         gh workflow run "$WORKFLOW_NAME" \
+  #           --repo "${{ github.repository }}" \
+  #           --ref main \
+  #           -f commit_sha="${{ github.sha }}"
+  # --- END DISABLED ---
 
   review:
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -2,8 +2,10 @@
 name: Post-Merge Test Review
 
 on:
-  push:
-    branches: [main]
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # push:
+  #   branches: [main]
+  # --- END DISABLED ---
   workflow_dispatch:
     inputs:
       commit_sha:
@@ -20,21 +22,23 @@ permissions:
   pull-requests: write
 
 jobs:
-  dispatch:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - name: Re-trigger as workflow_dispatch
-        env:
-          WORKFLOW_NAME: ${{ github.workflow }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh workflow run "$WORKFLOW_NAME" \
-            --repo "${{ github.repository }}" \
-            --ref main \
-            -f commit_sha="${{ github.sha }}"
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # dispatch:
+  #   if: github.event_name == 'push'
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: write
+  #   steps:
+  #     - name: Re-trigger as workflow_dispatch
+  #       env:
+  #         WORKFLOW_NAME: ${{ github.workflow }}
+  #         GH_TOKEN: ${{ github.token }}
+  #       run: |
+  #         gh workflow run "$WORKFLOW_NAME" \
+  #           --repo "${{ github.repository }}" \
+  #           --ref main \
+  #           -f commit_sha="${{ github.sha }}"
+  # --- END DISABLED ---
 
   review:
     if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary
- Converted all 10 Claude-executing workflows from automatic triggers (pull_request, schedule, push, workflow_run, issues, etc.) to workflow_dispatch only
- Commented out dead-code jobs/conditions (dispatch jobs, concurrency groups, conditional `if` blocks) that depend on the disabled triggers
- All original triggers preserved with `DISABLED AUTOMATIC TRIGGERS` markers for easy restoration

## Workflows modified
- **claude-review.yml** - disabled pull_request + issue_comment triggers
- **final-pr-review.yml** - disabled pull_request_review + check_suite triggers
- **best-practices.yml** - disabled schedule trigger
- **code-simplifier.yml** - disabled schedule trigger
- **next-steps.yml** - disabled schedule trigger
- **issue-sweeper.yml** - disabled schedule trigger
- **post-merge-docs-review.yml** - disabled push trigger + dispatch job
- **post-merge-tests.yml** - disabled push trigger + dispatch job
- **issue-auto-resolve.yml** - disabled issues trigger + dispatch job
- **ci-fix.yml** - disabled workflow_run trigger + concurrency + job if

## Test plan
- [ ] Verify no workflows auto-trigger on PR events, push to main, schedules, or issue events
- [ ] Verify each workflow can still be triggered manually via workflow_dispatch
- [ ] Confirm ci-fail-issue.yml and non-Claude workflows (ansible-lint, molecule, release-please) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR cleanly converts all 10 Claude-executing workflows from automatic triggers (`pull_request`, `schedule`, `push`, `workflow_run`, `issues`, etc.) to `workflow_dispatch`-only, implementing a cost-control mechanism to prevent Claude from auto-consuming API budget. The approach is mechanically sound and reversible — all original triggers are preserved as commented-out blocks with clear `DISABLED AUTOMATIC TRIGGERS` markers for easy restoration.

**Changes summary:**
- **4 schedule-based workflows** (`best-practices`, `code-simplifier`, `next-steps`, `issue-sweeper`) — schedule triggers commented out, no structural changes
- **2 pull_request/review-triggered workflows** (`claude-review`, `final-pr-review`) — automatic triggers and dispatch re-trigger jobs disabled
- **2 push-triggered workflows** (`post-merge-docs-review`, `post-merge-tests`) — push triggers and re-dispatch jobs commented out; `if:` guards left for future restoration
- **1 issues-triggered workflow** (`issue-auto-resolve`) — automatic trigger and dispatch re-trigger job disabled
- **1 workflow_run-triggered workflow** (`ci-fix`) — trigger, concurrency block, and job-level `if:` guard all commented out; job now runs unconditionally on manual dispatch

All disable operations follow the same pattern with clear markers, making the changeset easy to audit and reverse. The code changes carry no logic risk — they simply make workflows manual-only via `workflow_dispatch`.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — all 10 workflows are cleanly converted to manual-only dispatch with no logic risk or unintended consequences.
- All changes are mechanical, straightforward, and low-risk. Original triggers are preserved as clearly-marked commented blocks, making restoration trivial. No YAML syntax errors, no logic changes, and no dead code paths created. The changeset accomplishes exactly what the PR describes: converting automatic triggers to workflow_dispatch-only. The documented test plan (manual dispatch testing) is the appropriate place to verify runtime behavior.
- No files require special attention.

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph BEFORE["Before PR (Auto-Triggers)"]
        A1["pull_request / issue_comment"] --> B1["claude-review.yml"]
        A2["pull_request_review / check_suite"] --> B2["final-pr-review.yml"]
        A3["schedule (cron)"] --> B3["best-practices / code-simplifier\nnext-steps / issue-sweeper"]
        A4["push: main"] --> B4["post-merge-docs-review\npost-merge-tests"]
        A5["issues: opened/labeled"] --> B5["issue-auto-resolve.yml"]
        A6["workflow_run: Ansible Lint"] --> B6["ci-fix.yml"]
    end

    subgraph AFTER["After PR (Manual Only)"]
        C1["workflow_dispatch 🖱️"] --> D1["claude-review.yml"]
        C2["workflow_dispatch 🖱️"] --> D2["final-pr-review.yml"]
        C3["workflow_dispatch 🖱️"] --> D3["best-practices / code-simplifier\nnext-steps / issue-sweeper"]
        C4["workflow_dispatch 🖱️"] --> D4["post-merge-docs-review\npost-merge-tests"]
        C5["workflow_dispatch 🖱️"] --> D5["issue-auto-resolve.yml"]
        C6["workflow_dispatch 🖱️"] --> D6["ci-fix.yml"]
    end

    style BEFORE fill:#ffeded,stroke:#cc0000
    style AFTER fill:#edfff0,stroke:#00aa44
```

<sub>Last reviewed commit: fec6f0b</sub>

**Context used:**

- Rule used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=e8c13f98-efee-454a-8db3-d26090d1a0f3))
- Rule used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=186af18c-7423-453d-9ea3-cd5e9ed7d073))

<!-- /greptile_comment -->