### PR TITLE
fix(ci): implement Merge Gatekeeper pattern with ci-gate

### DIFF
--- a/.github/workflows/_ansible-lint.yml
+++ b/.github/workflows/_ansible-lint.yml
@@ -2,30 +2,8 @@
 name: Ansible Lint
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'playbooks/**/*.yml'
-      - 'playbooks/**/*.yaml'
-      - 'roles/**/*.yml'
-      - 'roles/**/*.yaml'
-      - 'inventory/**'
-      - 'tests/**'
-      - '.ansible-lint'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'playbooks/**/*.yml'
-      - 'playbooks/**/*.yaml'
-      - 'roles/**/*.yml'
-      - 'roles/**/*.yaml'
-      - 'inventory/**'
-      - 'tests/**'
-      - '.ansible-lint'
+  workflow_call:
 
-# Minimum required permissions for security (least privilege)
 permissions:
   contents: read
 

--- a/.github/workflows/_molecule.yml
+++ b/.github/workflows/_molecule.yml
@@ -2,22 +2,7 @@
 name: Molecule
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "molecule/**"
-      - "roles/**/*.yml"
-      - "roles/**/*.yaml"
-      - "roles/**/*.j2"
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "molecule/**"
-      - "roles/**/*.yml"
-      - "roles/**/*.yaml"
-      - "roles/**/*.j2"
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -1,0 +1,101 @@
+---
+# CI Gate - Conditional Required Checks
+#
+# FRAMEWORK: Merge Gatekeeper Pattern
+# ====================================
+# Solves: "Required checks that only run when relevant files change"
+#
+# Problem: GitHub branch protection only supports "always required" or "not required"
+#          Path-filtered workflows that don't run = pending forever = blocks merge
+#
+# Solution: Single workflow that:
+# 1. Always triggers on ALL PRs (no path filters at workflow level)
+# 2. Detects which file categories changed
+# 3. Calls reusable workflows conditionally (skipped = success)
+# 4. Final "Merge Gate" job aggregates all results
+#
+# Branch Protection: Set ONLY "Merge Gate" as required check
+#
+# Adding New Checks:
+# 1. Create reusable workflow: _your-check.yml with `on: workflow_call`
+# 2. Add filter pattern under `changes.steps.filter.with.filters`
+# 3. Add job that calls the reusable workflow with appropriate `if:` condition
+# 4. Add job name to `gate.needs` array and `allowed-skips`
+
+name: CI Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  # ==========================================================================
+  # CHANGE DETECTION
+  # ==========================================================================
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      ansible: ${{ steps.filter.outputs.ansible }}
+      molecule: ${{ steps.filter.outputs.molecule }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            ansible:
+              - 'playbooks/**/*.yml'
+              - 'playbooks/**/*.yaml'
+              - 'roles/**/*.yml'
+              - 'roles/**/*.yaml'
+              - 'inventory/**'
+              - 'tests/**'
+              - '.ansible-lint'
+              - 'requirements.yml'
+            molecule:
+              - 'molecule/**'
+              - 'roles/**/*.yml'
+              - 'roles/**/*.yaml'
+              - 'roles/**/*.j2'
+
+  # ==========================================================================
+  # CONDITIONAL CHECKS (call reusable workflows)
+  # ==========================================================================
+  ansible-lint:
+    name: Ansible Lint
+    needs: changes
+    if: needs.changes.outputs.ansible == 'true'
+    uses: ./.github/workflows/_ansible-lint.yml
+
+  molecule:
+    name: Molecule
+    needs: changes
+    if: needs.changes.outputs.molecule == 'true'
+    uses: ./.github/workflows/_molecule.yml
+
+  # ==========================================================================
+  # MERGE GATE - The ONLY required check in branch protection
+  # ==========================================================================
+  gate:
+    name: Merge Gate
+    needs: [changes, ansible-lint, molecule]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all results
+        uses: re-actors/alls-green@release/v1
+        with:
+          allowed-skips: ansible-lint, molecule
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary

- Create `ci-gate.yml` implementing the Merge Gatekeeper pattern
- Convert `ansible-lint.yml` and `molecule.yml` to reusable workflows (`_ansible-lint.yml`, `_molecule.yml`)
- CI Gate conditionally calls reusable workflows based on file change detection
- Gate uses `re-actors/alls-green` to aggregate all results

## Test plan

- [ ] Verify "Merge Gate" check appears and passes on this PR
- [ ] Confirm ansible-lint runs when playbook/role files change
- [ ] Confirm molecule runs when molecule/role files change
- [ ] Confirm all jobs skip (gate still passes) for non-matching file changes
- [ ] After merge, update ruleset to require only "Merge Gate"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements the **Merge Gatekeeper pattern** — a common and clever solution to the GitHub branch protection dilemma where path-filtered workflows that *don't run* leave required checks eternally pending. The approach converts `ansible-lint.yml` and `molecule.yml` into `workflow_call`-only reusable workflows (`_ansible-lint.yml`, `_molecule.yml`) and introduces a new `ci-gate.yml` orchestrator that always triggers on PRs, detects file changes via `dorny/paths-filter`, conditionally calls the reusable workflows, and uses `re-actors/alls-green` to aggregate all results into a single "Merge Gate" check.

**The core logic is correct:** `alls-green` + `allowed-skips: ansible-lint, molecule` + `if: ${{ !cancelled() }}` on the gate is the well-known canonical implementation of this pattern (even endorsed by the `alls-green` maintainer). The `concurrency: cancel-in-progress` setup also correctly interacts with the gate.

Key issues found:

- **Missing `push` trigger (logic):** The old standalone workflows triggered on both `push` to `main` and `pull_request`. `ci-gate.yml` is `pull_request`-only, meaning direct pushes to `main` (hotfixes, bot commits) produce zero CI. This is safe only if branch protection already blocks direct pushes, but since updating the ruleset is called out as a *post-merge* step, there may be a timing gap.
- **Redundant checkout in `changes` job (style):** `dorny/paths-filter@v3` on `pull_request` events uses the GitHub API for file-change detection — no git checkout required. Removing `actions/checkout@v6` from the `changes` job saves a few seconds per run.
- **Mutable action tags (style):** Both `re-actors/alls-green@release/v1` and `dorny/paths-filter@v3` use floating branch/version tags instead of pinned commit SHAs, which is a supply chain risk.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with caveats — the gating logic is correct, but the missing `push` trigger creates a CI coverage gap on `main` if the branch ruleset isn't already enforcing PR-only merges.
- The Merge Gatekeeper pattern is implemented correctly: `alls-green` + `allowed-skips` + `if: !cancelled()` is the canonical approach, and the `concurrency` group handles cancel-in-progress safely. The two reusable workflow conversions are clean. Score is held to 3 due to the logic issue (no `push` trigger, potential CI gap on `main`), the redundant checkout step, and mutable action tags — all of which are fixable before or immediately after merge.
- `ci-gate.yml` needs attention — specifically the missing `push` trigger and the mutable action tag pins. The reusable workflow files (`_ansible-lint.yml`, `_molecule.yml`) are clean.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci-gate.yml | New orchestrator workflow implementing the Merge Gatekeeper pattern. Logic is sound — `alls-green` + `allowed-skips` + `if: !cancelled()` is a well-understood combo — but has three issues: missing `push` trigger removes CI on direct `main` commits, redundant `checkout` step in the `changes` job, and mutable action tags for `re-actors/alls-green` and `dorny/paths-filter`. |
| .github/workflows/_ansible-lint.yml | Converted from a standalone scheduled workflow to a `workflow_call`-only reusable workflow. Jobs (lint, syntax-check, validate-inventory-schema, verify-inventory-load) are unchanged and look correct. Permissions are appropriately scoped to `contents: read`. |
| .github/workflows/_molecule.yml | Converted from standalone to `workflow_call`-only reusable workflow. Jobs (molecule test and template-render) are unchanged. Clean conversion with no issues introduced. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PR([Pull Request\nopened / sync / reopened]) --> CG[CI Gate workflow starts]

    CG --> CH{{"changes job\n(Detect Changes)\ndorny/paths-filter@v3"}}

    CH -->|ansible == 'true'| AL["ansible-lint job\ncalls _ansible-lint.yml\n(lint, syntax-check,\nvalidate-schema, verify-load)"]
    CH -->|ansible == 'false'| ALS[ansible-lint: SKIPPED ✅]

    CH -->|molecule == 'true'| ML["molecule job\ncalls _molecule.yml\n(test, template-render)"]
    CH -->|molecule == 'false'| MLS[molecule: SKIPPED ✅]

    AL -->|success| G
    AL -->|failure| G
    ALS --> G
    ML -->|success| G
    ML -->|failure| G
    MLS --> G

    subgraph gate["gate job (if: !cancelled())"]
        G["re-actors/alls-green\nallowed-skips: ansible-lint, molecule\njobs: toJSON(needs)"]
    end

    G -->|all green or skipped| PASS["✅ Merge Gate\nPASSES\n→ PR can merge"]
    G -->|any failure| FAIL["❌ Merge Gate\nFAILS\n→ PR blocked"]

    style PASS fill:#22c55e,color:#fff
    style FAIL fill:#ef4444,color:#fff
    style gate fill:#f0f9ff,stroke:#0ea5e9
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/ci-gate.yml
Line: 52-54

Comment:
**Redundant checkout step for PR events**

For `pull_request` events, `dorny/paths-filter@v3` automatically uses the GitHub API to retrieve the list of changed files — no git clone needed. The `actions/checkout@v6` step on line 53 consumes a full checkout (including network I/O and disk space) but provides nothing extra for this event type.

You can drop the checkout step entirely from the `changes` job:

```suggestion
    steps:
      - uses: dorny/paths-filter@v3
```

This shaves off several seconds per run and reduces the attack surface from the checkout action. If you ever add a `push` trigger to this workflow in the future, you'd need to add checkout back — worth a note in a comment.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/ci-gate.yml
Line: 27-29

Comment:
**No `push` trigger removes CI coverage for direct commits to `main`**

The original `ansible-lint.yml` and `molecule.yml` both triggered on `push` to `main` (in addition to `pull_request`). This `ci-gate.yml` is `pull_request`-only, so any direct commit pushed to `main` — a hotfix, a bot commit, a merge commit from a squash-merge, etc. — will produce **zero CI runs** and leave `main` without a green check.

This is safe only if your branch ruleset is already configured to:
1. Require PRs for all merges to `main` (no direct pushes).
2. Require the "Merge Gate" check to pass before merging.

The PR description mentions "After merge, update ruleset to require only 'Merge Gate'" as a post-merge step, which means at the time this is merged that ruleset change hasn't happened yet. If the old required checks are removed before the new ruleset is applied, there will be a window where `main` has no required checks at all.

Consider also adding a `push` trigger (or confirming the branch protection is already ironclad) to avoid this gap:

```suggestion
on:
  pull_request:
    types: [opened, synchronize, reopened]
  push:
    branches:
      - main
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/ci-gate.yml
Line: 98-100

Comment:
**Mutable action tag is a supply-chain risk**

`re-actors/alls-green@release/v1` resolves to whatever commit the `release/v1` branch points to at runtime. A compromised upstream repo could redirect that branch to malicious code and silently affect every CI run. Same concern applies to `dorny/paths-filter@v3` on line 54.

Pin both to their full commit SHAs (e.g. from their respective latest release pages) for deterministic, tamper-evident builds:

```suggestion
        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # release/v1
```

And for `dorny/paths-filter@v3` on line 54:
```yaml
      - uses: dorny/paths-filter@de90cc6fb38505f5d5d0eef8e89cf75f3c822072  # v3.0.2
```

Dependabot (or Renovate) can keep these SHAs fresh automatically if you add a `github-actions` dependency update configuration.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 9f2ab78</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->