### PR TITLE
fix(tests): roll Cribl fixture image to :latest

### DIFF
--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -18,8 +18,11 @@
   gather_facts: false
 
   vars:
-    # Mirror the role defaults (cribl_docker_stack/defaults/main.yml)
-    cribl_docker_stack_image: "cribl/cribl:4.10.1"
+    # Mirror the role defaults (cribl_docker_stack/defaults/main.yml).
+    # Role default is `cribl/cribl:latest`; this fixture tracks the same tag
+    # so the test never silently freezes on an old version (was 4.10.1, eight
+    # minor versions stale; Cribl is now at 4.18.x).
+    cribl_docker_stack_image: "cribl/cribl:latest"
     cribl_docker_stack_edge_replicas: 2
     cribl_docker_stack_edge_cpu_limit: "1"
     cribl_docker_stack_edge_memory_limit: "1024M"

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -20,8 +20,10 @@
   vars:
     # Mirror the role defaults (cribl_docker_stack/defaults/main.yml).
     # Role default is `cribl/cribl:latest`; this fixture tracks the same tag
-    # so the test never silently freezes on an old version (was 4.10.1, eight
-    # minor versions stale; Cribl is now at 4.18.x).
+    # so the test never silently freezes on an old version. The previous
+    # hand-pin (`cribl/cribl:4.10.1`) is what motivated this — by the time
+    # it was noticed, it had drifted 8 minor versions behind the role
+    # default and was no longer testing what the role actually deploys.
     cribl_docker_stack_image: "cribl/cribl:latest"
     cribl_docker_stack_edge_replicas: 2
     cribl_docker_stack_edge_cpu_limit: "1"


### PR DESCRIPTION
Roll the cribl_docker_stack template-render fixture from cribl/cribl:4.10.1 (2024-Q3, 8 minor versions stale) onto :latest, matching the role default.