### PR TITLE
fix(minio): split binary staging into separate localhost play

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -58,7 +58,31 @@
 # =============================================================================
 # Phase 0b: MinIO Object Storage
 # S3-compatible artifact store for Splunk add-ons and other deployment assets
+#
+# Two plays:
+#   1. Stage binaries on the Ansible controller (no become — runs as the
+#      operator user). Required because the minio host has restricted
+#      outbound and cannot reach dl.min.io itself.
+#   2. Install MinIO on the target container (with become).
+#
+# Splitting into two plays is necessary because Ansible 2.19's task-level
+# `become: false` does NOT reliably override a play-level `become: true`
+# for delegated tasks — sudo is still attempted on the controller.
 # =============================================================================
+
+- name: Stage MinIO binaries on Ansible controller
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tags:
+    - minio
+    - storage
+  tasks:
+    - name: Stage minio binaries
+      ansible.builtin.import_role:
+        name: minio
+        tasks_from: stage_binaries
 
 - name: Deploy MinIO object storage
   hosts: minio_group

--- a/roles/minio/tasks/main.yml
+++ b/roles/minio/tasks/main.yml
@@ -44,39 +44,10 @@
     group: "{{ minio_group }}"
     mode: "0750"
 
-# Phase 4: Download binaries
-# Downloads are staged on the Ansible controller then copied to the target.
-# This supports containers with restricted outbound (e.g., outbound-internal
-# firewall group) that cannot reach dl.min.io directly.
-#
-# force: true ensures fresh binaries every run — the dl.min.io URLs point
-# to the rolling "latest" release, so any cached copy in /tmp may be stale.
-#
-# delegate_to + connection: local runs the task directly on the controller
-# via the local connection plugin (no SSH loopback). become: false is
-# required because we don't (and shouldn't) have sudo on the controller.
-- name: Download minio server binary to controller
-  ansible.builtin.get_url:
-    url: "{{ minio_binary_url }}"
-    dest: "/tmp/minio-server"
-    mode: "0755"
-    force: true
-  delegate_to: localhost
-  connection: local
-  become: false
-  run_once: true
-
-- name: Download minio client binary to controller
-  ansible.builtin.get_url:
-    url: "{{ minio_mc_binary_url }}"
-    dest: "/tmp/minio-mc"
-    mode: "0755"
-    force: true
-  delegate_to: localhost
-  connection: local
-  become: false
-  run_once: true
-
+# Phase 4: Copy binaries from controller to target.
+# The download itself runs in a separate `hosts: localhost` play (see
+# tasks/stage_binaries.yml) before this role executes — that play stages
+# the binaries at /tmp/minio-server and /tmp/minio-mc on the controller.
 - name: Copy minio server binary to target
   ansible.builtin.copy:
     src: "/tmp/minio-server"

--- a/roles/minio/tasks/stage_binaries.yml
+++ b/roles/minio/tasks/stage_binaries.yml
@@ -1,0 +1,32 @@
+---
+# Stage MinIO binaries on the Ansible controller.
+#
+# Runs on localhost (NOT on the minio host) so that the binaries are
+# downloaded from dl.min.io to the controller, then copied via SCP to
+# the target. This supports containers with restricted outbound (e.g.,
+# the outbound-internal firewall group on VMID 107) that intentionally
+# cannot reach dl.min.io.
+#
+# This file is included from a separate `hosts: localhost` play with
+# `become: false`. Splitting it out (rather than relying on
+# `delegate_to: localhost` + task-level `become: false`) is necessary
+# because Ansible 2.19's task-level `become: false` does NOT reliably
+# override a play-level `become: true` for delegated tasks — sudo is
+# still attempted on the controller.
+#
+# `force: true` ensures fresh binaries every run; the dl.min.io URLs
+# point to the rolling "latest" release.
+
+- name: Download minio server binary to controller
+  ansible.builtin.get_url:
+    url: "{{ minio_binary_url }}"
+    dest: "/tmp/minio-server"
+    mode: "0755"
+    force: true
+
+- name: Download minio client binary to controller
+  ansible.builtin.get_url:
+    url: "{{ minio_mc_binary_url }}"
+    dest: "/tmp/minio-mc"
+    mode: "0755"
+    force: true


### PR DESCRIPTION
## Summary

Phase 0b of \`playbooks/site.yml\` was failing on the minio role's \`Download minio server binary to controller\` task with:

\`\`\`
Premature end of stream waiting for become success.
sudo: a password is required
\`\`\`

## Root cause

Ansible 2.19's task-level \`become: false\` does NOT reliably override a play-level \`become: true\` for delegated tasks. The reviewer-approved pattern from #161 (\`delegate_to: localhost\` + \`connection: local\` + \`become: false\`) gets overridden, and ansible attempts sudo on the controller for the \`get_url\` task. Verified via \`-vvvv\`:

\`\`\`
<localhost> EXEC /bin/sh -c 'sudo -H -S -n -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-...
\`\`\`

## Fix

Extract download tasks into \`roles/minio/tasks/stage_binaries.yml\` and call them from a dedicated \`hosts: localhost\` play with \`become: false\` at the play level. The existing minio install play then runs against \`minio_group\` with \`become: true\` and just copies the pre-staged binaries from \`/tmp\`.

This is functionally identical to the #161 pattern but with become scoping that actually works in Ansible 2.19.

## Test plan

- [x] \`ansible-lint roles/minio playbooks/site.yml\` passes under production profile
- [ ] \`ansible-playbook playbooks/site.yml --tags minio\` succeeds end-to-end on minio host

Discovered while running the full E2E pipeline restart.