### PR TITLE
chore: audit cleanup pass (2026-05-22)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ secrets.dec.yaml
 *.dec.yml
 *.decrypted.yml
 
+# Vault password files (defensive — SOPS is primary)
+.vault-pass*
+.vault-password*
+
 # IDE
 .vscode/
 .idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,10 +6,10 @@ repos:
       - id: trailing-whitespace
         exclude: '^\.github/(aw/|workflows/(.*\.lock\.yml|agentics-maintenance\.yml))|roles/.*/templates/'
       - id: end-of-file-fixer
-        exclude: '^\.github/(aw/|workflows/(.*\.lock\.yml|agentics-maintenance\.yml))|roles/.*/templates/'
+        exclude: '^\.github/(aw/|workflows/(.*\.lock\.yml|agentics-maintenance\.yml))'
       - id: check-yaml
         args: [--unsafe]
-        exclude: '^\.github/(aw/|workflows/(.*\.lock\.yml|agentics-maintenance\.yml))|roles/.*/templates/'
+        exclude: '^\.github/(aw/|workflows/(.*\.lock\.yml|agentics-maintenance\.yml))'
       - id: check-added-large-files
 
   - repo: https://github.com/adrienverge/yamllint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,12 +4,12 @@ repos:
     rev: v6.0.0
     hooks:
       - id: trailing-whitespace
-        exclude: '^\.github/(aw/|workflows/(.*\.lock\.yml|agentics-maintenance\.yml))'
+        exclude: '^\.github/(aw/|workflows/(.*\.lock\.yml|agentics-maintenance\.yml))|roles/.*/templates/'
       - id: end-of-file-fixer
-        exclude: '^\.github/(aw/|workflows/(.*\.lock\.yml|agentics-maintenance\.yml))'
+        exclude: '^\.github/(aw/|workflows/(.*\.lock\.yml|agentics-maintenance\.yml))|roles/.*/templates/'
       - id: check-yaml
         args: [--unsafe]
-        exclude: '^\.github/(aw/|workflows/(.*\.lock\.yml|agentics-maintenance\.yml))'
+        exclude: '^\.github/(aw/|workflows/(.*\.lock\.yml|agentics-maintenance\.yml))|roles/.*/templates/'
       - id: check-added-large-files
 
   - repo: https://github.com/adrienverge/yamllint

--- a/roles/cribl_edge/meta/main.yml
+++ b/roles/cribl_edge/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: Deploy Cribl Edge agent
+  license: MIT
+  min_ansible_version: "2.17"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+
+dependencies: []

--- a/roles/cribl_edge/meta/main.yml
+++ b/roles/cribl_edge/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: JacobPEvans
   description: Deploy Cribl Edge agent
   license: MIT
-  min_ansible_version: "2.17"
+  min_ansible_version: "2.14"
 
   platforms:
     - name: Debian

--- a/roles/haproxy/meta/main.yml
+++ b/roles/haproxy/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: Deploy HAProxy load balancer
+  license: MIT
+  min_ansible_version: "2.17"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+
+dependencies: []

--- a/roles/haproxy/meta/main.yml
+++ b/roles/haproxy/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: JacobPEvans
   description: Deploy HAProxy load balancer
   license: MIT
-  min_ansible_version: "2.17"
+  min_ansible_version: "2.14"
 
   platforms:
     - name: Debian


### PR DESCRIPTION
Omnibus cleanup PR from the 2026-05-22 home lab audit.

## Changes
1. Added .vault-pass* and .vault-password* to .gitignore (defensive — SOPS is primary)
2. Excluded roles/*/templates from whitespace pre-commit hooks (Jinja2 templates legitimately have trailing whitespace)
3. Added meta/main.yml for cribl_edge role
4. Added meta/main.yml for haproxy role

## Deferred to org-wide trackers
- molecule scenarios for haproxy/cribl_edge/cribl_stream — JacobPEvans/ansible-proxmox#202
- CLAUDE.md trim to ≤200 lines (currently 260) — JacobPEvans/terraform-proxmox#306
- RunsOn v3 migration on ci-gate.yml — JacobPEvans/terraform-proxmox#307
- Issue #246 (OpenProject log forwarding) belongs under the Splunk integration tracker JacobPEvans/terraform-proxmox#303

## Related trackers
- JacobPEvans/ansible-proxmox#202 Ansible role standards
- JacobPEvans/terraform-proxmox#303 Splunk integration
- JacobPEvans/terraform-proxmox#306 CLAUDE.md size
- JacobPEvans/terraform-proxmox#307 RunsOn v3