### PR TITLE
feat(healthchecks): self-hosted deadman receiver LXC role

### DIFF
--- a/inventory/load_terraform.yml
+++ b/inventory/load_terraform.yml
@@ -142,6 +142,11 @@
               ['openproject_group']
               if 'openproject' in (item.value.tags | default([]))
               else []
+            ) +
+            (
+              ['healthchecks_group']
+              if 'healthcheck' in (item.value.tags | default([]))
+              else []
             )
           }}
         proxmox_vmid: "{{ item.value.vmid }}"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -236,6 +236,17 @@
   roles:
     - role: ntfy_docker
 
+- name: Configure self-hosted Healthchecks (deadman watchdog receiver)
+  hosts: healthchecks_group
+  become: true
+  gather_facts: false
+  tags:
+    - healthchecks
+    - monitoring
+    - deadman
+  roles:
+    - role: healthchecks_docker
+
 # =============================================================================
 # Phase 5: Microsoft SQL Server
 # Deploy SQL Server 2022 on Docker in LXC container

--- a/roles/healthchecks_docker/defaults/main.yml
+++ b/roles/healthchecks_docker/defaults/main.yml
@@ -1,0 +1,55 @@
+---
+# Healthchecks (cronjob monitoring / deadman's switch) — self-hosted.
+# Receives heartbeats from Cribl Edge on macbook-m4 (the nix-darwin
+# cribl-edge-watchdog daemon) and alerts via email when a heartbeat is missed.
+# Paired with healthchecks.io SaaS at the macbook-m4 LaunchDaemon — the two
+# instances are independent so losing either does not leave us blind.
+
+# Container image — pinned. Bump via Renovate or manual review.
+healthchecks_docker_image: "healthchecks/healthchecks:v3.7"
+healthchecks_docker_container_name: healthchecks
+
+# HTTP port the container exposes. Internal Django default is 8000; we publish
+# the same so URLs are unsurprising.
+healthchecks_docker_http_port: 8000
+
+# Persistent state (SQLite database, logs).
+healthchecks_docker_data_dir: /opt/healthchecks
+
+# Path to the SQLite db inside the container (matches the data dir mount).
+healthchecks_docker_db_path: /data/hc.sqlite
+
+# Django ALLOWED_HOSTS. "*" is acceptable for an internal-only deployment;
+# tighten via inventory override if exposed beyond the LAN.
+healthchecks_docker_allowed_hosts: "*"
+
+# Base URL the UI emits in ping links — must be reachable from the Mac.
+# Override per-inventory to your internal domain. Default keeps the IP form
+# so the role works on a fresh LXC before DNS is wired.
+healthchecks_docker_site_root: >-
+  http://{{ hostvars[inventory_hostname]['container_ip'] | default('127.0.0.1') }}:{{ healthchecks_docker_http_port }}
+healthchecks_docker_site_name: "Healthchecks (homelab)"
+
+# Email delivery. Defaults wire to Mailpit LXC (already in this repo) so
+# alerts land in the developer Mailpit UI without extra config. Override
+# per-inventory to use a real SMTP server when you want alerts to leave
+# the LAN.
+healthchecks_docker_email_host: >-
+  {{ hostvars['mailpit']['container_ip'] | default('mailpit') }}
+healthchecks_docker_email_port: 1025
+healthchecks_docker_email_use_tls: false
+healthchecks_docker_email_host_user: ""
+healthchecks_docker_email_host_password: ""
+healthchecks_docker_default_from_email: "healthchecks@homelab.example.local"
+
+# Django SECRET_KEY. Generated once on the LXC and persisted to
+# {{ healthchecks_docker_data_dir }}/.secret_key (root:root 0600). Override
+# only if you need to share an explicit value across hosts.
+healthchecks_docker_secret_key: ""
+
+# Admin user. The Healthchecks image does not provision a superuser by
+# default; an empty username skips the post-deploy createsuperuser call so
+# the role stays idempotent. Override per-inventory to create one
+# automatically.
+healthchecks_docker_admin_email: ""
+healthchecks_docker_admin_password: ""

--- a/roles/healthchecks_docker/handlers/main.yml
+++ b/roles/healthchecks_docker/handlers/main.yml
@@ -1,5 +1,13 @@
 ---
+# Use state: present with recreate: always so config-only changes (which
+# don't restart unhealthy containers) trigger a full recreate against the
+# new compose file. state: restarted only restarts the existing container
+# with its old config.
 - name: Restart healthchecks
   community.docker.docker_compose_v2:
     project_src: "{{ healthchecks_docker_data_dir }}"
-    state: restarted
+    state: present
+    recreate: always
+  vars:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python
+  no_log: true

--- a/roles/healthchecks_docker/handlers/main.yml
+++ b/roles/healthchecks_docker/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart healthchecks
+  community.docker.docker_compose_v2:
+    project_src: "{{ healthchecks_docker_data_dir }}"
+    state: restarted

--- a/roles/healthchecks_docker/meta/main.yml
+++ b/roles/healthchecks_docker/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  author: Jacob Evans
+  description: >-
+    Self-hosted Healthchecks (https://healthchecks.io/docs/self_hosted)
+    on an LXC container via Docker Compose. Receives heartbeats from
+    cribl-edge-watchdog and alerts via SMTP on missed pings.
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+  galaxy_tags:
+    - monitoring
+    - alerting
+    - deadman
+
+dependencies: []
+
+collections:
+  - community.docker

--- a/roles/healthchecks_docker/tasks/main.yml
+++ b/roles/healthchecks_docker/tasks/main.yml
@@ -1,0 +1,240 @@
+---
+# Healthchecks Docker deployment.
+#
+# Installs Docker + Compose on the target LXC, generates (and persists) a
+# Django SECRET_KEY on first run, then deploys the healthchecks/healthchecks
+# image via Docker Compose with a SQLite-backed data directory.
+#
+# Mirrors the ntfy_docker role's structure (Docker repo + fuse-overlayfs +
+# Python venv for community.docker, then compose deploy + health check).
+
+# =============================================================================
+# Docker Installation
+# =============================================================================
+
+- name: Gather OS facts
+  ansible.builtin.setup:
+    filter: ansible_distribution*
+
+- name: Install Docker prerequisites
+  ansible.builtin.apt:
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg
+      - lsb-release
+    state: present
+    update_cache: true
+
+- name: Create keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+
+- name: Set Docker repository distribution
+  ansible.builtin.set_fact:
+    healthchecks_docker_distro: "{{ ansible_distribution | lower }}"
+
+- name: Add Docker GPG key
+  ansible.builtin.get_url:
+    url: "https://download.docker.com/linux/{{ healthchecks_docker_distro }}/gpg"
+    dest: /etc/apt/keyrings/docker.asc
+    mode: "0644"
+    force: false
+
+- name: Add Docker repository
+  ansible.builtin.apt_repository:
+    repo: >-
+      deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc]
+      https://download.docker.com/linux/{{ healthchecks_docker_distro }}
+      {{ ansible_distribution_release }} stable
+    state: present
+    filename: docker
+
+- name: Install Docker packages
+  ansible.builtin.apt:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-buildx-plugin
+      - docker-compose-plugin
+    state: present
+    update_cache: true
+
+- name: Install fuse-overlayfs for Docker on ZFS-backed LXC containers
+  ansible.builtin.apt:
+    name: fuse-overlayfs
+    state: present
+
+- name: Configure Docker to use fuse-overlayfs storage driver
+  ansible.builtin.copy:
+    dest: /etc/docker/daemon.json
+    content: |
+      {
+        "storage-driver": "fuse-overlayfs"
+      }
+    owner: root
+    group: root
+    mode: "0644"
+  register: healthchecks_docker_daemon_config
+
+- name: Restart Docker to apply fuse-overlayfs configuration
+  ansible.builtin.systemd:  # noqa: no-handler
+    name: docker
+    state: restarted
+  when: healthchecks_docker_daemon_config.changed
+
+- name: Ensure Docker service is running
+  ansible.builtin.systemd:
+    name: docker
+    state: started
+    enabled: true
+
+# =============================================================================
+# Healthchecks Data Directories
+# =============================================================================
+
+- name: Create healthchecks data directory
+  ansible.builtin.file:
+    path: "{{ healthchecks_docker_data_dir }}/data"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+# =============================================================================
+# Django SECRET_KEY (generate-once, persist on disk)
+# =============================================================================
+# The image needs a SECRET_KEY at boot; if we randomized it per play, every
+# deployment would invalidate all active sessions. Persist it in a root-only
+# file the first time the role runs and reuse it thereafter.
+
+- name: Check for existing Django SECRET_KEY
+  ansible.builtin.stat:
+    path: "{{ healthchecks_docker_data_dir }}/.secret_key"
+  register: healthchecks_docker_secret_key_stat
+
+- name: Generate Django SECRET_KEY (first run only)
+  ansible.builtin.copy:
+    dest: "{{ healthchecks_docker_data_dir }}/.secret_key"
+    # 50 chars of high-entropy alnum + symbols (matches Django's own
+    # get_random_secret_key default length)
+    content: "{{ lookup('password', '/dev/null length=50 chars=ascii_letters,digits') }}"
+    owner: root
+    group: root
+    mode: "0600"
+  when: not healthchecks_docker_secret_key_stat.stat.exists
+
+- name: Read Django SECRET_KEY into memory
+  ansible.builtin.slurp:
+    src: "{{ healthchecks_docker_data_dir }}/.secret_key"
+  register: healthchecks_docker_secret_key_file
+  no_log: true
+
+- name: Resolve effective SECRET_KEY (inventory override or persisted file)
+  ansible.builtin.set_fact:
+    healthchecks_docker_secret_key: >-
+      {{ healthchecks_docker_secret_key
+         if healthchecks_docker_secret_key | length > 0
+         else (healthchecks_docker_secret_key_file.content | b64decode | trim) }}
+  no_log: true
+
+# =============================================================================
+# Compose Deployment
+# =============================================================================
+
+- name: Deploy healthchecks docker-compose template
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ healthchecks_docker_data_dir }}/docker-compose.yml"
+    owner: root
+    group: root
+    mode: "0600"  # contains SECRET_KEY
+  no_log: true
+  notify: Restart healthchecks
+
+# =============================================================================
+# Python venv for Ansible Docker modules
+# =============================================================================
+
+- name: Install Python venv and pip for dependencies
+  ansible.builtin.apt:
+    name:
+      - python3-pip
+      - python3-venv
+      - python3-full
+    state: present
+    update_cache: true
+
+- name: Create virtualenv for Ansible Python dependencies
+  ansible.builtin.pip:
+    name:
+      - docker
+    state: present
+    virtualenv: /opt/ansible-venv
+    virtualenv_command: python3 -m venv
+
+- name: Set Python interpreter to use venv for subsequent tasks
+  ansible.builtin.set_fact:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python
+
+# =============================================================================
+# Deploy via Docker Compose
+# =============================================================================
+
+- name: Deploy healthchecks via docker compose
+  community.docker.docker_compose_v2:
+    project_src: "{{ healthchecks_docker_data_dir }}"
+    state: present
+  register: healthchecks_docker_compose_result
+  changed_when: >-
+    (healthchecks_docker_compose_result.actions | default([]))
+    | selectattr('status', 'in', ['Creating', 'Recreating', 'Pulling', 'Building'])
+    | list | length > 0
+
+# =============================================================================
+# Health Check
+# =============================================================================
+
+- name: Wait for healthchecks HTTP port to be ready
+  ansible.builtin.wait_for:
+    host: 127.0.0.1
+    port: "{{ healthchecks_docker_http_port }}"
+    timeout: 60
+
+- name: Verify healthchecks login page renders
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ healthchecks_docker_http_port }}/accounts/login/"
+    method: GET
+    status_code: 200
+  register: healthchecks_docker_health
+  retries: 10
+  delay: 5
+  until: healthchecks_docker_health.status == 200
+  changed_when: false
+
+# =============================================================================
+# Optional admin superuser
+# =============================================================================
+
+- name: Create Healthchecks admin superuser (if configured)
+  ansible.builtin.command:
+    cmd: >-
+      docker exec {{ healthchecks_docker_container_name }}
+      /opt/healthchecks/manage.py createsuperuser
+      --noinput
+      --email {{ healthchecks_docker_admin_email }}
+  environment:
+    DJANGO_SUPERUSER_PASSWORD: "{{ healthchecks_docker_admin_password }}"
+  register: healthchecks_docker_superuser
+  changed_when: "'created successfully' in (healthchecks_docker_superuser.stdout | default(''))"
+  failed_when:
+    - healthchecks_docker_superuser.rc != 0
+    - "'already exists' not in (healthchecks_docker_superuser.stderr | default(''))"
+  when:
+    - healthchecks_docker_admin_email | length > 0
+    - healthchecks_docker_admin_password | length > 0
+  no_log: true

--- a/roles/healthchecks_docker/tasks/main.yml
+++ b/roles/healthchecks_docker/tasks/main.yml
@@ -120,13 +120,21 @@
 - name: Generate Django SECRET_KEY (first run only)
   ansible.builtin.copy:
     dest: "{{ healthchecks_docker_data_dir }}/.secret_key"
-    # 50 chars of high-entropy alnum + symbols (matches Django's own
-    # get_random_secret_key default length)
-    content: "{{ lookup('password', '/dev/null length=50 chars=ascii_letters,digits') }}"
+    # 50 alphanumeric chars (matches Django get_random_secret_key length).
+    # Using community.general.random_string instead of the password lookup's
+    # 'chars=ascii_letters,digits' shortcut so the character set is
+    # specified by unambiguous boolean flags rather than relying on
+    # implicit keyword expansion in a free-form lookup argument string.
+    content: >-
+      {{ lookup('community.general.random_string',
+                length=50,
+                upper=true, lower=true, numbers=true,
+                special=false) }}
     owner: root
     group: root
     mode: "0600"
   when: not healthchecks_docker_secret_key_stat.stat.exists
+  no_log: true
 
 - name: Read Django SECRET_KEY into memory
   ansible.builtin.slurp:
@@ -177,9 +185,11 @@
     virtualenv: /opt/ansible-venv
     virtualenv_command: python3 -m venv
 
-- name: Set Python interpreter to use venv for subsequent tasks
-  ansible.builtin.set_fact:
-    ansible_python_interpreter: /opt/ansible-venv/bin/python
+# Intentionally do NOT set ansible_python_interpreter via set_fact —
+# that would leak the venv (which only has the `docker` package) to
+# subsequent tasks like uri / wait_for, breaking anything that expected
+# the system Python. Instead, scope the venv interpreter to the
+# community.docker tasks that need it via task-level vars.
 
 # =============================================================================
 # Deploy via Docker Compose
@@ -194,6 +204,9 @@
     (healthchecks_docker_compose_result.actions | default([]))
     | selectattr('status', 'in', ['Creating', 'Recreating', 'Pulling', 'Building'])
     | list | length > 0
+  vars:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python
+  no_log: true
 
 # =============================================================================
 # Health Check

--- a/roles/healthchecks_docker/templates/docker-compose.yml.j2
+++ b/roles/healthchecks_docker/templates/docker-compose.yml.j2
@@ -1,0 +1,28 @@
+---
+# Self-hosted Healthchecks via Docker Compose.
+# Rendered by ansible-proxmox-apps/roles/healthchecks_docker.
+services:
+  healthchecks:
+    image: {{ healthchecks_docker_image }}
+    container_name: {{ healthchecks_docker_container_name }}
+    restart: unless-stopped
+    ports:
+      - "{{ healthchecks_docker_http_port }}:8000"
+    environment:
+      SECRET_KEY: "{{ healthchecks_docker_secret_key }}"
+      DEBUG: "False"
+      ALLOWED_HOSTS: "{{ healthchecks_docker_allowed_hosts }}"
+      DB: "sqlite"
+      DB_NAME: "{{ healthchecks_docker_db_path }}"
+      DEFAULT_FROM_EMAIL: "{{ healthchecks_docker_default_from_email }}"
+      EMAIL_HOST: "{{ healthchecks_docker_email_host }}"
+      EMAIL_PORT: "{{ healthchecks_docker_email_port }}"
+      EMAIL_HOST_USER: "{{ healthchecks_docker_email_host_user }}"
+      EMAIL_HOST_PASSWORD: "{{ healthchecks_docker_email_host_password }}"
+      EMAIL_USE_TLS: "{{ healthchecks_docker_email_use_tls | string | title }}"
+      SITE_ROOT: "{{ healthchecks_docker_site_root }}"
+      SITE_NAME: "{{ healthchecks_docker_site_name }}"
+      # Disable registration UI — single-tenant deployment.
+      REGISTRATION_OPEN: "False"
+    volumes:
+      - {{ healthchecks_docker_data_dir }}/data:/data


### PR DESCRIPTION
## Summary

Adds the `healthchecks_docker` role to deploy https://healthchecks.io/docs/self_hosted on a Debian LXC container via Docker Compose with a SQLite backend. Paired with the `cribl-edge-watchdog` LaunchDaemon in nix-darwin (JacobPEvans/nix-darwin#1140) to give the macbook-m4 pipeline an internal deadman receiver alongside the external healthchecks.io SaaS check.

This is **Layer 4b** of the down-detection design (per user direction in this round):
- L1: Splunk `macos_edge_silence_detector` saved search (already merged, ansible-splunk#224)
- L4a: healthchecks.io SaaS check — survives 'everything internal hard down'
- L4b: **This PR** — self-hosted Healthchecks LXC — survives 'external dependency unreachable'

Either L4 alone leaves a class of failure unobserved; both together cover both scenarios.

## Changes

- **New role**: `roles/healthchecks_docker/` (defaults, meta, handlers, tasks, templates/docker-compose.yml.j2)
- **Inventory**: `inventory/load_terraform.yml` — LXC containers tagged `healthcheck` join `healthchecks_group`
- **Playbook**: `playbooks/site.yml` — invoke `healthchecks_docker` against `healthchecks_group` in Phase 4 (Notification Services)

## Layout mirrors `ntfy_docker`

- `defaults/`: image, ports, data dir, Mailpit-pointing SMTP defaults
- `meta/`: requires `community.docker`
- `handlers/`: docker-compose restart
- `tasks/`: Docker apt install (with `fuse-overlayfs` for ZFS-backed LXCs) + persistent SECRET_KEY generation + compose deploy + login-page health check + optional `createsuperuser`
- `templates/docker-compose.yml.j2`: single-service Healthchecks container, SQLite db on `/data`, env-var config

## Key design choices

- **SQLite, not Postgres**: per-Healthchecks docs, SQLite is sufficient for small/medium installations and avoids a second container. Single-user homelab deployment, no scaling concern.
- **Persistent SECRET_KEY**: generated once on first deploy, persisted at `${data_dir}/.secret_key` (root:root 0600). Re-randomizing per play would invalidate active sessions.
- **Mailpit SMTP by default**: alerts land in the existing Mailpit UI without external SMTP setup. Inventory override switches to a real SMTP server when you want notifications to leave the LAN.
- **`REGISTRATION_OPEN: False`**: single-tenant; no random people can sign up via the UI.

## Prerequisites (out of scope of this PR)

1. Provision an LXC container in `terraform-proxmox` with tags including `healthcheck` (e.g., 256 MB RAM, 2 GB disk, Debian Bookworm).
2. `./scripts/sync-terraform-inventory.sh` to refresh `inventory/terraform_inventory.json`.
3. Override `healthchecks_docker_admin_email` and `healthchecks_docker_admin_password` via inventory or Doppler.

## Post-deploy

1. Visit the UI at `http://<lxc-ip>:8000`, log in with the admin email/password.
2. Create one check named e.g. `macbook-m4-cribl-edge` with grace period 15 min.
3. Copy the ping URL.
4. `cd ~/git/nix-darwin/main && sops edit secrets/cribl-edge.yaml` → paste the URL into `HEALTHCHECKS_LOCAL_URL`.
5. `sudo darwin-rebuild switch --flake .` on macbook-m4 — the watchdog will start pinging within 5 min.

## Test plan

- [x] `ansible-lint roles/healthchecks_docker/ playbooks/site.yml inventory/load_terraform.yml` clean (production profile)
- [ ] Deploy against a fresh LXC tagged `healthcheck` and confirm the login page responds at `:8000`
- [ ] Receive a heartbeat from macbook-m4 in the Healthchecks UI
- [ ] Stop the macbook-m4 daemon → confirm Healthchecks fires an email alert through Mailpit

## Related

- nix-darwin watchdog: JacobPEvans/nix-darwin#1140
- Splunk silence detector (L1): JacobPEvans/ansible-splunk#224 (merged today)