### PR TITLE
feat(idrac_kvm_docker): rebuild viewer image with AVCT client; LXC wiring + ports 5410/5710

### DIFF
--- a/inventory/load_terraform.yml
+++ b/inventory/load_terraform.yml
@@ -152,6 +152,11 @@
               ['healthchecks_group']
               if 'healthcheck' in (item.value.tags | default([]))
               else []
+            ) +
+            (
+              ['idrac_kvm_group']
+              if 'idrac' in (item.value.tags | default([]))
+              else []
             )
           }}
         proxmox_vmid: "{{ item.value.vmid }}"
@@ -202,14 +207,13 @@
     # NOTE: Docker VMs (docker-host) are for TESTING/DEV ONLY.
     # Production syslog/netflow pipelines use native Cribl Edge/Stream
     # on LXC containers (cribl_edge, cribl_stream_group).
-    # Exception: idrac-kvm VM runs vendor domistyle/idrac6 containers (no native path).
+    # (idrac-kvm is now a Docker-in-LXC, joined to idrac_kvm_group by the LXC task above.)
     - name: Add Docker VMs to inventory (SSH connection — testing/dev only)
       ansible.builtin.add_host:
         name: "{{ item.key }}"
         groups: >-
           {{
             ['docker_vms', 'cribl_docker_group', 'all']
-            + (['idrac_kvm_group'] if 'idrac' in (item.value.tags | default([])) else [])
           }}
         ansible_host: "{{ item.value.ip }}"
         ansible_connection: "{{ item.value.ansible_connection }}"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -301,7 +301,7 @@
 
 # =============================================================================
 # Phase 7b: iDRAC KVM HTML5 Viewer
-# domistyle/idrac6 containers (R410 + R710) on dedicated VM 251.
+# domistyle/idrac6-based viewers (R410 + R710) on dedicated LXC 251.
 # Credentials come from Doppler IDRAC_R*_HOST/USER/PASSWORD env vars.
 # =============================================================================
 

--- a/roles/idrac_kvm_docker/README.md
+++ b/roles/idrac_kvm_docker/README.md
@@ -1,27 +1,30 @@
 # idrac_kvm_docker
 
-Deploys one `domistyle/idrac6` container per physical iDRAC on a dedicated
-Docker VM (`idrac-kvm`, VM 251), exposes the HTML5-rendered KVM viewer on a
-per-iDRAC host port, and installs `ipmitool` on the VM for non-Java chassis
-operations.
+Runs both `domistyle/idrac6`-based viewers (one Docker container per physical
+iDRAC) on a single dedicated Docker-in-LXC (`idrac-kvm`, LXC 251), exposes each
+HTML5-rendered KVM viewer on a per-iDRAC host port, and installs `ipmitool` for
+non-Java chassis operations.
 
 End users hit the viewer at a normal HTTP URL — no JNLP file, no local Java,
-no jar-signing dance, no Firefox MIME handler. The `domistyle/idrac6` image
-bundles the legacy Java client + AVCT viewer and transcodes the framebuffer
-to a browser-renderable HTML5 stream inside the container.
+no jar-signing dance, no Firefox MIME handler. The container transcodes the
+iDRAC framebuffer to a browser-renderable HTML5 stream. Note: the upstream
+`domistyle/idrac6` image does NOT ship Dell's AVCT KVM client; this role bakes
+it in via a local image rebuild (see "Viewer image" below).
 
 ## Installation
 
 The role is wired into `playbooks/site.yml` (Phase 7b) and runs against any
 host in `idrac_kvm_group`. The group is populated by `inventory/load_terraform.yml`
-from `docker_vms` tagged `idrac` in the Terraform inventory (see
-terraform-proxmox VM 251 `idrac-kvm`).
+from `containers` tagged `idrac` in the Terraform inventory (see terraform-proxmox
+LXC 251 `idrac-kvm`), reached over `proxmox_pct_remote`.
 
 Prerequisites:
 
-- VM 251 `idrac-kvm` exists (Terraform-managed; tags include `docker` and `idrac`).
+- LXC 251 `idrac-kvm` exists (Terraform-managed; tags include `container` and `idrac`).
 - Doppler config `iac-conf-mgmt/prd` populated with all six
   `IDRAC_R410_*` / `IDRAC_R710_*` variables (see Secrets table below).
+- The Dell AVCT client artifact staged in private storage and
+  `idrac_kvm_docker_avct_artifact_url` set (see "Viewer image" below).
 - `community.docker` Ansible collection installed (`ansible-galaxy collection
   install -r requirements.yml` from the repo root).
 
@@ -56,15 +59,33 @@ and fails fast with a Doppler pointer if any are missing.
 
 ## Access
 
-After a successful run on VM 251:
+After a successful run on LXC 251 (IP 10.0.1.251):
 
-| Server | URL                              | Container        |
-| ------ | -------------------------------- | ---------------- |
-| R410   | `http://<vm-251-ip>:5800/`       | `idrac-r410`     |
-| R710   | `http://<vm-251-ip>:5801/`       | `idrac-r710`     |
+| Server | URL                       | Container    |
+| ------ | ------------------------- | ------------ |
+| R410   | `http://10.0.1.251:5410/` | `idrac-r410` |
+| R710   | `http://10.0.1.251:5710/` | `idrac-r710` |
 
 Credentials are baked into the container via `.env` and forwarded to the
 iDRAC by the bundled viewer — no separate login screen on the HTML5 page.
+
+## Viewer image (Dell AVCT client)
+
+The stock `domistyle/idrac6` image does **not** ship Dell's proprietary AVCT KVM
+client (`avctKVM.jar`, `avctKVMIOLinux64.jar`, `avctVMLinux64.jar`,
+`libavctKVMIO.so`, `libavmlinux.so`, signed `META-INF`). Without it the HTML5
+viewer cannot connect. This role rebuilds a small local image instead:
+
+- `templates/Dockerfile.j2` → `FROM domistyle/idrac6` + `COPY app/ /app/`.
+- The `app/` payload is fetched at build time from
+  `idrac_kvm_docker_avct_artifact_url` (a tar archive whose top level is `app/`),
+  staged in private storage (MinIO/NAS) — it is **never** committed to git.
+- The image is tagged `idrac_kvm_docker_image` (default `idrac6-avct:local`) and
+  compose runs it with `pull: never` (local-only tag).
+
+The R410 and R710 clients are byte-identical, so one image serves both. To
+refresh the client, replace the artifact and remove `idrac_kvm_docker_build_dir`
+(or the image) before re-running.
 
 ## CLI Fallback (ipmitool)
 

--- a/roles/idrac_kvm_docker/defaults/main.yml
+++ b/roles/idrac_kvm_docker/defaults/main.yml
@@ -1,6 +1,17 @@
 ---
-idrac_kvm_docker_image: "domistyle/idrac6"
+# Locally rebuilt image: the vendor base + Dell/Avocent AVCT KVM client baked into
+# /app. domistyle/idrac6 does NOT ship the AVCT client; it is fetched from private
+# storage at build time (idrac_kvm_docker_avct_artifact_url) and never committed.
+idrac_kvm_docker_base_image: "domistyle/idrac6"
+idrac_kvm_docker_image: "idrac6-avct:local"
 idrac_kvm_docker_data_dir: /opt/idrac-kvm
+idrac_kvm_docker_build_dir: /opt/idrac-kvm/build
+# URL of a tar archive whose top level is an `app/` directory holding the AVCT client
+# (app/avctKVM.jar, app/lib/*.jar, app/lib/*.so, app/lib/META-INF/*). Stage it privately
+# (MinIO/NAS) — REQUIRED for the build. Empty = the build asserts and fails fast.
+idrac_kvm_docker_avct_artifact_url: ""
+# Optional sha256 of the artifact for integrity verification (recommended).
+idrac_kvm_docker_avct_artifact_sha256: ""
 idrac_kvm_docker_bind_address: "0.0.0.0"
 idrac_kvm_docker_tz: "UTC"
 idrac_kvm_docker_prune_unused: false
@@ -10,8 +21,8 @@ idrac_kvm_docker_prune_unused: false
 # IDRAC_<PREFIX>_USER, IDRAC_<PREFIX>_PASSWORD lookups in env.j2.
 idrac_kvm_docker_targets:
   - name: r410
-    host_port: 5800
+    host_port: 5410
     env_prefix: IDRAC_R410
   - name: r710
-    host_port: 5801
+    host_port: 5710
     env_prefix: IDRAC_R710

--- a/roles/idrac_kvm_docker/tasks/main.yml
+++ b/roles/idrac_kvm_docker/tasks/main.yml
@@ -177,6 +177,67 @@
     ansible_python_interpreter: /opt/ansible-venv/bin/python
 
 # =============================================================================
+# Build the local viewer image (vendor base + Dell AVCT KVM client)
+# =============================================================================
+# domistyle/idrac6 ships no AVCT KVM client; the iDRAC6 HTML5 viewer needs the
+# Dell/Avocent jars + native libs in /app. Fetch that proprietary artifact from
+# private storage and bake it into a local image via a tiny Dockerfile.
+
+- name: Assert AVCT client artifact URL is set
+  ansible.builtin.assert:
+    that:
+      - idrac_kvm_docker_avct_artifact_url | length > 0
+    fail_msg: >-
+      idrac_kvm_docker_avct_artifact_url must point to the private AVCT client
+      tarball (top-level app/ dir). Stage the captured app.tar in MinIO/NAS and
+      set the variable (see role README "Viewer image").
+
+- name: Create build context directory
+  ansible.builtin.file:
+    path: "{{ idrac_kvm_docker_build_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Fetch AVCT client artifact into build context
+  vars:
+    _avct_sha: "{{ idrac_kvm_docker_avct_artifact_sha256 }}"
+  ansible.builtin.get_url:
+    url: "{{ idrac_kvm_docker_avct_artifact_url }}"
+    dest: "{{ idrac_kvm_docker_build_dir }}/app.tar"
+    checksum: "{{ ('sha256:' ~ _avct_sha) if _avct_sha else omit }}"
+    mode: "0644"
+
+- name: Unpack AVCT client into build context (creates app/)
+  ansible.builtin.unarchive:
+    src: "{{ idrac_kvm_docker_build_dir }}/app.tar"
+    dest: "{{ idrac_kvm_docker_build_dir }}"
+    remote_src: true
+    creates: "{{ idrac_kvm_docker_build_dir }}/app"
+
+- name: Render Dockerfile for the rebuilt viewer image
+  ansible.builtin.template:
+    src: Dockerfile.j2
+    dest: "{{ idrac_kvm_docker_build_dir }}/Dockerfile"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart idrac-kvm
+
+- name: Build local viewer image (base + AVCT client baked into /app)
+  community.docker.docker_image:
+    name: "{{ idrac_kvm_docker_image }}"
+    source: build
+    build:
+      path: "{{ idrac_kvm_docker_build_dir }}"
+      pull: true
+    state: present
+  vars:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python
+  notify: Restart idrac-kvm
+
+# =============================================================================
 # Deploy via Docker Compose
 # =============================================================================
 
@@ -184,6 +245,7 @@
   community.docker.docker_compose_v2:
     project_src: "{{ idrac_kvm_docker_data_dir }}"
     state: present
+    pull: never
   no_log: true
   vars:
     ansible_python_interpreter: /opt/ansible-venv/bin/python

--- a/roles/idrac_kvm_docker/templates/Dockerfile.j2
+++ b/roles/idrac_kvm_docker/templates/Dockerfile.j2
@@ -1,0 +1,7 @@
+# Managed by Ansible (idrac_kvm_docker role). Do not edit manually.
+# Rebuilds the vendor base with Dell's AVCT KVM client, which domistyle/idrac6
+# does not ship. The proprietary client (app/) is fetched from private storage
+# into the build context at deploy time and is NEVER committed to git.
+FROM {{ idrac_kvm_docker_base_image }}
+
+COPY app/ /app/


### PR DESCRIPTION
idrac-kvm moves from a never-provisioned VM to a managed Docker-in-LXC
(terraform-proxmox 251). Wire it up and reproduce the hand-built viewers properly:

- inventory: add idrac-tagged LXCs to idrac_kvm_group via the proxmox_pct_remote
  container path; drop the now-dead idrac injection from the docker_vms (SSH) path.
- image: rebuild locally (FROM domistyle/idrac6 + COPY app/ /app/) because the base
  image ships no Dell AVCT KVM client. The proprietary client is fetched at build
  time from idrac_kvm_docker_avct_artifact_url (private storage, never git); compose
  runs the local tag with pull: never.
- ports: host 5800/5801 -> 5410/5710 (R410/R710 mnemonic).
- README: document the LXC move, proxmox_pct_remote wiring, and the rebuilt image.

Pairs with terraform-proxmox (LXC 251 def + firewall) and ansible-proxmox (pve
kiosk). Requires staging the captured app.tar artifact + setting the URL var
before deploy.

Assisted-by: Claude <noreply@anthropic.com>
