### PR TITLE
fix: apt-cacher-ng startup + minio restricted-outbound deployment

### DIFF
--- a/.github/workflows/ai-merge-gate.yml
+++ b/.github/workflows/ai-merge-gate.yml
@@ -1,3 +1,4 @@
+---
 name: AI Merge Gate
 on: pull_request
 permissions: read-all

--- a/roles/apt_cacher_ng/tasks/main.yml
+++ b/roles/apt_cacher_ng/tasks/main.yml
@@ -24,12 +24,15 @@
     mode: '0755'
 
 - name: Deploy apt-cacher-ng configuration
+  # Mode 0640 + apt-cacher-ng group — required because AdminAuth (with
+  # credentials) is inlined into acng.conf. World-readable (0644) would
+  # expose the admin password to any local user.
   ansible.builtin.template:
     src: acng.conf.j2
     dest: /etc/apt-cacher-ng/acng.conf
     owner: root
-    group: root
-    mode: '0644'
+    group: apt-cacher-ng
+    mode: '0640'
     backup: true
   notify: Restart apt-cacher-ng
 

--- a/roles/apt_cacher_ng/tasks/main.yml
+++ b/roles/apt_cacher_ng/tasks/main.yml
@@ -84,16 +84,14 @@
   when: apt_cacher_ng_firewall_enabled
 
 - name: Wait for apt-cacher-ng to be ready
-  # This check runs inside the container via pct_remote connection
-  # Uses 127.0.0.1 since we're executing inside the container itself
-  ansible.builtin.uri:
-    url: "http://127.0.0.1:{{ apt_cacher_ng_port }}/{{ apt_cacher_ng_report_page }}"
-    status_code: 200
-  register: apt_cacher_ng_health
-  until: apt_cacher_ng_health.status == 200
-  retries: 10
-  delay: 3
-  changed_when: false
+  # apt-cacher-ng 3.x treats HTTP paths as proxy targets, so fetching
+  # /acng-report.html locally returns 503 ("Host not found"). Use a TCP
+  # port check instead — it is unambiguous and works from inside the container.
+  ansible.builtin.wait_for:
+    host: 127.0.0.1
+    port: "{{ apt_cacher_ng_port }}"
+    state: started
+    timeout: 30
 
 - name: Display apt-cacher-ng access information
   ansible.builtin.debug:

--- a/roles/apt_cacher_ng/templates/acng.conf.j2
+++ b/roles/apt_cacher_ng/templates/acng.conf.j2
@@ -1,8 +1,10 @@
 # Apt-Cacher-NG configuration
 # Managed by Ansible - do not edit manually
 
-# Include security configuration (admin authentication)
-Include: /etc/apt-cacher-ng/security.conf
+# Admin authentication (apt-cacher-ng 3.x does not support Include directives)
+{% if apt_cacher_ng_admin_enabled %}
+AdminAuth: admin:{{ apt_cacher_ng_admin_password | mandatory('apt_cacher_ng_admin_password must be set via inventory or extra-vars when admin is enabled.') }}
+{% endif %}
 
 # Cache directory
 CacheDir: {{ apt_cacher_ng_cache_dir }}
@@ -61,4 +63,3 @@ FreshIndexMaxAge: 1
 # Don't serve stale data when upstream is unavailable
 OfflineMode: 0
 
-# Admin authentication is configured in security.conf

--- a/roles/minio/tasks/main.yml
+++ b/roles/minio/tasks/main.yml
@@ -48,16 +48,22 @@
 # Downloads are staged on the Ansible controller then copied to the target.
 # This supports containers with restricted outbound (e.g., outbound-internal
 # firewall group) that cannot reach dl.min.io directly.
+#
+# force: true ensures fresh binaries every run — the dl.min.io URLs point
+# to the rolling "latest" release, so any cached copy in /tmp may be stale.
+#
+# delegate_to + connection: local runs the task directly on the controller
+# via the local connection plugin (no SSH loopback). become: false is
+# required because we don't (and shouldn't) have sudo on the controller.
 - name: Download minio server binary to controller
   ansible.builtin.get_url:
     url: "{{ minio_binary_url }}"
     dest: "/tmp/minio-server"
     mode: "0755"
+    force: true
   delegate_to: localhost
+  connection: local
   become: false
-  vars:
-    ansible_become: false
-    ansible_connection: local
   run_once: true
 
 - name: Download minio client binary to controller
@@ -65,11 +71,10 @@
     url: "{{ minio_mc_binary_url }}"
     dest: "/tmp/minio-mc"
     mode: "0755"
+    force: true
   delegate_to: localhost
+  connection: local
   become: false
-  vars:
-    ansible_become: false
-    ansible_connection: local
   run_once: true
 
 - name: Copy minio server binary to target

--- a/roles/minio/tasks/main.yml
+++ b/roles/minio/tasks/main.yml
@@ -55,6 +55,9 @@
     mode: "0755"
   delegate_to: localhost
   become: false
+  vars:
+    ansible_become: false
+    ansible_connection: local
   run_once: true
 
 - name: Download minio client binary to controller
@@ -64,6 +67,9 @@
     mode: "0755"
   delegate_to: localhost
   become: false
+  vars:
+    ansible_become: false
+    ansible_connection: local
   run_once: true
 
 - name: Copy minio server binary to target

--- a/roles/minio/tasks/main.yml
+++ b/roles/minio/tasks/main.yml
@@ -45,18 +45,36 @@
     mode: "0750"
 
 # Phase 4: Download binaries
-# get_url is idempotent — skips download when dest exists and hasn't changed
-- name: Download minio server binary
+# Downloads are staged on the Ansible controller then copied to the target.
+# This supports containers with restricted outbound (e.g., outbound-internal
+# firewall group) that cannot reach dl.min.io directly.
+- name: Download minio server binary to controller
   ansible.builtin.get_url:
     url: "{{ minio_binary_url }}"
+    dest: "/tmp/minio-server"
+    mode: "0755"
+  delegate_to: localhost
+  run_once: true
+
+- name: Download minio client binary to controller
+  ansible.builtin.get_url:
+    url: "{{ minio_mc_binary_url }}"
+    dest: "/tmp/minio-mc"
+    mode: "0755"
+  delegate_to: localhost
+  run_once: true
+
+- name: Copy minio server binary to target
+  ansible.builtin.copy:
+    src: "/tmp/minio-server"
     dest: "{{ minio_install_dir }}/minio"
     owner: root
     group: root
     mode: "0755"
 
-- name: Download minio client binary
-  ansible.builtin.get_url:
-    url: "{{ minio_mc_binary_url }}"
+- name: Copy minio client binary to target
+  ansible.builtin.copy:
+    src: "/tmp/minio-mc"
     dest: "{{ minio_install_dir }}/mc"
     owner: root
     group: root

--- a/roles/minio/tasks/main.yml
+++ b/roles/minio/tasks/main.yml
@@ -54,6 +54,7 @@
     dest: "/tmp/minio-server"
     mode: "0755"
   delegate_to: localhost
+  become: false
   run_once: true
 
 - name: Download minio client binary to controller
@@ -62,6 +63,7 @@
     dest: "/tmp/minio-mc"
     mode: "0755"
   delegate_to: localhost
+  become: false
   run_once: true
 
 - name: Copy minio server binary to target


### PR DESCRIPTION
## Summary

Unblocks the E2E deployment pipeline by fixing three runtime failures discovered during the MinIO Phase 2 rollout on VMID 107.

## Changes

### apt-cacher-ng
- **Remove unsupported `Include:` directive** from `acng.conf.j2` — apt-cacher-ng 3.7.5 removes support for this, causing `Error reading main options, terminating` on startup. `AdminAuth` is now inlined under the existing `apt_cacher_ng_admin_enabled` conditional.
- **Tighten `acng.conf` permissions to 0640 + `apt-cacher-ng` group** so that the inlined admin credentials are not world-readable (addresses review feedback from gemini-code-assist and copilot).
- **Replace `uri` health check with `wait_for` TCP port check** — apt-cacher-ng parses loopback URL paths as proxy destinations and returns 503, making the old check unreliable.

### MinIO (restricted-outbound deployment)
- **Stage binaries on the Ansible controller** via `delegate_to: localhost` + `connection: local` + `become: false`, then `copy` them to the target. VMID 107 has `policy_out: DROP` (`outbound-internal` firewall group, RFC1918-only egress) and cannot reach `dl.min.io` directly.
- **Remove reserved `ansible_*` variable overrides** from task `vars:` (flagged by ansible-lint production profile). Use task-level `connection: local` instead.
- **Add `force: true` to `get_url` tasks** so the rolling "latest" URLs (`dl.min.io/server/minio/release/linux-amd64/minio`) always fetch fresh binaries, eliminating stale-cache risk on the controller.

### CI
- Add `---` YAML document-start marker to `.github/workflows/ai-merge-gate.yml` so `ansible-lint` passes.

## Root causes

1. `Include:` removed in apt-cacher-ng 3.x — binary exits `Error reading main options, terminating`
2. `/acng-report.html` fetched via 127.0.0.1 returns 503 because apt-cacher-ng parses the path as a proxy destination
3. VMID 107 intentionally has `outbound-internal` firewall — `dl.min.io` downloads must be staged on the controller

## Test plan

- [x] `ansible-lint roles/apt_cacher_ng roles/minio` passes locally under production profile
- [x] `--tags apt_proxy,minio` play runs cleanly: `minio ok=18 changed=11 failed=0`
- [x] `curl http://10.0.1.107:9000/minio/health/live` → `200`
- [x] `mc version info homelab/splunk-addons` → `versioning is enabled`
- [x] `mc anonymous get homelab/splunk-addons` → `download`

Related: #124 (MinIO artifact store propagation in ansible-splunk)