### PR TITLE
fix(cribl_edge): correct systemd service name cribl → cribl-edge

### DIFF
--- a/inventory/group_vars/cribl_edge.yml
+++ b/inventory/group_vars/cribl_edge.yml
@@ -1,6 +1,6 @@
 ---
 systemd_restart_policy_services:
-  - cribl
+  - cribl-edge
 
 # Cribl Edge containers have the `outbound-internal` firewall group applied
 # (RFC1918 only), so they cannot reach cdn.cribl.io directly. Serve the

--- a/roles/cribl_edge/defaults/main.yml
+++ b/roles/cribl_edge/defaults/main.yml
@@ -19,8 +19,10 @@ cribl_edge_install_dir: /opt/cribl
 cribl_edge_user: cribl
 cribl_edge_group: cribl
 
-# Systemd service
-cribl_edge_service_name: cribl
+# Systemd service — the unit file is created by `cribl boot-start enable`,
+# which derives the service name from the Cribl operating mode. With
+# `cribl mode-edge`, the unit is installed as `cribl-edge.service`.
+cribl_edge_service_name: cribl-edge
 
 # Syslog ports from terraform constants (no hardcoded values)
 cribl_edge_syslog_ports: >-

--- a/roles/cribl_edge/tasks/main.yml
+++ b/roles/cribl_edge/tasks/main.yml
@@ -121,9 +121,12 @@
   notify: Restart cribl edge
 
 - name: Enable Cribl Edge systemd service
+  # `cribl boot-start enable` installs the unit file with a name derived
+  # from the operating mode. After `cribl mode-edge` the unit is
+  # cribl-edge.service, not cribl.service.
   ansible.builtin.command:
     cmd: "{{ cribl_edge_install_dir }}/bin/cribl boot-start enable -m systemd -u {{ cribl_edge_user }}"
-    creates: /etc/systemd/system/cribl.service
+    creates: "/etc/systemd/system/{{ cribl_edge_service_name }}.service"
 
 - name: Start Cribl Edge service
   ansible.builtin.systemd:


### PR DESCRIPTION
## Summary

Phase 3 \`cribl_edge\` play was failing on \`Start Cribl Edge service\`:

\`\`\`
fatal: [cribl-edge-01]: FAILED! => {
  \"msg\": \"Could not find the requested service cribl: host\"
}
\`\`\`

## Root cause

\`cribl boot-start enable\` installs a systemd unit whose filename is derived from the Cribl operating mode. After \`cribl mode-edge\` the file on disk is \`/etc/systemd/system/cribl-edge.service\`, NOT \`cribl.service\`. The role's defaults had \`cribl_edge_service_name: cribl\`, so:

1. The \`creates:\` idempotency guard on the boot-start task pointed at a file that never existed, so it ran every play run
2. The next \`Start Cribl Edge service\` task looked for a systemd unit named \`cribl\`, which does not exist, and failed
3. \`systemd_restart_policy_services: [cribl]\` in group_vars would have caused the shared restart-policy role to fail later too

## Fix

Set \`cribl_edge_service_name: cribl-edge\` in the role defaults. Derive the \`creates:\` path from the variable so future mode changes stay consistent. Update the group_vars entry to match.

\`cribl_stream\` is untouched — \`cribl mode-single\` (which that role uses) installs \`cribl.service\` and the existing defaults are correct for that mode.

## Test plan

- [x] \`ansible-lint roles/cribl_edge inventory/group_vars/\` passes under production profile
- [ ] \`ansible-playbook playbooks/site.yml --tags cribl_edge\` starts the service successfully and reaches the end of the play