### PR TITLE
fix(pre-commit): exclude release-please CHANGELOG.md from markdownlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,4 @@ repos:
     hooks:
       - id: markdownlint
         args: [--config, .markdownlint.json]
+        exclude: ^CHANGELOG\.md$


### PR DESCRIPTION
Mirrors the canonical fix from [JacobPEvans/ansible-proxmox#201](https://github.com/JacobPEvans/ansible-proxmox/pull/201) (which closes [JacobPEvans/ansible-proxmox#200](https://github.com/JacobPEvans/ansible-proxmox/issues/200)).

## Problem

The `markdownlint` pre-commit hook (`igorshubovych/markdownlint-cli`) fails on `CHANGELOG.md`, which release-please auto-generates with formatting that violates this project's markdownlint rules:

- `MD012/no-multiple-blanks`: release-please inserts two blank lines between version sections.
- `MD013/line-length`: commit/PR links (e.g., `https://github.com/.../commit/<sha>`) routinely exceed 160 chars.

The CHANGELOG is regenerated on every release-please bump, so hand-formatting it is not viable. Every push gets blocked unless the developer uses `--no-verify`, which violates the no-bypass policy.

## Fix

Add an `exclude` regex to the `markdownlint` hook to skip `CHANGELOG.md`:

```yaml
exclude: ^CHANGELOG\.md$
```

The markdownlint hook had no prior `exclude`, so this is a single-pattern regex rather than the regex union used in `ansible-proxmox`.

## Verification

```text
$ pre-commit run markdownlint --files CHANGELOG.md
markdownlint.........................................(no files to check)Skipped

$ pre-commit run markdownlint --files README.md
markdownlint.............................................................Passed
```

## Test plan

- [x] `pre-commit run markdownlint --files CHANGELOG.md` correctly skips
- [x] `pre-commit run markdownlint --files README.md` still runs and passes (no regression)
- [x] Commit is GPG-signed