### PR TITLE
fix(mssql_docker): set data dir owner to UID 10001 for SQL Server

### DIFF
--- a/roles/mssql_docker/tasks/main.yml
+++ b/roles/mssql_docker/tasks/main.yml
@@ -66,12 +66,20 @@
 # =============================================================================
 
 - name: Create MSSQL data directories
+  # Microsoft's official SQL Server 2022 Linux container runs as UID 10001
+  # (internal user `mssql`) and GID 0 (root group). The host directories
+  # mounted at /var/opt/mssql/{data,log,backup} must be writable by that
+  # UID or SQL Server fails to bootstrap with:
+  #   ERROR: Setup FAILED copying system data file 'C:\templatedata\master.mdf'
+  #   to '/var/opt/mssql/data/master.mdf':  5(Access is denied.)
+  # owner: "10001" grants write access without relying on world-writable dirs.
+  # Source: https://learn.microsoft.com/en-us/sql/linux/quickstart-install-connect-docker
   ansible.builtin.file:
     path: "{{ mssql_docker_data_dir }}/{{ item }}"
     state: directory
-    owner: root
+    owner: "10001"
     group: root
-    mode: "0755"
+    mode: "0770"
   loop:
     - data
     - log


### PR DESCRIPTION
## Summary

Phase 3 \`mssql_docker\` play was failing because the SQL Server container kept crashing on bootstrap and Docker put it into an endless restart loop:

\`\`\`
TASK [mssql_docker : Verify SQL Server is accepting connections]
FAILED - RETRYING: (6 retries left)
...
\"msg\": \"Container dcf89efc75d9... is restarting, wait until the container is running\"
\`\`\`

Container logs:

\`\`\`
ERROR: Setup FAILED copying system data file 'C:\\templatedata\\master.mdf'
to '/var/opt/mssql/data/master.mdf':  5(Access is denied.)
SQL Server 2022 will run as non-root by default.
This container is running as user mssql.
\`\`\`

## Root cause

Microsoft's official SQL Server 2022 Linux container runs as **UID 10001** (internal user \`mssql\`, GID 0). The host directories mounted at \`/var/opt/mssql/{data,log,backup}\` must be writable by that UID.

The role was creating those directories as \`root:root\` with mode \`0755\`. The container user can read them but cannot write, so SQL Server fails to copy its bootstrap system data files, exits, and Docker restarts it forever.

## Fix

Set the directory owner to \`10001\` (as a string — Ansible's file module accepts numeric UIDs via \`owner\`) and mode \`0770\`. Matches [Microsoft's Quick Start guide](https://learn.microsoft.com/en-us/sql/linux/quickstart-install-connect-docker) without world-writable directories.

## Test plan

- [x] \`ansible-lint roles/mssql_docker\` passes under production profile
- [ ] \`ansible-playbook playbooks/site.yml --tags mssql\` succeeds end-to-end; container stays \"running\" and the health check passes