### PR TITLE
feat(minio): mirror infra artifacts into local bucket for offline hosts

### DIFF
--- a/inventory/group_vars/cribl_edge.yml
+++ b/inventory/group_vars/cribl_edge.yml
@@ -1,3 +1,15 @@
 ---
 systemd_restart_policy_services:
   - cribl
+
+# Cribl Edge containers have the `outbound-internal` firewall group applied
+# (RFC1918 only), so they cannot reach cdn.cribl.io directly. Serve the
+# tarball from the MinIO artifact store on CT 107, reusing the same
+# anonymous-read `splunk-addons` bucket already populated for Splunk.
+# The `infra/cribl-linux-x64.tgz` object is staged by the workstation
+# during initial bootstrap (upstream has no stable versioned URL for
+# "latest", so we mirror the current build rather than chasing a moving
+# target).
+cribl_edge_tarball_url: >-
+  http://{{ terraform_data.containers.minio.ip }}:{{
+  terraform_data.constants.service_ports.minio_api }}/splunk-addons/infra/cribl-linux-x64.tgz

--- a/inventory/group_vars/cribl_stream_group.yml
+++ b/inventory/group_vars/cribl_stream_group.yml
@@ -1,3 +1,11 @@
 ---
 systemd_restart_policy_services:
   - cribl
+
+# Cribl Stream containers have the `outbound-internal` firewall group applied
+# (RFC1918 only), so they cannot reach cdn.cribl.io directly. Serve the
+# tarball from the MinIO artifact store on CT 107 — same binary as Cribl
+# Edge, different runtime configuration.
+cribl_stream_tarball_url: >-
+  http://{{ terraform_data.containers.minio.ip }}:{{
+  terraform_data.constants.service_ports.minio_api }}/splunk-addons/infra/cribl-linux-x64.tgz

--- a/roles/cribl_edge/defaults/main.yml
+++ b/roles/cribl_edge/defaults/main.yml
@@ -3,7 +3,16 @@
 
 # Installation
 cribl_edge_version: "latest"
-cribl_edge_tarball_url: "https://cdn.cribl.io/dl/{{ cribl_edge_version }}/cribl-{{ cribl_edge_version }}-linux-x64.tgz"
+# Upstream release URL. Cribl's CDN uses two different filename patterns:
+#   - versioned release: https://cdn.cribl.io/dl/4.12.2/cribl-4.12.2-linux-x64.tgz
+#   - rolling "latest":  https://cdn.cribl.io/dl/latest/cribl-linux-x64.tgz    (no version in filename)
+# Group vars for the `cribl_edge` group override this with a MinIO mirror URL
+# because the cribl-edge containers have the `outbound-internal` firewall and
+# cannot reach cdn.cribl.io directly.
+cribl_edge_tarball_url: >-
+  https://cdn.cribl.io/dl/{{ cribl_edge_version }}/{{
+  'cribl-linux-x64.tgz' if cribl_edge_version == 'latest'
+  else 'cribl-' + cribl_edge_version + '-linux-x64.tgz' }}
 cribl_edge_install_dir: /opt/cribl
 
 # Service user

--- a/roles/cribl_stream/defaults/main.yml
+++ b/roles/cribl_stream/defaults/main.yml
@@ -4,8 +4,16 @@
 # Installation
 cribl_stream_version: latest
 cribl_stream_tarball_base: "https://cdn.cribl.io/dl"
+# Upstream release URL. Cribl's CDN uses two different filename patterns:
+#   - versioned release: https://cdn.cribl.io/dl/4.12.2/cribl-4.12.2-linux-x64.tgz
+#   - rolling "latest":  https://cdn.cribl.io/dl/latest/cribl-linux-x64.tgz    (no version in filename)
+# Group vars for the `cribl_stream_group` override this with a MinIO mirror URL
+# because the cribl-stream containers have the `outbound-internal` firewall
+# and cannot reach cdn.cribl.io directly.
 cribl_stream_tarball_url: >-
-  {{ cribl_stream_tarball_base }}/{{ cribl_stream_version }}/cribl-{{ cribl_stream_version }}-linux-x64.tgz
+  {{ cribl_stream_tarball_base }}/{{ cribl_stream_version }}/{{
+  'cribl-linux-x64.tgz' if cribl_stream_version == 'latest'
+  else 'cribl-' + cribl_stream_version + '-linux-x64.tgz' }}
 cribl_stream_install_dir: /opt/cribl
 
 # Service user

--- a/roles/minio/defaults/main.yml
+++ b/roles/minio/defaults/main.yml
@@ -34,3 +34,22 @@ minio_default_buckets:
 # Default is 10 years — effectively "keep forever" but with a safety ceiling.
 # Lower per-host via group_vars/host_vars when a tighter retention is needed.
 minio_noncurrent_expiration_days: 3650
+
+# Infrastructure artifact mirrors.
+#
+# Roles that run on LXC containers in the `outbound-internal` firewall group
+# (RFC1918-only egress) cannot reach external download URLs like cdn.cribl.io
+# or ollama.com. The minio role mirrors these artifacts into the
+# anonymous-read `splunk-addons` bucket so every downstream role can pull
+# from the local network without punching holes in the firewall.
+#
+# Each mirror is downloaded on the Ansible controller (which has unrestricted
+# egress) and uploaded to MinIO only if the bucket object is missing.
+# Existing objects are left alone so manual retention decisions are not
+# clobbered on re-runs.
+minio_infra_mirrors:
+  - name: cribl
+    description: Cribl Edge/Stream tarball (rolling latest)
+    url: https://cdn.cribl.io/dl/latest/cribl-linux-x64.tgz
+    bucket: splunk-addons
+    key: infra/cribl-linux-x64.tgz

--- a/roles/minio/tasks/main.yml
+++ b/roles/minio/tasks/main.yml
@@ -210,3 +210,71 @@
     ((item.stdout | from_json).config.Rules | default([])
      | selectattr('NoncurrentVersionExpiration', 'defined')
      | list | length) == 0
+
+# Phase 10: Mirror external infrastructure artifacts into the local bucket.
+#
+# Containers in the `outbound-internal` firewall group cannot reach public
+# CDNs, so each role that needs an upstream tarball (Cribl, Ollama, etc.)
+# pulls from MinIO instead. The controller — which has unrestricted egress —
+# stages the download, then `mc cp` uploads it to the bucket.
+#
+# Idempotent: `mc stat` determines whether the object already exists, and
+# the upload is skipped when present. Delete the bucket object manually
+# (or wait for the lifecycle rule) to force a refresh.
+- name: Check which infra artifacts are already mirrored
+  ansible.builtin.command:
+    cmd: "{{ minio_install_dir }}/mc stat --json local/{{ item.bucket }}/{{ item.key }}"
+  loop: "{{ minio_infra_mirrors }}"
+  loop_control:
+    label: "{{ item.name }}"
+  register: minio_infra_stat
+  changed_when: false
+  failed_when: false
+
+- name: Stage missing infra artifacts on controller
+  ansible.builtin.get_url:
+    url: "{{ item.item.url }}"
+    dest: "/tmp/minio-mirror-{{ item.item.name }}"
+    mode: "0644"
+    force: false
+  loop: "{{ minio_infra_stat.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  run_once: true
+  when: item.rc != 0
+
+- name: Push missing infra artifacts to target
+  ansible.builtin.copy:
+    src: "/tmp/minio-mirror-{{ item.item.name }}"
+    dest: "/tmp/minio-mirror-{{ item.item.name }}"
+    mode: "0644"
+  loop: "{{ minio_infra_stat.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  when: item.rc != 0
+
+- name: Upload missing infra artifacts to MinIO
+  ansible.builtin.command:
+    cmd: >-
+      {{ minio_install_dir }}/mc cp /tmp/minio-mirror-{{ item.item.name }}
+      local/{{ item.item.bucket }}/{{ item.item.key }}
+  loop: "{{ minio_infra_stat.results }}"
+  loop_control:
+    label: "{{ item.item.name }} -> {{ item.item.bucket }}/{{ item.item.key }}"
+  register: minio_infra_upload
+  changed_when: "'Total:' in minio_infra_upload.stdout"
+  when: item.rc != 0
+
+- name: Remove staging files from target
+  ansible.builtin.file:
+    path: "/tmp/minio-mirror-{{ item.item.name }}"
+    state: absent
+  loop: "{{ minio_infra_stat.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  when: item.rc != 0

--- a/roles/minio/tasks/main.yml
+++ b/roles/minio/tasks/main.yml
@@ -218,9 +218,17 @@
 # pulls from MinIO instead. The controller — which has unrestricted egress —
 # stages the download, then `mc cp` uploads it to the bucket.
 #
-# Idempotent: `mc stat` determines whether the object already exists, and
-# the upload is skipped when present. Delete the bucket object manually
-# (or wait for the lifecycle rule) to force a refresh.
+# Idempotency: `mc stat` per-host decides whether the object already exists,
+# and subsequent tasks short-circuit on the same host when it does. Existing
+# objects are left alone so manual retention decisions are not clobbered on
+# re-runs. Delete the bucket object manually (or wait for the lifecycle rule)
+# to force a refresh.
+#
+# Per-host (no run_once): when minio_group grows beyond one host, each host
+# re-checks `mc stat` against its own MinIO instance and independently
+# triggers the controller download it needs. `get_url force: true` is safe
+# under concurrent delegated invocations because the file is rewritten
+# atomically and each host names its own staging path.
 - name: Check which infra artifacts are already mirrored
   ansible.builtin.command:
     cmd: "{{ minio_install_dir }}/mc stat --json local/{{ item.bucket }}/{{ item.key }}"
@@ -232,11 +240,14 @@
   failed_when: false
 
 - name: Stage missing infra artifacts on controller
+  # force: true — these point at rolling "latest" upstream URLs, so
+  # anything cached in /tmp from a prior run is assumed stale. The
+  # controller always re-fetches to guarantee freshness.
   ansible.builtin.get_url:
     url: "{{ item.item.url }}"
-    dest: "/tmp/minio-mirror-{{ item.item.name }}"
+    dest: "/tmp/minio-mirror-{{ inventory_hostname }}-{{ item.item.name }}"
     mode: "0644"
-    force: false
+    force: true
   loop: "{{ minio_infra_stat.results }}"
   loop_control:
     label: "{{ item.item.name }}"
@@ -245,12 +256,11 @@
   become: false
   vars:
     ansible_become: false
-  run_once: true
   when: item.rc != 0
 
 - name: Push missing infra artifacts to target
   ansible.builtin.copy:
-    src: "/tmp/minio-mirror-{{ item.item.name }}"
+    src: "/tmp/minio-mirror-{{ inventory_hostname }}-{{ item.item.name }}"
     dest: "/tmp/minio-mirror-{{ item.item.name }}"
     mode: "0644"
   loop: "{{ minio_infra_stat.results }}"
@@ -277,4 +287,20 @@
   loop: "{{ minio_infra_stat.results }}"
   loop_control:
     label: "{{ item.item.name }}"
+  when: item.rc != 0
+
+- name: Remove staging files from controller
+  # Tarballs can be hundreds of MB (Cribl is ~76 MB). Leaving them in /tmp
+  # on the workstation after upload accumulates disk usage over many runs.
+  ansible.builtin.file:
+    path: "/tmp/minio-mirror-{{ inventory_hostname }}-{{ item.item.name }}"
+    state: absent
+  loop: "{{ minio_infra_stat.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
   when: item.rc != 0

--- a/roles/minio/tasks/main.yml
+++ b/roles/minio/tasks/main.yml
@@ -230,6 +230,14 @@
 # under concurrent delegated invocations because the file is rewritten
 # atomically and each host names its own staging path.
 - name: Check which infra artifacts are already mirrored
+  # Non-zero exit from `mc stat` is expected when the object is missing
+  # (that is the signal that drives the downstream "if item.rc != 0" guard).
+  # However, we want the task to fail loudly on any OTHER mc error —
+  # alias misconfigured, MinIO unreachable, auth failure, etc. — rather
+  # than silently treating "mc is broken" as "object missing" and
+  # triggering a pointless download/upload pass. Accept only the two
+  # known "missing object" signals: the message string mc emits and the
+  # S3 error code in --json output.
   ansible.builtin.command:
     cmd: "{{ minio_install_dir }}/mc stat --json local/{{ item.bucket }}/{{ item.key }}"
   loop: "{{ minio_infra_mirrors }}"
@@ -237,7 +245,11 @@
     label: "{{ item.name }}"
   register: minio_infra_stat
   changed_when: false
-  failed_when: false
+  failed_when: >-
+    minio_infra_stat.rc is defined and
+    minio_infra_stat.rc != 0 and
+    'Object does not exist' not in (minio_infra_stat.stderr | default('')) and
+    'NoSuchKey' not in (minio_infra_stat.stdout | default(''))
 
 - name: Stage missing infra artifacts on controller
   # force: true — these point at rolling "latest" upstream URLs, so


### PR DESCRIPTION
## Summary

Unblocks Phase 3 of the E2E deployment pipeline — the \`cribl_edge\` and \`cribl_stream\` plays were failing because the Cribl LXC containers have the \`outbound-internal\` firewall group applied (RFC1918-only egress) and cannot reach \`cdn.cribl.io\` directly.

## The pattern

Every infra role that needs an upstream tarball now pulls from a local MinIO mirror instead. The mirror is maintained by the \`minio\` role itself, which:

1. Reads a list of mirror definitions from \`minio_infra_mirrors\` (URL + bucket/key)
2. For each entry, uses \`mc stat\` to check whether the object already exists
3. If missing, downloads from upstream **on the Ansible controller** (unrestricted egress) via \`delegate_to: localhost\`
4. Copies the staged file to the MinIO container and runs \`mc cp\` to upload
5. Idempotent — existing objects are left alone so manual retention decisions are not clobbered on re-runs

## Initial manifest

\`\`\`yaml
minio_infra_mirrors:
  - name: cribl
    url: https://cdn.cribl.io/dl/latest/cribl-linux-x64.tgz
    bucket: splunk-addons
    key: infra/cribl-linux-x64.tgz
\`\`\`

Extend this list as more roles (Ollama install script, etc.) hit the same wall.

## Consumers

- \`inventory/group_vars/cribl_edge.yml\` — override \`cribl_edge_tarball_url\` with the MinIO URL
- \`inventory/group_vars/cribl_stream_group.yml\` — override \`cribl_stream_tarball_url\` with the MinIO URL

Both use \`terraform_data.containers.minio.ip\` + \`terraform_data.constants.service_ports.minio_api\` so there are no hardcoded IPs.

## Bonus fix

The upstream URL template in both \`cribl_edge/defaults\` and \`cribl_stream/defaults\` is corrected while we're here. Cribl's CDN uses two different filename patterns:

- versioned release: \`https://cdn.cribl.io/dl/4.12.2/cribl-4.12.2-linux-x64.tgz\`
- rolling \"latest\":  \`https://cdn.cribl.io/dl/latest/cribl-linux-x64.tgz\` (no version in filename)

The previous template always embedded the literal \`latest\` in the filename, producing a 404 for the default configuration. Now it switches on \`version == 'latest'\`.

## Test plan

- [x] \`ansible-lint roles/minio roles/cribl_edge roles/cribl_stream inventory/group_vars/\` passes under production profile
- [ ] First \`ansible-playbook playbooks/site.yml --tags minio\` run downloads and mirrors \`cribl-linux-x64.tgz\` into the bucket
- [ ] Subsequent \`--tags minio\` runs are no-ops (idempotent)
- [ ] \`ansible-playbook playbooks/site.yml --tags cribl_edge,cribl_stream\` succeeds end-to-end on the restricted containers