### PR TITLE
feat(openproject): add OpenProject CE Docker-in-LXC role

### DIFF
--- a/inventory/load_terraform.yml
+++ b/inventory/load_terraform.yml
@@ -137,6 +137,11 @@
               ['technitium_dns_group']
               if 'dns' in (item.value.tags | default([]))
               else []
+            ) +
+            (
+              ['openproject_group']
+              if 'openproject' in (item.value.tags | default([]))
+              else []
             )
           }}
         proxmox_vmid: "{{ item.value.vmid }}"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -287,6 +287,25 @@
     - role: llamaindex
 
 # =============================================================================
+# Phase 8b: OpenProject Community Edition
+# Project management web app — Docker all-in-one in LXC (bundles postgres,
+# memcached, web, worker). Reachable on container_ip:80 internally; DNS A
+# record (openproject.{domain}) is auto-created by technitium_dns from
+# the hostname + container_ip in inventory.
+# =============================================================================
+
+- name: Configure OpenProject Community Edition
+  hosts: openproject_group
+  become: true
+  gather_facts: false
+  tags:
+    - openproject_docker
+    - projects
+    - collaboration
+  roles:
+    - role: openproject_docker
+
+# =============================================================================
 # Phase 9: Systemd Restart Policies
 # Apply restart-on-failure policies to all managed services
 # Each group defines its services via group_vars

--- a/roles/openproject_docker/defaults/main.yml
+++ b/roles/openproject_docker/defaults/main.yml
@@ -29,12 +29,23 @@ openproject_docker_secret_key_base: >-
      | mandatory('OPENPROJECT_SECRET_KEY_BASE must be set (openssl rand -hex 64; store in SOPS)') }}
 
 # SMTP relay — point at the existing Mailpit container.
-# Mailpit listens on its container_ip:1025 (terraform-proxmox service_ports.mailpit_smtp).
-openproject_docker_smtp_address: "{{ hostvars['mailpit']['container_ip'] | default('') }}"
+# Both values are mandatory: a silently-empty SMTP host would let the role
+# converge while email delivery is broken. Mailpit must be in the inventory
+# and the canonical port lives in constants.notification_ports.
+_openproject_docker_smtp_address_err: >-
+  mailpit container_ip not found in inventory — openproject_docker
+  requires the mailpit host so the SMTP relay address resolves.
+_openproject_docker_smtp_port_err: >-
+  terraform_data.constants.notification_ports.mailpit_smtp missing —
+  regenerate terraform_inventory.json via
+  `terragrunt output -json ansible_inventory`.
+openproject_docker_smtp_address: >-
+  {{ hostvars['mailpit']['container_ip']
+     | mandatory(_openproject_docker_smtp_address_err) }}
 openproject_docker_smtp_port: >-
   {{ hostvars['localhost']['terraform_data']
-     ['constants']['service_ports']['mailpit_smtp']
-     | default(1025) }}
+     ['constants']['notification_ports']['mailpit_smtp']
+     | mandatory(_openproject_docker_smtp_port_err) }}
 openproject_docker_smtp_domain: "{{ lookup('env', 'PROXMOX_DOMAIN') }}"
 openproject_docker_mail_from: "openproject@{{ lookup('env', 'PROXMOX_DOMAIN') }}"
 

--- a/roles/openproject_docker/defaults/main.yml
+++ b/roles/openproject_docker/defaults/main.yml
@@ -1,0 +1,49 @@
+---
+# OpenProject Community Edition (all-in-one Docker image)
+# https://www.openproject.org/docs/installation-and-operations/installation/docker/
+# The AIO image bundles PostgreSQL, memcached, web (Puma), and a background worker.
+
+openproject_docker_image: "openproject/community:15"
+openproject_docker_container_name: openproject
+openproject_docker_data_dir: /opt/openproject
+
+# AIO image listens on 80 internally; bind to host 80 so DNS A record
+# (openproject.{domain}) reaches it directly. No HTTP reverse proxy
+# exists in this repo (haproxy is TCP-only for syslog/netflow).
+openproject_docker_web_port: 80
+
+# FQDN used for cookie scoping and external URL generation.
+# Auto-derived from inventory hostname + PROXMOX_DOMAIN.
+openproject_docker_host_name: "{{ hostname }}.{{ lookup('env', 'PROXMOX_DOMAIN') }}"
+
+# HTTPS off by default — homelab serves plain HTTP over the trusted LAN.
+# Set to "true" when fronted by NPM/HAProxy with TLS termination.
+openproject_docker_https: false
+
+# SECRET_KEY_BASE: Rails session/cookie signing key.
+# MUST be stable across restarts. Generate once with:
+#   openssl rand -hex 64
+# Store in SOPS (secrets.enc.yaml) as OPENPROJECT_SECRET_KEY_BASE.
+openproject_docker_secret_key_base: >-
+  {{ lookup('env', 'OPENPROJECT_SECRET_KEY_BASE')
+     | mandatory('OPENPROJECT_SECRET_KEY_BASE must be set (openssl rand -hex 64; store in SOPS)') }}
+
+# SMTP relay — point at the existing Mailpit container.
+# Mailpit listens on its container_ip:1025 (terraform-proxmox service_ports.mailpit_smtp).
+openproject_docker_smtp_address: "{{ hostvars['mailpit']['container_ip'] | default('') }}"
+openproject_docker_smtp_port: >-
+  {{ hostvars['localhost']['terraform_data']
+     ['constants']['service_ports']['mailpit_smtp']
+     | default(1025) }}
+openproject_docker_smtp_domain: "{{ lookup('env', 'PROXMOX_DOMAIN') }}"
+openproject_docker_mail_from: "openproject@{{ lookup('env', 'PROXMOX_DOMAIN') }}"
+
+# Default seeded admin email (only used on initial container bootstrap)
+openproject_docker_admin_email: "admin@{{ lookup('env', 'PROXMOX_DOMAIN') }}"
+
+# Locale and rails env
+openproject_docker_default_language: en
+openproject_docker_rails_env: production
+
+# Worker count (forked Puma workers). 2 is plenty for a homelab.
+openproject_docker_web_concurrency: 2

--- a/roles/openproject_docker/handlers/main.yml
+++ b/roles/openproject_docker/handlers/main.yml
@@ -9,3 +9,5 @@
     project_src: "{{ openproject_docker_data_dir }}"
     state: present
     recreate: always
+  vars:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python

--- a/roles/openproject_docker/handlers/main.yml
+++ b/roles/openproject_docker/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Restart docker
+  ansible.builtin.systemd:
+    name: docker
+    state: restarted
+
+- name: Restart openproject
+  community.docker.docker_compose_v2:
+    project_src: "{{ openproject_docker_data_dir }}"
+    state: present
+    recreate: always

--- a/roles/openproject_docker/meta/main.yml
+++ b/roles/openproject_docker/meta/main.yml
@@ -1,0 +1,25 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: Deploy OpenProject Community Edition as an all-in-one Docker container in LXC
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+
+  galaxy_tags:
+    - openproject
+    - docker
+    - projects
+    - collaboration
+
+dependencies: []
+  # community.docker collection is specified in requirements.yml

--- a/roles/openproject_docker/tasks/main.yml
+++ b/roles/openproject_docker/tasks/main.yml
@@ -1,0 +1,191 @@
+---
+# OpenProject Community Edition Deployment Tasks
+# Deploys the OpenProject all-in-one Docker image in an LXC container.
+# The AIO image bundles PostgreSQL, memcached, web (Puma), and a worker.
+
+# =============================================================================
+# Docker Installation
+# =============================================================================
+
+- name: Gather OS facts
+  ansible.builtin.setup:
+    filter: ansible_distribution*
+
+- name: Install Docker prerequisites
+  ansible.builtin.apt:
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg
+      - lsb-release
+    state: present
+    update_cache: true
+
+- name: Create keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+
+- name: Set Docker repository distribution
+  ansible.builtin.set_fact:
+    openproject_docker_distro: "{{ ansible_distribution | lower }}"
+
+- name: Add Docker GPG key
+  ansible.builtin.get_url:
+    url: "https://download.docker.com/linux/{{ openproject_docker_distro }}/gpg"
+    dest: /etc/apt/keyrings/docker.asc
+    mode: "0644"
+    force: false
+
+- name: Add Docker repository
+  ansible.builtin.apt_repository:
+    repo: >-
+      deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc]
+      https://download.docker.com/linux/{{ openproject_docker_distro }}
+      {{ ansible_distribution_release }} stable
+    state: present
+    filename: docker
+
+- name: Install Docker packages
+  ansible.builtin.apt:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-buildx-plugin
+      - docker-compose-plugin
+    state: present
+    update_cache: true
+
+- name: Install fuse-overlayfs for Docker on ZFS-backed LXC containers
+  ansible.builtin.apt:
+    name: fuse-overlayfs
+    state: present
+
+- name: Configure Docker to use fuse-overlayfs storage driver (required for ZFS-backed LXC)
+  ansible.builtin.copy:
+    dest: /etc/docker/daemon.json
+    content: |
+      {
+        "storage-driver": "fuse-overlayfs"
+      }
+    owner: root
+    group: root
+    mode: "0644"
+  register: openproject_docker_daemon_config
+
+- name: Restart Docker to apply fuse-overlayfs configuration
+  ansible.builtin.systemd:  # noqa: no-handler
+    name: docker
+    state: restarted
+  when: openproject_docker_daemon_config.changed
+
+- name: Ensure Docker service is running
+  ansible.builtin.systemd:
+    name: docker
+    state: started
+    enabled: true
+
+# =============================================================================
+# Data Directories
+# The AIO image runs internally as the `app` user (UID 1000). The pgdata and
+# assets subdirectories must be writable by that UID. In an unprivileged LXC,
+# host UID 1000 is mapped to a high-numbered subuid (e.g. 101000), so we
+# chown to 1000:1000 inside the LXC, which translates correctly.
+# =============================================================================
+
+- name: Create OpenProject data subdirectories
+  ansible.builtin.file:
+    path: "{{ openproject_docker_data_dir }}/{{ item }}"
+    state: directory
+    owner: "1000"
+    group: "1000"
+    mode: "0755"
+  loop:
+    - pgdata
+    - assets
+
+# =============================================================================
+# Docker Compose Configuration
+# =============================================================================
+
+- name: Deploy OpenProject docker-compose template
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ openproject_docker_data_dir }}/docker-compose.yml"
+    owner: root
+    group: root
+    mode: "0640"
+  no_log: true
+  notify: Restart openproject
+
+# =============================================================================
+# Python venv for Ansible Docker modules
+# =============================================================================
+
+- name: Install Python venv and pip for dependencies
+  ansible.builtin.apt:
+    name:
+      - python3-pip
+      - python3-venv
+      - python3-full
+    state: present
+    update_cache: true
+
+- name: Create virtualenv for Ansible Python dependencies
+  ansible.builtin.pip:
+    name:
+      - docker
+    state: present
+    virtualenv: /opt/ansible-venv
+    virtualenv_command: python3 -m venv
+
+- name: Set Python interpreter to use venv for subsequent tasks
+  ansible.builtin.set_fact:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python
+
+# =============================================================================
+# Deploy via Docker Compose
+# =============================================================================
+
+- name: Check if openproject container is running
+  ansible.builtin.command: docker ps -q --filter name={{ openproject_docker_container_name }} --filter status=running
+  register: openproject_docker_running_check
+  changed_when: false
+  failed_when: false
+
+- name: Clean stale Docker state before fresh deployment
+  ansible.builtin.command: docker system prune -af --volumes
+  when: openproject_docker_running_check.stdout == ''
+  changed_when: true
+
+- name: Deploy OpenProject via docker compose
+  community.docker.docker_compose_v2:
+    project_src: "{{ openproject_docker_data_dir }}"
+    state: present
+
+# =============================================================================
+# Health Check
+# First boot can take 60-180 seconds: postgres initdb, asset precompile,
+# database migrations, default data seed.
+# =============================================================================
+
+- name: Wait for OpenProject web port to accept TCP connections
+  ansible.builtin.wait_for:
+    host: 127.0.0.1
+    port: "{{ openproject_docker_web_port }}"
+    timeout: 300
+
+- name: Verify OpenProject health endpoint
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ openproject_docker_web_port }}/health_checks/default"
+    method: GET
+    status_code: 200
+    return_content: false
+  register: openproject_docker_health
+  retries: 30
+  delay: 10
+  until: openproject_docker_health.status == 200
+  changed_when: false

--- a/roles/openproject_docker/tasks/main.yml
+++ b/roles/openproject_docker/tasks/main.yml
@@ -142,12 +142,11 @@
     virtualenv: /opt/ansible-venv
     virtualenv_command: python3 -m venv
 
-- name: Set Python interpreter to use venv for subsequent tasks
-  ansible.builtin.set_fact:
-    ansible_python_interpreter: /opt/ansible-venv/bin/python
-
 # =============================================================================
 # Deploy via Docker Compose
+# Note: ansible_python_interpreter is set as a task-level var (not via set_fact)
+# so the venv interpreter does NOT leak to subsequent plays (e.g. Phase 9
+# systemd_restart_policy) that need system Python for apt/dbus.
 # =============================================================================
 
 - name: Check if openproject container is running
@@ -165,6 +164,9 @@
   community.docker.docker_compose_v2:
     project_src: "{{ openproject_docker_data_dir }}"
     state: present
+  no_log: true
+  vars:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python
 
 # =============================================================================
 # Health Check

--- a/roles/openproject_docker/templates/docker-compose.yml.j2
+++ b/roles/openproject_docker/templates/docker-compose.yml.j2
@@ -1,0 +1,29 @@
+---
+services:
+  openproject:
+    image: "{{ openproject_docker_image }}"
+    container_name: "{{ openproject_docker_container_name }}"
+    restart: unless-stopped
+    ports:
+      - "{{ openproject_docker_web_port }}:80"
+    environment:
+      # Core
+      OPENPROJECT_HOST__NAME: "{{ openproject_docker_host_name }}"
+      OPENPROJECT_HTTPS: "{{ openproject_docker_https | lower }}"
+      OPENPROJECT_DEFAULT__LANGUAGE: "{{ openproject_docker_default_language }}"
+      RAILS_ENV: "{{ openproject_docker_rails_env }}"
+      SECRET_KEY_BASE: "{{ openproject_docker_secret_key_base }}"
+      WEB_CONCURRENCY: "{{ openproject_docker_web_concurrency }}"
+      # Initial admin (only consumed on first bootstrap)
+      OPENPROJECT_SEED__ADMIN__USER__MAIL: "{{ openproject_docker_admin_email }}"
+      # SMTP — relay through Mailpit
+      OPENPROJECT_EMAIL__DELIVERY__METHOD: smtp
+      OPENPROJECT_SMTP__ADDRESS: "{{ openproject_docker_smtp_address }}"
+      OPENPROJECT_SMTP__PORT: "{{ openproject_docker_smtp_port }}"
+      OPENPROJECT_SMTP__DOMAIN: "{{ openproject_docker_smtp_domain }}"
+      OPENPROJECT_SMTP__AUTHENTICATION: none
+      OPENPROJECT_SMTP__ENABLE__STARTTLS__AUTO: "false"
+      OPENPROJECT_MAIL__FROM: "{{ openproject_docker_mail_from }}"
+    volumes:
+      - "{{ openproject_docker_data_dir }}/pgdata:/var/openproject/pgdata"
+      - "{{ openproject_docker_data_dir }}/assets:/var/openproject/assets"

--- a/roles/openproject_docker/templates/docker-compose.yml.j2
+++ b/roles/openproject_docker/templates/docker-compose.yml.j2
@@ -12,7 +12,7 @@ services:
       OPENPROJECT_HTTPS: "{{ openproject_docker_https | lower }}"
       OPENPROJECT_DEFAULT__LANGUAGE: "{{ openproject_docker_default_language }}"
       RAILS_ENV: "{{ openproject_docker_rails_env }}"
-      SECRET_KEY_BASE: "{{ openproject_docker_secret_key_base }}"
+      OPENPROJECT_SECRET_KEY_BASE: "{{ openproject_docker_secret_key_base }}"
       WEB_CONCURRENCY: "{{ openproject_docker_web_concurrency }}"
       # Initial admin (only consumed on first bootstrap)
       OPENPROJECT_SEED__ADMIN__USER__MAIL: "{{ openproject_docker_admin_email }}"

--- a/secrets.enc.yaml.example
+++ b/secrets.enc.yaml.example
@@ -46,3 +46,9 @@ MSSQL_SA_PASSWORD: your-strong-sa-password-here
 
 # Qdrant Vector Database
 QDRANT_API_KEY: your-qdrant-api-key-here
+
+# OpenProject Community Edition
+# Generate with: openssl rand -hex 64
+# This value MUST be stable across restarts — rotating it invalidates all
+# Rails sessions and existing cookies.
+OPENPROJECT_SECRET_KEY_BASE: your-128-char-hex-secret-here

--- a/tests/inventory_load/terraform_inventory.json
+++ b/tests/inventory_load/terraform_inventory.json
@@ -109,6 +109,16 @@
       "tags": ["terraform", "container", "push", "notifications"],
       "node": "pve",
       "pool_id": "homelab"
+    },
+    "openproject": {
+      "vmid": 140,
+      "ip": "192.168.0.140",
+      "hostname": "openproject",
+      "ansible_connection": "community.proxmox.proxmox_pct_remote",
+      "ansible_pct_vmid": 140,
+      "tags": ["terraform", "container", "openproject", "projects", "docker"],
+      "node": "pve",
+      "pool_id": "infrastructure"
     }
   },
   "vms": {},

--- a/tests/inventory_load/verify_inventory.yml
+++ b/tests/inventory_load/verify_inventory.yml
@@ -86,6 +86,7 @@
           - "'llamaindex' in groups['lxc_containers']"
           - "'mailpit' in groups['lxc_containers']"
           - "'ntfy' in groups['lxc_containers']"
+          - "'openproject' in groups['lxc_containers']"
         fail_msg: >-
           lxc_containers group is missing terraform hosts;
           current members: {{ groups['lxc_containers'] | default([]) | join(', ') }}
@@ -197,6 +198,15 @@
           ntfy_group should contain 'ntfy' (push tag);
           got {{ groups['ntfy_group'] | default([]) }}
 
+    - name: Verify openproject is in openproject_group
+      ansible.builtin.assert:
+        that:
+          - groups['openproject_group'] is defined
+          - "'openproject' in groups['openproject_group']"
+        fail_msg: >-
+          openproject_group should contain 'openproject' (openproject tag);
+          got {{ groups['openproject_group'] | default([]) }}
+
     - name: Display group membership summary
       ansible.builtin.debug:
         msg: |
@@ -213,3 +223,4 @@
           - llamaindex_group:    {{ groups['llamaindex_group'] | default([]) | join(', ') }}
           - mailpit_group:      {{ groups['mailpit_group'] | default([]) | join(', ') }}
           - ntfy_group:         {{ groups['ntfy_group'] | default([]) | join(', ') }}
+          - openproject_group:  {{ groups['openproject_group'] | default([]) | join(', ') }}

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -345,3 +345,99 @@
           Ntfy template assertions passed:
           - docker-compose.yml.j2: HTTP port 8080:80, image, config mount
           - server.yml.j2: cache-file, listen-http, cache-duration
+
+- name: Render and verify openproject_docker templates
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    # Mirror roles/openproject_docker/defaults/main.yml
+    openproject_docker_image: "openproject/community:15"
+    openproject_docker_container_name: openproject
+    openproject_docker_data_dir: /opt/openproject
+    openproject_docker_web_port: 80
+    openproject_docker_host_name: "openproject.test.example.com"
+    openproject_docker_https: false
+    openproject_docker_secret_key_base: "test-secret-key-base-placeholder-do-not-use-in-production"
+    openproject_docker_smtp_address: "192.168.0.110"
+    openproject_docker_smtp_port: 1025
+    openproject_docker_smtp_domain: "test.example.com"
+    openproject_docker_mail_from: "openproject@test.example.com"
+    openproject_docker_admin_email: "admin@test.example.com"
+    openproject_docker_default_language: en
+    openproject_docker_rails_env: production
+    openproject_docker_web_concurrency: 2
+    _template_dir: "../../roles/openproject_docker/templates"
+
+  tasks:
+    - name: Render openproject docker-compose.yml.j2 to /tmp
+      ansible.builtin.template:
+        src: "{{ _template_dir }}/docker-compose.yml.j2"
+        dest: /tmp/test_openproject_compose.yml
+        mode: "0644"
+
+    - name: Read rendered openproject docker-compose.yml
+      ansible.builtin.slurp:
+        src: /tmp/test_openproject_compose.yml
+      register: _openproject_compose_raw
+
+    - name: Decode openproject compose content
+      ansible.builtin.set_fact:
+        _openproject_compose: "{{ _openproject_compose_raw.content | b64decode }}"
+
+    - name: Assert openproject compose references expected image
+      ansible.builtin.assert:
+        that:
+          - "'openproject/community:15' in _openproject_compose"
+        fail_msg: "openproject docker-compose.yml.j2 does not reference expected image"
+
+    - name: Assert openproject compose publishes web port 80
+      ansible.builtin.assert:
+        that:
+          - "'80:80' in _openproject_compose"
+        fail_msg: "openproject docker-compose.yml.j2 missing web port mapping 80:80"
+
+    - name: Assert openproject compose uses OPENPROJECT_-prefixed secret env var
+      ansible.builtin.assert:
+        that:
+          - "'OPENPROJECT_SECRET_KEY_BASE' in _openproject_compose"
+        fail_msg: >-
+          openproject docker-compose.yml.j2 must pass the secret as
+          OPENPROJECT_SECRET_KEY_BASE (the OpenProject image config layer
+          expects the OPENPROJECT_ prefix)
+
+    - name: Assert openproject compose configures SMTP env vars
+      ansible.builtin.assert:
+        that:
+          - "'OPENPROJECT_SMTP__ADDRESS' in _openproject_compose"
+          - "'OPENPROJECT_SMTP__PORT' in _openproject_compose"
+          - "'192.168.0.110' in _openproject_compose"
+        fail_msg: >-
+          openproject docker-compose.yml.j2 missing SMTP relay env vars
+          (OPENPROJECT_SMTP__ADDRESS / __PORT) or SMTP host substitution
+
+    - name: Assert openproject compose mounts persistent volumes
+      ansible.builtin.assert:
+        that:
+          - "'/opt/openproject/pgdata:/var/openproject/pgdata' in _openproject_compose"
+          - "'/opt/openproject/assets:/var/openproject/assets' in _openproject_compose"
+        fail_msg: >-
+          openproject docker-compose.yml.j2 missing required persistent
+          volume mounts for pgdata and assets
+
+    - name: Assert openproject compose sets OPENPROJECT_HOST__NAME
+      ansible.builtin.assert:
+        that:
+          - "'OPENPROJECT_HOST__NAME' in _openproject_compose"
+          - "'openproject.test.example.com' in _openproject_compose"
+        fail_msg: >-
+          openproject docker-compose.yml.j2 missing OPENPROJECT_HOST__NAME
+          or did not substitute the FQDN
+
+    - name: OpenProject template rendering PASSED
+      ansible.builtin.debug:
+        msg: |
+          OpenProject template assertions passed:
+          - docker-compose.yml.j2: image, port 80:80, OPENPROJECT_SECRET_KEY_BASE,
+            SMTP env vars, persistent volumes, host name


### PR DESCRIPTION
## Summary

Adds the `openproject_docker` Ansible role to deploy [OpenProject Community Edition](https://www.openproject.org/) onto the LXC container provisioned by [terraform-proxmox#284](https://github.com/JacobPEvans/terraform-proxmox/pull/284) (vmid 140, tagged `openproject`).

Uses the official **all-in-one** Docker image (`openproject/community:15`) which bundles PostgreSQL, memcached, Puma web, and a background worker into a single container — appropriate for a homelab where the multi-service compose stack is overkill. Mirrors the existing `mailpit_docker` role pattern for consistency (Docker install, fuse-overlayfs for ZFS-backed LXC, docker-compose-v2 deploy, TCP + HTTP health checks).

## Changes

- `roles/openproject_docker/` — new role
  - `tasks/main.yml`: install Docker + fuse-overlayfs, create `pgdata`/`assets` subdirs with UID 1000 ownership (AIO image's `app` user), template compose, deploy, wait + verify `/health_checks/default`
  - `templates/docker-compose.yml.j2`: AIO image, bind to host port 80, persistent volumes on the 50 GB `/opt/openproject` mount, SMTP relays through the existing Mailpit container, SECRET_KEY_BASE from env
  - `defaults/main.yml`, `meta/main.yml`, `handlers/main.yml`: standard
- `inventory/load_terraform.yml`: route containers carrying the `openproject` tag into a new `openproject_group`
- `playbooks/site.yml`: add **Phase 8b** play binding the role to that group

## What this does NOT include

- **TLS / HTTPS**: HAProxy in this repo is TCP-only (syslog/netflow). OpenProject is reachable on plain HTTP at `http://openproject.{domain}:80` over the trusted LAN. TLS termination via NPM (or a future HTTP reverse proxy) is a separate effort.
- **DNS A record**: already auto-handled by `technitium_dns` from inventory `hostname` + `container_ip`. No work needed here.
- **Backups, log forwarding (Splunk/Cribl), metrics** — tracked as follow-up issues.

## Prerequisites for first apply

`OPENPROJECT_SECRET_KEY_BASE` must be present in SOPS (`secrets.enc.yaml`). Generate once:

```bash
openssl rand -hex 64
```

The same value must persist across restarts — Rails will invalidate all sessions/cookies otherwise.

## Test plan

- [x] `yamllint roles/openproject_docker/ playbooks/site.yml inventory/load_terraform.yml` — clean
- [x] `ansible-lint roles/openproject_docker/` — 0 failures, production profile
- [x] `ansible-playbook playbooks/site.yml --syntax-check` — clean; `openproject_group` recognized
- [x] `pre-commit run` on changed files — all checks pass
- [ ] After [terraform-proxmox#284](https://github.com/JacobPEvans/terraform-proxmox/pull/284) merges and `terragrunt apply` provisions vmid 140: `ansible-playbook playbooks/site.yml --limit openproject_group --check --diff`
- [ ] `ansible-playbook playbooks/site.yml --limit openproject_group` runs idempotently (second run reports 0 changes)
- [ ] `curl http://openproject.{domain}/health_checks/default` returns 200
- [ ] Browser login at `http://openproject.{domain}` prompts for admin password reset

Related: JacobPEvans/terraform-proxmox#284