### PR TITLE
chore: add IP rules and propagate terraform_data

### DIFF
--- a/.claude/rules/inventory-patterns.md
+++ b/.claude/rules/inventory-patterns.md
@@ -9,7 +9,8 @@ description: Terraform-driven inventory consumption
 
 Inventory is loaded dynamically from terraform state via
 `inventory/terraform_inventory.json`. The `load_terraform.yml` playbook
-must run before all other playbooks.
+must run before all other playbooks. It also delegates `terraform_data`
+to all inventory hosts so roles can access it without indirection.
 
 ## Data Structure
 
@@ -23,14 +24,13 @@ The terraform_inventory.json contains:
   "docker_vms": { ... },
   "constants": {
     "service_ports": {
-      "ssh": 22,
-      "splunk_web": 8000,
-      "splunk_hec": 8088,
+      "splunk_web": "...",
+      "splunk_hec": "...",
       ...
     },
     "syslog_ports": {
-      "unifi": 1514,
-      "paloalto": 1515,
+      "unifi": "...",
+      "palo_alto": "...",
       ...
     }
   }
@@ -41,31 +41,38 @@ The terraform_inventory.json contains:
 
 ### Host Information
 
+Host type determines which keys are available:
+
 ```yaml
-# IP address (no default fallback)
-ansible_host: "{{ hostvars['splunk']['ansible_host'] }}"
+# VMs and Splunk VM — use ansible_host for the IP
+splunk_ip: "{{ hostvars['splunk']['ansible_host'] }}"
 
-# Hostname
+# LXC containers — use container_ip for the IP
+cribl_ip: "{{ hostvars['cribl-edge-01']['container_ip'] }}"
+
+# Containers — Proxmox guest ID
+proxmox_vmid: "{{ hostvars['cribl-edge-01']['proxmox_vmid'] }}"
+
+# Hostname (all host types)
 hostname: "{{ hostvars['splunk']['hostname'] }}"
-
-# VMID
-vmid: "{{ hostvars['splunk']['vmid'] }}"
 ```
 
 ### Port Constants
 
+`terraform_data` is delegated to all hosts by `load_terraform.yml`,
+so roles access it directly:
+
 ```yaml
-# Service ports
+# Service port
 port: "{{ terraform_data.constants.service_ports.splunk_hec }}"
 
-# Syslog ports (as list)
+# Syslog ports as a list
 ports: "{{ terraform_data.constants.syslog_ports.values() | list }}"
 
-# Syslog ports (as dict for iteration)
-{% for name, port in terraform_data.constants.syslog_ports.items() %}
-  - name: {{ name }}
-    port: {{ port }}
-{% endfor %}
+# Syslog ports as key/value pairs
+ports: >-
+  {{ terraform_data.constants.syslog_ports
+     | dict2items(key_name='name', value_name='port') }}
 ```
 
 ## Validation
@@ -80,7 +87,5 @@ If validation fails, regenerate the inventory from terraform-proxmox.
 ## Regenerating Inventory
 
 ```bash
-cd ~/git/terraform-proxmox/main
-terragrunt output -json ansible_inventory > \
-  ~/git/ansible-proxmox-apps/main/inventory/terraform_inventory.json
+./scripts/sync-terraform-inventory.sh
 ```

--- a/.claude/rules/inventory-patterns.md
+++ b/.claude/rules/inventory-patterns.md
@@ -1,0 +1,86 @@
+---
+name: inventory-patterns
+description: Terraform-driven inventory consumption
+---
+
+# Inventory Patterns
+
+## Principle
+
+Inventory is loaded dynamically from terraform state via
+`inventory/terraform_inventory.json`. The `load_terraform.yml` playbook
+must run before all other playbooks.
+
+## Data Structure
+
+The terraform_inventory.json contains:
+
+```json
+{
+  "containers": { ... },
+  "vms": { ... },
+  "splunk_vm": { ... },
+  "docker_vms": { ... },
+  "constants": {
+    "service_ports": {
+      "ssh": 22,
+      "splunk_web": 8000,
+      "splunk_hec": 8088,
+      ...
+    },
+    "syslog_ports": {
+      "unifi": 1514,
+      "paloalto": 1515,
+      ...
+    }
+  }
+}
+```
+
+## Accessing Values
+
+### Host Information
+
+```yaml
+# IP address (no default fallback)
+ansible_host: "{{ hostvars['splunk']['ansible_host'] }}"
+
+# Hostname
+hostname: "{{ hostvars['splunk']['hostname'] }}"
+
+# VMID
+vmid: "{{ hostvars['splunk']['vmid'] }}"
+```
+
+### Port Constants
+
+```yaml
+# Service ports
+port: "{{ terraform_data.constants.service_ports.splunk_hec }}"
+
+# Syslog ports (as list)
+ports: "{{ terraform_data.constants.syslog_ports.values() | list }}"
+
+# Syslog ports (as dict for iteration)
+{% for name, port in terraform_data.constants.syslog_ports.items() %}
+  - name: {{ name }}
+    port: {{ port }}
+{% endfor %}
+```
+
+## Validation
+
+The `load_terraform.yml` playbook validates that:
+
+1. `terraform_inventory.json` exists
+2. The `constants` section is present
+
+If validation fails, regenerate the inventory from terraform-proxmox.
+
+## Regenerating Inventory
+
+```bash
+cd ~/git/terraform-proxmox/main
+terragrunt output -json ansible_inventory > \
+  ~/git/ansible-proxmox-apps/main/inventory/terraform_inventory.json
+```

--- a/.claude/rules/ip-addressing.md
+++ b/.claude/rules/ip-addressing.md
@@ -1,0 +1,62 @@
+---
+name: ip-addressing
+description: No hardcoded values - terraform is authority
+---
+
+# IP Addressing Rule
+
+## Principle
+
+**terraform-proxmox is the single source of truth** for all infrastructure
+constants. This repository CONSUMES values, never DEFINES them.
+
+## Prohibited Patterns
+
+Never use these in role defaults or tasks:
+
+```yaml
+# BAD - hardcoded IP with default
+splunk_host: "{{ hostvars['splunk'].ansible_host | default('192.168.0.200') }}"
+
+# BAD - hardcoded port
+splunk_hec_port: 8088
+
+# BAD - hardcoded port list
+syslog_ports:
+  - 1514
+  - 1515
+```
+
+## Required Patterns
+
+Always reference terraform_data.constants:
+
+```yaml
+# GOOD - IP from inventory only (no fallback)
+splunk_host: "{{ hostvars['splunk']['ansible_host'] }}"
+
+# GOOD - port from terraform constants
+splunk_hec_port: "{{ terraform_data.constants.service_ports.splunk_hec }}"
+
+# GOOD - port list from terraform constants
+syslog_ports: "{{ terraform_data.constants.syslog_ports.values() | list }}"
+```
+
+## Updating Values
+
+To change any port or IP:
+
+1. Update `terraform-proxmox/main/locals.tf`
+2. Run `terragrunt apply` in terraform-proxmox
+3. Regenerate inventory:
+
+   ```bash
+   cd ~/git/terraform-proxmox/main
+   terragrunt output -json ansible_inventory > \
+     ~/git/ansible-proxmox-apps/main/inventory/terraform_inventory.json
+   ```
+
+## Documentation
+
+Never document specific port numbers or IPs in this repository.
+Document HOW to retrieve values, not the values themselves.

--- a/.claude/rules/ip-addressing.md
+++ b/.claude/rules/ip-addressing.md
@@ -12,28 +12,29 @@ constants. This repository CONSUMES values, never DEFINES them.
 
 ## Prohibited Patterns
 
-Never use these in role defaults or tasks:
+Never hardcode IPs or port numbers in role defaults or tasks:
 
 ```yaml
-# BAD - hardcoded IP with default
-splunk_host: "{{ hostvars['splunk'].ansible_host | default('192.168.0.200') }}"
+# BAD - hardcoded IP with fallback
+splunk_host: "{{ hostvars['splunk'].ansible_host | default('<any-ip>') }}"
 
 # BAD - hardcoded port
-splunk_hec_port: 8088
+splunk_hec_port: <some-port-number>
 
 # BAD - hardcoded port list
 syslog_ports:
-  - 1514
-  - 1515
+  - <port>
+  - <port>
 ```
 
 ## Required Patterns
 
-Always reference terraform_data.constants:
+`load_terraform.yml` delegates `terraform_data` to all inventory hosts, so
+roles can reference it directly:
 
 ```yaml
-# GOOD - IP from inventory only (no fallback)
-splunk_host: "{{ hostvars['splunk']['ansible_host'] }}"
+# GOOD - IP from inventory (no fallback)
+splunk_ip: "{{ hostvars['splunk']['ansible_host'] }}"
 
 # GOOD - port from terraform constants
 splunk_hec_port: "{{ terraform_data.constants.service_ports.splunk_hec }}"
@@ -51,9 +52,7 @@ To change any port or IP:
 3. Regenerate inventory:
 
    ```bash
-   cd ~/git/terraform-proxmox/main
-   terragrunt output -json ansible_inventory > \
-     ~/git/ansible-proxmox-apps/main/inventory/terraform_inventory.json
+   ./scripts/sync-terraform-inventory.sh
    ```
 
 ## Documentation

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ env/
 # Ansible
 *.retry
 .ansible_cache/
+.ansible/
 /roles/requirements/
 inventory/terraform_inventory.json
 

--- a/inventory/load_terraform.yml
+++ b/inventory/load_terraform.yml
@@ -205,3 +205,13 @@
       when:
         - terraform_data.docker_vms is defined
         - terraform_data.docker_vms | length > 0
+
+    # Push terraform_data onto every dynamically-added host so roles can access
+    # terraform_data.constants.* directly without hostvars['localhost'] indirection.
+    - name: Propagate terraform_data to all inventory hosts
+      ansible.builtin.set_fact:
+        terraform_data: "{{ terraform_data }}"
+      delegate_to: "{{ item }}"
+      delegate_facts: true
+      loop: "{{ groups['all'] | reject('equalto', 'localhost') | list }}"
+      when: terraform_data is defined


### PR DESCRIPTION
# PR #160 - Add IP Addressing Rules and Terraform Data Propagation

## Summary

- Add `.claude/rules/ip-addressing.md` — prohibits hardcoded IPs and ports in role
  defaults/tasks, requires all values to come from `terraform_data.constants` via
  the terraform inventory
- Add `.claude/rules/inventory-patterns.md` — canonical patterns for accessing host
  IPs, hostnames, VMIDs, and port constants from the terraform-driven inventory
- Propagate `terraform_data` to all inventory hosts via `delegate_facts` in
  `load_terraform.yml` so roles access constants directly without indirection
- Update rule docs for clarity: remove concrete examples, fix VM vs container
  patterns, correct Jinja syntax, replace hardcoded paths with sync script
  references
- Clean up `.ansible/` directory from git tracking (gitignore runtime artifacts)

## Why

Prevents accidental hardcoding of internal IPs or ports in committed files.
`terraform-proxmox` is the single source of truth; this repo only consumes values
from its inventory output. By propagating `terraform_data` to all hosts, roles can
access constants directly and consistently.

## Changes

- **`.claude/rules/ip-addressing.md`** — Enforcement rule with prohibited/required
  patterns
- **`.claude/rules/inventory-patterns.md`** — Reference guide with data structure
  and access examples
- **`inventory/load_terraform.yml`** — Added set_fact + delegate_facts task to
  distribute terraform_data to all inventory hosts
- **`.gitignore`** — Added `.ansible/` to prevent runtime artifacts from being
  tracked

## Test plan

- [x] Rules present in `.claude/rules/` for auto-load by Claude Code
- [x] terraform_data is now available to all roles via direct access
- [x] Ansible cache and lock files properly gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)
