### PR TITLE
fix(technitium): use ?token= query param instead of X-Api-Token header

### DIFF
--- a/roles/technitium_dns/tasks/main.yml
+++ b/roles/technitium_dns/tasks/main.yml
@@ -29,16 +29,18 @@
   loop_control:
     label: "{{ item.key }}"
 
+# Technitium authenticates API calls via `?token=...` query parameter,
+# NOT via an X-Api-Token header. The header is silently ignored and
+# the server responds with "Parameter 'token' missing."
 - name: Check if DNS zone exists
   ansible.builtin.uri:
-    url: "{{ technitium_dns_api_url }}/api/zones/list"
+    url: "{{ technitium_dns_api_url }}/api/zones/list?token={{ technitium_dns_api_token }}"
     method: GET
-    headers:
-      X-Api-Token: "{{ technitium_dns_api_token }}"
     return_content: true
     timeout: "{{ technitium_dns_api_timeout }}"
   register: technitium_dns_zones_response
   changed_when: false
+  no_log: true
 
 - name: Parse existing zones
   ansible.builtin.set_fact:
@@ -47,10 +49,8 @@
 
 - name: Create internal DNS zone
   ansible.builtin.uri:
-    url: "{{ technitium_dns_api_url }}/api/zones/create"
+    url: "{{ technitium_dns_api_url }}/api/zones/create?token={{ technitium_dns_api_token }}"
     method: POST
-    headers:
-      X-Api-Token: "{{ technitium_dns_api_token }}"
     body_format: form-urlencoded
     body:
       zone: "{{ technitium_dns_internal_domain }}"
@@ -61,27 +61,26 @@
   register: technitium_dns_zone_create
   changed_when: technitium_dns_zone_create.json.status == "ok"
   when: technitium_dns_internal_domain not in technitium_dns_existing_zones
+  no_log: true
 
 - name: Get existing A records for zone
   ansible.builtin.uri:
     url: >-
-      {{ technitium_dns_api_url }}/api/zones/records/get?domain={{
+      {{ technitium_dns_api_url }}/api/zones/records/get?token={{
+      technitium_dns_api_token }}&domain={{
       technitium_dns_internal_domain | urlencode }}&zone={{
       technitium_dns_internal_domain | urlencode }}
     method: GET
-    headers:
-      X-Api-Token: "{{ technitium_dns_api_token }}"
     return_content: true
     timeout: "{{ technitium_dns_api_timeout }}"
   register: technitium_dns_existing_records
   changed_when: false
+  no_log: true
 
 - name: Create A records for infrastructure hosts
   ansible.builtin.uri:
-    url: "{{ technitium_dns_api_url }}/api/zones/records/add"
+    url: "{{ technitium_dns_api_url }}/api/zones/records/add?token={{ technitium_dns_api_token }}"
     method: POST
-    headers:
-      X-Api-Token: "{{ technitium_dns_api_token }}"
     body_format: form-urlencoded
     body:
       domain: "{{ item.name }}.{{ technitium_dns_internal_domain }}"
@@ -98,15 +97,14 @@
   register: technitium_dns_a_record_result
   changed_when: technitium_dns_a_record_result.json.status == "ok"
   failed_when:
-    - technitium_dns_a_record_result.json.status != "ok"
+    - technitium_dns_a_record_result.json.status | default('') != "ok"
     - "'already exists' not in (technitium_dns_a_record_result.json.errorMessage | default(''))"
+  no_log: true
 
 - name: Create CNAME records for service aliases
   ansible.builtin.uri:
-    url: "{{ technitium_dns_api_url }}/api/zones/records/add"
+    url: "{{ technitium_dns_api_url }}/api/zones/records/add?token={{ technitium_dns_api_token }}"
     method: POST
-    headers:
-      X-Api-Token: "{{ technitium_dns_api_token }}"
     body_format: form-urlencoded
     body:
       domain: "{{ item.name }}.{{ technitium_dns_internal_domain }}"
@@ -123,19 +121,19 @@
   register: technitium_dns_cname_result
   changed_when: technitium_dns_cname_result.json.status == "ok"
   failed_when:
-    - technitium_dns_cname_result.json.status != "ok"
+    - technitium_dns_cname_result.json.status | default('') != "ok"
     - "'already exists' not in (technitium_dns_cname_result.json.errorMessage | default(''))"
+  no_log: true
 
 - name: Verify DNS zone is active
   ansible.builtin.uri:
-    url: "{{ technitium_dns_api_url }}/api/zones/list"
+    url: "{{ technitium_dns_api_url }}/api/zones/list?token={{ technitium_dns_api_token }}"
     method: GET
-    headers:
-      X-Api-Token: "{{ technitium_dns_api_token }}"
     return_content: true
     timeout: "{{ technitium_dns_api_timeout }}"
   register: technitium_dns_final_zones
   changed_when: false
   failed_when: >-
     technitium_dns_internal_domain not in
-    (technitium_dns_final_zones.json.response.zones | map(attribute='name') | list)
+    (technitium_dns_final_zones.json.response.zones | default([]) | map(attribute='name') | list)
+  no_log: true

--- a/roles/technitium_install/tasks/main.yml
+++ b/roles/technitium_install/tasks/main.yml
@@ -164,3 +164,4 @@
   register: technitium_install_health
   changed_when: false
   failed_when: technitium_install_health.json.status | default('') != "ok"
+  no_log: true

--- a/roles/technitium_install/tasks/main.yml
+++ b/roles/technitium_install/tasks/main.yml
@@ -153,13 +153,14 @@
   when: technitium_install_token_result is changed
 
 - name: Verify Technitium DNS is healthy
+  # Technitium authenticates API calls via ?token=... query parameter,
+  # NOT via an X-Api-Token header. The header is silently ignored and
+  # the server responds with "Parameter 'token' missing."
   ansible.builtin.uri:
-    url: "{{ technitium_install_api_url }}/api/zones/list"
+    url: "{{ technitium_install_api_url }}/api/zones/list?token={{ technitium_install_token_result.json.token }}"
     method: GET
-    headers:
-      X-Api-Token: "{{ technitium_install_token_result.json.token }}"
     return_content: true
     timeout: "{{ technitium_install_api_timeout }}"
   register: technitium_install_health
   changed_when: false
-  failed_when: technitium_install_health.json.status != "ok"
+  failed_when: technitium_install_health.json.status | default('') != "ok"


### PR DESCRIPTION
## Summary

Technitium DNS authenticates API calls via a \`?token=\` URL query parameter. Both the \`technitium_install\` and \`technitium_dns\` roles were passing the token as an \`X-Api-Token\` HTTP header, which the server silently ignores — every authenticated call returned \`Parameter 'token' missing.\` with HTTP 200.

## The fix

All 7 authenticated calls across both roles now pass the token via \`?token={{ ... }}\` in the URL. Per [Technitium API docs](https://github.com/TechnitiumSoftware/DnsServer/blob/master/APIDOCS.md):

> After obtaining a token via createToken, you pass it as a query parameter named \`token\` in subsequent API requests.
> Not a header-based approach — no \`Authorization\` header or \`X-Api-Token\` header is used.

## Tasks fixed

| Role | Task |
|------|------|
| technitium_install | Verify Technitium DNS is healthy |
| technitium_dns | Check if DNS zone exists |
| technitium_dns | Create internal DNS zone |
| technitium_dns | Get existing A records for zone |
| technitium_dns | Create A records for infrastructure hosts |
| technitium_dns | Create CNAME records for service aliases |
| technitium_dns | Verify DNS zone is active |

## Also

- Added \`no_log: true\` to the above tasks since the URL now embeds the API token, which we don't want showing up in task output or on error.
- Tightened \`failed_when\` on the A/CNAME record tasks to use \`json.status | default('') != \"ok\"\` for consistency with #166.

## Test plan

- [x] \`ansible-lint roles/technitium_install roles/technitium_dns\` passes under production profile
- [ ] \`ansible-playbook playbooks/site.yml --tags technitium_install\` reaches the health check and succeeds
- [ ] \`ansible-playbook playbooks/site.yml --tags technitium_dns\` creates zone + records successfully