### PR TITLE
fix(cribl): install sudo so become_user: cribl actually works

### DIFF
--- a/roles/cribl_edge/tasks/main.yml
+++ b/roles/cribl_edge/tasks/main.yml
@@ -11,10 +11,10 @@
     - /var/tmp/.ansible
 
 - name: Install required packages
-  # sudo is required because later tasks use `become_user: cribl` to run
-  # `cribl mode-edge` as the non-root service user. The Proxmox LXC base
-  # image does not ship sudo — without this the task fails with
-  # `/bin/sh: 1: sudo: not found`.
+  # sudo is required because later tasks use `become_user:
+  # {{ cribl_edge_user }}` to run `cribl mode-edge` as the non-root
+  # service user. The Proxmox LXC base image does not ship sudo —
+  # without this the task fails with `/bin/sh: 1: sudo: not found`.
   ansible.builtin.apt:
     name:
       - curl
@@ -22,6 +22,7 @@
       - sudo
     state: present
     update_cache: true
+    cache_valid_time: 3600
 
 - name: Create cribl system group
   ansible.builtin.group:

--- a/roles/cribl_edge/tasks/main.yml
+++ b/roles/cribl_edge/tasks/main.yml
@@ -11,10 +11,15 @@
     - /var/tmp/.ansible
 
 - name: Install required packages
+  # sudo is required because later tasks use `become_user: cribl` to run
+  # `cribl mode-edge` as the non-root service user. The Proxmox LXC base
+  # image does not ship sudo — without this the task fails with
+  # `/bin/sh: 1: sudo: not found`.
   ansible.builtin.apt:
     name:
       - curl
       - tar
+      - sudo
     state: present
     update_cache: true
 

--- a/roles/cribl_stream/tasks/main.yml
+++ b/roles/cribl_stream/tasks/main.yml
@@ -1,6 +1,19 @@
 ---
 # Cribl Stream native installation in LXC containers
 
+- name: Install required packages
+  # sudo is required because later tasks use `become_user: cribl` to run
+  # `cribl mode-stream` as the non-root service user. The Proxmox LXC base
+  # image does not ship sudo — without this those tasks fail with
+  # `/bin/sh: 1: sudo: not found`.
+  ansible.builtin.apt:
+    name:
+      - curl
+      - tar
+      - sudo
+    state: present
+    update_cache: true
+
 - name: Create cribl system group
   ansible.builtin.group:
     name: "{{ cribl_stream_group }}"

--- a/roles/cribl_stream/tasks/main.yml
+++ b/roles/cribl_stream/tasks/main.yml
@@ -2,17 +2,19 @@
 # Cribl Stream native installation in LXC containers
 
 - name: Install required packages
-  # sudo is required because later tasks use `become_user: cribl` to run
-  # `cribl mode-stream` as the non-root service user. The Proxmox LXC base
-  # image does not ship sudo — without this those tasks fail with
-  # `/bin/sh: 1: sudo: not found`.
+  # sudo is required because later tasks use `become_user:
+  # {{ cribl_stream_user }}` to run `cribl mode-single` as the non-root
+  # service user. The Proxmox LXC base image does not ship sudo —
+  # without this those tasks fail with `/bin/sh: 1: sudo: not found`.
+  # (curl is intentionally omitted — this role uses get_url, not the
+  # curl CLI, and the tarball is extracted with ansible.builtin.unarchive.)
   ansible.builtin.apt:
     name:
-      - curl
       - tar
       - sudo
     state: present
     update_cache: true
+    cache_valid_time: 3600
 
 - name: Create cribl system group
   ansible.builtin.group:


### PR DESCRIPTION
## Summary

Phase 3 cribl_edge play was failing on \`Set Cribl to Edge mode\`:

\`\`\`
fatal: [cribl-edge-01]: FAILED! => {
  \"msg\": \"Module result deserialization failed: No start of json char found\",
  \"module_stdout\": \"/bin/sh: 1: sudo: not found\r\r\n\",
  \"rc\": 127
}
\`\`\`

## Root cause

The task uses \`become: true\` + \`become_user: cribl\` to run the cribl CLI as the unprivileged service user. Ansible's become layer invokes \`sudo\` to switch users. The Proxmox LXC base image does not ship sudo.

Other roles (\`apt_cacher_ng\`, \`minio\`, \`technitium_install\`) never hit this because they only ever become root, and the \`community.proxmox.proxmox_pct_remote\` connection plugin short-circuits the sudo call when source and target user are both root. The moment a different \`become_user\` is requested sudo is invoked for real.

## Fix

Add \`sudo\` to the apt prerequisites in both \`cribl_edge\` and \`cribl_stream\`. Also adds a missing prereq task to \`cribl_stream\` — it wasn't installing curl/tar at all, which would have broken the subsequent tarball download the moment the base image didn't happen to ship them.

## Test plan

- [x] \`ansible-lint roles/cribl_edge roles/cribl_stream\` passes under production profile
- [ ] \`ansible-playbook playbooks/site.yml --tags cribl_edge,cribl_stream\` succeeds end-to-end on restricted LXC containers