### PR TITLE
feat: add MinIO role for artifact storage

### DIFF
--- a/inventory/group_vars/minio_group.yml
+++ b/inventory/group_vars/minio_group.yml
@@ -1,0 +1,4 @@
+---
+# MinIO group variables
+systemd_restart_policy_services:
+  - minio

--- a/inventory/load_terraform.yml
+++ b/inventory/load_terraform.yml
@@ -129,6 +129,11 @@
               else []
             ) +
             (
+              ['minio_group']
+              if 'minio' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
               ['technitium_dns_group']
               if 'dns' in (item.value.tags | default([]))
               else []

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -56,6 +56,21 @@
         state: absent
 
 # =============================================================================
+# Phase 0b: MinIO Object Storage
+# S3-compatible artifact store for Splunk add-ons and other deployment assets
+# =============================================================================
+
+- name: Deploy MinIO object storage
+  hosts: minio_group
+  become: true
+  gather_facts: false
+  tags:
+    - minio
+    - storage
+  roles:
+    - role: minio
+
+# =============================================================================
 # Phase 1a: DNS Installation
 # Install Technitium DNS server and bootstrap credentials from Doppler.
 # Must run BEFORE record management (Phase 1b).

--- a/roles/minio/defaults/main.yml
+++ b/roles/minio/defaults/main.yml
@@ -1,0 +1,29 @@
+---
+# MinIO object storage role defaults
+
+# Binary download URLs
+minio_binary_url: "https://dl.min.io/server/minio/release/linux-amd64/minio"
+minio_mc_binary_url: "https://dl.min.io/client/mc/release/linux-amd64/mc"
+
+# Installation paths
+minio_install_dir: /usr/local/bin
+minio_data_dir: /opt/minio/data
+minio_config_dir: /etc/minio
+
+# Service configuration
+minio_api_port: 9000
+minio_console_port: 9001
+
+# System user
+minio_user: minio-user
+minio_group: minio-user
+
+# Credentials (from Doppler)
+minio_root_user: "{{ lookup('env', 'MINIO_ROOT_USER') }}"
+minio_root_password: "{{ lookup('env', 'MINIO_ROOT_PASSWORD') }}"
+
+# Default buckets to create
+minio_default_buckets:
+  - name: splunk-addons
+    policy: download
+    versioning: true

--- a/roles/minio/handlers/main.yml
+++ b/roles/minio/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart minio
+  ansible.builtin.systemd:
+    name: minio
+    state: restarted
+    daemon_reload: true

--- a/roles/minio/meta/main.yml
+++ b/roles/minio/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: Deploy MinIO S3-compatible object storage
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+  galaxy_tags:
+    - minio
+    - s3
+    - storage
+dependencies: []

--- a/roles/minio/tasks/main.yml
+++ b/roles/minio/tasks/main.yml
@@ -24,7 +24,7 @@
     system: true
     shell: /usr/sbin/nologin
     home: /opt/minio
-    create_home: false
+    create_home: true
     state: present
 
 # Phase 3: Create directories
@@ -45,11 +45,7 @@
     mode: "0750"
 
 # Phase 4: Download binaries
-- name: Check if minio binary exists
-  ansible.builtin.stat:
-    path: "{{ minio_install_dir }}/minio"
-  register: minio_binary
-
+# get_url is idempotent — skips download when dest exists and hasn't changed
 - name: Download minio server binary
   ansible.builtin.get_url:
     url: "{{ minio_binary_url }}"
@@ -57,21 +53,14 @@
     owner: root
     group: root
     mode: "0755"
-  when: not minio_binary.stat.exists
-
-- name: Check if mc binary exists
-  ansible.builtin.stat:
-    path: "{{ minio_install_dir }}/mc"
-  register: minio_mc_binary
 
 - name: Download minio client binary
   ansible.builtin.get_url:
-    url: "{{ minio_minio_mc_binary_url }}"
+    url: "{{ minio_mc_binary_url }}"
     dest: "{{ minio_install_dir }}/mc"
     owner: root
     group: root
     mode: "0755"
-  when: not minio_mc_binary.stat.exists
 
 # Phase 5: Deploy configuration
 - name: Deploy MinIO environment file
@@ -117,8 +106,8 @@
   ansible.builtin.command:
     cmd: >-
       {{ minio_install_dir }}/mc alias set local
-      http://127.0.0.1:{{ minio_api_port }}
-      {{ minio_root_user }} {{ minio_root_password }}
+      "http://127.0.0.1:{{ minio_api_port }}"
+      "{{ minio_root_user }}" "{{ minio_root_password }}"
   no_log: true
   changed_when: false
 

--- a/roles/minio/tasks/main.yml
+++ b/roles/minio/tasks/main.yml
@@ -1,0 +1,148 @@
+---
+# MinIO object storage installation and configuration
+
+# Phase 1: Install prerequisites
+- name: Install required packages
+  ansible.builtin.apt:
+    name:
+      - curl
+      - ca-certificates
+    state: present
+    update_cache: true
+
+# Phase 2: Create system user
+- name: Create minio system group
+  ansible.builtin.group:
+    name: "{{ minio_group }}"
+    system: true
+    state: present
+
+- name: Create minio system user
+  ansible.builtin.user:
+    name: "{{ minio_user }}"
+    group: "{{ minio_group }}"
+    system: true
+    shell: /usr/sbin/nologin
+    home: /opt/minio
+    create_home: false
+    state: present
+
+# Phase 3: Create directories
+- name: Create MinIO data directory
+  ansible.builtin.file:
+    path: "{{ minio_data_dir }}"
+    state: directory
+    owner: "{{ minio_user }}"
+    group: "{{ minio_group }}"
+    mode: "0750"
+
+- name: Create MinIO config directory
+  ansible.builtin.file:
+    path: "{{ minio_config_dir }}"
+    state: directory
+    owner: "{{ minio_user }}"
+    group: "{{ minio_group }}"
+    mode: "0750"
+
+# Phase 4: Download binaries
+- name: Check if minio binary exists
+  ansible.builtin.stat:
+    path: "{{ minio_install_dir }}/minio"
+  register: minio_binary
+
+- name: Download minio server binary
+  ansible.builtin.get_url:
+    url: "{{ minio_binary_url }}"
+    dest: "{{ minio_install_dir }}/minio"
+    owner: root
+    group: root
+    mode: "0755"
+  when: not minio_binary.stat.exists
+
+- name: Check if mc binary exists
+  ansible.builtin.stat:
+    path: "{{ minio_install_dir }}/mc"
+  register: minio_mc_binary
+
+- name: Download minio client binary
+  ansible.builtin.get_url:
+    url: "{{ minio_minio_mc_binary_url }}"
+    dest: "{{ minio_install_dir }}/mc"
+    owner: root
+    group: root
+    mode: "0755"
+  when: not minio_mc_binary.stat.exists
+
+# Phase 5: Deploy configuration
+- name: Deploy MinIO environment file
+  ansible.builtin.template:
+    src: minio.env.j2
+    dest: /etc/default/minio
+    owner: root
+    group: "{{ minio_group }}"
+    mode: "0640"
+  no_log: true
+  notify: Restart minio
+
+- name: Deploy MinIO systemd unit file
+  ansible.builtin.template:
+    src: minio.service.j2
+    dest: /etc/systemd/system/minio.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart minio
+
+# Phase 6: Enable and start service
+- name: Enable and start MinIO service
+  ansible.builtin.systemd:
+    name: minio
+    state: started
+    enabled: true
+    daemon_reload: true
+
+# Phase 7: Health check
+- name: Wait for MinIO to be ready
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ minio_api_port }}/minio/health/live"
+    status_code: 200
+  register: minio_health
+  until: minio_health.status == 200
+  retries: 10
+  delay: 3
+  changed_when: false
+
+# Phase 8: Create buckets
+- name: Configure mc alias for local MinIO
+  ansible.builtin.command:
+    cmd: >-
+      {{ minio_install_dir }}/mc alias set local
+      http://127.0.0.1:{{ minio_api_port }}
+      {{ minio_root_user }} {{ minio_root_password }}
+  no_log: true
+  changed_when: false
+
+- name: Create default buckets
+  ansible.builtin.command:
+    cmd: "{{ minio_install_dir }}/mc mb --ignore-existing local/{{ item.name }}"
+  loop: "{{ minio_default_buckets }}"
+  register: minio_bucket_result
+  changed_when: "'Bucket created' in minio_bucket_result.stdout"
+
+- name: Enable versioning on buckets
+  ansible.builtin.command:
+    cmd: "{{ minio_install_dir }}/mc version enable local/{{ item.name }}"
+  loop: "{{ minio_default_buckets | selectattr('versioning', 'defined') | selectattr('versioning') | list }}"
+  register: minio_versioning_result
+  changed_when: "'is already enabled' not in minio_versioning_result.stdout"
+
+- name: Set anonymous download policy on buckets
+  ansible.builtin.command:
+    cmd: "{{ minio_install_dir }}/mc anonymous set download local/{{ item.name }}"
+  loop: >-
+    {{ minio_default_buckets
+       | selectattr('policy', 'defined')
+       | selectattr('policy', 'equalto', 'download')
+       | list }}
+  register: minio_policy_result
+  changed_when: "'is already set' not in minio_policy_result.stdout"

--- a/roles/minio/templates/minio.env.j2
+++ b/roles/minio/templates/minio.env.j2
@@ -1,0 +1,7 @@
+# MinIO environment configuration
+# Managed by Ansible — do not edit manually
+
+MINIO_ROOT_USER="{{ minio_root_user }}"
+MINIO_ROOT_PASSWORD="{{ minio_root_password }}"
+MINIO_VOLUMES="{{ minio_data_dir }}"
+MINIO_OPTS="--console-address :{{ minio_console_port }}"

--- a/roles/minio/templates/minio.service.j2
+++ b/roles/minio/templates/minio.service.j2
@@ -1,0 +1,21 @@
+[Unit]
+Description=MinIO Object Storage
+Documentation=https://min.io/docs/minio/linux/index.html
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=notify
+User={{ minio_user }}
+Group={{ minio_group }}
+EnvironmentFile=/etc/default/minio
+ExecStart={{ minio_install_dir }}/minio server $MINIO_VOLUMES $MINIO_OPTS
+Restart=on-failure
+RestartSec=10
+LimitNOFILE=65536
+TasksMax=infinity
+TimeoutStartSec=0
+TimeoutStopSec=120
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# MinIO Role for Artifact Storage

## Summary

Add MinIO role for S3-compatible artifact storage. This enables centralized
management of Splunk app archives and other artifacts via a standalone
systemd service (no Docker dependency).

## Changes

- **New `minio` role** — Standalone binary install via systemd
  - Downloads MinIO server and mc CLI
  - Creates `minio-user` system user with home directory
  - Configures auto-start via systemd with resource limits
- **Bucket configuration** — `splunk-addons` bucket with anonymous read
  access and versioning enabled
- **Inventory integration** — Automatic host assignment via `minio` tag
  from Terraform output
- **Playbook sequencing** — Phase 0b in `site.yml` (after apt-cacher-ng,
  before DNS)
- **Review feedback addressed**
  - Fixed variable naming typo (`minio_minio_mc_binary_url`)
  - Removed redundant stat guards (get_url handles idempotency)
  - Added `create_home: true` for minio user
  - Properly quote credentials in mc alias command

## Test Plan

- [ ] Deploy MinIO: `doppler run -- ansible-playbook playbooks/site.yml -t minio`
- [ ] Health check: `curl -s http://10.0.1.107:9000/minio/health/live` returns
  200
- [ ] Console: `http://10.0.1.107:9001` shows login page
- [ ] Bucket exists: `mc ls lab/splunk-addons/`
- [ ] Versioning enabled: `mc version info lab/splunk-addons`
- [ ] Anonymous download works:
  `curl -sO http://10.0.1.107:9000/splunk-addons/test.tar`

## Related PRs

- [terraform-proxmox#216](https://github.com/JacobPEvans/terraform-proxmox/pull/216)
  — LXC container provisioning for MinIO
- [ansible-splunk#118](https://github.com/JacobPEvans/ansible-splunk/pull/118)
  — Consumes MinIO for Splunk app downloads

Generated with [Claude Code](https://claude.com/claude-code)
