### PR TITLE
fix(ci): inline shared health-audit config to break runtime-import dep (#185)

### DIFF
--- a/.github/workflows/repo-health-audit.lock.yml
+++ b/.github/workflows/repo-health-audit.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"8b5708802fcd2e876efca4ce16e031b1bd83cac7752273171cee0f0332bf69c4","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"332fbb46c456a1357f6148026cc887da22d42ed4cd63233304694d133468e1c5","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -23,13 +23,6 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 # Daily repository health audit
-#
-# Resolved workflow manifest:
-#   Imports:
-#     - JacobPEvans/.github/.github/workflows/shared/repo-health-audit-config.md@main
-#   Includes:
-#     - /tmp/gh-aw-include-110159752.md
-#     - /tmp/gh-aw-include-474866344.md
 #
 # Secrets used:
 #   - COPILOT_GITHUB_TOKEN
@@ -171,14 +164,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_b2968f7f97c5d780_EOF'
+          cat << 'GH_AW_PROMPT_c0327ed8dbe2552f_EOF'
           <system>
-          GH_AW_PROMPT_b2968f7f97c5d780_EOF
+          GH_AW_PROMPT_c0327ed8dbe2552f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b2968f7f97c5d780_EOF'
+          cat << 'GH_AW_PROMPT_c0327ed8dbe2552f_EOF'
           <safe-output-tools>
           Tools: create_issue(max:8), close_issue(max:10), add_labels(max:16), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -210,13 +203,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_b2968f7f97c5d780_EOF
+          GH_AW_PROMPT_c0327ed8dbe2552f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b2968f7f97c5d780_EOF'
+          cat << 'GH_AW_PROMPT_c0327ed8dbe2552f_EOF'
           </system>
-          {{#runtime-import .github/632931dae1f842cc819ec52236412cc00629ccb1/.github_workflows_shared_repo-health-audit-config.md}}
           {{#runtime-import .github/workflows/repo-health-audit.md}}
-          GH_AW_PROMPT_b2968f7f97c5d780_EOF
+          GH_AW_PROMPT_c0327ed8dbe2552f_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -389,9 +381,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_c687ba0ec55fb831_EOF'
-          {"add_labels":{"allowed":["type:ci","type:chore","type:security","priority:critical","priority:high","priority:medium","priority:low","size:xs"],"max":16},"close_issue":{"max":10,"required_labels":["ai:created"],"required_title_prefix":"[health-audit] ","state_reason":"completed"},"create_issue":{"close_older_issues":true,"expires":168,"group":true,"labels":["ai:created"],"max":8,"title_prefix":"[health-audit] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_c687ba0ec55fb831_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_89d3915f25a0479b_EOF'
+          {"add_labels":{"allowed":["type:ci","type:chore","type:security","priority:critical","priority:high","priority:medium","priority:low","size:xs"],"max":16},"close_issue":{"max":10,"required_labels":["ai:created"],"required_title_prefix":"[health-audit] "},"create_issue":{"close_older_issues":true,"expires":168,"group":true,"labels":["ai:created"],"max":8,"title_prefix":"[health-audit] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_89d3915f25a0479b_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -625,7 +617,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_7b22726526a55685_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_560a183c7fea79ca_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -666,7 +658,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_7b22726526a55685_EOF
+          GH_AW_MCP_CONFIG_560a183c7fea79ca_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1215,7 +1207,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_labels\":{\"allowed\":[\"type:ci\",\"type:chore\",\"type:security\",\"priority:critical\",\"priority:high\",\"priority:medium\",\"priority:low\",\"size:xs\"],\"max\":16},\"close_issue\":{\"max\":10,\"required_labels\":[\"ai:created\"],\"required_title_prefix\":\"[health-audit] \",\"state_reason\":\"completed\"},\"create_issue\":{\"close_older_issues\":true,\"expires\":168,\"group\":true,\"labels\":[\"ai:created\"],\"max\":8,\"title_prefix\":\"[health-audit] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_labels\":{\"allowed\":[\"type:ci\",\"type:chore\",\"type:security\",\"priority:critical\",\"priority:high\",\"priority:medium\",\"priority:low\",\"size:xs\"],\"max\":16},\"close_issue\":{\"max\":10,\"required_labels\":[\"ai:created\"],\"required_title_prefix\":\"[health-audit] \"},\"create_issue\":{\"close_older_issues\":true,\"expires\":168,\"group\":true,\"labels\":[\"ai:created\"],\"max\":8,\"title_prefix\":\"[health-audit] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/repo-health-audit.md
+++ b/.github/workflows/repo-health-audit.md
@@ -2,12 +2,39 @@
 description: "Daily repository health audit"
 engine: copilot
 
+# Cross-repo `imports:` of JacobPEvans/.github/.github/workflows/shared/
+# repo-health-audit-config.md@main was producing every-run failures with
+# ERR_SYSTEM: Runtime import file not found because gh-aw v0.68.3 generates
+# a {{#runtime-import .github/<SHA>/...}} macro from cross-repo frontmatter
+# imports but only stores the content at .github/aw/imports/<org>/<repo>/<SHA>/.
+# Even `inlined-imports: true` did not bridge the gap in v0.68.3.
+# Source content is mirrored inline below and stays in sync via gh-aw-sync-upstream.
+
 on:
   schedule: daily
   workflow_dispatch:
 
-imports:
-  - JacobPEvans/.github/.github/workflows/shared/repo-health-audit-config.md@main
+tools:
+  github:
+    toolsets: [default]
+
+safe-outputs:
+  create-issue:
+    title-prefix: "[health-audit] "
+    labels: ["ai:created"]
+    group: true
+    max: 8
+    expires: 7d
+    close-older-issues: true
+
+  add-labels:
+    allowed: ["type:ci", "type:chore", "type:security", "priority:critical", "priority:high", "priority:medium", "priority:low", "size:xs"]
+    max: 16
+
+  close-issue:
+    required-title-prefix: "[health-audit] "
+    required-labels: ["ai:created"]
+    max: 10
 
 permissions:
   contents: read
@@ -21,4 +48,140 @@ timeout-minutes: 15
 
 # Repo Health Audit
 
-{{#import JacobPEvans/.github/.github/workflows/shared/repo-health-audit-prompt.md@main}}
+You are a repository health auditor. Your job is to inspect this repository for problems
+and create a structured report as GitHub Issues.
+
+## Instructions
+
+Today's date is available from the workflow run timestamp. Use it to label the parent issue.
+
+### Step 1: Create Parent Issue
+
+Create a parent issue titled `[health-audit] Daily Health Audit - YYYY-MM-DD` (replace with today's date).
+
+The body should contain a summary table with one row per category, showing Pass/Fail and a brief note.
+Populate this after gathering findings.
+
+Labels: `ai:created`, `type:chore`, `priority:low`, `size:xs`
+
+### Step 2: Audit Each Category
+
+For each category below, gather findings. If a category has findings, create a sub-issue linked to
+the parent. If it has no findings, mark it as Pass in the summary table.
+
+#### Category: Failed CI on Main
+
+Check workflow runs on the `main` branch over the last 7 days. In the GitHub Actions API, look for runs where `status` is
+`completed` and `conclusion` is `failure` or `cancelled`.
+
+If findings exist:
+
+- Create sub-issue: `[health-audit] Failed CI on Main`
+- List each failed workflow by name, run ID, and failure date
+- Apply labels: `type:ci`, `size:xs`, and the appropriate priority:
+  - `priority:high` if any failure occurred in the last 24 hours
+  - `priority:medium` otherwise
+
+#### Category: Failed CI on Open PRs
+
+Check all open pull requests. For each PR, inspect the most recent check suite. Flag PRs where checks
+have been failing for more than 48 hours.
+
+Exclude: draft PRs, PRs authored by bots (Renovate, Dependabot).
+
+If findings exist:
+
+- Create sub-issue: `[health-audit] Failed CI on Open PRs`
+- List each PR by number, title, failing check names, and how long it has been failing
+- Apply labels: `type:ci`, `priority:medium`, `size:xs`
+
+#### Category: CodeQL and Security Scanning Alerts
+
+Check open code scanning alerts (CodeQL). Group by severity: critical, high, medium, low.
+
+If findings exist:
+
+- Create sub-issue: `[health-audit] Security Scanning Alerts`
+- List alert titles, severity, and affected file/line where available
+- Apply labels: `type:security`, `size:xs`, and:
+  - `priority:critical` if any critical or high severity alerts exist
+  - `priority:medium` if only medium/low severity alerts exist
+
+#### Category: Dependency Security Alerts
+
+Check for open Dependabot or Renovate vulnerability alerts. Include package name, severity, and CVE if available.
+
+If findings exist:
+
+- Create sub-issue: `[health-audit] Dependency Security Alerts`
+- List each vulnerable dependency with severity and fix version if known
+- Apply labels: `type:security`, `size:xs`, and:
+  - `priority:critical` if any critical severity alerts
+  - `priority:high` if any high severity alerts
+  - `priority:medium` otherwise
+
+#### Category: Secret Scanning Alerts
+
+Check for open secret scanning alerts.
+
+If findings exist:
+
+- Create sub-issue: `[health-audit] Secret Scanning Alerts`
+- List each alert type (do NOT include actual secret values)
+- Apply labels: `type:security`, `priority:critical`, `size:xs`
+
+#### Category: Stale Pull Requests
+
+Find open pull requests that meet all of the following:
+
+- Have been open for more than 7 days
+- Have had no activity (comments, commits, review events) in the last 7 days
+- Are not drafts
+- Are not authored by bots (Renovate, Dependabot, copilot)
+
+If findings exist:
+
+- Create sub-issue: `[health-audit] Stale Pull Requests`
+- List each stale PR by number, title, author, and days since last activity
+- Apply labels: `type:chore`, `priority:low`, `size:xs`
+
+#### Category: Failed Scheduled Workflows
+
+Check all workflows configured with `schedule` triggers. Find any that have failed or not run in the
+last 25 hours (to account for timing variance in daily schedules).
+
+Exclude this workflow itself from the check.
+
+If findings exist:
+
+- Create sub-issue: `[health-audit] Failed Scheduled Workflows`
+- List each affected workflow by name and last run status/date
+- Apply labels: `type:ci`, `priority:high`, `size:xs`
+
+### Step 3: Finalize Parent Issue
+
+Update the parent issue body with the complete summary table:
+
+| Category | Status | Details |
+| --- | --- | --- |
+| Failed CI on Main | ✅ Pass / ❌ Fail | brief note |
+| Failed CI on Open PRs | ✅ Pass / ❌ Fail | brief note |
+| CodeQL / Security Scanning | ✅ Pass / ❌ Fail | brief note |
+| Dependency Security | ✅ Pass / ❌ Fail | brief note |
+| Secret Scanning | ✅ Pass / ❌ Fail | brief note |
+| Stale Pull Requests | ✅ Pass / ❌ Fail | brief note |
+| Failed Scheduled Workflows | ✅ Pass / ❌ Fail | brief note |
+
+If ALL categories pass, still create the parent issue with the all-clear table — it serves as an audit trail.
+
+### Step 4: Close Empty Sub-Issues
+
+If you created any sub-issues that ended up with no findings (due to race conditions or data changing
+during the audit), close them with state-reason `completed`.
+
+### Notes
+
+- Do not include raw secret values in any issue body
+- Issue titles must use the `[health-audit]` prefix as configured
+- The `close-older-issues: true` setting auto-closes the previous audit issue when this one is created
+- Keep sub-issue bodies concise but actionable — each finding should have enough information to act on it


### PR DESCRIPTION
Replicates the verified fix from JacobPEvans/ansible-proxmox#151. Fixes the chronic 'ERR_SYSTEM: Runtime import file not found' failures in repo-health-audit.lock.yml.

Verification: ansible-proxmox#151 confirmed end-to-end success after applying this exact change.

Relates to #185 (filed in JacobPEvans/ai-workflows).