### PR TITLE
chore(sops): bootstrap secrets.enc.yaml with OpenProject signing key

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -9,7 +9,9 @@ exclude_paths:
   - .venv
   - venv
   # SOPS-encrypted files are opaque ciphertext + metadata; linting is meaningless.
-  - secrets.enc.yaml
+  # Match the `.sops.yaml` rule (`\.enc\.ya?ml$`) — both .yaml and .yml.
+  - "*.enc.yaml"
+  - "*.enc.yml"
 
 # File type overrides - tell linter the correct type for files in non-standard locations
 kinds:

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -9,9 +9,10 @@ exclude_paths:
   - .venv
   - venv
   # SOPS-encrypted files are opaque ciphertext + metadata; linting is meaningless.
-  # Match the `.sops.yaml` rule (`\.enc\.ya?ml$`) — both .yaml and .yml.
-  - "*.enc.yaml"
-  - "*.enc.yml"
+  # Recursive glob matches the `.sops.yaml` rule (`\.enc\.ya?ml$`)
+  # and catches encrypted files in any subdirectory.
+  - "**/*.enc.yaml"
+  - "**/*.enc.yml"
 
 # File type overrides - tell linter the correct type for files in non-standard locations
 kinds:

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -8,6 +8,8 @@ exclude_paths:
   - .git
   - .venv
   - venv
+  # SOPS-encrypted files are opaque ciphertext + metadata; linting is meaningless.
+  - secrets.enc.yaml
 
 # File type overrides - tell linter the correct type for files in non-standard locations
 kinds:

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -4,8 +4,9 @@
 # Age key generation (one-time setup):
 #   age-keygen -o ~/.config/sops/age/keys.txt
 #
-# The public key below must match your age key. Matches the
-# ansible-proxmox and terraform-proxmox sibling repos.
+# The public key below must match your age key. It is a PUBLIC recipient
+# identifier — safe to commit. Matches the ansible-proxmox and
+# terraform-proxmox sibling repos.
 creation_rules:
   - path_regex: \.enc\.ya?ml$
     age: "age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9"

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,5 +1,11 @@
 ---
+# SOPS configuration for ansible-proxmox-apps
+#
+# Age key generation (one-time setup):
+#   age-keygen -o ~/.config/sops/age/keys.txt
+#
+# The public key below must match your age key. Matches the
+# ansible-proxmox and terraform-proxmox sibling repos.
 creation_rules:
   - path_regex: \.enc\.ya?ml$
-    age: >-
-      age1your-public-key-here
+    age: "age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9"

--- a/.yamllint
+++ b/.yamllint
@@ -9,10 +9,11 @@ ignore: |
   .github/workflows/*.lock.yml
   .github/workflows/agentics-maintenance.yml
   # SOPS-encrypted files have long base64 lines and non-standard
-  # indentation that linting cannot meaningfully evaluate. Match the
-  # `.sops.yaml` rule (`\.enc\.ya?ml$`) — both .yaml and .yml.
-  *.enc.yaml
-  *.enc.yml
+  # indentation that linting cannot meaningfully evaluate. Recursive
+  # glob matches the `.sops.yaml` rule (`\.enc\.ya?ml$`) and catches
+  # any future encrypted files in subdirectories.
+  **/*.enc.yaml
+  **/*.enc.yml
 
 rules:
   line-length:

--- a/.yamllint
+++ b/.yamllint
@@ -8,6 +8,10 @@ ignore: |
   .github/aw/
   .github/workflows/*.lock.yml
   .github/workflows/agentics-maintenance.yml
+  # SOPS-encrypted files have long base64 lines and non-standard
+  # indentation that linting cannot meaningfully evaluate.
+  secrets.enc.yaml
+  *.enc.yaml
 
 rules:
   line-length:

--- a/.yamllint
+++ b/.yamllint
@@ -9,9 +9,10 @@ ignore: |
   .github/workflows/*.lock.yml
   .github/workflows/agentics-maintenance.yml
   # SOPS-encrypted files have long base64 lines and non-standard
-  # indentation that linting cannot meaningfully evaluate.
-  secrets.enc.yaml
+  # indentation that linting cannot meaningfully evaluate. Match the
+  # `.sops.yaml` rule (`\.enc\.ya?ml$`) — both .yaml and .yml.
   *.enc.yaml
+  *.enc.yml
 
 rules:
   line-length:

--- a/secrets.enc.yaml
+++ b/secrets.enc.yaml
@@ -1,0 +1,21 @@
+#ENC[AES256_GCM,data:FUMhEpatxWgjCalQBiCm/JH22KZlrzZa/tl7QXLCNG/JuS/arg5fLLE/CsiuJgEALA==,iv:XjfFKGyo5qnXjQdcM9pcR32AC1ET/iHvq2CSTdG7WzI=,tag:3NZGL79+eysL0Yy2uWce/A==,type:comment]
+#ENC[AES256_GCM,data:3SIoqrI5ITVF6LoqQdzY3xV8lz5S+3V9jrGOOkrmYjvT,iv:CylGVU1cwraGjxOtQhfNeTk9QMOlkKQrBKUsh5KoOtc=,tag:x3s2vJ3Fy9Gm78Tk8/5xxg==,type:comment]
+#ENC[AES256_GCM,data:GTP09RDlL30N7b7rub/zQ6s9X99X3+OOHmjWz2yyGolhabX6byHRj9mFzIR5QeQN/Q==,iv:OwKxvD35TXcFNC1QcwPREy6we1836FA5nljq6mIDqoU=,tag:YIZKsS04NoVIQ1rh2PIGqA==,type:comment]
+#ENC[AES256_GCM,data:DHkdJaSQjsedpqY2rrn/TrbRiQoAssg6pAnNQhl6H+lCoewSMzaHGYtKK4gUeHHIFmvw+eKqVD0oHkh4yxvdRlkG,iv:I9Zq+JxiX4TTnhIHmWFfJ39ANE92eQ32OvcLtum9rmU=,tag:YmJGx1uDQOnDw23hMDRyag==,type:comment]
+#ENC[AES256_GCM,data:4/PfNrBLMQkiggZc51qttISS4Bo9GFivuXgDes10UHmViz8dMFweDrhw/4BzYMKZ07LJ41Y6pQ5ZPfqek5nUgK8l9Xg=,iv:WjXM9Tfho1wMTavVA058F9B9dSrLlviR/U5AI08BAHk=,tag:LwtHtsXMy3ufznMRTIAEWw==,type:comment]
+OPENPROJECT_SECRET_KEY_BASE: ENC[AES256_GCM,data:PXKMGU0jwSVESZtKVo0Ekl52ly5qAmwUfGx+yOrZ9E0XhoI0LKSReg2JxCcZGbe6WPDLeJxerlcJ8xcqHDaEewGvRay7SY0pM5636h63XSQdIrgj1KXd2S6rSFPDPlNZuYYBW+TgwkCNNKPPDg2ztyGFdB29mlpOVA14Mq0JD7U=,iv:vn/GbkwD7vnktaPmGr+e2mi2zDXnKctUAf878oovMfU=,tag:YKQ9MGW8lFNWWgElJpVH9g==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFUkpCZlhUbU9EVjgyTkhJ
+            NitiTlZOd2QvdnE4Y3VUdjIzaldNbXhGT21RCkd5TWhEQ1I5dDh3dUhCUmNobUIr
+            RnZ2OXF0MDgwb2prWGkxcUhsckZsUXcKLS0tIE02ZDFKb0FBVmM2OGx5YnJTYklx
+            Z3RhQjhBZWZzNGhHQ1g0QytpbStoTDQKifyhMCeddKVDkstLc1Jmz2FirNYsq4gc
+            yB3E157iHA3Qn3eYx7vfSFrviMIZFhWdAsVZ821y/cDXeUfG0yU33g==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
+    lastmodified: "2026-05-13T22:33:03Z"
+    mac: ENC[AES256_GCM,data:sFIUq3Ur+U/7FK3cfJGo60Zavw7xhnDPUapgN2ECBWOWxIy8Ma8t4CYahVlWFRiqd5Osuqtw9Y8MHGf+jLXOChpHBBgr0x826sbQVXmoBiyAh8uJ9ua6z4n3JwI8w/pADpDfX+aXC6sraqd2N5GalLoKNjkdptbvhIVUz9YBnPo=,iv:yrZiXRvM9tNhQtFRhEfAFs/d8VBv2RRAYeRPshO5jZE=,tag:wqYtSgHqElgIcfe9eYQ8/Q==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.0


### PR DESCRIPTION
## Summary

Bootstrap the SOPS-encrypted secrets file that the merged [`openproject_docker`](https://github.com/JacobPEvans/ansible-proxmox-apps/pull/244) role requires.

After PR #244 merged, the OpenProject role looks up `OPENPROJECT_SECRET_KEY_BASE` from the environment via `sops exec-env secrets.enc.yaml ...`. That file didn't exist in the repo (PR #45 added the SOPS scaffolding but no secrets blob was ever committed) and `.sops.yaml` still had a placeholder age recipient. This PR fixes both.

## Changes

1. **`.sops.yaml`** — replace the placeholder `age1your-public-key-here` with the actual public key (`age1y0jvt...88tp9`). Matches the existing config in the `ansible-proxmox` and `terraform-proxmox` sibling repos.
2. **`secrets.enc.yaml`** — new file, encrypted with `sops` + age. Contains a freshly generated 128-char hex `OPENPROJECT_SECRET_KEY_BASE` (via `openssl rand -hex 64`). The plaintext was never written to a tracked file; round-trip was verified by decrypting and asserting on length (128) + hex shape, never on the value itself.
3. **`.yamllint` / `.ansible-lint`** — exclude `*.enc.yaml` from linting. SOPS encrypted output has long base64 lines and non-standard indentation by design, so lint signals on it are noise.

## How the key was generated

```bash
OPENPROJECT_KEY=$(openssl rand -hex 64)
# wrote secrets.enc.yaml plaintext with that one value, then:
sops --encrypt --in-place secrets.enc.yaml
# verified: sops --decrypt | python -c 'len = 128, all hex = True'
```

## Out of scope (for follow-up)

`secrets.enc.yaml` currently contains only `OPENPROJECT_SECRET_KEY_BASE`. Other role-required env vars listed in `secrets.enc.yaml.example` (`MAILPIT_*`, `SPLUNK_*`, `MSSQL_SA_PASSWORD`, `QDRANT_API_KEY`, etc.) are not yet in the encrypted file — presumably they currently come from Doppler or shell env. Add them interactively with `sops secrets.enc.yaml` when needed.

## Test plan

- [x] `pre-commit run` — all hooks pass (yamllint, ansible-lint, etc.)
- [x] `sops --decrypt secrets.enc.yaml` returns valid YAML with `OPENPROJECT_SECRET_KEY_BASE` as a 128-char lowercase hex string
- [ ] After merge: `sops exec-env secrets.enc.yaml -- env | grep OPENPROJECT_SECRET_KEY_BASE` exports the value
- [ ] After merge: `ansible-playbook playbooks/site.yml --limit openproject_group` succeeds (the role's `mandatory()` check passes)

## Rotation note

This value MUST remain stable across container restarts — rotating it invalidates every existing Rails session/cookie in OpenProject. To rotate intentionally: `sops secrets.enc.yaml`, edit the value, commit, redeploy.

Related: #244, #245, #246, #247