### PR TITLE
fix(apt_cacher_ng): append :443$ to PassThroughPattern for CONNECT match

### DIFF
--- a/roles/apt_cacher_ng/defaults/main.yml
+++ b/roles/apt_cacher_ng/defaults/main.yml
@@ -15,8 +15,13 @@ apt_cacher_ng_bind_address: "0.0.0.0"
 # Passthrough HTTPS (for repos that require it)
 # Disabled by default to preserve caching benefits. Enable only for
 # repositories that cannot be cached (e.g., HTTPS with authentication).
+#
+# apt-cacher-ng matches this regex against the CONNECT target — `host:port`,
+# e.g. `registry-1.docker.io:443`. Host-only or URL-style patterns will NOT
+# match real CONNECT requests; each alternation must end in `:<port>$`.
+# Example: `(^|\.)(registry-1\.docker\.io|gcr\.io|quay\.io):443$`
 apt_cacher_ng_passthrough_enabled: false
-apt_cacher_ng_passthrough_pattern: "https?://(registry-1\\.docker\\.io|gcr\\.io|quay\\.io)/.*"
+apt_cacher_ng_passthrough_pattern: "(^|\\.)(registry-1\\.docker\\.io|gcr\\.io|quay\\.io):443$"
 
 # Admin interface
 apt_cacher_ng_admin_enabled: false

--- a/roles/apt_cacher_ng/templates/acng.conf.j2
+++ b/roles/apt_cacher_ng/templates/acng.conf.j2
@@ -39,13 +39,21 @@ Remap-secdeb: file:backends_debian_security /debian-security
 # Ubuntu support (if needed)
 Remap-uburep: file:backends_ubuntu /ubuntu
 
-# HTTPS passthrough for repos that require it (typically due to HTTPS and token-based authentication)
+# HTTPS passthrough for repos that require it (typically because of HTTPS
+# plus token-based authentication).
+#
+# apt-cacher-ng's PassThroughPattern is matched against the full CONNECT
+# target — `host:port`, e.g. `download.docker.com:443`. A pattern that
+# only names the host without `:443$` never matches a real CONNECT
+# request and apt-cacher-ng returns
+#   HTTP/1.0 403 CONNECT denied (ask the admin to allow HTTPS tunnels)
+# We append `:443$` to every pattern we inject to make the match work.
 {% set passthrough_patterns = [] %}
 {% if apt_cacher_ng_passthrough_enabled %}
 {% set _ = passthrough_patterns.append(apt_cacher_ng_passthrough_pattern) %}
 {% endif %}
 {% if apt_cacher_ng_docker_passthrough %}
-{% set _ = passthrough_patterns.append('download\\.docker\\.com') %}
+{% set _ = passthrough_patterns.append('(^|\\.)download\\.docker\\.com:443$') %}
 {% endif %}
 {% if passthrough_patterns %}
 PassThroughPattern: {{ passthrough_patterns | join('|') }}

--- a/roles/apt_cacher_ng/templates/acng.conf.j2
+++ b/roles/apt_cacher_ng/templates/acng.conf.j2
@@ -44,10 +44,14 @@ Remap-uburep: file:backends_ubuntu /ubuntu
 #
 # apt-cacher-ng's PassThroughPattern is matched against the full CONNECT
 # target — `host:port`, e.g. `download.docker.com:443`. A pattern that
-# only names the host without `:443$` never matches a real CONNECT
+# only names the host without `:<port>$` never matches a real CONNECT
 # request and apt-cacher-ng returns
 #   HTTP/1.0 403 CONNECT denied (ask the admin to allow HTTPS tunnels)
-# We append `:443$` to every pattern we inject to make the match work.
+#
+# The built-in Docker pattern below includes `:443$` explicitly. The
+# user-supplied `apt_cacher_ng_passthrough_pattern` is rendered verbatim —
+# callers who enable it must include their own `:<port>$` anchor, e.g.
+# `(^|\.)my\.repo\.example\.com:443$`.
 {% set passthrough_patterns = [] %}
 {% if apt_cacher_ng_passthrough_enabled %}
 {% set _ = passthrough_patterns.append(apt_cacher_ng_passthrough_pattern) %}


### PR DESCRIPTION
## Summary

Phase 3 \`mailpit_docker\` play was failing on \`Install Docker prerequisites\` because \`apt update\` couldn't fetch the Docker repo:

\`\`\`
Err:1 https://download.docker.com/linux/debian trixie InRelease
  Invalid response from proxy: HTTP/1.0 403 CONNECT denied (ask the admin to allow HTTPS tunnels)
  [IP: 10.0.1.106 3142]
\`\`\`

## Root cause

apt-cacher-ng's \`PassThroughPattern\` regex is matched against the full CONNECT target, \`host:port\` — e.g. \`download.docker.com:443\`. Our template rendered the pattern as \`download\\.docker\\.com\`, which never matches \`download.docker.com:443\`, so every HTTPS tunnel request to Docker's repo gets denied. The apt-cacher-ng docs call this out but it's easy to miss (the default example pattern in the man page includes \`:443$\`).

## Fix

Render the docker passthrough pattern as \`(^|\\.)download\\.docker\\.com:443$\` so it explicitly matches the CONNECT target. The \`(^|\\.)\` anchor is there so a future subdomain (e.g. \`hub.download.docker.com\`) would also match.

Any future passthrough rule should follow the same pattern — append \`:<port>$\` to the host-only regex.

## Test plan

- [x] \`ansible-lint roles/apt_cacher_ng\` passes under production profile
- [ ] After re-running the \`apt_cacher_ng\` role on CT 106, \`apt update\` on \`mailpit\` no longer fails on \`download.docker.com\`
- [ ] \`ansible-playbook playbooks/site.yml --tags mailpit\` succeeds end-to-end