### PR TITLE
fix(technitium_install): correct API params for changePassword + createToken

### DIFF
--- a/roles/technitium_install/tasks/main.yml
+++ b/roles/technitium_install/tasks/main.yml
@@ -83,20 +83,34 @@
     (technitium_install_default_login.json.status | default('')) == 'ok'
   block:
     - name: Change admin password
+      # Technitium /api/user/changePassword requires THREE parameters:
+      # token (session), pass (current/old password), newPass (new password).
+      # Sending only token+pass silently rejects with
+      # "Parameter 'newPass' missing." Previously the role used `pass`
+      # alone, treating it as the new value, so the password change
+      # never actually took effect — bootstrap appeared to succeed
+      # while leaving the default admin/admin credentials active.
       ansible.builtin.uri:
         url: "{{ technitium_install_api_url }}/api/user/changePassword"
         method: POST
         body_format: form-urlencoded
         body:
           token: "{{ technitium_install_default_login.json.token }}"
-          pass: "{{ technitium_install_admin_password }}"
+          pass: "{{ technitium_install_default_password }}"
+          newPass: "{{ technitium_install_admin_password }}"
         return_content: true
         timeout: "{{ technitium_install_api_timeout }}"
       register: technitium_install_password_change
       changed_when: technitium_install_password_change.json.status == "ok"
+      failed_when:
+        - technitium_install_password_change.json is defined
+        - technitium_install_password_change.json.status != "ok"
       no_log: true
 
-- name: Login with configured password
+- name: Verify login with configured password
+  # Confirms the password change took effect (or that the password was
+  # already set on a prior run). Failing here means the configured admin
+  # password disagrees with what's actually on the server.
   ansible.builtin.uri:
     url: "{{ technitium_install_api_url }}/api/user/login"
     method: POST
@@ -107,21 +121,32 @@
     return_content: true
     timeout: "{{ technitium_install_api_timeout }}"
   register: technitium_install_login
+  failed_when:
+    - technitium_install_login.json is defined
+    - technitium_install_login.json.status != "ok"
   no_log: true
 
 - name: Create API token
+  # Technitium /api/user/createToken takes user/pass directly (not a
+  # session token) and produces a long-lived token that does not expire.
+  # The previous role passed a session token in `token` along with `user`
+  # but no `pass`, which the server interprets as a malformed login and
+  # rejects with "Parameter 'pass' missing."
   ansible.builtin.uri:
     url: "{{ technitium_install_api_url }}/api/user/createToken"
     method: POST
     body_format: form-urlencoded
     body:
-      token: "{{ technitium_install_login.json.token }}"
       user: "{{ technitium_install_admin_user }}"
+      pass: "{{ technitium_install_admin_password }}"
       tokenName: "{{ technitium_install_token_name }}"
     return_content: true
     timeout: "{{ technitium_install_api_timeout }}"
   register: technitium_install_token_result
   changed_when: technitium_install_token_result.json.status == "ok"
+  failed_when:
+    - technitium_install_token_result.json is defined
+    - technitium_install_token_result.json.status != "ok"
   no_log: true
 
 - name: Display API token for Doppler storage  # noqa: no-handler

--- a/roles/technitium_install/tasks/main.yml
+++ b/roles/technitium_install/tasks/main.yml
@@ -102,9 +102,7 @@
         timeout: "{{ technitium_install_api_timeout }}"
       register: technitium_install_password_change
       changed_when: technitium_install_password_change.json.status == "ok"
-      failed_when:
-        - technitium_install_password_change.json is defined
-        - technitium_install_password_change.json.status != "ok"
+      failed_when: technitium_install_password_change.json.status | default('') != "ok"
       no_log: true
 
 - name: Verify login with configured password
@@ -121,9 +119,8 @@
     return_content: true
     timeout: "{{ technitium_install_api_timeout }}"
   register: technitium_install_login
-  failed_when:
-    - technitium_install_login.json is defined
-    - technitium_install_login.json.status != "ok"
+  changed_when: false
+  failed_when: technitium_install_login.json.status | default('') != "ok"
   no_log: true
 
 - name: Create API token
@@ -144,9 +141,7 @@
     timeout: "{{ technitium_install_api_timeout }}"
   register: technitium_install_token_result
   changed_when: technitium_install_token_result.json.status == "ok"
-  failed_when:
-    - technitium_install_token_result.json is defined
-    - technitium_install_token_result.json.status != "ok"
+  failed_when: technitium_install_token_result.json.status | default('') != "ok"
   no_log: true
 
 - name: Display API token for Doppler storage  # noqa: no-handler


### PR DESCRIPTION
## Summary

Two latent bugs in the \`technitium_install\` role made it look like password bootstrap and API token creation were succeeding while they were actually no-ops. Both tasks reported \`ok\` because Technitium returns HTTP 200 with a JSON \`{\"status\":\"error\"}\` body that the role wasn't validating.

## The bugs

### 1. \`/api/user/changePassword\` requires three parameters

Per [Technitium API docs](https://github.com/TechnitiumSoftware/DnsServer/blob/master/APIDOCS.md):

\`\`\`
token  - session token
pass   - the CURRENT password
newPass - the new password
\`\`\`

The role sent \`{token, pass}\`, treating \`pass\` as the new value. The server rejected with \`Parameter 'newPass' missing.\` The default \`admin/admin\` credentials remained active after every bootstrap.

### 2. \`/api/user/createToken\` does not take a session token

Per Technitium API docs, it takes \`user\`, \`pass\`, \`tokenName\` directly and produces a long-lived token. The role passed \`{token, user, tokenName}\` (no \`pass\`), which the server interprets as a malformed login and rejects with \`Parameter 'pass' missing.\`

## Fix

- \`changePassword\`: send \`token\`, \`pass: technitium_install_default_password\`, \`newPass: technitium_install_admin_password\`.
- \`createToken\`: drop session-token logic; send \`user\`, \`pass: technitium_install_admin_password\`, \`tokenName\`.
- Both tasks now \`failed_when: json.status != \"ok\"\` so silent mis-bootstraps cannot recur.
- Renamed \`Login with configured password\` → \`Verify login with configured password\` to make its purpose explicit.

## Verification

Manually validated against freshly-installed Technitium 13.x containers (CT 103, CT 104):

\`\`\`bash
# changePassword with all 3 params
curl -X POST --data-urlencode 'token=...' --data-urlencode 'pass=admin' \\
  --data-urlencode 'newPass=<from-doppler>' \\
  http://10.0.1.103:5380/api/user/changePassword
# {\"status\":\"ok\"}

# createToken with user/pass/tokenName
curl -X POST --data-urlencode 'user=admin' --data-urlencode 'pass=<from-doppler>' \\
  --data-urlencode 'tokenName=ansible-103' \\
  http://10.0.1.103:5380/api/user/createToken
# {\"token\":\"743beac0...\",\"status\":\"ok\"}
\`\`\`

## Test plan

- [x] \`ansible-lint roles/technitium_install\` passes under production profile
- [ ] \`ansible-playbook playbooks/site.yml --tags technitium_install\` succeeds end-to-end against fresh and bootstrapped containers