### PR TITLE
feat(e2e): add macOS Cribl Edge → Splunk freshness gate (test_macos.py)

### DIFF
--- a/.github/workflows/_e2e-tests.yml
+++ b/.github/workflows/_e2e-tests.yml
@@ -8,9 +8,15 @@ on:
 permissions:
   contents: read
 
+# One job per test file so each suite's pass/fail is independently visible
+# in the GitHub UI, logs are separate, and any data-flow suite that touches
+# the live cluster can run in parallel with the others. Smoke gates the
+# data-flow suites — no point chasing data through Splunk if Cribl/HAProxy
+# are down.
+
 jobs:
-  e2e:
-    name: Pipeline E2E Tests
+  smoke:
+    name: Smoke tests (service health)
     runs-on: [self-hosted, Linux]
     steps:
       - name: Checkout code
@@ -18,15 +24,59 @@ jobs:
 
       # Runner prerequisites: self-hosted runner is pre-baked with
       # Python 3, SOPS, age keys, and pytest. No setup steps needed.
+      - name: pytest tests/e2e/test_smoke.py
+        run: python3 -m pytest tests/e2e/test_smoke.py -v
+
+  pipeline:
+    name: Pipeline data flow
+    needs: smoke
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: Mask secrets
         uses: JacobPEvans/.github/actions/mask-secrets@main
         with:
           sops-file: secrets.enc.yaml
 
-      - name: Smoke tests (service health)
-        run: python3 -m pytest tests/e2e/test_smoke.py -v
-
-      - name: Pipeline E2E tests (data flow through HAProxy and Splunk)
+      - name: pytest tests/e2e/test_pipeline.py
         run: >-
           sops exec-env secrets.enc.yaml
-          'python3 -m pytest tests/e2e/test_pipeline.py tests/e2e/test_forwarding.py tests/e2e/test_macos.py -v'
+          'python3 -m pytest tests/e2e/test_pipeline.py -v'
+
+  forwarding:
+    name: Index routing and protocol forwarding
+    needs: smoke
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Mask secrets
+        uses: JacobPEvans/.github/actions/mask-secrets@main
+        with:
+          sops-file: secrets.enc.yaml
+
+      - name: pytest tests/e2e/test_forwarding.py
+        run: >-
+          sops exec-env secrets.enc.yaml
+          'python3 -m pytest tests/e2e/test_forwarding.py -v'
+
+  macos:
+    name: macOS pipeline freshness
+    needs: smoke
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Mask secrets
+        uses: JacobPEvans/.github/actions/mask-secrets@main
+        with:
+          sops-file: secrets.enc.yaml
+
+      - name: pytest tests/e2e/test_macos.py
+        run: >-
+          sops exec-env secrets.enc.yaml
+          'python3 -m pytest tests/e2e/test_macos.py -v'

--- a/.github/workflows/_e2e-tests.yml
+++ b/.github/workflows/_e2e-tests.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Pipeline E2E tests (data flow through HAProxy and Splunk)
         run: >-
           sops exec-env secrets.enc.yaml
-          'python3 -m pytest tests/e2e/test_pipeline.py tests/e2e/test_forwarding.py -v'
+          'python3 -m pytest tests/e2e/test_pipeline.py tests/e2e/test_forwarding.py tests/e2e/test_macos.py -v'

--- a/tests/e2e/test_macos.py
+++ b/tests/e2e/test_macos.py
@@ -1,0 +1,119 @@
+"""macOS Cribl Edge -> Cribl Cloud -> Splunk freshness gate.
+
+Verifies the macbook-m4 Cribl Edge node continues to emit events through
+Cribl Cloud and into Splunk. Catches silent chain breakage at any layer
+(Mac offline, pack misconfigured, Cribl Cloud rejecting enrollment,
+Stream pipeline broken, Splunk indexer down).
+
+Complements the Splunk silence-detector saved search in ansible-splunk —
+the saved search alerts an on-call human; this pytest test fails the
+scheduled E2E run so CI catches the same condition.
+
+Design note: this is a freshness gate, not a sentinel injection. The Mac
+pack continuously emits events (system_metrics every 60s,
+apple_unified_logs streaming), so any 5-minute window of silence is a
+real failure. Sentinel injection from a Linux runner to a Mac at a
+remote site would require either runner-to-Mac SSH or a publicly-reachable
+HEC endpoint on the Mac — both add deployment complexity without
+materially improving the failure detection signal.
+"""
+
+from .helpers import query_splunk
+
+
+class TestMacOSPipelineFreshness:
+    """Verify the macOS Cribl Edge -> Splunk chain produces fresh data."""
+
+    def test_macos_pack_events_arrive(self, splunk_creds):
+        """Assert at least one macOS pack event landed in Splunk in the
+        last 5 minutes.
+
+        Searches both indexes the pack routes to (``os`` for log events,
+        ``mac_perf`` for metric snapshots) and matches any ``macos:*``
+        sourcetype set by the pack's main pipeline.
+        """
+        mgmt_url, user, password = splunk_creds
+        search_str = (
+            "search (index=os OR index=mac_perf) sourcetype=macos:* "
+            "earliest=-5m | head 5"
+        )
+        result = query_splunk(
+            mgmt_url, user, password, search_str, timeout=30
+        )
+        results = result.get("results", [])
+        assert results, (
+            "macbook-m4 Cribl Edge -> Cloud -> Splunk chain appears broken: "
+            "no events with sourcetype=macos:* in (os OR mac_perf) within "
+            "the last 5 minutes. Investigate: Cribl Edge daemon on macbook-m4, "
+            "Cribl Cloud enrollment status, Cribl Stream pipelines, and "
+            "Splunk HEC ingestion."
+        )
+
+    def test_macos_native_sources_emitting(self, splunk_creds):
+        """Assert both 4.18 native Source types are emitting data.
+
+        Verifies the pack's apple_unified_logs and system_metrics sources
+        are actually producing events, not just any macOS sourcetype.
+        Catches the case where one native source is enabled but stuck.
+
+        Uses tstats on the indexed sourcetype field so the search is cheap
+        even over a multi-hour window.
+        """
+        mgmt_url, user, password = splunk_creds
+        search_str = (
+            "| tstats count WHERE "
+            "(index=os OR index=mac_perf) earliest=-15m "
+            "BY sourcetype | search "
+            'sourcetype IN ("macos:unified_log", "macos:system:*")'
+        )
+        result = query_splunk(
+            mgmt_url, user, password, search_str, timeout=30
+        )
+        results = result.get("results", [])
+        sourcetypes_seen = {row.get("sourcetype") for row in results}
+
+        assert any(
+            st == "macos:unified_log" for st in sourcetypes_seen
+        ), (
+            "apple_unified_logs source not emitting: no events with "
+            "sourcetype=macos:unified_log in last 15m. The native Cribl 4.18 "
+            "apple_unified_logs Source on macbook-m4 may be misconfigured "
+            "or the daemon predicate is filtering everything out."
+        )
+        assert any(
+            st.startswith("macos:system:") for st in sourcetypes_seen
+        ), (
+            "system_metrics source not emitting: no events with "
+            "sourcetype=macos:system:* in last 15m. The native Cribl 4.18 "
+            "system_metrics Source on macbook-m4 may be misconfigured."
+        )
+
+    def test_macos_pack_recently_active(self, splunk_creds):
+        """Latest event timestamp on the chain is within the last 5 minutes.
+
+        Stricter than ``test_macos_pack_events_arrive``: instead of "any
+        event in 5m", asserts the freshest event is recent. Catches
+        backed-up pipelines where old events keep arriving long after
+        the source went silent.
+        """
+        mgmt_url, user, password = splunk_creds
+        search_str = (
+            "| tstats latest(_time) as last_seen WHERE "
+            "(index=os OR index=mac_perf) sourcetype=macos:* "
+            "| eval seconds_ago = now() - last_seen | head 1"
+        )
+        result = query_splunk(
+            mgmt_url, user, password, search_str, timeout=30
+        )
+        results = result.get("results", [])
+        assert results, (
+            "tstats returned no rows for macOS pack events — index may "
+            "be empty or the pack may have never emitted data"
+        )
+
+        seconds_ago = float(results[0].get("seconds_ago", "inf"))
+        assert seconds_ago < 300, (
+            f"newest macbook-m4 pack event is {seconds_ago:.0f}s old "
+            f"(threshold: 300s). Chain appears to have backed up or "
+            f"stalled between Edge and Splunk."
+        )

--- a/tests/e2e/test_macos.py
+++ b/tests/e2e/test_macos.py
@@ -60,11 +60,14 @@ class TestMacOSPipelineFreshness:
         even over a multi-hour window.
         """
         mgmt_url, user, password = splunk_creds
+        # Splunk's IN(...) operator does not support wildcards — its
+        # arguments are matched literally. Use OR'd sourcetype clauses so
+        # `macos:system:*` expands as a glob on the indexed sourcetype.
         search_str = (
             "| tstats count WHERE "
             "(index=os OR index=mac_perf) earliest=-15m "
-            "BY sourcetype | search "
-            'sourcetype IN ("macos:unified_log", "macos:system:*")'
+            "(sourcetype=macos:unified_log OR sourcetype=macos:system:*) "
+            "BY sourcetype"
         )
         result = query_splunk(
             mgmt_url, user, password, search_str, timeout=30
@@ -97,9 +100,15 @@ class TestMacOSPipelineFreshness:
         the source went silent.
         """
         mgmt_url, user, password = splunk_creds
+        # `tstats latest(...) WHERE ...` without a BY clause always emits
+        # a single row even when no events match (the aggregate is null),
+        # so the row count alone is not a freshness signal. Filter out the
+        # null case with `where isnotnull(last_seen)` so the assertion below
+        # actually detects a never-indexed pack vs. a stalled one.
         search_str = (
             "| tstats latest(_time) as last_seen WHERE "
             "(index=os OR index=mac_perf) sourcetype=macos:* "
+            "| where isnotnull(last_seen) "
             "| eval seconds_ago = now() - last_seen | head 1"
         )
         result = query_splunk(
@@ -107,11 +116,19 @@ class TestMacOSPipelineFreshness:
         )
         results = result.get("results", [])
         assert results, (
-            "tstats returned no rows for macOS pack events — index may "
-            "be empty or the pack may have never emitted data"
+            "no macOS pack events ever indexed in (index=os OR index=mac_perf): "
+            "the pack may have never emitted data, or the indexes do not "
+            "exist yet"
         )
 
-        seconds_ago = float(results[0].get("seconds_ago", "inf"))
+        # tstats can emit null/missing aggregates even after the filter when
+        # the underlying index has no data — coerce defensively.
+        raw_seconds_ago = results[0].get("seconds_ago")
+        assert raw_seconds_ago not in (None, ""), (
+            f"tstats returned a row but seconds_ago is empty "
+            f"({raw_seconds_ago!r}) — pack may have never emitted data"
+        )
+        seconds_ago = float(raw_seconds_ago)
         assert seconds_ago < 300, (
             f"newest macbook-m4 pack event is {seconds_ago:.0f}s old "
             f"(threshold: 300s). Chain appears to have backed up or "


### PR DESCRIPTION
## Summary

Adds `tests/e2e/test_macos.py` with three freshness assertions covering the macbook-m4 → Cribl Cloud → Cribl Stream → Splunk chain that the v0.3.0 native macOS pack now exercises.

This is **Phase F** of the Cribl Mac monitoring lockdown plan. Phases A-E and H landed in the previous round (PRs #260 / nix-darwin#1123 / cc-edge-the-mac-pack-io#8 / dryvist#7); Phase D ships as JacobPEvans/nix-darwin#1137 in parallel. Phase G (Splunk silence alert in `ansible-splunk`) is up next.

## Changes

- **New**: `tests/e2e/test_macos.py` — 3 tests:
  - `test_macos_pack_events_arrive` — any `macos:*` event in last 5 min
  - `test_macos_native_sources_emitting` — both `apple_unified_logs` AND `system_metrics` sourcetypes present in last 15 min
  - `test_macos_pack_recently_active` — newest event < 300s old (catches stalled pipelines)
- **Modified**: `.github/workflows/_e2e-tests.yml` — adds `tests/e2e/test_macos.py` to the SOPS-wrapped pytest invocation alongside `test_pipeline.py` + `test_forwarding.py`

## Design note: freshness gate, not sentinel injection

The plan originally called for sentinel injection from the runner to macbook-m4. The Mac pack continuously emits events (`system_metrics` every 60s, `apple_unified_logs` streaming), so 5+ minutes of silence is already a real failure — injection adds deployment complexity (runner-to-Mac SSH or publicly-reachable HEC) without materially improving the failure detection signal. Documented in the module docstring.

Complements the Splunk silence-detector saved search arriving in `ansible-splunk`: the saved search alerts on-call humans; this pytest catches the same condition in the scheduled E2E run.

## Gate

The `e2e-pipeline-schedule.yml` gate (`vars.E2E_RUNNERS_ENABLED == 'true'`) remains the single off-switch. The repo variable will be set to `true` after this PR merges so the daily 08:30 UTC schedule begins running the full suite.

## Test plan

- [x] `python3 -m py_compile tests/e2e/test_macos.py` clean
- [x] `ansible-lint .github/workflows/_e2e-tests.yml` passed (production profile)
- [x] `yamllint .github/workflows/_e2e-tests.yml` clean
- [ ] Set `E2E_RUNNERS_ENABLED=true` repo variable after merge
- [ ] Trigger `e2e-pipeline-schedule.yml` manually post-merge, confirm `test_macos.py` passes
- [ ] Confirm `test_pipeline.py` + `test_forwarding.py` still pass alongside

## Related

- Mac pack v0.3.0 release: https://github.com/JacobPEvans/cc-edge-the-mac-pack-io/releases/tag/v0.3.0
- Phase D wiring: JacobPEvans/nix-darwin#1137 (concurrent)
- Predecessor in this repo: #260 (test fixture rolling)