### PR TITLE
fix(cribl_edge): deploy all config to local/edge context

### DIFF
--- a/roles/cribl_edge/tasks/main.yml
+++ b/roles/cribl_edge/tasks/main.yml
@@ -76,26 +76,24 @@
   register: cribl_edge_mode_result
   changed_when: "'already' not in cribl_edge_mode_result.stdout"
 
-- name: Ensure config directory exists
+- name: Ensure Edge config directories exist
+  # Cribl Edge worker (LEADER process) loads ALL config (inputs, outputs,
+  # pipelines) from local/edge/, not local/cribl/. The local/edge/ dir is
+  # created by `cribl mode-edge` but we ensure the full tree here.
   ansible.builtin.file:
-    path: "{{ cribl_edge_install_dir }}/local/cribl"
+    path: "{{ item }}"
     owner: "{{ cribl_edge_user }}"
     group: "{{ cribl_edge_group }}"
     mode: "0755"
     state: directory
-
-- name: Ensure pipeline directory exists
-  ansible.builtin.file:
-    path: "{{ cribl_edge_install_dir }}/local/cribl/pipelines/syslog"
-    owner: "{{ cribl_edge_user }}"
-    group: "{{ cribl_edge_group }}"
-    mode: "0755"
-    state: directory
+  loop:
+    - "{{ cribl_edge_install_dir }}/local/edge"
+    - "{{ cribl_edge_install_dir }}/local/edge/pipelines/syslog"
 
 - name: Deploy Cribl Edge outputs configuration
   ansible.builtin.template:
     src: outputs.yml.j2
-    dest: "{{ cribl_edge_install_dir }}/local/cribl/outputs.yml"
+    dest: "{{ cribl_edge_install_dir }}/local/edge/outputs.yml"
     owner: "{{ cribl_edge_user }}"
     group: "{{ cribl_edge_group }}"
     mode: "0600"
@@ -105,7 +103,7 @@
 - name: Deploy Cribl Edge inputs configuration
   ansible.builtin.template:
     src: inputs.yml.j2
-    dest: "{{ cribl_edge_install_dir }}/local/cribl/inputs.yml"
+    dest: "{{ cribl_edge_install_dir }}/local/edge/inputs.yml"
     owner: "{{ cribl_edge_user }}"
     group: "{{ cribl_edge_group }}"
     mode: "0644"
@@ -114,7 +112,7 @@
 - name: Deploy syslog pipeline configuration
   ansible.builtin.template:
     src: pipelines/syslog/conf.yml.j2
-    dest: "{{ cribl_edge_install_dir }}/local/cribl/pipelines/syslog/conf.yml"
+    dest: "{{ cribl_edge_install_dir }}/local/edge/pipelines/syslog/conf.yml"
     owner: "{{ cribl_edge_user }}"
     group: "{{ cribl_edge_group }}"
     mode: "0644"


### PR DESCRIPTION
## Summary

- Cribl Edge worker (LEADER) loads ALL config from `local/edge/`, not `local/cribl/` (Stream context)
- Role was deploying inputs, outputs, and pipelines to wrong path, causing:
  - Syslog ports 1514-1518 never binding
  - `splunk_hec` output never initializing
  - Syslog processing pipeline not applied
- All three config files now deploy to `local/edge/`

## Root Cause

Worker log showed only `default/edge/inputs.yml` being loaded. The `splunk_hec` output only showed `"Successfully initialized destination"` after copying `outputs.yml` to `local/edge/`. Before that, events were ingested but silently dropped.

## Test Plan

- [x] Manually deployed all config to `local/edge/` on CT 180 and 181
- [x] All 5 syslog ports (1514-1518) binding after restart
- [x] `output:splunk_hec` successfully initialized in worker log
- [x] E2E verified: UniFi syslog events landing in Splunk (index=unifi, sourcetype=ubiquiti:unifi)
- [x] `validate-pipeline.yml` passes for both Cribl Edge nodes

Generated with [Claude Code](https://claude.com/claude-code)