### PR TITLE
feat(infisical): add infisical_docker role + group_vars + tests

### DIFF
--- a/inventory/group_vars/haproxy_group.yml
+++ b/inventory/group_vars/haproxy_group.yml
@@ -2,3 +2,22 @@
 systemd_restart_policy_services:
   - haproxy
   - nginx
+
+# HTTP/HTTPS reverse-proxy frontends.
+#
+# Flip haproxy_http_enabled to true ONLY after terraform-proxmox PR #320
+# has been activated and the per-service ACME cert has been delivered to
+# /etc/ssl/private/<name>.pem on this LXC. With the flag off (default),
+# the haproxy role renders the TCP-only config and ignores the frontends
+# list entirely.
+#
+# server_name uses {{ terraform_data.domain }} so the same group_vars
+# work across environments. backend_host/port come from the upstream
+# host's inventory entry + the pipeline_constants port map (DRY).
+haproxy_http_enabled: false
+haproxy_http_frontends:
+  - name: infisical
+    server_name: "infisical.{{ terraform_data.domain }}"
+    backend_host: "{{ hostvars['infisical'].container_ip }}"
+    backend_port: "{{ terraform_data.constants.service_ports.infisical_api }}"
+    cert_path: "{{ haproxy_ssl_crt_base }}/infisical.pem"

--- a/inventory/group_vars/infisical_group.yml
+++ b/inventory/group_vars/infisical_group.yml
@@ -1,0 +1,8 @@
+---
+# Infisical LXC inventory group vars.
+# Container itself is configured via roles/infisical_docker (Docker Compose
+# bringing up postgres + redis + infisical app). Host-side defaults below
+# apply to the LXC's systemd_restart_policy and any future host-only tasks.
+
+systemd_restart_policy_services:
+  - docker

--- a/inventory/load_terraform.yml
+++ b/inventory/load_terraform.yml
@@ -144,6 +144,11 @@
               else []
             ) +
             (
+              ['infisical_group']
+              if 'infisical' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
               ['healthchecks_group']
               if 'healthcheck' in (item.value.tags | default([]))
               else []

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -358,6 +358,26 @@
     - role: openproject_docker
 
 # =============================================================================
+# Phase 8.5: Infisical self-hosted secrets management
+# Bundled Docker Compose stack (postgres + redis + infisical app) in LXC.
+# Fronted by HAProxy on TLS once roles/haproxy haproxy_http_enabled flips
+# to true (see inventory/group_vars/haproxy_group.yml). DNS A record
+# (infisical.{domain}) is auto-created by technitium_dns from the
+# hostname + container_ip in inventory.
+# =============================================================================
+
+- name: Configure Infisical secrets-management platform
+  hosts: infisical_group
+  become: true
+  gather_facts: false
+  tags:
+    - infisical_docker
+    - secrets
+    - secrets-management
+  roles:
+    - role: infisical_docker
+
+# =============================================================================
 # Phase 9: Systemd Restart Policies
 # Apply restart-on-failure policies to all managed services
 # Each group defines its services via group_vars

--- a/roles/infisical_docker/defaults/main.yml
+++ b/roles/infisical_docker/defaults/main.yml
@@ -1,0 +1,88 @@
+---
+# Infisical self-hosted secrets-management platform (Docker Compose in LXC)
+# https://infisical.com/docs/self-hosting/deployments/docker-compose
+#
+# Bundled stack: postgres + redis + infisical app.
+# All literals live here; the template references vars only (DRY).
+
+# Image tags — single source of truth.
+infisical_docker_postgres_image: "postgres:14-alpine"
+infisical_docker_redis_image: "redis:7-alpine"
+infisical_docker_app_image: "infisical/infisical:latest"
+
+infisical_docker_container_name: infisical
+infisical_docker_data_dir: /opt/infisical
+infisical_docker_postgres_data_dir: "{{ infisical_docker_data_dir }}/postgres"
+infisical_docker_redis_data_dir: "{{ infisical_docker_data_dir }}/redis"
+
+# Container-internal mount paths (image contracts — set once, referenced in template).
+infisical_docker_postgres_internal_data: /var/lib/postgresql/data
+infisical_docker_redis_internal_data: /data
+
+# Compose service names (also used as Docker DNS hostnames in env vars).
+infisical_docker_db_service: db
+infisical_docker_redis_service: redis
+infisical_docker_app_service: infisical
+
+# Database identity.
+infisical_docker_db_name: infisical
+infisical_docker_db_user: infisical
+
+# Restart policy applied to every service in the stack.
+infisical_docker_restart_policy: unless-stopped
+
+# Site URL composition. Auto-derived from inventory hostname + PROXMOX_DOMAIN.
+# Always HTTPS because the canonical access path is HAProxy → Infisical, and the
+# HAProxy frontend enforces TLS (see roles/haproxy → haproxy_http_frontends).
+infisical_docker_site_url: "https://{{ hostname }}.{{ lookup('env', 'PROXMOX_DOMAIN') }}"
+
+# Port pulled from the terraform pipeline_constants (DRY: no port literal here).
+_infisical_docker_api_port_err: >-
+  terraform_data.constants.service_ports.infisical_api missing —
+  regenerate terraform_inventory.json via
+  `terragrunt output -json ansible_inventory`.
+infisical_docker_api_port: >-
+  {{ hostvars['localhost']['terraform_data']
+     ['constants']['service_ports']['infisical_api']
+     | mandatory(_infisical_docker_api_port_err) }}
+_infisical_docker_postgres_port_err: >-
+  terraform_data.constants.service_ports.postgres_default missing —
+  regenerate terraform_inventory.json via
+  `terragrunt output -json ansible_inventory`.
+infisical_docker_postgres_port: >-
+  {{ hostvars['localhost']['terraform_data']
+     ['constants']['service_ports']['postgres_default']
+     | mandatory(_infisical_docker_postgres_port_err) }}
+_infisical_docker_redis_port_err: >-
+  terraform_data.constants.service_ports.redis_default missing —
+  regenerate terraform_inventory.json via
+  `terragrunt output -json ansible_inventory`.
+infisical_docker_redis_port: >-
+  {{ hostvars['localhost']['terraform_data']
+     ['constants']['service_ports']['redis_default']
+     | mandatory(_infisical_docker_redis_port_err) }}
+
+# URL composition — no port literals in the template, all reference vars above.
+infisical_docker_db_uri: >-
+  postgres://{{ infisical_docker_db_user }}:{{ infisical_docker_db_password }}@{{
+  infisical_docker_db_service }}:{{ infisical_docker_postgres_port }}/{{
+  infisical_docker_db_name }}
+infisical_docker_redis_url: >-
+  redis://{{ infisical_docker_redis_service }}:{{ infisical_docker_redis_port }}
+
+# Secrets (sourced from SOPS via `sops exec-env secrets.enc.yaml ...`).
+# Same precedent as roles/mssql_docker/defaults: lookup('env') + mandatory.
+# Generate locally:
+#   openssl rand -base64 32   # INFISICAL_ENCRYPTION_KEY
+#   openssl rand -base64 32   # INFISICAL_AUTH_SECRET
+#   openssl rand -base64 24   # INFISICAL_DB_PASSWORD
+# Then `sops secrets.enc.yaml` and paste.
+infisical_docker_encryption_key: >-
+  {{ lookup('env', 'INFISICAL_ENCRYPTION_KEY')
+     | mandatory('INFISICAL_ENCRYPTION_KEY must be set (openssl rand -base64 32; store in SOPS)') }}
+infisical_docker_auth_secret: >-
+  {{ lookup('env', 'INFISICAL_AUTH_SECRET')
+     | mandatory('INFISICAL_AUTH_SECRET must be set (openssl rand -base64 32; store in SOPS)') }}
+infisical_docker_db_password: >-
+  {{ lookup('env', 'INFISICAL_DB_PASSWORD')
+     | mandatory('INFISICAL_DB_PASSWORD must be set (openssl rand -base64 24; store in SOPS)') }}

--- a/roles/infisical_docker/handlers/main.yml
+++ b/roles/infisical_docker/handlers/main.yml
@@ -9,5 +9,6 @@
     project_src: "{{ infisical_docker_data_dir }}"
     state: present
     recreate: always
+  no_log: true  # compose carries INFISICAL_ENCRYPTION_KEY/AUTH_SECRET/DB_PASSWORD env vars
   vars:
     ansible_python_interpreter: /opt/ansible-venv/bin/python

--- a/roles/infisical_docker/handlers/main.yml
+++ b/roles/infisical_docker/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+- name: Restart docker
+  ansible.builtin.systemd:
+    name: docker
+    state: restarted
+
+- name: Restart infisical
+  community.docker.docker_compose_v2:
+    project_src: "{{ infisical_docker_data_dir }}"
+    state: present
+    recreate: always
+  vars:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python

--- a/roles/infisical_docker/meta/main.yml
+++ b/roles/infisical_docker/meta/main.yml
@@ -1,0 +1,27 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: >-
+    Deploy Infisical self-hosted secrets-management (postgres + redis + app)
+    via Docker Compose in LXC.
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+
+  galaxy_tags:
+    - infisical
+    - docker
+    - secrets
+    - secretsmanagement
+
+dependencies: []
+  # community.docker collection is specified in requirements.yml

--- a/roles/infisical_docker/tasks/main.yml
+++ b/roles/infisical_docker/tasks/main.yml
@@ -1,0 +1,171 @@
+---
+# Infisical self-hosted secrets-management deployment.
+# Bundled stack: postgres + redis + infisical app via Docker Compose in LXC.
+
+# =============================================================================
+# Docker Installation
+# =============================================================================
+
+- name: Gather OS facts
+  ansible.builtin.setup:
+    filter: ansible_distribution*
+
+- name: Install Docker prerequisites
+  ansible.builtin.apt:
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg
+      - lsb-release
+    state: present
+    update_cache: true
+
+- name: Create keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+
+- name: Set Docker repository distribution
+  ansible.builtin.set_fact:
+    infisical_docker_distro: "{{ ansible_distribution | lower }}"
+
+- name: Add Docker GPG key
+  ansible.builtin.get_url:
+    url: "https://download.docker.com/linux/{{ infisical_docker_distro }}/gpg"
+    dest: /etc/apt/keyrings/docker.asc
+    mode: "0644"
+    force: false
+
+- name: Add Docker repository
+  ansible.builtin.apt_repository:
+    repo: >-
+      deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc]
+      https://download.docker.com/linux/{{ infisical_docker_distro }}
+      {{ ansible_distribution_release }} stable
+    state: present
+    filename: docker
+
+- name: Install Docker packages
+  ansible.builtin.apt:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-buildx-plugin
+      - docker-compose-plugin
+    state: present
+    update_cache: true
+
+- name: Install fuse-overlayfs for Docker on ZFS-backed LXC containers
+  ansible.builtin.apt:
+    name: fuse-overlayfs
+    state: present
+
+- name: Configure Docker to use fuse-overlayfs storage driver (required for ZFS-backed LXC)
+  ansible.builtin.copy:
+    dest: /etc/docker/daemon.json
+    content: |
+      {
+        "storage-driver": "fuse-overlayfs"
+      }
+    owner: root
+    group: root
+    mode: "0644"
+  register: infisical_docker_daemon_config
+
+- name: Restart Docker to apply fuse-overlayfs configuration
+  ansible.builtin.systemd:  # noqa: no-handler
+    name: docker
+    state: restarted
+  when: infisical_docker_daemon_config.changed
+
+- name: Ensure Docker service is running
+  ansible.builtin.systemd:
+    name: docker
+    state: started
+    enabled: true
+
+# =============================================================================
+# Data Directories
+# Postgres and Redis containers write to bind-mounted volumes under
+# {{ infisical_docker_data_dir }}. Image entrypoints run as their own UIDs
+# (postgres: 999, redis: 999); in an unprivileged LXC the host UIDs map to
+# subuids, so leave ownership defaults — chown happens inside the container.
+# =============================================================================
+
+- name: Create Infisical data subdirectories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  loop:
+    - "{{ infisical_docker_data_dir }}"
+    - "{{ infisical_docker_postgres_data_dir }}"
+    - "{{ infisical_docker_redis_data_dir }}"
+
+# =============================================================================
+# Compose File
+# =============================================================================
+
+- name: Render Infisical docker-compose.yml
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ infisical_docker_data_dir }}/docker-compose.yml"
+    owner: root
+    group: root
+    mode: "0600"  # contains DB_CONNECTION_URI with the DB password
+  no_log: true
+
+# =============================================================================
+# Deploy via Docker Compose
+# Note: ansible_python_interpreter is set as a task-level var (not via set_fact)
+# so the venv interpreter does NOT leak to subsequent plays (e.g. Phase 9
+# systemd_restart_policy) that need system Python for apt/dbus.
+# =============================================================================
+
+- name: Check if infisical container is running
+  ansible.builtin.command: docker ps -q --filter name={{ infisical_docker_container_name }} --filter status=running
+  register: infisical_docker_running_check
+  changed_when: false
+  failed_when: false
+
+- name: Clean stale Docker state before fresh deployment
+  ansible.builtin.command: docker system prune -af --volumes
+  when: infisical_docker_running_check.stdout == ''
+  changed_when: true
+
+- name: Deploy Infisical via docker compose
+  community.docker.docker_compose_v2:
+    project_src: "{{ infisical_docker_data_dir }}"
+    state: present
+  no_log: true
+  vars:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python
+
+# =============================================================================
+# Health Check
+# First boot can take 30-90 seconds: postgres initdb, redis startup, and
+# the infisical app running its migrations against the fresh DB.
+# =============================================================================
+
+- name: Wait for Infisical API port to accept TCP connections
+  ansible.builtin.wait_for:
+    host: 127.0.0.1
+    port: "{{ infisical_docker_api_port }}"
+    timeout: 300
+
+- name: Verify Infisical API status endpoint
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ infisical_docker_api_port }}/api/status"
+    method: GET
+    status_code: 200
+    return_content: false
+  register: infisical_docker_health
+  retries: 30
+  delay: 10
+  until: infisical_docker_health.status == 200
+  changed_when: false

--- a/roles/infisical_docker/templates/docker-compose.yml.j2
+++ b/roles/infisical_docker/templates/docker-compose.yml.j2
@@ -1,0 +1,33 @@
+---
+services:
+  {{ infisical_docker_db_service }}:
+    image: {{ infisical_docker_postgres_image }}
+    environment:
+      POSTGRES_USER: {{ infisical_docker_db_user }}
+      POSTGRES_PASSWORD: "{{ infisical_docker_db_password }}"
+      POSTGRES_DB: {{ infisical_docker_db_name }}
+    volumes:
+      - {{ infisical_docker_postgres_data_dir }}:{{ infisical_docker_postgres_internal_data }}
+    restart: {{ infisical_docker_restart_policy }}
+
+  {{ infisical_docker_redis_service }}:
+    image: {{ infisical_docker_redis_image }}
+    volumes:
+      - {{ infisical_docker_redis_data_dir }}:{{ infisical_docker_redis_internal_data }}
+    restart: {{ infisical_docker_restart_policy }}
+
+  {{ infisical_docker_app_service }}:
+    image: {{ infisical_docker_app_image }}
+    container_name: "{{ infisical_docker_container_name }}"
+    depends_on:
+      - {{ infisical_docker_db_service }}
+      - {{ infisical_docker_redis_service }}
+    environment:
+      ENCRYPTION_KEY: "{{ infisical_docker_encryption_key }}"
+      AUTH_SECRET: "{{ infisical_docker_auth_secret }}"
+      DB_CONNECTION_URI: "{{ infisical_docker_db_uri }}"
+      REDIS_URL: "{{ infisical_docker_redis_url }}"
+      SITE_URL: "{{ infisical_docker_site_url }}"
+    ports:
+      - "{{ infisical_docker_api_port }}:{{ infisical_docker_api_port }}"
+    restart: {{ infisical_docker_restart_policy }}

--- a/secrets.enc.yaml.example
+++ b/secrets.enc.yaml.example
@@ -52,3 +52,15 @@ QDRANT_API_KEY: your-qdrant-api-key-here
 # This value MUST be stable across restarts — rotating it invalidates all
 # Rails sessions and existing cookies.
 OPENPROJECT_SECRET_KEY_BASE: your-128-char-hex-secret-here
+
+# Infisical self-hosted secrets-management platform
+# Generate locally, then `sops secrets.enc.yaml` to paste real values:
+#   openssl rand -base64 32   # INFISICAL_ENCRYPTION_KEY  (32-byte AES key)
+#   openssl rand -base64 32   # INFISICAL_AUTH_SECRET     (JWT signing secret)
+#   openssl rand -base64 24   # INFISICAL_DB_PASSWORD     (bundled postgres)
+# All three are local-radius (consumed only by the Infisical LXC's
+# bundled Compose stack) — they fit the SOPS pattern alongside
+# MSSQL_SA_PASSWORD/HAPROXY_STATS_PASSWORD/etc., not Doppler.
+INFISICAL_ENCRYPTION_KEY: your-base64-32-byte-encryption-key-here
+INFISICAL_AUTH_SECRET: your-base64-32-byte-auth-secret-here
+INFISICAL_DB_PASSWORD: your-base64-24-byte-db-password-here

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -447,6 +447,128 @@
           - docker-compose.yml.j2: image, port 80:80, OPENPROJECT_SECRET_KEY_BASE,
             SMTP env vars, persistent volumes, host name
 
+- name: Render and verify infisical_docker templates
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    # Mirror roles/infisical_docker/defaults/main.yml (test stand-ins for
+    # SOPS-sourced env lookups and terraform_data constants).
+    infisical_docker_postgres_image: "postgres:14-alpine"
+    infisical_docker_redis_image: "redis:7-alpine"
+    infisical_docker_app_image: "infisical/infisical:latest"
+    infisical_docker_container_name: infisical
+    infisical_docker_data_dir: /opt/infisical
+    infisical_docker_postgres_data_dir: /opt/infisical/postgres
+    infisical_docker_redis_data_dir: /opt/infisical/redis
+    infisical_docker_postgres_internal_data: /var/lib/postgresql/data
+    infisical_docker_redis_internal_data: /data
+    infisical_docker_db_service: db
+    infisical_docker_redis_service: redis
+    infisical_docker_app_service: infisical
+    infisical_docker_db_name: infisical
+    infisical_docker_db_user: infisical
+    infisical_docker_restart_policy: unless-stopped
+    infisical_docker_api_port: 8080
+    infisical_docker_postgres_port: 5432
+    infisical_docker_redis_port: 6379
+    infisical_docker_site_url: "https://infisical.test.example.com"
+    infisical_docker_db_uri: "postgres://infisical:test-db-pw@db:5432/infisical"
+    infisical_docker_redis_url: "redis://redis:6379"
+    infisical_docker_encryption_key: "test-encryption-key-placeholder-do-not-use"
+    infisical_docker_auth_secret: "test-auth-secret-placeholder-do-not-use"
+    infisical_docker_db_password: "test-db-pw"
+    _template_dir: "../../roles/infisical_docker/templates"
+
+  tasks:
+    - name: Render infisical docker-compose.yml.j2 to /tmp
+      ansible.builtin.template:
+        src: "{{ _template_dir }}/docker-compose.yml.j2"
+        dest: /tmp/test_infisical_compose.yml
+        mode: "0644"
+
+    - name: Read rendered infisical docker-compose.yml
+      ansible.builtin.slurp:
+        src: /tmp/test_infisical_compose.yml
+      register: _infisical_compose_raw
+
+    - name: Decode infisical compose content
+      ansible.builtin.set_fact:
+        _infisical_compose: "{{ _infisical_compose_raw.content | b64decode }}"
+
+    - name: Assert infisical compose references all three expected images
+      ansible.builtin.assert:
+        that:
+          - "'postgres:14-alpine' in _infisical_compose"
+          - "'redis:7-alpine' in _infisical_compose"
+          - "'infisical/infisical:latest' in _infisical_compose"
+        fail_msg: >-
+          infisical docker-compose.yml.j2 missing one of the three required
+          images (postgres:14-alpine, redis:7-alpine, infisical/infisical:latest)
+
+    - name: Assert infisical compose publishes api port 8080:8080
+      ansible.builtin.assert:
+        that:
+          - "'8080:8080' in _infisical_compose"
+        fail_msg: >-
+          infisical docker-compose.yml.j2 missing api port mapping 8080:8080
+          (service_ports.infisical_api must be on both sides)
+
+    - name: Assert infisical compose builds DB_CONNECTION_URI from vars (no literal port)
+      ansible.builtin.assert:
+        that:
+          - "'DB_CONNECTION_URI' in _infisical_compose"
+          - "'postgres://infisical:test-db-pw@db:5432/infisical' in _infisical_compose"
+        fail_msg: >-
+          infisical docker-compose.yml.j2 missing DB_CONNECTION_URI or it does
+          not assemble from the DRY pieces (user, password, service host,
+          postgres_default port, db_name)
+
+    - name: Assert infisical compose builds REDIS_URL from vars (no literal port)
+      ansible.builtin.assert:
+        that:
+          - "'REDIS_URL' in _infisical_compose"
+          - "'redis://redis:6379' in _infisical_compose"
+        fail_msg: >-
+          infisical docker-compose.yml.j2 missing REDIS_URL or it does not
+          assemble from the redis service host + redis_default port
+
+    - name: Assert infisical compose sets SITE_URL to the HTTPS FQDN
+      ansible.builtin.assert:
+        that:
+          - "'SITE_URL' in _infisical_compose"
+          - "'https://infisical.test.example.com' in _infisical_compose"
+        fail_msg: >-
+          infisical docker-compose.yml.j2 missing SITE_URL or did not
+          substitute the HTTPS FQDN
+
+    - name: Assert infisical compose mounts persistent volumes for postgres and redis
+      ansible.builtin.assert:
+        that:
+          - "'/opt/infisical/postgres:/var/lib/postgresql/data' in _infisical_compose"
+          - "'/opt/infisical/redis:/data' in _infisical_compose"
+        fail_msg: >-
+          infisical docker-compose.yml.j2 missing required persistent volume
+          mounts for postgres and redis
+
+    - name: Assert infisical compose passes ENCRYPTION_KEY and AUTH_SECRET
+      ansible.builtin.assert:
+        that:
+          - "'ENCRYPTION_KEY' in _infisical_compose"
+          - "'AUTH_SECRET' in _infisical_compose"
+        fail_msg: >-
+          infisical docker-compose.yml.j2 must pass ENCRYPTION_KEY and
+          AUTH_SECRET (Infisical fails to start without them)
+
+    - name: Infisical template rendering PASSED
+      ansible.builtin.debug:
+        msg: |
+          Infisical template assertions passed:
+          - docker-compose.yml.j2: postgres+redis+app images, port 8080:8080,
+            DB_CONNECTION_URI, REDIS_URL, SITE_URL, persistent volumes,
+            ENCRYPTION_KEY/AUTH_SECRET
+
 - name: Render and verify haproxy templates
   hosts: localhost
   connection: local


### PR DESCRIPTION
## Summary

Adds the Infisical self-hosted secrets-management deployment to ansible-proxmox-apps. Mirrors `roles/openproject_docker` (bundled Postgres + Redis + app via Docker Compose in LXC). Closes the Ansible side of Phase 1 in [JacobPEvans/terraform-proxmox#136](https://github.com/JacobPEvans/terraform-proxmox/issues/136).

## What this PR ships

### `roles/infisical_docker/`

- `defaults/main.yml` — every literal lives here (image tags, DB identity, service names, paths, restart policy). Ports come from `terraform_data.constants.service_ports.*` (DRY: no port literal in any template). Secrets use the `lookup('env', '...')` pattern with `mandatory()` — same precedent as `roles/mssql_docker`.
- `handlers/main.yml` — restart docker + restart infisical via `docker_compose_v2`.
- `meta/main.yml` — galaxy info, tags, license.
- `tasks/main.yml` — Docker install (with `fuse-overlayfs` for ZFS-backed LXC), data dirs, compose render with `no_log`, deploy, TCP wait, `/api/status` health check.
- `templates/docker-compose.yml.j2` — postgres + redis + infisical app. Zero literals; every value via `{{ var }}`.

### Inventory + playbook wiring

- `playbooks/site.yml` — new Phase 8.5 play targeting `infisical_group` (between Phase 8 openproject and Phase 9 systemd_restart_policy).
- `inventory/load_terraform.yml` — branch maps the `infisical` tag from Terraform inventory to `infisical_group` (mirrors `openproject_group` branch shape).
- `inventory/group_vars/infisical_group.yml` — new file. `systemd_restart_policy_services: [docker]`.
- `inventory/group_vars/haproxy_group.yml` — defines the canonical `haproxy_http_frontends` entry for Infisical (server_name from `terraform_data.domain`, backend_host from `hostvars['infisical'].container_ip`, backend_port from `terraform_data.constants.service_ports.infisical_api`, cert_path under `haproxy_ssl_crt_base`). **`haproxy_http_enabled` stays at the default `false`** — flip to `true` only after terraform-proxmox PR #320 is activated and `/etc/ssl/private/infisical.pem` is delivered to the HAProxy LXC.

### Secrets

- `secrets.enc.yaml.example` — adds `INFISICAL_ENCRYPTION_KEY`, `INFISICAL_AUTH_SECRET`, `INFISICAL_DB_PASSWORD` with the `openssl rand -base64 …` generation commands. These are local-radius secrets (consumed only by the Infisical LXC's bundled stack), so they go in SOPS alongside `MSSQL_SA_PASSWORD`, `HAPROXY_STATS_PASSWORD`, `MAILPIT_RELAY_PASSWORD` — **not** Doppler (which stays reserved for cross-system creds like `PROXMOX_VE_*`).

### Tests

- `tests/template_render/verify_templates.yml` — new `infisical_docker` block with 7 assertions:
  - All three images (`postgres:14-alpine`, `redis:7-alpine`, `infisical/infisical:latest`)
  - Port mapping `8080:8080` (both sides via `service_ports.infisical_api`)
  - `DB_CONNECTION_URI` assembled from DRY pieces
  - `REDIS_URL` assembled from DRY pieces
  - `SITE_URL` is the HTTPS FQDN
  - Persistent volumes for postgres + redis
  - `ENCRYPTION_KEY` and `AUTH_SECRET` env vars present

## Verification (local)

- ✅ `ansible-playbook tests/template_render/verify_templates.yml -c local`: **82 tasks, 0 failures** (full template-render suite including the new infisical block)
- ✅ `ansible-lint roles/infisical_docker/ playbooks/site.yml tests/template_render/verify_templates.yml`: **0 failures, 0 warnings, profile `production` passed**
- ⚠️ End-to-end deploy + smoke (web UI + API + token-based secret retrieval) needs to run against the live cluster after merge — CI cannot reach the cluster.

## Deploy procedure (after merge)

```bash
# 1. Generate the 3 SOPS secrets locally:
openssl rand -base64 32   # INFISICAL_ENCRYPTION_KEY
openssl rand -base64 32   # INFISICAL_AUTH_SECRET
openssl rand -base64 24   # INFISICAL_DB_PASSWORD
sops secrets.enc.yaml     # paste the 3 values

# 2. Ensure Technitium has an A record for infisical.<domain>
#    pointing at hostvars['infisical'].container_ip (10.0.1.108).

# 3. Deploy. SOPS injects INFISICAL_*, Doppler injects PROXMOX_VE_*
#    (pattern from ansible-proxmox-apps/CLAUDE.md:169):
sops exec-env secrets.enc.yaml 'doppler run -- ansible-playbook \
  -i inventory/hosts.yml \
  -i inventory/load_terraform.yml \
  playbooks/site.yml --tags infisical_docker'

# 4. After terraform-proxmox PR #320 is activated and the cert lands at
#    /etc/ssl/private/infisical.pem on the haproxy LXC, flip
#    haproxy_http_enabled to true in
#    inventory/group_vars/haproxy_group.yml and re-run the haproxy play
#    to bring up the HTTPS frontend.

# 5. End-to-end smoke (closes Phase 1):
curl -fsS https://infisical.<domain>/api/status
open https://infisical.<domain>
```

## Test plan

- [x] Template render tests pass (82/82)
- [x] ansible-lint profile 'production' passes
- [ ] User: generate SOPS secrets + Technitium A record
- [ ] User: deploy via the command above, confirm `infisical_docker_health` task reports 200 from `/api/status`
- [ ] User (after PR #320 activated): flip `haproxy_http_enabled` to true, re-run haproxy play, smoke `https://infisical.<domain>`

## Related

- Related: [JacobPEvans/terraform-proxmox#136](https://github.com/JacobPEvans/terraform-proxmox/issues/136) (Phase 1 Infisical deploy)
- Related: [JacobPEvans/terraform-proxmox#315](https://github.com/JacobPEvans/terraform-proxmox/pull/315) (LXC + DRY constants)
- Related: [JacobPEvans/terraform-proxmox#318](https://github.com/JacobPEvans/terraform-proxmox/pull/318) (keyctl/fuse fix — merged)
- Related: [JacobPEvans/terraform-proxmox#320](https://github.com/JacobPEvans/terraform-proxmox/pull/320) (ACME SAN list + LXC cert delivery — must be activated before flipping `haproxy_http_enabled`)