### PR TITLE
feat(cribl_packs): deploy orphan Cribl packs and add E2E schedule

### DIFF
--- a/.github/workflows/e2e-pipeline-schedule.yml
+++ b/.github/workflows/e2e-pipeline-schedule.yml
@@ -1,0 +1,50 @@
+---
+# Daily E2E pipeline validation (UniFi -> HAProxy -> Cribl -> Splunk).
+#
+# Runs the existing reusable `_e2e-tests.yml` against the live cluster.
+# Triggered by:
+#   - daily cron at 08:30 UTC (early-morning local time)
+#   - manual workflow_dispatch
+#
+# Gated by repo variable `E2E_RUNNERS_ENABLED == 'true'` (same gate the
+# PR-driven path uses in `ci-gate.yml`). When the gate is off, the job
+# no-ops cleanly with a status notice instead of failing.
+#
+# Closes terraform-proxmox#202 (Splunk cluster validation tests).
+
+name: E2E Pipeline Schedule
+
+on:
+  schedule:
+    # Daily at 08:30 UTC -- well clear of cluster maintenance windows.
+    - cron: '30 8 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gate-check:
+    name: Check E2E gate
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.gate.outputs.enabled }}
+    steps:
+      - id: gate
+        name: Evaluate E2E_RUNNERS_ENABLED
+        env:
+          E2E_RUNNERS_ENABLED: ${{ vars.E2E_RUNNERS_ENABLED }}
+        run: |
+          if [ "${E2E_RUNNERS_ENABLED}" = "true" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::E2E_RUNNERS_ENABLED is true -- proceeding"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::E2E_RUNNERS_ENABLED is not true -- skipping E2E run"
+          fi
+
+  e2e:
+    name: Run pipeline E2E tests
+    needs: gate-check
+    if: needs.gate-check.outputs.enabled == 'true'
+    uses: ./.github/workflows/_e2e-tests.yml

--- a/.github/workflows/gh-aw-pin-refresh.yml
+++ b/.github/workflows/gh-aw-pin-refresh.yml
@@ -1,3 +1,4 @@
+---
 name: gh-aw pin refresh
 
 on:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,21 +67,34 @@ CI runners MUST NOT share Docker networks with dev/test services.
 | 1517 | Linux | os |
 | 1518 | Windows | os |
 
+### NetFlow Port (from terraform pipeline_constants)
+
+| Port | Source | Splunk Index |
+| --- | --- | --- |
+| 2055 | UniFi IPFIX (UDP) | network |
+
 ### Service Ports (from terraform pipeline_constants)
 
 | Port | Service |
 | --- | --- |
 | 8000 | Splunk Web UI |
-| 8088 | Splunk HEC |
+| 8088 | Splunk HEC (HTTPS) |
 | 8089 | Splunk Management |
 | 8404 | HAProxy Stats |
-| 9000 | Cribl Edge API |
-| 9100 | Cribl Stream API |
+| 9420 | Cribl Edge API |
+| 9000 | Cribl Stream API (also MinIO API on `minio` LXC) |
+| 9001 | MinIO Console |
+| 3142 | apt-cacher-ng |
 | 1025 | Mailpit SMTP |
 | 8025 | Mailpit Web UI |
 | 8080 | ntfy HTTP |
 | 6333 | Qdrant HTTP (from terraform `vector_db_ports`) |
 | 6334 | Qdrant gRPC (from terraform `vector_db_ports`) |
+
+Values are sourced from `terraform-proxmox/locals.tf`
+`pipeline_constants.{service_ports, netflow_ports, vector_db_ports}`.
+Do not hand-edit — fix the constant and refresh
+`inventory/terraform_inventory.json`.
 
 ## Inventory
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,8 +82,8 @@ CI runners MUST NOT share Docker networks with dev/test services.
 | 8089 | Splunk Management |
 | 8404 | HAProxy Stats |
 | 9420 | Cribl Edge API |
-| 9000 | Cribl Stream API (also MinIO API on `minio` LXC) |
-| 9001 | MinIO Console |
+| 9000 | Cribl Stream API (also S3 API on `object-storage` LXC; `minio` LXC during 30-day soak) |
+| 9001 | object-storage Console (loopback only; `minio` Console during 30-day soak) |
 | 3142 | apt-cacher-ng |
 | 1025 | Mailpit SMTP |
 | 8025 | Mailpit Web UI |

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -152,6 +152,25 @@
     - role: cribl_stream
 
 # =============================================================================
+# Phase 2c: Cribl Packs
+# Install .crbl pack assets onto Edge and Stream LXCs after the base
+# Cribl install is up. Runs against the union of both groups; the role
+# detects target via group_names and is a no-op for non-Cribl hosts.
+# =============================================================================
+
+- name: Install Cribl packs
+  hosts: cribl_edge:cribl_stream_group
+  become: true
+  gather_facts: false
+  tags:
+    - cribl_packs
+    - cribl
+    - pipeline
+
+  roles:
+    - role: cribl_packs
+
+# =============================================================================
 # Phase 3: HAProxy Syslog/NetFlow VIP
 # Forwards syslog to Cribl Edge LXCs, IPFIX to Cribl Stream LXCs
 # =============================================================================

--- a/roles/cribl_packs/README.md
+++ b/roles/cribl_packs/README.md
@@ -1,0 +1,57 @@
+# cribl_packs
+
+Install Cribl `.crbl` packs onto Cribl Edge and Cribl Stream LXC containers
+from public GitHub release assets.
+
+## What it does
+
+For each host the role detects whether it belongs to `cribl_edge` or
+`cribl_stream_group` (set up by inventory loading), then installs the
+corresponding pack list under the right Cribl mode directory:
+
+- Edge LXCs (`cribl_edge` group) → `/opt/cribl/local/edge/packs/<pack-name>/`
+- Stream LXCs (`cribl_stream_group`) → `/opt/cribl/local/cribl/packs/<pack-name>/`
+
+Hosts in neither group are skipped (no-op).
+
+## Idempotency
+
+Each pack installation drops a sentinel file `.<version>.installed` inside the
+pack directory. Re-runs on the same version skip the download. Re-runs on a
+new version remove the prior pack directory, redownload, and unarchive — then
+notify the appropriate `Restart cribl` handler.
+
+## Installation
+
+This role lives in `ansible-proxmox-apps/roles/cribl_packs/` and is referenced
+directly by `playbooks/site.yml`. There is no Galaxy install step — the role
+ships in this repo.
+
+It depends on `cribl_edge` or `cribl_stream` having already installed the
+Cribl binary and started the service, so run it after both in `site.yml`.
+
+## Usage
+
+In `playbooks/site.yml`, after the `cribl_edge` and `cribl_stream` plays:
+
+```yaml
+- name: Install Cribl packs
+  hosts: cribl_edge:cribl_stream_group
+  become: true
+  roles:
+    - cribl_packs
+```
+
+Override the pack list per inventory by setting `cribl_packs_for_edge` or
+`cribl_packs_for_stream` in inventory/group_vars. See `defaults/main.yml`
+for the default list (cc-edge-copilot-otel, cc-edge-vscode-io,
+cc-stream-github-copilot-rest-io).
+
+## Variables
+
+See `defaults/main.yml` for the full list. Pin a specific version by editing
+the `version:` field on the relevant pack entry.
+
+## License
+
+MIT (matches the parent repo).

--- a/roles/cribl_packs/defaults/main.yml
+++ b/roles/cribl_packs/defaults/main.yml
@@ -1,0 +1,35 @@
+---
+# Cribl install paths (must match cribl_edge / cribl_stream roles)
+cribl_packs_install_dir: /opt/cribl
+cribl_packs_user: cribl
+cribl_packs_group: cribl
+
+# Edge service unit (matches cribl_edge_service_name)
+cribl_packs_edge_service: cribl-edge
+# Stream service unit (matches cribl_stream_service_name)
+cribl_packs_stream_service: cribl
+
+# Edge config tree root (cribl mode-edge)
+cribl_packs_edge_config_root: "{{ cribl_packs_install_dir }}/local/edge"
+# Stream config tree root
+cribl_packs_stream_config_root: "{{ cribl_packs_install_dir }}/local/cribl"
+
+# Pack list for Edge LXCs (cribl_edge group). Each pack:
+#   name:    pack name (used as directory name under packs/)
+#   repo:    GitHub <owner>/<repo>
+#   version: release tag (e.g. v1.0.1)
+# Asset URL is constructed as:
+#   https://github.com/{{ repo }}/releases/download/{{ version }}/{{ name }}-{{ version }}.crbl
+cribl_packs_for_edge:
+  - name: cc-edge-copilot-otel
+    repo: JacobPEvans/cc-edge-copilot-otel
+    version: v1.0.1
+  - name: cc-edge-vscode-io
+    repo: JacobPEvans/cc-edge-vscode-io
+    version: v1.0.1
+
+# Pack list for Stream LXCs (cribl_stream_group)
+cribl_packs_for_stream:
+  - name: cc-stream-github-copilot-rest-io
+    repo: JacobPEvans/cc-stream-github-copilot-rest-io
+    version: v1.0.0

--- a/roles/cribl_packs/handlers/main.yml
+++ b/roles/cribl_packs/handlers/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Restart cribl edge
+  ansible.builtin.systemd:
+    name: "{{ cribl_packs_edge_service }}"
+    state: restarted
+    daemon_reload: false
+  when: "'cribl_edge' in group_names"
+
+- name: Restart cribl stream
+  ansible.builtin.systemd:
+    name: "{{ cribl_packs_stream_service }}"
+    state: restarted
+    daemon_reload: false
+  when: "'cribl_stream_group' in group_names"

--- a/roles/cribl_packs/meta/main.yml
+++ b/roles/cribl_packs/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  role_name: cribl_packs
+  author: JacobPEvans
+  description: Install Cribl .crbl packs onto Edge and Stream LXC nodes
+  license: MIT
+  min_ansible_version: "2.16"
+  platforms:
+    - name: Debian
+      versions:
+        - all
+  galaxy_tags:
+    - cribl
+    - logging
+    - observability
+dependencies: []

--- a/roles/cribl_packs/tasks/main.yml
+++ b/roles/cribl_packs/tasks/main.yml
@@ -1,0 +1,94 @@
+---
+# Resolve pack target and per-target paths from inventory group membership.
+- name: Determine pack target
+  ansible.builtin.set_fact:
+    cribl_packs_target: >-
+      {{
+        'edge' if 'cribl_edge' in group_names
+        else ('stream' if 'cribl_stream_group' in group_names else '')
+      }}
+
+- name: Skip hosts that are neither Cribl Edge nor Cribl Stream
+  ansible.builtin.meta: end_host
+  when: cribl_packs_target == ''
+
+- name: Set per-target Cribl paths
+  ansible.builtin.set_fact:
+    _cribl_packs_config_root: >-
+      {{
+        cribl_packs_edge_config_root if cribl_packs_target == 'edge'
+        else cribl_packs_stream_config_root
+      }}
+    _cribl_packs_list: >-
+      {{
+        cribl_packs_for_edge if cribl_packs_target == 'edge'
+        else cribl_packs_for_stream
+      }}
+
+- name: Ensure packs directory exists
+  ansible.builtin.file:
+    path: "{{ _cribl_packs_config_root }}/packs"
+    state: directory
+    owner: "{{ cribl_packs_user }}"
+    group: "{{ cribl_packs_group }}"
+    mode: "0755"
+
+# Detect installed pack versions via per-version sentinel files. We list each
+# pack's directory and compare against the desired sentinel name. Drift means
+# the desired version is not currently installed.
+- name: Stat installed-version sentinel for each pack
+  ansible.builtin.stat:
+    path: "{{ _cribl_packs_config_root }}/packs/{{ item.name }}/.{{ item.version }}.installed"
+  loop: "{{ _cribl_packs_list }}"
+  loop_control:
+    label: "{{ item.name }}"
+  register: cribl_packs_sentinel_stats
+
+- name: Remove pack directory when desired version is not installed
+  ansible.builtin.file:
+    path: "{{ _cribl_packs_config_root }}/packs/{{ item.item.name }}"
+    state: absent
+  loop: "{{ cribl_packs_sentinel_stats.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  when: not item.stat.exists
+
+- name: Recreate pack directory after pruning
+  ansible.builtin.file:
+    path: "{{ _cribl_packs_config_root }}/packs/{{ item.item.name }}"
+    state: directory
+    owner: "{{ cribl_packs_user }}"
+    group: "{{ cribl_packs_group }}"
+    mode: "0755"
+  loop: "{{ cribl_packs_sentinel_stats.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  when: not item.stat.exists
+
+- name: Download and unarchive Cribl pack
+  vars:
+    _pack_asset: "{{ item.item.name }}-{{ item.item.version }}.crbl"
+    _pack_release: "https://github.com/{{ item.item.repo }}/releases/download/{{ item.item.version }}"
+  ansible.builtin.unarchive:
+    src: "{{ _pack_release }}/{{ _pack_asset }}"
+    dest: "{{ _cribl_packs_config_root }}/packs/{{ item.item.name }}/"
+    remote_src: true
+    owner: "{{ cribl_packs_user }}"
+    group: "{{ cribl_packs_group }}"
+  loop: "{{ cribl_packs_sentinel_stats.results }}"
+  loop_control:
+    label: "{{ item.item.name }} {{ item.item.version }}"
+  when: not item.stat.exists
+  notify: "{{ 'Restart cribl edge' if cribl_packs_target == 'edge' else 'Restart cribl stream' }}"
+
+- name: Write installed-version sentinel
+  ansible.builtin.copy:
+    dest: "{{ _cribl_packs_config_root }}/packs/{{ item.item.name }}/.{{ item.item.version }}.installed"
+    content: "{{ item.item.version }}\n"
+    owner: "{{ cribl_packs_user }}"
+    group: "{{ cribl_packs_group }}"
+    mode: "0644"
+  loop: "{{ cribl_packs_sentinel_stats.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  when: not item.stat.exists

--- a/roles/cribl_packs/tasks/main.yml
+++ b/roles/cribl_packs/tasks/main.yml
@@ -44,46 +44,88 @@
     label: "{{ item.name }}"
   register: cribl_packs_sentinel_stats
 
-- name: Remove pack directory when desired version is not installed
-  ansible.builtin.file:
-    path: "{{ _cribl_packs_config_root }}/packs/{{ item.item.name }}"
-    state: absent
-  loop: "{{ cribl_packs_sentinel_stats.results }}"
-  loop_control:
-    label: "{{ item.item.name }}"
-  when: not item.stat.exists
-
-- name: Recreate pack directory after pruning
-  ansible.builtin.file:
-    path: "{{ _cribl_packs_config_root }}/packs/{{ item.item.name }}"
-    state: directory
-    owner: "{{ cribl_packs_user }}"
-    group: "{{ cribl_packs_group }}"
-    mode: "0755"
-  loop: "{{ cribl_packs_sentinel_stats.results }}"
-  loop_control:
-    label: "{{ item.item.name }}"
-  when: not item.stat.exists
-
-- name: Download and unarchive Cribl pack
-  vars:
-    _pack_asset: "{{ item.item.name }}-{{ item.item.version }}.crbl"
-    _pack_release: "https://github.com/{{ item.item.repo }}/releases/download/{{ item.item.version }}"
-  ansible.builtin.unarchive:
-    src: "{{ _pack_release }}/{{ _pack_asset }}"
-    dest: "{{ _cribl_packs_config_root }}/packs/{{ item.item.name }}/"
-    remote_src: true
-    owner: "{{ cribl_packs_user }}"
-    group: "{{ cribl_packs_group }}"
+# Download pack assets on the Ansible controller (unrestricted egress).
+# Cribl Edge/Stream LXCs are in the outbound-internal firewall group
+# (RFC1918-only), so they cannot reach github.com directly. The controller
+# fetches the .crbl asset and Ansible's copy/unarchive mechanism transfers
+# it to the target — matching the pattern used by the minio role for Cribl
+# tarballs.
+#
+# ansible_become: false (via vars:) is REQUIRED. Task-level `become: false`
+# alone is insufficient on Ansible 2.19: the play's `become: true` is
+# inherited on delegated tasks, causing `sudo: a password is required` on
+# the controller. Setting ansible_become via task vars explicitly overrides
+# the inherited value.
+- name: Download pack asset to controller
+  ansible.builtin.get_url:
+    url: >-
+      https://github.com/{{ item.item.repo }}/releases/download/{{
+      item.item.version }}/{{ item.item.name }}-{{ item.item.version }}.crbl
+    dest: "/tmp/cribl-pack-{{ inventory_hostname }}-{{ item.item.name }}-{{ item.item.version }}.crbl"
+    mode: "0644"
+    force: true
   loop: "{{ cribl_packs_sentinel_stats.results }}"
   loop_control:
     label: "{{ item.item.name }} {{ item.item.version }}"
   when: not item.stat.exists
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+
+# Extract to a temporary directory first so that a failed download or
+# extraction does not leave the host with a missing or partially-extracted
+# pack. Only once extraction succeeds is the live pack directory replaced
+# via an atomic rename.
+- name: Create temporary extraction directory for each pack
+  ansible.builtin.tempfile:
+    state: directory
+    suffix: "-cribl-pack-{{ item.item.name }}"
+    path: "{{ _cribl_packs_config_root }}/packs"
+  loop: "{{ cribl_packs_sentinel_stats.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  when: not item.stat.exists
+  register: cribl_packs_tmp_dirs
+
+- name: Unarchive pack into temporary directory
+  ansible.builtin.unarchive:
+    src: "/tmp/cribl-pack-{{ inventory_hostname }}-{{ item.item.item.name }}-{{ item.item.item.version }}.crbl"
+    dest: "{{ item.path }}"
+    owner: "{{ cribl_packs_user }}"
+    group: "{{ cribl_packs_group }}"
+  loop: "{{ cribl_packs_tmp_dirs.results }}"
+  loop_control:
+    label: "{{ item.item.item.name }} {{ item.item.item.version }}"
+  when: not (item.skipped | default(false))
+
+- name: Remove existing pack directory before atomic replace
+  ansible.builtin.file:
+    path: "{{ _cribl_packs_config_root }}/packs/{{ item.item.item.name }}"
+    state: absent
+  loop: "{{ cribl_packs_tmp_dirs.results }}"
+  loop_control:
+    label: "{{ item.item.item.name }}"
+  when: not (item.skipped | default(false))
+
+- name: Move extracted pack into place
+  ansible.builtin.command:
+    cmd: >-
+      mv {{ item.path }}
+      {{ _cribl_packs_config_root }}/packs/{{ item.item.item.name }}
+  loop: "{{ cribl_packs_tmp_dirs.results }}"
+  loop_control:
+    label: "{{ item.item.item.name }}"
+  when: not (item.skipped | default(false))
+  changed_when: true
   notify: "{{ 'Restart cribl edge' if cribl_packs_target == 'edge' else 'Restart cribl stream' }}"
 
 - name: Write installed-version sentinel
   ansible.builtin.copy:
-    dest: "{{ _cribl_packs_config_root }}/packs/{{ item.item.name }}/.{{ item.item.version }}.installed"
+    dest: >-
+      {{ _cribl_packs_config_root }}/packs/{{
+      item.item.name }}/.{{ item.item.version }}.installed
     content: "{{ item.item.version }}\n"
     owner: "{{ cribl_packs_user }}"
     group: "{{ cribl_packs_group }}"
@@ -92,3 +134,17 @@
   loop_control:
     label: "{{ item.item.name }}"
   when: not item.stat.exists
+
+- name: Remove pack staging files from controller
+  ansible.builtin.file:
+    path: "/tmp/cribl-pack-{{ inventory_hostname }}-{{ item.item.name }}-{{ item.item.version }}.crbl"
+    state: absent
+  loop: "{{ cribl_packs_sentinel_stats.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  when: not item.stat.exists
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false

--- a/roles/cribl_packs/tasks/main.yml
+++ b/roles/cribl_packs/tasks/main.yml
@@ -48,8 +48,8 @@
 # Cribl Edge/Stream LXCs are in the outbound-internal firewall group
 # (RFC1918-only), so they cannot reach github.com directly. The controller
 # fetches the .crbl asset and Ansible's copy/unarchive mechanism transfers
-# it to the target — matching the pattern used by the minio role for Cribl
-# tarballs.
+# it to the target — matching the controller-stage-then-copy pattern used
+# by the artifact-mirror role for Cribl tarballs.
 #
 # ansible_become: false (via vars:) is REQUIRED. Task-level `become: false`
 # alone is insufficient on Ansible 2.19: the play's `become: true` is


### PR DESCRIPTION
## Summary

- Adds `cribl_packs` role to deploy three orphan Cribl packs (`cc-edge-copilot-otel`, `cc-edge-vscode-io`, `cc-stream-github-copilot-rest-io`) from GitHub releases into Cribl Edge and Stream LXCs
- Fixes CLAUDE.md service ports table (Cribl Edge API corrected to 9420, Stream API to 9000 per terraform-proxmox locals)
- Adds scheduled E2E pipeline workflow for daily validation of log pipeline (UniFi → HAProxy → Cribl → Splunk)

## Changes

- **roles/cribl_packs/** (new) - Role detects target (Edge vs Stream) from `group_names`, downloads `.crbl` asset from GitHub release, unpacks into `local/<mode>/packs/<name>/`, notifies handlers. Idempotent via per-version sentinel files; same-version reruns are no-ops. Integrated into site.yml Phase 2c (between Cribl install and HAProxy).
- **CLAUDE.md** - Service ports table corrected (Edge 9420, Stream 9000), added NetFlow port row, MinIO console row, apt-cacher-ng row, and terraform locals reference note. Includes future-proof MinIO→RustFS migration callout.
- **.github/workflows/e2e-pipeline-schedule.yml** (new) - Reusable wrapper around existing `_e2e-tests.yml`, runs daily at 08:30 UTC, gated by `E2E_RUNNERS_ENABLED` repo variable.
- **.github/workflows/gh-aw-pin-refresh.yml** - Fix: added missing YAML document start (`---`)
- **playbooks/site.yml** - Phase 2c slot added for `cribl_packs` role

## Test Plan

- [ ] `ansible-lint roles/cribl_packs/ playbooks/site.yml` passes (production profile)
- [ ] CI: Ansible Lint and Molecule jobs pass
- [ ] Post-merge: deploy to live Cribl LXCs via `playbooks/site.yml`
- [ ] Verify packs present in `/opt/cribl/local/<mode>/packs/<name>/` with correct version sentinel
- [ ] Manually trigger `E2E Pipeline Schedule` workflow; confirm pytest tests pass
- [ ] GitHub Copilot REST pack: verify collectors present and disabled by default (manual enablement required)

Generated with [Claude Code](https://claude.com/claude-code)