### PR TITLE
fix(technitium_dns): override ansible_become + fix Build A records loop

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -107,6 +107,12 @@
   vars:
     # Derive Technitium DNS host IP from gateway (VMID 103)
     technitium_dns_host: "{{ lookup('env', 'PROXMOX_VE_GATEWAY') | regex_replace('\\.[0-9]+$', '.103') }}"
+    # group_vars/all.yml sets ansible_become: true for every host. Play-level
+    # `become: false` does NOT win over group_vars in Ansible's variable
+    # precedence — group_vars > play vars (keywords). Setting
+    # `ansible_become: false` here as a play var explicitly overrides it for
+    # this localhost-only play that just hits HTTP APIs and never needs sudo.
+    ansible_become: false
 
   roles:
     - role: technitium_dns

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -107,11 +107,11 @@
   vars:
     # Derive Technitium DNS host IP from gateway (VMID 103)
     technitium_dns_host: "{{ lookup('env', 'PROXMOX_VE_GATEWAY') | regex_replace('\\.[0-9]+$', '.103') }}"
-    # group_vars/all.yml sets ansible_become: true for every host. Play-level
-    # `become: false` does NOT win over group_vars in Ansible's variable
-    # precedence — group_vars > play vars (keywords). Setting
-    # `ansible_become: false` here as a play var explicitly overrides it for
-    # this localhost-only play that just hits HTTP APIs and never needs sudo.
+    # group_vars/all.yml sets `ansible_become: true` (an inventory variable),
+    # which Ansible applies via the connection layer and which overrides the
+    # play-level `become: false` keyword. The reliable way to disable become
+    # for this localhost-only play (which just hits HTTP APIs and never needs
+    # sudo) is to override the inventory variable directly via play vars.
     ansible_become: false
 
   roles:

--- a/roles/technitium_dns/tasks/main.yml
+++ b/roles/technitium_dns/tasks/main.yml
@@ -16,18 +16,25 @@
     quiet: true
 
 - name: Build A records from inventory
+  # Iterate over groups['all'] explicitly. Iterating `hostvars | dict2items`
+  # in Ansible 2.19 returns HostVarsVars proxy objects whose attribute
+  # `is defined` checks behave differently from plain dicts and silently
+  # skip every host. Using groups + hostvars[host] is the supported pattern.
   ansible.builtin.set_fact:
     technitium_dns_a_records: >-
       {{
         technitium_dns_a_records | default([]) +
-        [{'name': item.value.hostname, 'ip': item.value.container_ip | default(item.value.ansible_host)}]
+        [{
+          'name': hostvars[item].hostname,
+          'ip': hostvars[item].container_ip | default(hostvars[item].ansible_host)
+        }]
       }}
-  loop: "{{ hostvars | dict2items }}"
+  loop: "{{ groups['all'] | default([]) | reject('equalto', 'localhost') | list }}"
   when:
-    - item.value.ansible_host is defined
-    - item.value.hostname is defined
+    - hostvars[item].hostname is defined
+    - (hostvars[item].container_ip is defined) or (hostvars[item].ansible_host is defined)
   loop_control:
-    label: "{{ item.key }}"
+    label: "{{ item }}"
 
 # Technitium authenticates API calls via `?token=...` query parameter,
 # NOT via an X-Api-Token header. The header is silently ignored and


### PR DESCRIPTION
## Summary

Phase 1b of the E2E pipeline (\`Configure Technitium DNS with internal A records\`) was failing with two distinct issues.

## Issue 1: localhost play tries sudo despite \`become: false\`

The play has \`hosts: localhost\` and play-level \`become: false\`, but \`inventory/group_vars/all.yml\` sets \`ansible_become: true\`. **Group vars beat play-level keywords in Ansible's variable precedence**, so the play still attempted sudo and failed with:

\`\`\`
Premature end of stream waiting for become success.
sudo: a password is required
\`\`\`

**Fix**: set \`ansible_become: false\` in the play \`vars:\` block, which does win over group_vars. Same pattern as the minio fix in #163.

## Issue 2: \"Build A records from inventory\" silently skips every host

The role looped over \`hostvars | dict2items\` and never produced any records:

\`\`\`
skipping: [localhost] => (item=ansible)
skipping: [localhost] => (item=apt-cacher-ng)
... (every single host)
\`\`\`

In Ansible 2.19, iterating \`hostvars\` yields \`HostVarsVars\` proxy objects whose attribute \`is defined\` check returns False even for vars that are actually present.

**Fix**: switch to the supported pattern — loop over \`groups['all']\` (minus localhost) and access \`hostvars[item]\` directly. Also slightly relax the guard so VMs that only have \`ansible_host\` (no \`container_ip\`) still get an A record.

## Test plan

- [x] \`ansible-lint roles/technitium_dns playbooks/site.yml\` passes under production profile
- [ ] \`ansible-playbook playbooks/site.yml --tags technitium_dns\` creates the zone and all expected A/CNAME records on first run
- [ ] Re-running the same play is idempotent