### PR TITLE
fix(ci): retarget reusable-workflow org refs (ansible-proxmox-apps)

### DIFF
--- a/.github/workflows/_e2e-tests.yml
+++ b/.github/workflows/_e2e-tests.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Mask secrets
-        uses: JacobPEvans/.github/actions/mask-secrets@main
+        uses: JacobPEvans-personal/.github/actions/mask-secrets@main
         with:
           sops-file: secrets.enc.yaml
 
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Mask secrets
-        uses: JacobPEvans/.github/actions/mask-secrets@main
+        uses: JacobPEvans-personal/.github/actions/mask-secrets@main
         with:
           sops-file: secrets.enc.yaml
 
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Mask secrets
-        uses: JacobPEvans/.github/actions/mask-secrets@main
+        uses: JacobPEvans-personal/.github/actions/mask-secrets@main
         with:
           sops-file: secrets.enc.yaml
 

--- a/.github/workflows/ai-merge-gate.yml
+++ b/.github/workflows/ai-merge-gate.yml
@@ -4,5 +4,5 @@ on: pull_request
 permissions: read-all
 jobs:
   gate:
-    uses: JacobPEvans/ai-workflows/.github/workflows/_ai-merge-gate.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/_ai-merge-gate.yml@main
     secrets: inherit

--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -16,5 +16,5 @@ permissions:
 
 jobs:
   recommend:
-    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/best-practices.yml@main
     secrets: inherit

--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   handle-failure:
     if: github.event.workflow_run.conclusion == 'failure'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fail-issue.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/ci-fail-issue.yml@main
     with:
       workflow_name: "Ansible Lint"
     secrets: inherit

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -29,7 +29,7 @@ jobs:
     #   github.event.workflow_run.conclusion == 'failure' &&
     #   github.event.workflow_run.head_branch != 'main'
     # --- END DISABLED ---
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/ci-fix.yml@main
     with:
       repo_context: "Ansible playbooks and roles for applications on Proxmox VMs/containers"
       ci_structure: "ansible-lint.yml (ansible-lint + ansible-playbook --syntax-check)"

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   simplify:
-    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/code-simplifier.yml@main
     secrets: inherit

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -19,5 +19,5 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/final-pr-review.yml@main
     secrets: inherit

--- a/.github/workflows/gh-aw-pin-refresh.yml
+++ b/.github/workflows/gh-aw-pin-refresh.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: JacobPEvans/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
     with:
       operation: ${{ inputs.operation || 'compile' }}
     secrets:

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -69,7 +69,7 @@ jobs:
 
   run-triage:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/issue-triage.yml@main
     secrets: inherit
     with:
       issue_number: ${{ inputs.issue_number }}
@@ -80,7 +80,7 @@ jobs:
       always() &&
       github.event_name == 'workflow_dispatch' &&
       (needs.run-triage.result == 'success' || needs.run-triage.result == 'skipped')
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/issue-resolver.yml@main
     secrets: inherit
     with:
       repo_context: "Ansible Proxmox application configuration"

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -16,9 +16,9 @@ permissions:
 
 jobs:
   sweep:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/issue-sweeper.yml@main
     secrets: inherit
 
   hygiene:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/issue-hygiene.yml@main
     secrets: inherit

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -16,5 +16,5 @@ permissions:
 
 jobs:
   analyze:
-    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/next-steps.yml@main
     secrets: inherit

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -42,7 +42,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/post-merge-docs-review.yml@main
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -42,7 +42,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/post-merge-tests.yml@main
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,6 +12,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_release-please.yml@main
     secrets:
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Root cause

GitHub Actions `uses:` fields do not follow repository transfer/rename redirects and cannot reference variables. All `uses: JacobPEvans/...` lines were pointing at a previous owner that no longer resolves correctly, causing workflow parse failures.

## Changes

| Old owner | New owner | Affected workflows |
|---|---|---|
| `JacobPEvans/ai-workflows/` | `dryvist/ai-workflows/` | issue-auto-resolve, issue-sweeper, ci-fix, ai-merge-gate, ci-fail-issue, post-merge-tests, final-pr-review, best-practices, next-steps, post-merge-docs-review, code-simplifier |
| `JacobPEvans/.github/` | `JacobPEvans-personal/.github/` | _e2e-tests (mask-secrets action), release-please, gh-aw-pin-refresh |

Only the owner prefix was changed; all paths and `@ref` pins are preserved verbatim.

Part of an org-wide sweep fixing shared-CI `uses:` references after the repo org migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)