### PR TITLE
fix(ci): use GitHub App token for release-please to trigger CI Gate

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,8 +10,7 @@ permissions: {}
 jobs:
   release-please:
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
     secrets:
       GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}


### PR DESCRIPTION
## Summary

- Pass GitHub App credentials explicitly to the release-please reusable workflow
- Tighten workflow-level permissions to \`{}\`; move to job-level

## Root Cause

Release-please used \`GITHUB_TOKEN\` to create PRs. GitHub does not trigger \`pull_request\` events for \`GITHUB_TOKEN\`-created PRs, so any Merge Gate check would never run — blocking release-please PRs indefinitely.

## Dependency

Requires JacobPEvans/.github#87 to be merged first.

## Test plan

- [ ] Merge JacobPEvans/.github#87 first
- [ ] Merge this PR
- [ ] Confirm the next release-please PR triggers Merge Gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a classic GitHub Actions bootstrapping problem: `GITHUB_TOKEN`-authored PRs are silently ignored by `pull_request` event triggers (by design, to prevent CI loops), which meant release-please PRs could never satisfy the Merge Gate and would be stuck indefinitely. The fix threads a GitHub App identity through the reusable workflow so PRs are created under an App token, which GitHub *does* forward as a `pull_request` event.

**Changes:**
- `permissions: {}` is now set at the workflow level — zero default permissions, a nice security hardening win 🔒
- `contents: write` and `pull-requests: write` are scoped to only the `release-please` job that actually needs them (least-privilege, textbook style)
- `GH_ACTION_JACOBPEVANS_APP_ID` and `GH_APP_PRIVATE_KEY` are explicitly forwarded to the reusable workflow via the `secrets:` block (more targeted than `secrets: inherit` used elsewhere in the repo)
- No functional changes to any Ansible roles or playbooks — pure CI plumbing

**Note:** This PR has a hard dependency on `JacobPEvans/.github#87` being merged first, since the reusable workflow needs to be updated to consume the new secrets. Merging in the wrong order will break the release workflow.

<h3>Confidence Score: 5/5</h3>

- Safe to merge after JacobPEvans/.github#87 lands; no application logic is touched.
- Single-file change limited to CI plumbing; permissions are correctly scoped; secret forwarding follows standard GitHub Actions reusable workflow patterns; the root cause and fix are well-understood and well-documented in the PR description. Only risk is merge ordering with the dependency PR, which the author has explicitly called out.
- No files require special attention — the change is minimal and mechanically correct.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-please.yml | Permissions moved from workflow-level to job-level (least-privilege hardening), and GitHub App credentials are explicitly forwarded to the reusable release-please workflow so PRs it creates can trigger the CI Gate. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant M as main branch
    participant RPA as release-please.yml<br/>(this workflow)
    participant RPW as _release-please.yml<br/>(reusable @ JacobPEvans/.github)
    participant GAT as GitHub App Token<br/>(APP_ID + PRIVATE_KEY)
    participant GH as GitHub API
    participant CI as CI Gate (pull_request event)

    M->>RPA: push to main
    RPA->>RPW: uses: workflow_call<br/>secrets: APP_ID, PRIVATE_KEY
    RPW->>GAT: Generate installation token
    GAT-->>RPW: Short-lived app token
    RPW->>GH: Create/update Release PR<br/>(as GitHub App identity)
    GH-->>CI: pull_request event FIRES 🎉<br/>(App token ≠ GITHUB_TOKEN)
    CI-->>GH: Merge Gate checks run ✅

    note over RPA,RPW: Previously used GITHUB_TOKEN<br/>→ pull_request event silently suppressed<br/>→ Merge Gate would never run ❌
```

<sub>Last reviewed commit: 4067db3</sub>

<!-- /greptile_comment -->