### PR TITLE
feat(minio): add validation checks and 10-year noncurrent lifecycle policy

### DIFF
--- a/playbooks/validate-pipeline.yml
+++ b/playbooks/validate-pipeline.yml
@@ -916,6 +916,99 @@
           - Container: mssql running
           - Port 1433: listening
 
+- name: Validate MinIO Object Storage
+  hosts: minio_group
+  become: true
+  gather_facts: false
+  tags:
+    - minio
+    - validation
+
+  # Load role defaults for minio_api_port, minio_install_dir,
+  # minio_default_buckets, minio_noncurrent_expiration_days. group_vars are
+  # empty for this role today; when overrides are introduced later, move
+  # those vars to group_vars/minio_group.yml so they win over these defaults.
+  vars_files:
+    - ../roles/minio/defaults/main.yml
+
+  tasks:
+    - name: Assert MinIO service is running
+      ansible.builtin.service_facts:
+      register: minio_service_facts
+
+    - name: Fail if MinIO service is not running
+      ansible.builtin.assert:
+        that:
+          - >-
+            minio_service_facts.ansible_facts.services['minio.service'].state
+            == 'running'
+        fail_msg: "MinIO service is not running on {{ inventory_hostname }}"
+        quiet: true
+
+    - name: Verify MinIO health endpoint
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ minio_api_port }}/minio/health/live"
+        status_code: 200
+      register: minio_health
+      retries: 3
+      delay: 3
+      until: minio_health.status == 200
+      changed_when: false
+
+    - name: Verify each default bucket exists
+      ansible.builtin.command:
+        cmd: "{{ minio_install_dir }}/mc ls local/{{ item.name }}"
+      loop: "{{ minio_default_buckets }}"
+      loop_control:
+        label: "{{ item.name }}"
+      changed_when: false
+
+    - name: Verify versioning is enabled on each versioned bucket
+      ansible.builtin.command:
+        cmd: "{{ minio_install_dir }}/mc version info local/{{ item.name }}"
+      loop: "{{ minio_default_buckets | selectattr('versioning', 'defined') | selectattr('versioning') | list }}"
+      loop_control:
+        label: "{{ item.name }}"
+      register: minio_version_check
+      changed_when: false
+      failed_when: "'versioning is enabled' not in minio_version_check.stdout"
+
+    - name: Verify anonymous download policy on each download bucket
+      ansible.builtin.command:
+        cmd: "{{ minio_install_dir }}/mc anonymous get local/{{ item.name }}"
+      loop: "{{ minio_default_buckets | selectattr('policy', 'equalto', 'download') | list }}"
+      loop_control:
+        label: "{{ item.name }}"
+      register: minio_policy_check
+      changed_when: false
+      failed_when: "'download' not in minio_policy_check.stdout"
+
+    - name: Verify noncurrent-expiration lifecycle rule is present on versioned buckets
+      ansible.builtin.command:
+        cmd: "{{ minio_install_dir }}/mc ilm rule ls --json local/{{ item.name }}"
+      loop: >-
+        {{ minio_default_buckets
+           | selectattr('versioning', 'defined')
+           | selectattr('versioning')
+           | list }}
+      loop_control:
+        label: "{{ item.name }}"
+      register: minio_ilm_query
+      changed_when: false
+      failed_when: >-
+        ((minio_ilm_query.stdout | default('{}') | from_json).config.Rules
+         | default([])
+         | selectattr('NoncurrentVersionExpiration', 'defined')
+         | list | length) == 0
+
+    - name: Display MinIO validation results
+      ansible.builtin.debug:
+        msg: |
+          MinIO validation passed on {{ inventory_hostname }}:
+          - Service: running, health 200
+          - Buckets: {{ minio_default_buckets | map(attribute='name') | join(', ') }}
+          - Lifecycle: noncurrent-expiration rule present
+
 - name: Pipeline Summary
   hosts: localhost
   gather_facts: false
@@ -939,6 +1032,7 @@
           Mailpit:      Docker running, SMTP+Web healthy
           ntfy:         Docker running, health endpoint healthy
           MSSQL:        Docker running, port 1433 listening
+          MinIO:        Service, bucket, versioning, policy, lifecycle
           E2E:          Data flowing through pipeline
           E2E (unifi):  Event landed in index=unifi
           E2E (HAProxy): Event via HAProxy in index=unifi

--- a/roles/minio/defaults/main.yml
+++ b/roles/minio/defaults/main.yml
@@ -27,3 +27,10 @@ minio_default_buckets:
   - name: splunk-addons
     policy: download
     versioning: true
+
+# Lifecycle: expire noncurrent object versions after this many days.
+# Bounds growth of the data volume when artifacts are repeatedly re-uploaded
+# (versioning retains every prior version indefinitely by default).
+# Default is 10 years — effectively "keep forever" but with a safety ceiling.
+# Lower per-host via group_vars/host_vars when a tighter retention is needed.
+minio_noncurrent_expiration_days: 3650

--- a/roles/minio/tasks/main.yml
+++ b/roles/minio/tasks/main.yml
@@ -53,8 +53,13 @@
 # to the rolling "latest" release, so any cached copy in /tmp may be stale.
 #
 # delegate_to + connection: local runs the task directly on the controller
-# via the local connection plugin (no SSH loopback). become: false is
-# required because we don't (and shouldn't) have sudo on the controller.
+# via the local connection plugin (no SSH loopback).
+#
+# ansible_become: false (via vars:) is REQUIRED. Task-level `become: false`
+# alone is insufficient: Ansible 2.19 inherits the play's `become: true` on
+# delegated tasks regardless of task-level become, causing `sudo: a password
+# is required` on the controller. Setting `ansible_become` via task vars
+# explicitly overrides the inherited value.
 - name: Download minio server binary to controller
   ansible.builtin.get_url:
     url: "{{ minio_binary_url }}"
@@ -64,6 +69,8 @@
   delegate_to: localhost
   connection: local
   become: false
+  vars:
+    ansible_become: false
   run_once: true
 
 - name: Download minio client binary to controller
@@ -75,6 +82,8 @@
   delegate_to: localhost
   connection: local
   become: false
+  vars:
+    ansible_become: false
   run_once: true
 
 - name: Copy minio server binary to target
@@ -166,3 +175,38 @@
        | list }}
   register: minio_policy_result
   changed_when: "'is already set' not in minio_policy_result.stdout"
+
+# Phase 9: Lifecycle policy — expire noncurrent versions to bound data volume.
+# Without this, every re-upload retains prior versions forever (versioning is
+# on), which will eventually fill the data volume.
+#
+# Add-if-missing only. If a noncurrent-expiration rule already exists the
+# role leaves it alone, so operators can tighten the retention by hand
+# without Ansible reverting the change on the next run.
+- name: Query existing lifecycle rules on versioned buckets
+  ansible.builtin.command:
+    cmd: "{{ minio_install_dir }}/mc ilm rule ls --json local/{{ item.name }}"
+  loop: >-
+    {{ minio_default_buckets
+       | selectattr('versioning', 'defined')
+       | selectattr('versioning')
+       | list }}
+  loop_control:
+    label: "{{ item.name }}"
+  register: minio_ilm_query
+  changed_when: false
+
+- name: Add noncurrent-expiration rule when none exists
+  ansible.builtin.command:
+    cmd: >-
+      {{ minio_install_dir }}/mc ilm rule add local/{{ item.item.name }}
+      --noncurrent-expire-days {{ minio_noncurrent_expiration_days }}
+  loop: "{{ minio_ilm_query.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  register: minio_ilm_add
+  changed_when: "'Lifecycle configuration rule added' in minio_ilm_add.stdout"
+  when: >-
+    ((item.stdout | from_json).config.Rules | default([])
+     | selectattr('NoncurrentVersionExpiration', 'defined')
+     | list | length) == 0


### PR DESCRIPTION
## Summary

Trimmed scope: 147 lines added across 3 files. Only what's needed for the simple use case (one bucket, lifecycle safety ceiling, basic validation).

- ✨ `roles/minio/defaults/main.yml`: `minio_noncurrent_expiration_days: 3650` (10 years). Override via group_vars/host_vars when tighter retention is wanted.
- ✨ `roles/minio/tasks/main.yml`: add-if-missing lifecycle rule. Query first, skip `mc ilm rule add` when a `NoncurrentVersionExpiration` rule already exists. Operators can tighten retention by hand without Ansible reverting it.
- ✨ `playbooks/validate-pipeline.yml`: six MinIO checks — service, health, bucket, versioning, anonymous policy, lifecycle presence. Loops over `minio_default_buckets` so adding a bucket needs no playbook change.
- 🐛 Fix: Ansible 2.19 inherits play-level `become: true` onto `delegate_to: localhost` download tasks; explicit `ansible_become: false` via task `vars:` overrides.

## Why

- **Lifecycle rule**: MinIO versioning retains every prior object version indefinitely, which will eventually fill the data volume as artifacts are re-uploaded. 10 years is a safety ceiling — effectively "keep forever" with a bounded upper limit.
- **Validation coverage**: catches service drift, bucket/versioning/policy regressions, and lifecycle rule absence in one place.
- **Become fix**: the role is otherwise broken — `sudo: a password is required` on the controller on every run.

## Verification

Ran against live MinIO LXC (10.0.1.107):

```bash
doppler run -- ansible-playbook -i inventory/hosts.yml playbooks/site.yml \
  --tags minio,always --limit minio_group,localhost
# Idempotent — add task skips because rule exists

doppler run -- ansible-playbook -i inventory/hosts.yml playbooks/validate-pipeline.yml \
  --tags minio,always --limit minio_group,localhost
# All six checks pass
```

Local `ansible-lint` passes: `0 failure(s), 0 warning(s) on 197 files. Profile 'production' passed.`

## Review comment resolutions

All prior Gemini + Copilot review points addressed:

- ✅ **Idempotent lifecycle rule**: add-if-missing via JSON query. Policy is "add once, manual tighten later" so no drift detection needed.
- ✅ **Hardcoded bucket names**: validation tasks loop over `minio_default_buckets`.
- ✅ **vars_files precedence concern**: documented in the play — move vars to `group_vars/minio_group.yml` if/when overrides are introduced (none today).
- ✅ **Fragile lifecycle string match**: `mc ilm rule ls --json` + `selectattr('NoncurrentVersionExpiration', 'defined')` — exact JSON field match, no digit false positives.

## Test plan

- [x] Local `ansible-lint` green
- [x] `site.yml --tags minio` is idempotent against live cluster
- [x] `validate-pipeline.yml --tags minio` passes against live cluster
- [x] Become fix verified — no `sudo: a password is required`
- [ ] CI: Ansible Lint + Molecule + Merge Gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)