### PR TITLE
feat(download_vpn): VPN-locked qBittorrent+Prowlarr LXC with fail-closed killswitch

### DIFF
--- a/.github/workflows/_molecule.yml
+++ b/.github/workflows/_molecule.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scenario: [default, qdrant, llamaindex]
+        scenario: [default, qdrant, llamaindex, download_vpn]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/_molecule.yml
+++ b/.github/workflows/_molecule.yml
@@ -41,6 +41,7 @@ jobs:
             'molecule-plugins[docker]>=23.0.0' \
             'ansible-core>=2.16' \
             'docker>=7.0.0' \
+            netaddr \
             ansible-lint
 
       - name: Install Ansible collections

--- a/.github/workflows/_molecule.yml
+++ b/.github/workflows/_molecule.yml
@@ -47,6 +47,15 @@ jobs:
       - name: Install Ansible collections
         run: ansible-galaxy collection install -r requirements.yml --force
 
+      # Least-privilege secret handling: this action (pinned v2.0.0) has NO
+      # allowlist input — it always fetches the entire iac-conf-mgmt/prd config.
+      # With inject-env-vars it would export EVERY key into the job environment
+      # for every subsequent step. We deliberately omit inject-env-vars so no
+      # secret lands in the ambient job env, then map ONLY the three keys the
+      # molecule scenarios actually consume into the test step's own env below.
+      # Each value is still registered with the runner's mask (the action calls
+      # core.setSecret per key), so it is redacted in logs. The values remain
+      # available as masked step outputs (steps.doppler.outputs.<KEY>).
       - name: Fetch secrets from Doppler
         uses: dopplerhq/secrets-fetch-action@451892f16195f9ac360e1a5bcbf0b5fd0e957534 # v2.0.0
         id: doppler
@@ -54,13 +63,22 @@ jobs:
           doppler-token: ${{ secrets.GH_ACTION_DOPPLER_IAC_CONF_MGMT }}
           doppler-project: iac-conf-mgmt
           doppler-config: prd
-          inject-env-vars: true
 
       - name: Run molecule tests
         env:
           PY_COLORS: "1"
           ANSIBLE_FORCE_COLOR: "1"
           MOLECULE_SCENARIO: ${{ matrix.scenario }}
+          # Only the secrets the scenarios reference (verified against
+          # molecule/*/molecule.yml provisioner.env and the exercised roles):
+          #   default     -> MSSQL_SA_PASSWORD
+          #   qdrant      -> QDRANT_API_KEY
+          #   llamaindex  -> QDRANT_API_KEY
+          #   download_vpn-> QBITTORRENT_ADMIN_PASSWORD (Proton WG keys use
+          #                  built-in dummy fallbacks; services not started in CI)
+          QDRANT_API_KEY: ${{ steps.doppler.outputs.QDRANT_API_KEY }}
+          MSSQL_SA_PASSWORD: ${{ steps.doppler.outputs.MSSQL_SA_PASSWORD }}
+          QBITTORRENT_ADMIN_PASSWORD: ${{ steps.doppler.outputs.QBITTORRENT_ADMIN_PASSWORD }}
         run: molecule test -s "$MOLECULE_SCENARIO"
 
   template-render:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,10 @@ this repo handles app config only.
   host `ipmitool`, Docker on dedicated VM 251). A Mac-only OrbStack exploratory
   variant lives at `orbstack-kubernetes/docker/idrac-webtop` (webtop +
   OpenWebStart + self-signed jar wrapper) and is not used in production.
+- **Media stack** (pve2): `download_vpn` (qBittorrent-nox + Prowlarr behind
+  Proton WireGuard with a fail-closed dual-stack nftables killswitch, NAT-PMP
+  port forwarding, and three layers of continuous killswitch validation), plus
+  LAN-only `sonarr`, `radarr`, `plex` (skeleton roles).
 
 **This repo does NOT own Splunk.** Splunk is managed by `ansible-splunk`.
 

--- a/inventory/group_vars/download_vpn_group.yml
+++ b/inventory/group_vars/download_vpn_group.yml
@@ -1,0 +1,9 @@
+---
+# download_vpn group variables.
+# Services the systemd_restart_policy role should apply restart-on-failure to.
+# wg + killswitch are oneshot (RemainAfterExit); the long-running services are
+# qBittorrent, Prowlarr, and the NAT-PMP keeper.
+systemd_restart_policy_services:
+  - qbittorrent-nox
+  - prowlarr
+  - download-vpn-natpmp

--- a/inventory/group_vars/plex_group.yml
+++ b/inventory/group_vars/plex_group.yml
@@ -1,0 +1,4 @@
+---
+# plex group variables
+systemd_restart_policy_services:
+  - plexmediaserver

--- a/inventory/group_vars/radarr_group.yml
+++ b/inventory/group_vars/radarr_group.yml
@@ -1,0 +1,4 @@
+---
+# radarr group variables
+systemd_restart_policy_services:
+  - radarr

--- a/inventory/group_vars/sonarr_group.yml
+++ b/inventory/group_vars/sonarr_group.yml
@@ -1,0 +1,4 @@
+---
+# sonarr group variables
+systemd_restart_policy_services:
+  - sonarr

--- a/inventory/load_terraform.yml
+++ b/inventory/load_terraform.yml
@@ -152,6 +152,31 @@
               ['healthchecks_group']
               if 'healthcheck' in (item.value.tags | default([]))
               else []
+            ) +
+            (
+              ['download_vpn_group']
+              if 'vpn' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
+              ['sonarr_group']
+              if 'sonarr' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
+              ['radarr_group']
+              if 'radarr' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
+              ['plex_group']
+              if 'plex' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
+              ['media_group']
+              if 'media' in (item.value.tags | default([]))
+              else []
             )
           }}
         proxmox_vmid: "{{ item.value.vmid }}"

--- a/molecule/download_vpn/converge.yml
+++ b/molecule/download_vpn/converge.yml
@@ -1,0 +1,29 @@
+---
+# Molecule converge for the download_vpn scenario.
+#
+# Runs the role with download_vpn_manage_services=false: all config (killswitch
+# ruleset, wg0.conf, qBittorrent.conf, unit files, validator) is rendered, but
+# the live service start / VPN bring-up / WebUI calls are skipped — there is no
+# real Proton tunnel in CI. verify.yml exercises the killswitch logic directly.
+
+- name: Converge
+  hosts: all
+  become: true
+  gather_facts: true
+
+  vars:
+    download_vpn_manage_services: false
+    # Mirror prepare.yml so the role's terraform_data lookups resolve.
+    container_ip: "192.168.0.210"
+    terraform_data:
+      constants:
+        media_ports:
+          qbittorrent_web: 8080
+          prowlarr_web: 9696
+        notification_ports:
+          ntfy_http: 8080
+
+  tasks:
+    - name: Include download_vpn role
+      ansible.builtin.include_role:
+        name: download_vpn

--- a/molecule/download_vpn/molecule.yml
+++ b/molecule/download_vpn/molecule.yml
@@ -1,0 +1,61 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: download-vpn-test
+    # No stable version tags available; geerlingguy only publishes :latest
+    image: geerlingguy/docker-debian12-ansible:latest
+    privileged: true
+    command: ""
+    pre_build_image: true
+    # NET_ADMIN is needed for nft + ip route inside the test container.
+    capabilities:
+      - NET_ADMIN
+      - NET_RAW
+    tmpfs:
+      - /run
+      - /run/lock
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    groups:
+      - download_vpn_group
+      - lxc_containers
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
+  env:
+    PROTON_WG_PRIVATE_KEY: "${PROTON_WG_PRIVATE_KEY:-QHk0aVZ2c2tleVRFU1Rvbmx5Tk9UcmVhbGtleQ==}"
+    PROTON_WG_ADDRESS: "${PROTON_WG_ADDRESS:-10.2.0.2/32}"
+    PROTON_WG_ENDPOINT: "${PROTON_WG_ENDPOINT:-203.0.113.7:51820}"
+    PROTON_WG_PEER_PUBLIC_KEY: "${PROTON_WG_PEER_PUBLIC_KEY:-cGVlclRFU1RwdWJsaWNrZXlOT1RyZWFsa2V5MDA=}"
+    PROTON_WG_DNS: "${PROTON_WG_DNS:-10.2.0.1}"
+    QBITTORRENT_ADMIN_PASSWORD: "${QBITTORRENT_ADMIN_PASSWORD:-molecule-test-pass}"
+
+verifier:
+  name: ansible
+
+scenario:
+  name: download_vpn
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - cleanup
+    - destroy

--- a/molecule/download_vpn/prepare.yml
+++ b/molecule/download_vpn/prepare.yml
@@ -1,0 +1,49 @@
+---
+# Molecule preparation for the download_vpn scenario.
+
+- name: Prepare
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Wait for container to be ready
+      ansible.builtin.wait_for_connection:
+        timeout: 30
+
+    - name: Gather facts
+      ansible.builtin.setup:
+
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: true
+      register: _apt_update
+      until: _apt_update is succeeded
+      retries: 3
+      delay: 10
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Install base packages the role expects pre-present
+      ansible.builtin.apt:
+        name:
+          - curl
+          - ca-certificates
+          - iproute2
+          - procps
+          - systemd
+        state: present
+      when: ansible_facts['os_family'] == 'Debian'
+
+    # The role consumes terraform_data.constants.media_ports and the host's
+    # container_ip (normally injected by load_terraform.yml). Provide a minimal
+    # stand-in so the role renders without the full terraform inventory.
+    - name: Inject minimal terraform_data + inventory facts for the role
+      ansible.builtin.set_fact:
+        container_ip: "192.168.0.210"
+        terraform_data:
+          constants:
+            media_ports:
+              qbittorrent_web: 8080
+              prowlarr_web: 9696
+            notification_ports:
+              ntfy_http: 8080

--- a/molecule/download_vpn/verify.yml
+++ b/molecule/download_vpn/verify.yml
@@ -1,0 +1,160 @@
+---
+# Molecule verification for download_vpn (validation layer 1 — the CI gate).
+#
+# Proves the killswitch logic without a real Proton VPN:
+#   1. The rendered nftables ruleset has output policy DROP and ONLY the
+#      allowed rules (loopback, LAN, Proton endpoint, wg0).
+#   2. qBittorrent is configured to bind to wg0.
+#   3. With the killswitch loaded and wg0 DOWN, the netns has NO IPv4 and NO
+#      IPv6 internet egress.
+#   4. The validator + deploy-time validate.yml cover v4 AND v6 (asserted by
+#      grepping their rendered logic).
+
+- name: Verify
+  hosts: all
+  become: true
+  gather_facts: true
+
+  vars:
+    download_vpn_wg_interface: wg0
+    download_vpn_nft_ruleset_path: /etc/nftables.d/download-vpn-killswitch.nft
+    download_vpn_qbittorrent_config_dir: /home/qbittorrent/.config/qBittorrent
+
+  tasks:
+    # --- 1. ruleset content ------------------------------------------------
+    - name: Read the rendered killswitch ruleset
+      ansible.builtin.slurp:
+        src: "{{ download_vpn_nft_ruleset_path }}"
+      register: ks_file
+
+    - name: Decode ruleset
+      ansible.builtin.set_fact:
+        ks: "{{ ks_file.content | b64decode }}"
+
+    - name: Assert output chain default policy is DROP
+      ansible.builtin.assert:
+        that:
+          - "'hook output' in ks"
+          - "'policy drop' in ks"
+        fail_msg: "Killswitch output chain is not default-DROP."
+
+    - name: Assert ONLY the allowed egress rules are present
+      ansible.builtin.assert:
+        that:
+          - "'oif \"lo\" accept' in ks"
+          - "'oifname \"' ~ download_vpn_wg_interface ~ '\" accept' in ks"
+          - "'udp dport' in ks"            # Proton handshake rule
+          - "'ip daddr' in ks"             # LAN allow rule
+          - "'log prefix \"killswitch-drop' in ks"
+          # Negative: no blanket internet accept, no v6 ::/0 accept.
+          - "'ip6 daddr ::/0 accept' not in ks"
+          - "'accept comment \"any\"' not in ks"
+        fail_msg: "Killswitch ruleset has unexpected or missing rules."
+
+    - name: Load the killswitch ruleset into the kernel
+      ansible.builtin.command:
+        cmd: "nft -f {{ download_vpn_nft_ruleset_path }}"
+      changed_when: true
+
+    - name: Read the live output chain policy
+      ansible.builtin.command:
+        cmd: nft list chain inet killswitch output
+      register: live_chain
+      changed_when: false
+
+    - name: Assert the LIVE killswitch output policy is drop
+      ansible.builtin.assert:
+        that:
+          - "'policy drop' in live_chain.stdout"
+        fail_msg: "Loaded killswitch output policy is not drop."
+
+    # --- 2. qBittorrent bound to wg0 ---------------------------------------
+    - name: Read qBittorrent config
+      ansible.builtin.slurp:
+        src: "{{ download_vpn_qbittorrent_config_dir }}/qBittorrent.conf"
+      register: qbt_conf
+
+    - name: Assert qBittorrent binds to wg0
+      ansible.builtin.assert:
+        that:
+          - "'Session\\\\Interface=' ~ download_vpn_wg_interface in (qbt_conf.content | b64decode)"
+          - "'Connection\\\\Interface=' ~ download_vpn_wg_interface in (qbt_conf.content | b64decode)"
+        fail_msg: "qBittorrent is not bound to wg0."
+
+    # --- 3. simulate wg0 down -> no v4/v6 egress ---------------------------
+    - name: Ensure IPv6 is disabled (as the role does on real hosts)
+      ansible.posix.sysctl:
+        name: "{{ item }}"
+        value: "1"
+        sysctl_set: true
+        state: present
+        reload: true
+      loop:
+        - net.ipv6.conf.all.disable_ipv6
+        - net.ipv6.conf.default.disable_ipv6
+      failed_when: false
+
+    - name: Confirm wg0 is absent (down) for the leak test
+      ansible.builtin.command:
+        cmd: ip link show wg0
+      register: wg0_present
+      changed_when: false
+      failed_when: false
+
+    # noqa command-instead-of-module: this leak test deliberately uses curl so
+    # behaviour matches the runtime validator exactly; the uri module's success
+    # semantics differ and would mask a partial leak.
+    - name: Attempt IPv4 internet egress with the killswitch up and wg0 down  # noqa: command-instead-of-module
+      ansible.builtin.command:
+        cmd: curl -fsS --max-time 6 https://ifconfig.me
+      register: leak_v4
+      changed_when: false
+      failed_when: false
+
+    - name: Assert NO IPv4 egress when wg0 is down (killswitch holds)
+      ansible.builtin.assert:
+        that:
+          - leak_v4.rc != 0
+          - (leak_v4.stdout | trim | length) == 0
+        fail_msg: >-
+          LEAK: IPv4 internet egress succeeded with wg0 down
+          (got '{{ leak_v4.stdout | trim }}'). Killswitch is not fail-closed.
+
+    # noqa command-instead-of-module: the uri module cannot force IPv6-only
+    # (curl -6); forcing the v6 family is the point of this leak test.
+    - name: Attempt IPv6 internet egress with the killswitch up  # noqa: command-instead-of-module
+      ansible.builtin.command:
+        cmd: curl -fsS -6 --max-time 6 https://ifconfig.me
+      register: leak_v6
+      changed_when: false
+      failed_when: false
+
+    - name: Assert NO IPv6 egress (disabled + dropped)
+      ansible.builtin.assert:
+        that:
+          - leak_v6.rc != 0
+          - (leak_v6.stdout | trim | length) == 0
+        fail_msg: >-
+          LEAK: IPv6 internet egress succeeded
+          (got '{{ leak_v6.stdout | trim }}'). IPv6 must have no path.
+
+    # --- 4. validator + deploy-time logic cover v4 AND v6 ------------------
+    - name: Read the runtime validator script
+      ansible.builtin.slurp:
+        src: /usr/local/bin/download-vpn-killswitch-validate.sh
+      register: validator
+
+    - name: Assert the validator checks both v4 and v6 egress + stops qBittorrent on breach
+      ansible.builtin.assert:
+        that:
+          - "'curl -6' in (validator.content | b64decode)"
+          - "'--interface eth0' in (validator.content | b64decode)"
+          - "'ip -6 route show default' in (validator.content | b64decode)"
+          - "'systemctl stop qbittorrent-nox.service' in (validator.content | b64decode)"
+        fail_msg: "Runtime validator does not cover both address families or does not fail closed."
+
+    - name: Clean up the loaded killswitch table
+      ansible.builtin.command:
+        cmd: nft delete table inet killswitch
+      changed_when: true
+      failed_when: false

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -378,6 +378,55 @@
     - role: infisical_docker
 
 # =============================================================================
+# Phase 8c: Media stack (pve2)
+# VPN-locked downloader (qBittorrent + Prowlarr behind Proton WireGuard with a
+# fail-closed nftables killswitch) plus LAN-only Sonarr/Radarr/Plex. The
+# download_vpn role imports its own validate.yml at the end and FAILS the run
+# on any killswitch/leak violation.
+# =============================================================================
+
+- name: Configure VPN-locked downloader (qBittorrent + Prowlarr)
+  hosts: download_vpn_group
+  become: true
+  gather_facts: true
+  tags:
+    - download_vpn
+    - media
+    - vpn
+  roles:
+    - role: download_vpn
+
+- name: Configure Sonarr (LAN-only TV PVR)
+  hosts: sonarr_group
+  become: true
+  gather_facts: true
+  tags:
+    - sonarr
+    - media
+  roles:
+    - role: sonarr
+
+- name: Configure Radarr (LAN-only movie PVR)
+  hosts: radarr_group
+  become: true
+  gather_facts: true
+  tags:
+    - radarr
+    - media
+  roles:
+    - role: radarr
+
+- name: Configure Plex Media Server (LAN-only)
+  hosts: plex_group
+  become: true
+  gather_facts: true
+  tags:
+    - plex
+    - media
+  roles:
+    - role: plex
+
+# =============================================================================
 # Phase 9: Systemd Restart Policies
 # Apply restart-on-failure policies to all managed services
 # Each group defines its services via group_vars

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,6 +5,9 @@ collections:
   - name: ansible.posix
     version: ">=1.3.0"
 
+  - name: ansible.utils
+    version: ">=2.10.0"  # ipaddr/ipv4 filters used by the download_vpn role
+
   - name: community.general
     version: ">=10.3.0"  # Required for proxmox_pct_remote connection plugin
 

--- a/roles/download_vpn/README.md
+++ b/roles/download_vpn/README.md
@@ -1,0 +1,86 @@
+# download_vpn
+
+VPN-locked downloader: **qBittorrent-nox + Prowlarr behind Proton WireGuard**
+with a **fail-closed nftables killswitch**. If the VPN tunnel (`wg0`) is down
+there is no route and no rule permitting non-VPN egress, so torrent and indexer
+traffic is cut off instantly.
+
+## Security model
+
+The role is built so qBittorrent is *provably* unable to send/receive traffic
+outside the VPN:
+
+1. **nftables killswitch** — a single `inet` table with `output` policy `drop`.
+   The only allowed egress is loopback, the LAN subnet (web UIs + *arr ⇄
+   qBittorrent/Prowlarr), UDP to the Proton endpoint IP:port (handshake), and
+   anything leaving via `wg0`. Covers IPv4 **and** IPv6.
+2. **IPv6 killed at the kernel** — Proton is dual-stack. `sysctl
+   net.ipv6.conf.{all,default,lo}.disable_ipv6=1` removes any IPv6 path; the
+   `nft ip6` coverage is defense-in-depth.
+3. **Interface binding** — qBittorrent's `Connection\Interface` and
+   `Session\Interface` are pinned to `wg0`. Binding + killswitch = zero leaks
+   (binding alone closed a 30% leak seen with the killswitch only).
+4. **NAT-PMP port forwarding** — a systemd service loops `natpmpc` against the
+   Proton gateway and pushes the assigned port into qBittorrent's listen port
+   via the WebUI API.
+5. **Boot-safe ordering** — qBittorrent/Prowlarr/NAT-PMP units
+   `Requires=`/`After=`/`BindsTo=` the killswitch + `wg0` units, so they can
+   never start (or stay up) without the lock.
+
+## Three validation layers (all mandatory)
+
+- **CI** — `molecule/download_vpn/verify.yml`, on every PR. Asserts the nft
+  DROP policy + only the allowed rules; qBittorrent interface == `wg0`; then
+  simulates `wg0` down and asserts the netns has no v4/v6 internet egress.
+- **Deploy-time** — `tasks/validate.yml`, imported at the role end so it runs
+  on every play. Asserts the killswitch is active, the only default route is
+  `wg0`, no IPv6 default route exists, qBittorrent is bound to `wg0`, live VPN
+  IPv4 egress works, and forced non-VPN IPv4 + all IPv6 egress are refused.
+  **Fails the play on any violation.**
+- **Runtime** — `download-vpn-validate.timer` (every ~2 min). Re-checks the
+  above; on ANY breach it stops qBittorrent, alerts ntfy, and pings the
+  healthchecks deadman. A stalled validator also pages (deadman semantics).
+
+## Installation
+
+Provisioned by the `download-vpn` LXC in `terraform-proxmox` (unprivileged,
+`/dev/net/tun` passthrough, `nesting`/`keyctl`, `tank/downloads` + `tank/media`
+bind-mounts). Deploy the role from this repo:
+
+```bash
+ansible-galaxy collection install -r requirements.yml
+sops exec-env secrets.enc.yaml 'doppler run -- ansible-playbook \
+  -i inventory/hosts.yml playbooks/site.yml --tags download_vpn'
+```
+
+## Requirements
+
+- Debian-based unprivileged LXC with `/dev/net/tun` and `nesting`/`keyctl`.
+- Proton WireGuard config delivered via SOPS (see repo
+  `secrets.enc.yaml.example`): `PROTON_WG_PRIVATE_KEY`, `PROTON_WG_ADDRESS`,
+  `PROTON_WG_ENDPOINT`, `PROTON_WG_PEER_PUBLIC_KEY`, `PROTON_WG_DNS`,
+  `QBITTORRENT_ADMIN_PASSWORD`.
+- `tank/downloads` + `tank/media` bind-mounted at `/mnt/downloads` and
+  `/mnt/media`.
+
+## Key variables
+
+All ports/IPs come from terraform (`terraform_data.constants.media_ports`,
+derived LAN subnet) — nothing is hardcoded. See `defaults/main.yml`.
+
+- `download_vpn_wg_endpoint` — Proton `host:port` (SOPS env).
+- `download_vpn_lan_subnet` — LAN allowed through the killswitch (derived).
+- `download_vpn_qbittorrent_web_port` — qBittorrent WebUI port (terraform).
+- `download_vpn_prowlarr_web_port` — Prowlarr WebUI port (terraform).
+- `download_vpn_validator_interval` — runtime validator cadence (default 2min).
+- `download_vpn_ntfy_url` / `download_vpn_healthcheck_url` — breach alerting.
+
+## Usage
+
+```yaml
+- name: Configure VPN-locked downloader
+  hosts: download_vpn_group
+  become: true
+  roles:
+    - role: download_vpn
+```

--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -1,0 +1,118 @@
+---
+# download_vpn role defaults
+#
+# VPN-locked downloader: qBittorrent-nox + Prowlarr behind a Proton WireGuard
+# tunnel (wg0) with a fail-closed nftables killswitch. wg0 down => no route =>
+# zero egress. Both apps bind to wg0 so even a killswitch gap cannot leak.
+#
+# SECURITY MODEL (do not weaken without re-running all three validation layers):
+#   - nftables output policy DROP on BOTH ip (v4) and ip6 (v6) families.
+#   - IPv6 is additionally disabled at the kernel (sysctl) because Proton is a
+#     dual-stack tunnel (Interface has a v6 address, AllowedIPs = 0.0.0.0/0,::/0).
+#     Defense in depth: even if a v6 path appeared, nft ip6 DROP catches it.
+#   - Allowed egress = loopback + LAN subnet + UDP to the Proton endpoint
+#     (handshake) + anything out wg0. Nothing else.
+
+# --- Service user / install layout ------------------------------------------
+download_vpn_user: qbittorrent
+download_vpn_group: media
+# Shared group GID so *arr LXCs and this LXC agree on ownership of the
+# bind-mounted tank datasets. Override to match the host `media` group.
+download_vpn_group_gid: 13000
+
+# Bind-mounted host datasets (provisioned by terraform mount_points).
+download_vpn_downloads_dir: /mnt/downloads
+download_vpn_media_dir: /mnt/media
+
+# --- WireGuard (Proton) ------------------------------------------------------
+download_vpn_wg_interface: wg0
+download_vpn_wg_config_path: /etc/wireguard/wg0.conf
+# Proton WireGuard parameters — sourced from SOPS env (see
+# secrets.enc.yaml.example). NEVER hardcode key material or the endpoint.
+download_vpn_wg_private_key: "{{ lookup('env', 'PROTON_WG_PRIVATE_KEY') }}"
+# Tunnel interface address(es). Proton issues a dual-stack pair
+# ("10.2.0.2/32,fd00::.../128"). We keep the full value for the wg0 Address line
+# but rely on kernel IPv6 disable + nft ip6 DROP so the v6 half cannot leak.
+download_vpn_wg_address: "{{ lookup('env', 'PROTON_WG_ADDRESS') }}"
+download_vpn_wg_dns: "{{ lookup('env', 'PROTON_WG_DNS') }}"
+# Proton server public key + "host:port" endpoint.
+download_vpn_wg_peer_public_key: "{{ lookup('env', 'PROTON_WG_PEER_PUBLIC_KEY') }}"
+download_vpn_wg_endpoint: "{{ lookup('env', 'PROTON_WG_ENDPOINT') }}"
+# AllowedIPs deliberately routes ONLY IPv4 default via the tunnel. We do NOT
+# add ::/0 — IPv6 is killed at the kernel, so adding a v6 default route would
+# only create a path the killswitch then has to fight. IPv4 default through
+# wg0 is what carries torrent + indexer traffic.
+download_vpn_wg_allowed_ips: "0.0.0.0/0"
+download_vpn_wg_persistent_keepalive: 25
+
+# --- LAN reachability --------------------------------------------------------
+# LAN subnet that may reach the web UIs and that *arr/qBit/Prowlarr use to talk
+# to each other. Derived from the container's own /24 (terraform-owned IP) so
+# nothing is hardcoded. Override only if the LAN is not a /24.
+download_vpn_lan_subnet: >-
+  {{ (container_ip | default(ansible_default_ipv4.address) ~ '/24')
+     | ansible.utils.ipaddr('network/prefix') }}
+
+# --- qBittorrent -------------------------------------------------------------
+download_vpn_qbittorrent_package: qbittorrent-nox
+download_vpn_qbittorrent_user: "{{ download_vpn_user }}"
+download_vpn_qbittorrent_config_dir: "/home/{{ download_vpn_user }}/.config/qBittorrent"
+# Web UI port from terraform constants (no hardcoded port).
+download_vpn_qbittorrent_web_port: >-
+  {{ terraform_data.constants.media_ports.qbittorrent_web }}
+# Admin password for the WebUI — from SOPS env.
+download_vpn_qbittorrent_admin_password: "{{ lookup('env', 'QBITTORRENT_ADMIN_PASSWORD') }}"
+# CRITICAL: bind qBittorrent's traffic to wg0 (interface binding). With the
+# killswitch this is belt-and-suspenders; binding alone closed the 30% leak
+# seen in killswitch-only testing.
+download_vpn_qbittorrent_interface: "{{ download_vpn_wg_interface }}"
+
+# --- Prowlarr ----------------------------------------------------------------
+download_vpn_prowlarr_install_dir: /opt/Prowlarr
+download_vpn_prowlarr_data_dir: "/var/lib/prowlarr"
+download_vpn_prowlarr_user: "{{ download_vpn_user }}"
+download_vpn_prowlarr_web_port: >-
+  {{ terraform_data.constants.media_ports.prowlarr_web }}
+# Prowlarr release tarball (linux-x64). Rolling "master" build channel.
+download_vpn_prowlarr_tarball_url: >-
+  https://prowlarr.servarr.com/v1/update/master/updatefile?os=linux&runtime=netcore&arch=x64
+
+# --- NAT-PMP port forwarding -------------------------------------------------
+# Proton supports NAT-PMP. A systemd service loops natpmpc to keep a forwarded
+# port alive and pushes it into qBittorrent's listen port via the WebUI API.
+download_vpn_natpmp_enabled: true
+# Proton NAT-PMP gateway is the tunnel gateway (10.2.0.1 for Proton). Derived
+# from the wg0 peer; override if Proton changes it.
+download_vpn_natpmp_gateway: "10.2.0.1"
+download_vpn_natpmp_refresh_seconds: 45
+
+# --- Continuous runtime validation ------------------------------------------
+# systemd timer cadence for the fail-closed validator. On ANY breach it stops
+# qBittorrent and alerts (ntfy + healthchecks deadman).
+download_vpn_validator_interval: "2min"
+# ntfy alert target. Reuses the repo's ntfy LXC + push topic convention.
+download_vpn_ntfy_url: >-
+  http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
+  terraform_data.constants.notification_ports.ntfy_http }}/{{ download_vpn_ntfy_topic }}
+download_vpn_ntfy_topic: "killswitch"
+# healthchecks.io-style deadman ping URL. Empty => deadman ping skipped (the
+# ntfy alert still fires). Set to the per-check URL from the healthchecks LXC.
+download_vpn_healthcheck_url: "{{ lookup('env', 'DOWNLOAD_VPN_HEALTHCHECK_URL') | default('', true) }}"
+
+# Public-IP probe used by the live egress checks (must return the caller IP).
+download_vpn_ip_probe_url: "https://ifconfig.me"
+download_vpn_ip_probe_url_v6: "https://ifconfig.me"
+
+# --- Test / orchestration toggles -------------------------------------------
+# When false, the role still renders ALL config (killswitch ruleset, wg0.conf,
+# qBittorrent.conf, unit files) but skips the live service start / VPN
+# bring-up / WebUI calls that need a real Proton tunnel. Molecule sets this
+# false so CI can exercise the killswitch logic without a real VPN. The live
+# deploy leaves it true.
+download_vpn_manage_services: true
+
+# --- Deployed file paths (rarely overridden) --------------------------------
+download_vpn_nft_ruleset_path: /etc/nftables.d/download-vpn-killswitch.nft
+download_vpn_natpmp_script_path: /usr/local/bin/download-vpn-natpmp.sh
+download_vpn_natpmp_env_path: /etc/default/download-vpn-natpmp
+download_vpn_validator_script_path: /usr/local/bin/download-vpn-killswitch-validate.sh

--- a/roles/download_vpn/handlers/main.yml
+++ b/roles/download_vpn/handlers/main.yml
@@ -1,0 +1,32 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: Reload killswitch
+  ansible.builtin.systemd:
+    name: download-vpn-killswitch.service
+    state: reloaded
+    daemon_reload: true
+  when: download_vpn_manage_services
+
+- name: Restart wg tunnel
+  ansible.builtin.systemd:
+    name: download-vpn-wg.service
+    state: restarted
+    daemon_reload: true
+  when: download_vpn_manage_services
+
+- name: Restart qbittorrent
+  ansible.builtin.systemd:
+    name: qbittorrent-nox.service
+    state: restarted
+    daemon_reload: true
+  when: download_vpn_manage_services
+
+- name: Restart natpmp
+  ansible.builtin.systemd:
+    name: download-vpn-natpmp.service
+    state: restarted
+    daemon_reload: true
+  when: download_vpn_manage_services

--- a/roles/download_vpn/meta/main.yml
+++ b/roles/download_vpn/meta/main.yml
@@ -1,0 +1,17 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: >-
+    VPN-locked downloader — qBittorrent-nox + Prowlarr behind a Proton
+    WireGuard tunnel with a fail-closed nftables killswitch (dual-stack),
+    NAT-PMP port forwarding, and continuous runtime validation.
+  license: MIT
+  min_ansible_version: "2.16"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+
+dependencies: []

--- a/roles/download_vpn/tasks/main.yml
+++ b/roles/download_vpn/tasks/main.yml
@@ -1,0 +1,319 @@
+---
+# download_vpn — qBittorrent + Prowlarr behind Proton WireGuard with a
+# fail-closed nftables killswitch. See defaults/main.yml for the security model.
+
+# --- Phase 0: resolve endpoint family (v4 vs v6) ----------------------------
+- name: Resolve Proton endpoint host/port
+  ansible.builtin.set_fact:
+    download_vpn_endpoint_host: "{{ download_vpn_wg_endpoint.split(':')[0] }}"
+    download_vpn_endpoint_port: "{{ download_vpn_wg_endpoint.split(':')[1] }}"
+
+- name: Classify Proton endpoint address family
+  ansible.builtin.set_fact:
+    download_vpn_endpoint_is_ipv4: "{{ download_vpn_endpoint_host is ansible.utils.ipv4 }}"
+
+- name: Derive the IPv4-only tunnel address (drop any v6 half Proton issues)
+  # Proton's Address is dual-stack ("10.2.0.2/32,fd00::.../128"); keep only the
+  # IPv4 entry on the wg0 Address line so no v6 address is configured.
+  ansible.builtin.set_fact:
+    download_vpn_wg_address_v4: >-
+      {{ download_vpn_wg_address.split(',') | map('trim')
+         | select('ansible.utils.ipv4') | list | first
+         | default(download_vpn_wg_address.split(',')[0] | trim) }}
+
+# --- Phase 1: packages -------------------------------------------------------
+- name: Install media + VPN + firewall packages
+  ansible.builtin.apt:
+    name:
+      - wireguard-tools
+      - nftables
+      - "{{ download_vpn_qbittorrent_package }}"
+      - natpmpc
+      - curl
+      - ca-certificates
+      - iproute2
+      - sqlite3
+      - libicu-dev
+      - gnupg
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+# --- Phase 2: service user / group + storage --------------------------------
+- name: Create media group (shared GID with *arr LXCs)
+  ansible.builtin.group:
+    name: "{{ download_vpn_group }}"
+    gid: "{{ download_vpn_group_gid }}"
+    system: true
+    state: present
+
+- name: Create qbittorrent service user
+  ansible.builtin.user:
+    name: "{{ download_vpn_user }}"
+    group: "{{ download_vpn_group }}"
+    system: true
+    shell: /usr/sbin/nologin
+    home: "/home/{{ download_vpn_user }}"
+    create_home: true
+    state: present
+
+- name: Ensure download + media directories exist with group ownership
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ download_vpn_user }}"
+    group: "{{ download_vpn_group }}"
+    mode: "2775"
+  loop:
+    - "{{ download_vpn_downloads_dir }}"
+    - "{{ download_vpn_downloads_dir }}/incomplete"
+    - "{{ download_vpn_media_dir }}"
+
+# --- Phase 3: KILL IPv6 at the kernel ---------------------------------------
+# Proton is dual-stack; we forbid IPv6 entirely so qBittorrent has no v6 path.
+# nft ip6 coverage (below) is the belt to this suspenders.
+- name: Disable IPv6 (sysctl, persistent)
+  ansible.posix.sysctl:
+    name: "{{ item }}"
+    value: "1"
+    sysctl_set: true
+    state: present
+    reload: true
+    sysctl_file: /etc/sysctl.d/99-download-vpn-no-ipv6.conf
+  loop:
+    - net.ipv6.conf.all.disable_ipv6
+    - net.ipv6.conf.default.disable_ipv6
+    - net.ipv6.conf.lo.disable_ipv6
+
+# --- Phase 4: killswitch ruleset (rendered FIRST, before anything routes) ----
+- name: Ensure nftables include directory exists
+  ansible.builtin.file:
+    path: "{{ download_vpn_nft_ruleset_path | dirname }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0750"
+
+- name: Deploy nftables killswitch ruleset
+  ansible.builtin.template:
+    src: killswitch.nft.j2
+    dest: "{{ download_vpn_nft_ruleset_path }}"
+    owner: root
+    group: root
+    mode: "0600"
+    validate: "/usr/sbin/nft -c -f %s"
+  notify: Reload killswitch
+
+- name: Deploy killswitch systemd unit
+  ansible.builtin.template:
+    src: download-vpn-killswitch.service.j2
+    dest: /etc/systemd/system/download-vpn-killswitch.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd
+
+- name: Enable + start the killswitch (must be active before the tunnel)
+  ansible.builtin.systemd:
+    name: download-vpn-killswitch.service
+    state: started
+    enabled: true
+    daemon_reload: true
+  when: download_vpn_manage_services
+
+# --- Phase 5: WireGuard tunnel ----------------------------------------------
+- name: Deploy WireGuard wg0 config
+  ansible.builtin.template:
+    src: wg0.conf.j2
+    dest: "{{ download_vpn_wg_config_path }}"
+    owner: root
+    group: root
+    mode: "0600"
+  no_log: true
+  notify: Restart wg tunnel
+
+- name: Deploy WireGuard systemd unit
+  ansible.builtin.template:
+    src: download-vpn-wg.service.j2
+    dest: /etc/systemd/system/download-vpn-wg.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd
+
+- name: Enable + start the WireGuard tunnel
+  ansible.builtin.systemd:
+    name: download-vpn-wg.service
+    state: started
+    enabled: true
+    daemon_reload: true
+  when: download_vpn_manage_services
+
+# --- Phase 6: qBittorrent ----------------------------------------------------
+- name: Ensure qBittorrent config directory exists
+  ansible.builtin.file:
+    path: "{{ download_vpn_qbittorrent_config_dir }}"
+    state: directory
+    owner: "{{ download_vpn_user }}"
+    group: "{{ download_vpn_group }}"
+    mode: "0750"
+
+- name: Deploy qBittorrent configuration (bound to wg0)
+  ansible.builtin.template:
+    src: qBittorrent.conf.j2
+    dest: "{{ download_vpn_qbittorrent_config_dir }}/qBittorrent.conf"
+    owner: "{{ download_vpn_user }}"
+    group: "{{ download_vpn_group }}"
+    mode: "0640"
+  notify: Restart qbittorrent
+
+- name: Deploy qBittorrent systemd unit
+  ansible.builtin.template:
+    src: qbittorrent-nox.service.j2
+    dest: /etc/systemd/system/qbittorrent-nox.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd
+
+- name: Enable + start qBittorrent
+  ansible.builtin.systemd:
+    name: qbittorrent-nox.service
+    state: started
+    enabled: true
+    daemon_reload: true
+  when: download_vpn_manage_services
+
+- name: Wait for the qBittorrent WebUI to answer
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ download_vpn_qbittorrent_web_port }}/api/v2/app/version"
+    status_code: [200, 403]
+  register: download_vpn_qbt_up
+  until: download_vpn_qbt_up.status in [200, 403]
+  retries: 10
+  delay: 3
+  changed_when: false
+  when: download_vpn_manage_services
+
+- name: Set the qBittorrent WebUI admin password via API
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ download_vpn_qbittorrent_web_port }}/api/v2/app/setPreferences"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      json: '{"web_ui_password":"{{ download_vpn_qbittorrent_admin_password }}"}'
+    status_code: 200
+  no_log: true
+  changed_when: false
+  when: download_vpn_manage_services
+
+# --- Phase 7: Prowlarr -------------------------------------------------------
+- name: Check if Prowlarr is already installed
+  ansible.builtin.stat:
+    path: "{{ download_vpn_prowlarr_install_dir }}/Prowlarr"
+  register: download_vpn_prowlarr_bin
+
+- name: Create Prowlarr data directory
+  ansible.builtin.file:
+    path: "{{ download_vpn_prowlarr_data_dir }}"
+    state: directory
+    owner: "{{ download_vpn_user }}"
+    group: "{{ download_vpn_group }}"
+    mode: "0750"
+
+- name: Download + extract Prowlarr
+  ansible.builtin.unarchive:
+    src: "{{ download_vpn_prowlarr_tarball_url }}"
+    dest: /opt
+    remote_src: true
+    owner: "{{ download_vpn_user }}"
+    group: "{{ download_vpn_group }}"
+  when: not download_vpn_prowlarr_bin.stat.exists
+
+- name: Deploy Prowlarr systemd unit
+  ansible.builtin.template:
+    src: prowlarr.service.j2
+    dest: /etc/systemd/system/prowlarr.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd
+
+- name: Enable + start Prowlarr
+  ansible.builtin.systemd:
+    name: prowlarr.service
+    state: started
+    enabled: true
+    daemon_reload: true
+  when: download_vpn_manage_services
+
+# --- Phase 8: NAT-PMP port forwarding ---------------------------------------
+- name: Deploy NAT-PMP env file (qBittorrent admin password)
+  ansible.builtin.copy:
+    dest: "{{ download_vpn_natpmp_env_path }}"
+    owner: root
+    group: "{{ download_vpn_group }}"
+    mode: "0640"
+    content: |
+      QBITTORRENT_ADMIN_PASSWORD={{ download_vpn_qbittorrent_admin_password }}
+  no_log: true
+
+- name: Deploy NAT-PMP forward script
+  ansible.builtin.template:
+    src: natpmp-forward.sh.j2
+    dest: "{{ download_vpn_natpmp_script_path }}"
+    owner: root
+    group: root
+    mode: "0755"
+  notify: Restart natpmp
+
+- name: Deploy NAT-PMP systemd unit
+  ansible.builtin.template:
+    src: download-vpn-natpmp.service.j2
+    dest: /etc/systemd/system/download-vpn-natpmp.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd
+
+- name: Enable + start NAT-PMP keeper
+  ansible.builtin.systemd:
+    name: download-vpn-natpmp.service
+    state: "{{ 'started' if download_vpn_natpmp_enabled else 'stopped' }}"
+    enabled: "{{ download_vpn_natpmp_enabled }}"
+    daemon_reload: true
+  when: download_vpn_manage_services
+
+# --- Phase 9: continuous runtime validator (systemd timer) ------------------
+- name: Deploy killswitch validator script
+  ansible.builtin.template:
+    src: killswitch-validate.sh.j2
+    dest: "{{ download_vpn_validator_script_path }}"
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Deploy validator systemd service + timer
+  ansible.builtin.template:
+    src: "{{ item.src }}"
+    dest: "/etc/systemd/system/{{ item.dest }}"
+    owner: root
+    group: root
+    mode: "0644"
+  loop:
+    - { src: download-vpn-validate.service.j2, dest: download-vpn-validate.service }
+    - { src: download-vpn-validate.timer.j2, dest: download-vpn-validate.timer }
+  notify: Reload systemd
+
+- name: Enable + start the validator timer
+  ansible.builtin.systemd:
+    name: download-vpn-validate.timer
+    state: started
+    enabled: true
+    daemon_reload: true
+  when: download_vpn_manage_services
+
+# --- Phase 10: MANDATORY deploy-time validation -----------------------------
+# Runs at the END of every play. FAILS the run on any killswitch/leak violation.
+- name: Run fail-closed deploy-time validation
+  ansible.builtin.import_tasks: validate.yml

--- a/roles/download_vpn/tasks/validate.yml
+++ b/roles/download_vpn/tasks/validate.yml
@@ -5,16 +5,14 @@
 # Any failed assertion FAILS the play — the killswitch is a merge/deploy gate,
 # not advisory. Covers IPv4 AND IPv6 egress.
 #
-# Skipped automatically under Molecule (no real VPN in the CI container); the
-# molecule verify.yml exercises the killswitch logic instead. Detect via the
-# MOLECULE_* env the driver sets.
-
-- name: Detect Molecule test context
-  ansible.builtin.set_fact:
-    download_vpn_in_molecule: "{{ lookup('env', 'MOLECULE_INSTANCE_NAME') | length > 0 }}"
+# Skipped when services are not managed (download_vpn_manage_services=false) —
+# i.e. render-only runs such as Molecule converge, where there is no live tunnel
+# or loaded killswitch to validate. In that case the molecule verify.yml
+# exercises the killswitch logic directly. On a real deploy manage_services is
+# true, so these fail-closed leak assertions run and gate the play.
 
 - name: Validate killswitch + VPN lock (deploy-time, fail-closed)
-  when: not download_vpn_in_molecule
+  when: download_vpn_manage_services | bool
   block:
     # --- A. nftables killswitch present + default drop ---------------------
     - name: Read killswitch output chain

--- a/roles/download_vpn/tasks/validate.yml
+++ b/roles/download_vpn/tasks/validate.yml
@@ -1,0 +1,166 @@
+---
+# download_vpn deploy-time validation (validation layer 2).
+#
+# Imported at the END of the role so it runs on EVERY ansible-playbook run.
+# Any failed assertion FAILS the play — the killswitch is a merge/deploy gate,
+# not advisory. Covers IPv4 AND IPv6 egress.
+#
+# Skipped automatically under Molecule (no real VPN in the CI container); the
+# molecule verify.yml exercises the killswitch logic instead. Detect via the
+# MOLECULE_* env the driver sets.
+
+- name: Detect Molecule test context
+  ansible.builtin.set_fact:
+    download_vpn_in_molecule: "{{ lookup('env', 'MOLECULE_INSTANCE_NAME') | length > 0 }}"
+
+- name: Validate killswitch + VPN lock (deploy-time, fail-closed)
+  when: not download_vpn_in_molecule
+  block:
+    # --- A. nftables killswitch present + default drop ---------------------
+    - name: Read killswitch output chain
+      ansible.builtin.command:
+        cmd: nft list chain inet killswitch output
+      register: download_vpn_nft_output
+      changed_when: false
+
+    - name: Assert killswitch table present + output policy is DROP
+      ansible.builtin.assert:
+        that:
+          - "'policy drop' in download_vpn_nft_output.stdout"
+        fail_msg: >-
+          KILLSWITCH NOT ACTIVE: 'inet killswitch' output chain is missing or
+          its policy is not 'drop'. Refusing to proceed.
+        success_msg: "Killswitch output policy is DROP."
+
+    - name: Assert killswitch allows ONLY loopback/LAN/endpoint/wg0
+      # No accept rule may reference a non-loopback, non-wg0, non-LAN, non-endpoint
+      # destination. We assert the expected allow rules exist and that the chain
+      # contains a terminal drop (the policy) plus the explicit log+drop.
+      ansible.builtin.assert:
+        that:
+          - "'oif \"lo\" accept' in download_vpn_nft_output.stdout"
+          - "download_vpn_wg_interface in download_vpn_nft_output.stdout"
+          - "download_vpn_lan_subnet.split('/')[0] in download_vpn_nft_output.stdout"
+          - "'counter packets' in download_vpn_nft_output.stdout or 'drop' in download_vpn_nft_output.stdout"
+        fail_msg: "Killswitch ruleset is missing one of the required allow rules."
+
+    # --- B. only IPv4 default route is wg0 ---------------------------------
+    - name: Read IPv4 default routes
+      ansible.builtin.command:
+        cmd: ip -4 route show default
+      register: download_vpn_v4_route
+      changed_when: false
+
+    - name: Assert the ONLY IPv4 default route is via wg0
+      ansible.builtin.assert:
+        that:
+          - download_vpn_v4_route.stdout_lines | length == 1
+          - "'dev ' ~ download_vpn_wg_interface in download_vpn_v4_route.stdout"
+        fail_msg: >-
+          IPv4 default route is not exclusively via {{ download_vpn_wg_interface }}:
+          {{ download_vpn_v4_route.stdout }}
+
+    # --- C. no IPv6 default route ------------------------------------------
+    - name: Read IPv6 default routes
+      ansible.builtin.command:
+        cmd: ip -6 route show default
+      register: download_vpn_v6_route
+      changed_when: false
+
+    - name: Assert there is NO IPv6 default route
+      ansible.builtin.assert:
+        that:
+          - download_vpn_v6_route.stdout | trim | length == 0
+        fail_msg: >-
+          An IPv6 default route exists (must be none — IPv6 is disabled):
+          {{ download_vpn_v6_route.stdout }}
+
+    # --- D. qBittorrent bound to wg0 ---------------------------------------
+    - name: Log in to qBittorrent WebUI
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ download_vpn_qbittorrent_web_port }}/api/v2/auth/login"
+        method: POST
+        body_format: form-urlencoded
+        body:
+          username: admin
+          password: "{{ download_vpn_qbittorrent_admin_password }}"
+        status_code: 200
+      register: download_vpn_qbt_login
+      no_log: true
+      changed_when: false
+
+    - name: Read qBittorrent preferences
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ download_vpn_qbittorrent_web_port }}/api/v2/app/preferences"
+        method: GET
+        headers:
+          Cookie: "{{ download_vpn_qbt_login.set_cookie | default('') }}"
+        return_content: true
+        status_code: 200
+      register: download_vpn_qbt_prefs
+      changed_when: false
+
+    - name: Assert qBittorrent is bound to wg0
+      ansible.builtin.assert:
+        that:
+          - download_vpn_wg_interface in (download_vpn_qbt_prefs.json.current_network_interface | default(''))
+        fail_msg: >-
+          qBittorrent is bound to
+          '{{ download_vpn_qbt_prefs.json.current_network_interface | default("(unset)") }}',
+          expected '{{ download_vpn_wg_interface }}'.
+
+    # --- E. live IPv4 egress via the VPN exit works ------------------------
+    # noqa command-instead-of-module: the uri module cannot bind a request to a
+    # specific source interface (curl --interface). Interface-scoped egress is
+    # the whole point of these leak tests, so curl is required, not get_url/uri.
+    - name: Check public IPv4 egress via the tunnel  # noqa: command-instead-of-module
+      ansible.builtin.command:
+        cmd: curl -fsS --max-time 10 --interface {{ download_vpn_wg_interface }} {{ download_vpn_ip_probe_url }}
+      register: download_vpn_vpn_ip
+      changed_when: false
+      failed_when: download_vpn_vpn_ip.rc != 0 or (download_vpn_vpn_ip.stdout | trim | length == 0)
+
+    # --- F. forced non-VPN IPv4 egress is REFUSED --------------------------
+    - name: Attempt a forced non-VPN IPv4 egress (must be refused)  # noqa: command-instead-of-module
+      ansible.builtin.command:
+        cmd: curl -fsS --max-time 8 --interface eth0 {{ download_vpn_ip_probe_url }}
+      register: download_vpn_leak_probe
+      changed_when: false
+      failed_when: false
+
+    - name: Assert non-VPN IPv4 egress is blocked
+      ansible.builtin.assert:
+        that:
+          - download_vpn_leak_probe.rc != 0
+          - (download_vpn_leak_probe.stdout | trim | length) == 0
+        fail_msg: >-
+          IPv4 LEAK: forced egress via eth0 succeeded
+          ({{ download_vpn_leak_probe.stdout | trim }}). Killswitch is NOT
+          fail-closed.
+
+    # --- G. IPv6 egress is REFUSED -----------------------------------------
+    # noqa command-instead-of-module: the uri module cannot force IPv6-only
+    # (curl -6). Forcing the v6 family is the point of this leak test.
+    - name: Attempt IPv6 egress (must be refused)  # noqa: command-instead-of-module
+      ansible.builtin.command:
+        cmd: curl -fsS -6 --max-time 8 {{ download_vpn_ip_probe_url_v6 }}
+      register: download_vpn_v6_probe
+      changed_when: false
+      failed_when: false
+
+    - name: Assert IPv6 egress is blocked
+      ansible.builtin.assert:
+        that:
+          - download_vpn_v6_probe.rc != 0
+          - (download_vpn_v6_probe.stdout | trim | length) == 0
+        fail_msg: >-
+          IPv6 LEAK: egress over IPv6 succeeded
+          ({{ download_vpn_v6_probe.stdout | trim }}). IPv6 must have no path.
+
+    - name: Report killswitch validation success
+      ansible.builtin.debug:
+        msg: >-
+          download-vpn killswitch validated: nft DROP active; only default route
+          is {{ download_vpn_wg_interface }}; no IPv6 default route; qBittorrent
+          bound to {{ download_vpn_wg_interface }}; VPN IPv4 egress works;
+          non-VPN IPv4 + all IPv6 egress refused.

--- a/roles/download_vpn/templates/download-vpn-killswitch.service.j2
+++ b/roles/download_vpn/templates/download-vpn-killswitch.service.j2
@@ -1,0 +1,20 @@
+[Unit]
+Description=download-vpn nftables killswitch (fail-closed VPN egress lock)
+Documentation=https://github.com/JacobPEvans/ansible-proxmox-apps
+# The killswitch must be in force before any networking that could leak.
+After=network-pre.target
+Wants=network-pre.target
+Before=network.target wg-quick@{{ download_vpn_wg_interface }}.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Load the ruleset. Failure here must abort (no torrenting without the lock).
+ExecStart=/usr/sbin/nft -f {{ download_vpn_nft_ruleset_path }}
+# On stop we flush ONLY our table; we do not "open" egress on a crash because
+# the apps Require= this unit and will be stopped first.
+ExecStop=/usr/sbin/nft delete table inet killswitch
+ExecReload=/usr/sbin/nft -f {{ download_vpn_nft_ruleset_path }}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/download_vpn/templates/download-vpn-natpmp.service.j2
+++ b/roles/download_vpn/templates/download-vpn-natpmp.service.j2
@@ -1,0 +1,19 @@
+[Unit]
+Description=download-vpn Proton NAT-PMP port-forward keeper
+After=download-vpn-wg.service qbittorrent-nox.service
+Requires=download-vpn-killswitch.service download-vpn-wg.service
+BindsTo=download-vpn-wg.service
+
+[Service]
+Type=simple
+User={{ download_vpn_user }}
+Group={{ download_vpn_group }}
+# QBITTORRENT_ADMIN_PASSWORD is delivered via a root-only EnvironmentFile so
+# the script can authenticate to the WebUI API.
+EnvironmentFile={{ download_vpn_natpmp_env_path }}
+ExecStart={{ download_vpn_natpmp_script_path }}
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/download_vpn/templates/download-vpn-validate.service.j2
+++ b/roles/download_vpn/templates/download-vpn-validate.service.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=download-vpn fail-closed killswitch validator (one-shot, timer-driven)
+After=download-vpn-wg.service
+
+[Service]
+Type=oneshot
+# Needs the qBittorrent admin password to query the WebUI API.
+EnvironmentFile={{ download_vpn_natpmp_env_path }}
+ExecStart={{ download_vpn_validator_script_path }}

--- a/roles/download_vpn/templates/download-vpn-validate.timer.j2
+++ b/roles/download_vpn/templates/download-vpn-validate.timer.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Run the download-vpn killswitch validator every {{ download_vpn_validator_interval }}
+Documentation=https://github.com/JacobPEvans/ansible-proxmox-apps
+
+[Timer]
+# Start shortly after boot, then on a fixed cadence. Persistent=true catches
+# missed runs (deadman semantics rely on regular execution).
+OnBootSec=90s
+OnUnitActiveSec={{ download_vpn_validator_interval }}
+AccuracySec=15s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/roles/download_vpn/templates/download-vpn-wg.service.j2
+++ b/roles/download_vpn/templates/download-vpn-wg.service.j2
@@ -1,0 +1,21 @@
+[Unit]
+Description=download-vpn WireGuard tunnel ({{ download_vpn_wg_interface }} -> Proton)
+After=network-online.target download-vpn-killswitch.service
+Wants=network-online.target
+# Never bring the tunnel up without the killswitch already loaded.
+Requires=download-vpn-killswitch.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# wg-quick honours `Table = off` in the config, so it sets up the interface
+# and address but installs no routes. We then add ONLY the IPv4 default route
+# via wg0 — no IPv6 default route is ever created.
+ExecStart=/usr/bin/wg-quick up {{ download_vpn_wg_interface }}
+ExecStartPost=/sbin/ip -4 route replace default dev {{ download_vpn_wg_interface }}
+ExecStop=/usr/bin/wg-quick down {{ download_vpn_wg_interface }}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/download_vpn/templates/killswitch-validate.sh.j2
+++ b/roles/download_vpn/templates/killswitch-validate.sh.j2
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# download-vpn fail-closed runtime validator.
+#
+# Rendered by the download_vpn Ansible role; run on a systemd timer (every
+# {{ download_vpn_validator_interval }}). Re-proves, every cycle, that
+# qBittorrent cannot send/receive outside the VPN. On ANY breach it:
+#   1. immediately stops qBittorrent (and the NAT-PMP keeper),
+#   2. pushes an alert to ntfy,
+#   3. pings the healthchecks deadman (failure endpoint).
+# On success it pings the healthchecks deadman OK endpoint so a silent
+# validator (crash) also pages.
+#
+# Checks (all must hold):
+#   A. nftables killswitch table present with output policy "drop".
+#   B. The ONLY IPv4 default route is via wg0.
+#   C. No IPv6 default route exists (IPv6 is disabled / must not egress).
+#   D. qBittorrent listen interface == wg0 (via WebUI API preferences).
+#   E. Live IPv4 egress leaves via the VPN exit (public IP differs from the
+#      LAN/WAN address and the request only succeeds through wg0).
+#   F. Forced non-VPN IPv4 egress (bound to eth0) is REFUSED.
+#   G. IPv6 egress is refused (curl -6 must fail).
+set -uo pipefail
+
+WG_IF="{{ download_vpn_wg_interface }}"
+NTFY_URL="{{ download_vpn_ntfy_url }}"
+HC_URL="{{ download_vpn_healthcheck_url }}"
+IP_PROBE="{{ download_vpn_ip_probe_url }}"
+IP_PROBE6="{{ download_vpn_ip_probe_url_v6 }}"
+
+breaches=()
+
+# --- A. killswitch present + default drop -----------------------------------
+if ! nft list table inet killswitch >/dev/null 2>&1; then
+  breaches+=("nftables 'inet killswitch' table is MISSING")
+else
+  policy="$(nft -a list chain inet killswitch output 2>/dev/null \
+    | awk '/policy/ {gsub(/;/,"",$NF); print $NF; exit}')"
+  [[ "${policy}" == "drop" ]] || breaches+=("killswitch output policy is '${policy:-unknown}', expected 'drop'")
+fi
+
+# --- B. only IPv4 default route is wg0 --------------------------------------
+v4_defaults="$(ip -4 route show default 2>/dev/null)"
+if [[ -z "${v4_defaults}" ]]; then
+  breaches+=("no IPv4 default route (VPN likely down)")
+elif ! grep -q "dev ${WG_IF}" <<<"${v4_defaults}"; then
+  breaches+=("IPv4 default route is NOT via ${WG_IF}: ${v4_defaults}")
+elif [[ "$(grep -c 'default' <<<"${v4_defaults}")" -ne 1 ]]; then
+  breaches+=("multiple IPv4 default routes present: ${v4_defaults}")
+fi
+
+# --- C. no IPv6 default route -----------------------------------------------
+v6_defaults="$(ip -6 route show default 2>/dev/null)"
+if [[ -n "${v6_defaults}" ]]; then
+  breaches+=("IPv6 default route present (must be none): ${v6_defaults}")
+fi
+
+# --- D. qBittorrent bound to wg0 --------------------------------------------
+cookie="$(mktemp)"
+if curl -fsS -c "${cookie}" \
+      --data-urlencode "username=admin" \
+      --data-urlencode "password=${QBITTORRENT_ADMIN_PASSWORD:-}" \
+      "http://127.0.0.1:{{ download_vpn_qbittorrent_web_port }}/api/v2/auth/login" >/dev/null 2>&1; then
+  iface="$(curl -fsS -b "${cookie}" \
+    "http://127.0.0.1:{{ download_vpn_qbittorrent_web_port }}/api/v2/app/preferences" 2>/dev/null \
+    | grep -o '"current_network_interface":"[^"]*"' | cut -d'"' -f4)"
+  if [[ -n "${iface}" && "${iface}" != "${WG_IF}" ]]; then
+    breaches+=("qBittorrent network interface is '${iface}', expected '${WG_IF}'")
+  fi
+fi
+rm -f "${cookie}"
+
+# --- E/F. live IPv4 egress checks -------------------------------------------
+# E: egress via the tunnel must succeed (we are connected to the VPN).
+vpn_ip="$(curl -fsS --max-time 10 --interface "${WG_IF}" "${IP_PROBE}" 2>/dev/null || true)"
+if [[ -z "${vpn_ip}" ]]; then
+  breaches+=("no IPv4 egress via ${WG_IF} (VPN exit unreachable)")
+fi
+# F: forced egress bound to the LAN interface must be REFUSED by the killswitch.
+leak_ip="$(curl -fsS --max-time 8 --interface eth0 "${IP_PROBE}" 2>/dev/null || true)"
+if [[ -n "${leak_ip}" ]]; then
+  breaches+=("LEAK: non-VPN IPv4 egress via eth0 succeeded (got ${leak_ip})")
+fi
+
+# --- G. IPv6 egress must be refused -----------------------------------------
+v6_ip="$(curl -fsS -6 --max-time 8 "${IP_PROBE6}" 2>/dev/null || true)"
+if [[ -n "${v6_ip}" ]]; then
+  breaches+=("LEAK: IPv6 egress succeeded (got ${v6_ip})")
+fi
+
+# --- verdict ----------------------------------------------------------------
+if [[ "${#breaches[@]}" -gt 0 ]]; then
+  msg="download-vpn KILLSWITCH BREACH on $(hostname): $(printf '%s; ' "${breaches[@]}")"
+  logger -t killswitch-validate "${msg}"
+  # 1. Stop the apps that could leak FIRST.
+  systemctl stop qbittorrent-nox.service download-vpn-natpmp.service || true
+  # 2. Alert ntfy.
+  curl -fsS --max-time 8 -H "Title: download-vpn killswitch breach" \
+    -H "Priority: urgent" -H "Tags: rotating_light" \
+    -d "${msg}" "${NTFY_URL}" >/dev/null 2>&1 || true
+  # 3. Deadman: signal failure.
+  if [[ -n "${HC_URL}" ]]; then
+    curl -fsS --max-time 8 -d "${msg}" "${HC_URL}/fail" >/dev/null 2>&1 || true
+  fi
+  exit 1
+fi
+
+# Healthy: ping the deadman OK endpoint so a stalled validator also pages.
+if [[ -n "${HC_URL}" ]]; then
+  curl -fsS --max-time 8 "${HC_URL}" >/dev/null 2>&1 || true
+fi
+exit 0

--- a/roles/download_vpn/templates/killswitch-validate.sh.j2
+++ b/roles/download_vpn/templates/killswitch-validate.sh.j2
@@ -88,7 +88,7 @@ if [[ -n "${v6_ip}" ]]; then
 fi
 
 # --- verdict ----------------------------------------------------------------
-if [[ "${#breaches[@]}" -gt 0 ]]; then
+if [[ "{% raw %}${#breaches[@]}{% endraw %}" -gt 0 ]]; then
   msg="download-vpn KILLSWITCH BREACH on $(hostname): $(printf '%s; ' "${breaches[@]}")"
   logger -t killswitch-validate "${msg}"
   # 1. Stop the apps that could leak FIRST.

--- a/roles/download_vpn/templates/killswitch.nft.j2
+++ b/roles/download_vpn/templates/killswitch.nft.j2
@@ -1,0 +1,60 @@
+#!/usr/sbin/nft -f
+{#
+  Fail-closed VPN killswitch for the download-vpn LXC.
+
+  Rendered by the download_vpn role. Default OUTPUT policy is DROP for BOTH
+  IPv4 and IPv6. The ONLY permitted egress is:
+    - loopback
+    - the LAN subnet (web UIs + *arr <-> qBittorrent/Prowlarr)
+    - UDP to the Proton WireGuard endpoint IP:port (the handshake)
+    - anything leaving via the wg0 tunnel interface
+  Everything else is dropped. If wg0 goes down there is no route and no rule
+  that permits non-VPN egress, so traffic is cut off instantly.
+
+  The single `inet` table applies to v4 and v6 simultaneously. IPv6 is also
+  disabled at the kernel (sysctl) — this ip6 saddr/daddr coverage is the
+  belt to that suspenders: even if v6 were re-enabled, only loopback, LAN and
+  wg0 could egress, never the public internet.
+-#}
+{% set _endpoint_host = download_vpn_wg_endpoint.split(':')[0] %}
+{% set _endpoint_port = download_vpn_wg_endpoint.split(':')[1] %}
+table inet killswitch {
+  chain input {
+    type filter hook input priority 0; policy accept;
+  }
+
+  chain forward {
+    type filter hook forward priority 0; policy drop;
+  }
+
+  chain output {
+    # FAIL-CLOSED: default drop. Order matters — accepts first, implicit drop.
+    type filter hook output priority 0; policy drop;
+
+    # 1. Loopback always allowed.
+    oif "lo" accept
+
+    # 2. Established/related return traffic.
+    ct state established,related accept
+
+    # 3. LAN subnet (web UIs + *arr <-> qBittorrent/Prowlarr coordination).
+    ip daddr {{ download_vpn_lan_subnet }} accept
+{% if download_vpn_endpoint_is_ipv4 %}
+    # 4. WireGuard handshake to the Proton endpoint (UDP). v4 endpoint.
+    ip daddr {{ _endpoint_host }} udp dport {{ _endpoint_port }} accept
+{% else %}
+    # 4. WireGuard handshake to the Proton endpoint (UDP). v6 endpoint.
+    ip6 daddr {{ _endpoint_host }} udp dport {{ _endpoint_port }} accept
+{% endif %}
+
+    # 5. Anything via the VPN tunnel.
+    oifname "{{ download_vpn_wg_interface }}" accept
+
+    # 6. DNS to the VPN-provided resolver only travels via wg0 (covered by #5);
+    #    no separate rule needed. Everything not matched above is dropped by
+    #    the chain policy — including ALL non-loopback IPv6 egress, which has
+    #    no accept rule here.
+    # Explicit log + drop for visibility during leak testing.
+    log prefix "killswitch-drop: " flags all counter drop
+  }
+}

--- a/roles/download_vpn/templates/natpmp-forward.sh.j2
+++ b/roles/download_vpn/templates/natpmp-forward.sh.j2
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Proton NAT-PMP port-forward keeper for qBittorrent.
+#
+# Rendered by the download_vpn Ansible role. Loops natpmpc to (a) keep the
+# Proton-forwarded port alive and (b) push the assigned port into qBittorrent's
+# listen port via the WebUI API whenever it changes. Runs as a systemd service.
+#
+# All network egress here leaves via wg0 (the NAT-PMP gateway is the tunnel
+# gateway), so it is permitted by the killswitch.
+set -euo pipefail
+
+GATEWAY="{{ download_vpn_natpmp_gateway }}"
+REFRESH="{{ download_vpn_natpmp_refresh_seconds }}"
+QBT_URL="http://127.0.0.1:{{ download_vpn_qbittorrent_web_port }}"
+COOKIE_JAR="$(mktemp)"
+trap 'rm -f "${COOKIE_JAR}"' EXIT
+
+last_port=""
+
+qbt_login() {
+  curl -fsS -c "${COOKIE_JAR}" \
+    --data-urlencode "username=admin" \
+    --data-urlencode "password=${QBITTORRENT_ADMIN_PASSWORD:-}" \
+    "${QBT_URL}/api/v2/auth/login" >/dev/null
+}
+
+qbt_set_port() {
+  local port="$1"
+  curl -fsS -b "${COOKIE_JAR}" \
+    --data-urlencode "json={\"listen_port\":${port}}" \
+    "${QBT_URL}/api/v2/app/setPreferences" >/dev/null
+}
+
+while true; do
+  # Request both TCP and UDP mappings (BitTorrent uses both). natpmpc prints
+  # the mapped public port; grab it from the UDP mapping line.
+  mapped_port="$(natpmpc -a 1 0 udp 60 -g "${GATEWAY}" \
+    | awk '/Mapped public port/ {print $4; exit}')"
+  natpmpc -a 1 0 tcp 60 -g "${GATEWAY}" >/dev/null 2>&1 || true
+
+  if [[ -n "${mapped_port}" && "${mapped_port}" != "${last_port}" ]]; then
+    if qbt_login; then
+      qbt_set_port "${mapped_port}"
+      last_port="${mapped_port}"
+      logger -t natpmp-forward "qBittorrent listen port set to ${mapped_port}"
+    else
+      logger -t natpmp-forward "qBittorrent login failed; will retry"
+    fi
+  fi
+  sleep "${REFRESH}"
+done

--- a/roles/download_vpn/templates/prowlarr.service.j2
+++ b/roles/download_vpn/templates/prowlarr.service.j2
@@ -1,0 +1,20 @@
+[Unit]
+Description=Prowlarr indexer manager (VPN-locked)
+Documentation=https://wiki.servarr.com/prowlarr
+After=download-vpn-wg.service
+# Boot-safe: Prowlarr reaches indexers via the VPN; never start without the
+# killswitch AND the tunnel.
+Requires=download-vpn-killswitch.service download-vpn-wg.service
+BindsTo=download-vpn-wg.service
+
+[Service]
+Type=simple
+User={{ download_vpn_user }}
+Group={{ download_vpn_group }}
+ExecStart={{ download_vpn_prowlarr_install_dir }}/Prowlarr -nobrowser -data={{ download_vpn_prowlarr_data_dir }}
+Restart=on-failure
+RestartSec=10
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/download_vpn/templates/qBittorrent.conf.j2
+++ b/roles/download_vpn/templates/qBittorrent.conf.j2
@@ -1,0 +1,28 @@
+{#
+  qBittorrent-nox configuration. The load-bearing security setting is
+  Session\Interface* = wg0: qBittorrent will ONLY send/receive BitTorrent
+  traffic bound to the wg0 device. Combined with the nftables killswitch this
+  gives zero-leak behaviour (binding alone closed the 30% leak observed with
+  the killswitch only).
+-#}
+[Application]
+FileLogger\Enabled=true
+
+[BitTorrent]
+Session\Interface={{ download_vpn_wg_interface }}
+Session\InterfaceName={{ download_vpn_wg_interface }}
+# Refuse to use any interface other than wg0 — if wg0 is absent qBittorrent
+# listens on nothing rather than falling back to eth0.
+Session\InterfaceAddress=
+Session\Port={{ download_vpn_qbittorrent_listen_port | default(6881) }}
+Session\AnonymousModeEnabled=true
+
+[Preferences]
+Connection\InterfaceName={{ download_vpn_wg_interface }}
+Connection\Interface={{ download_vpn_wg_interface }}
+General\Locale=en
+WebUI\Address=*
+WebUI\Port={{ download_vpn_qbittorrent_web_port }}
+WebUI\LocalHostAuth=false
+Downloads\SavePath={{ download_vpn_downloads_dir }}/
+Downloads\TempPath={{ download_vpn_downloads_dir }}/incomplete/

--- a/roles/download_vpn/templates/qbittorrent-nox.service.j2
+++ b/roles/download_vpn/templates/qbittorrent-nox.service.j2
@@ -1,0 +1,22 @@
+[Unit]
+Description=qBittorrent-nox (VPN-locked)
+Documentation=https://github.com/qbittorrent/qBittorrent
+After=download-vpn-wg.service
+# Boot-safe: qBittorrent never starts without the killswitch AND the tunnel.
+Requires=download-vpn-killswitch.service download-vpn-wg.service
+# If the tunnel unit stops, take qBittorrent down with it.
+BindsTo=download-vpn-wg.service
+
+[Service]
+Type=exec
+User={{ download_vpn_user }}
+Group={{ download_vpn_group }}
+ExecStart=/usr/bin/qbittorrent-nox --webui-port={{ download_vpn_qbittorrent_web_port }}
+Restart=on-failure
+RestartSec=10
+# Hardening
+NoNewPrivileges=true
+ProtectSystem=full
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/download_vpn/templates/wg0.conf.j2
+++ b/roles/download_vpn/templates/wg0.conf.j2
@@ -1,0 +1,25 @@
+{#
+  Proton WireGuard tunnel config for the download-vpn LXC.
+  Rendered from SOPS-provided secrets — NEVER commit real key material.
+
+  IPv6 note: Proton issues a dual-stack Address. We keep the v4 address only
+  on the Address line and set AllowedIPs to the IPv4 default route. IPv6 is
+  disabled at the kernel + dropped by nftables, so we deliberately do NOT add
+  ::/0 here — that would build a v6 default route the killswitch must fight.
+-#}
+[Interface]
+PrivateKey = {{ download_vpn_wg_private_key }}
+Address = {{ download_vpn_wg_address_v4 }}
+{% if download_vpn_wg_dns | trim | length > 0 %}
+DNS = {{ download_vpn_wg_dns }}
+{% endif %}
+# Table = off keeps wg-quick from installing routes for us; the killswitch +
+# the explicit wg0 default route (added by the role) own routing so no v6
+# default route can sneak in.
+Table = off
+
+[Peer]
+PublicKey = {{ download_vpn_wg_peer_public_key }}
+Endpoint = {{ download_vpn_wg_endpoint }}
+AllowedIPs = {{ download_vpn_wg_allowed_ips }}
+PersistentKeepalive = {{ download_vpn_wg_persistent_keepalive }}

--- a/roles/plex/README.md
+++ b/roles/plex/README.md
@@ -1,0 +1,38 @@
+# plex
+
+Plex Media Server, LAN-only (no VPN). Skeleton role: installs from Plex's
+official apt repo and enables the bundled systemd service. Library setup and
+server claim happen in the Plex web UI after deploy.
+
+## Installation
+
+Provisioned by the `plex` LXC in `terraform-proxmox` (pve2, `tank/media`
+bind-mount). Deploy via this repo:
+
+```bash
+ansible-playbook -i inventory/hosts.yml playbooks/site.yml --tags plex
+```
+
+## Requirements
+
+- Debian-based LXC.
+- `tank/media` bind-mounted at `/mnt/media`.
+
+## Key variables
+
+Server port comes from terraform (`terraform_data.constants.media_ports.plex_web`).
+See `defaults/main.yml`.
+
+- `plex_media_dir` — media library root (default `/mnt/media`).
+- `plex_apt_repo` — Plex apt repository line.
+- `plex_web_port` — server/web UI port (terraform-derived).
+
+## Usage
+
+```yaml
+- name: Configure Plex Media Server
+  hosts: plex_group
+  become: true
+  roles:
+    - role: plex
+```

--- a/roles/plex/defaults/main.yml
+++ b/roles/plex/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+# plex role defaults — LAN-only Plex Media Server. No VPN.
+# Skeleton: install from Plex's official apt repo + enable the service.
+# Library setup + claim happen in the Plex web UI after deploy.
+plex_user: plex
+plex_group: media
+plex_group_gid: 13000
+plex_media_dir: /mnt/media
+# Web UI / server port from terraform constants (no hardcoded port).
+plex_web_port: "{{ terraform_data.constants.media_ports.plex_web }}"
+# Official Plex apt repo (public channel).
+plex_apt_key_url: https://downloads.plex.tv/plex-keys/PlexSign.key
+plex_apt_repo: "deb https://downloads.plex.tv/repo/deb public main"
+plex_package: plexmediaserver
+plex_manage_services: true

--- a/roles/plex/meta/main.yml
+++ b/roles/plex/meta/main.yml
@@ -1,0 +1,14 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: Plex Media Server (LAN-only, no VPN) — minimal install skeleton.
+  license: MIT
+  min_ansible_version: "2.16"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+
+dependencies: []

--- a/roles/plex/tasks/main.yml
+++ b/roles/plex/tasks/main.yml
@@ -1,0 +1,63 @@
+---
+# plex — minimal LAN-only install from the official Plex apt repo (skeleton).
+
+- name: Install Plex prerequisites
+  ansible.builtin.apt:
+    name:
+      - curl
+      - ca-certificates
+      - gnupg
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Create media group
+  ansible.builtin.group:
+    name: "{{ plex_group }}"
+    gid: "{{ plex_group_gid }}"
+    system: true
+    state: present
+
+- name: Add Plex apt signing key
+  ansible.builtin.get_url:
+    url: "{{ plex_apt_key_url }}"
+    dest: /etc/apt/keyrings/plex.asc
+    mode: "0644"
+
+- name: Add Plex apt repository
+  ansible.builtin.apt_repository:
+    repo: "{{ plex_apt_repo }}"
+    filename: plexmediaserver
+    state: present
+  register: plex_repo
+
+- name: Install Plex Media Server
+  ansible.builtin.apt:
+    name: "{{ plex_package }}"
+    state: present
+    update_cache: "{{ plex_repo is changed }}"
+
+- name: Ensure plex user is in the media group (read tank/media)
+  ansible.builtin.user:
+    name: "{{ plex_user }}"
+    groups: "{{ plex_group }}"
+    append: true
+  register: plex_user_group
+  failed_when: false
+
+- name: Ensure media directory exists
+  ansible.builtin.file:
+    path: "{{ plex_media_dir }}"
+    state: directory
+    owner: "{{ plex_user }}"
+    group: "{{ plex_group }}"
+    mode: "2775"
+  failed_when: false
+
+- name: Enable + start Plex Media Server
+  ansible.builtin.systemd:
+    name: plexmediaserver.service
+    state: started
+    enabled: true
+    daemon_reload: true
+  when: plex_manage_services

--- a/roles/radarr/README.md
+++ b/roles/radarr/README.md
@@ -1,0 +1,40 @@
+# radarr
+
+Radarr movie PVR, LAN-only (no VPN). Skeleton role: minimal native install
+plus a systemd service. Indexers and the download client are wired up in the
+Radarr UI after deploy — it reaches Prowlarr + qBittorrent on the
+`download-vpn` LXC over the LAN.
+
+## Installation
+
+Provisioned by the `radarr` LXC in `terraform-proxmox` (pve2, `tank/media` +
+`tank/downloads` bind-mounts). Deploy via this repo:
+
+```bash
+ansible-playbook -i inventory/hosts.yml playbooks/site.yml --tags radarr
+```
+
+## Requirements
+
+- Debian-based LXC.
+- `tank/media` + `tank/downloads` bind-mounted at `/mnt/media` and
+  `/mnt/downloads`.
+
+## Key variables
+
+Web UI port comes from terraform (`terraform_data.constants.media_ports.radarr_web`).
+See `defaults/main.yml`.
+
+- `radarr_install_dir` — install location (default `/opt/Radarr`).
+- `radarr_data_dir` — app data (default `/var/lib/radarr`).
+- `radarr_web_port` — web UI port (terraform-derived).
+
+## Usage
+
+```yaml
+- name: Configure Radarr
+  hosts: radarr_group
+  become: true
+  roles:
+    - role: radarr
+```

--- a/roles/radarr/defaults/main.yml
+++ b/roles/radarr/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+# radarr role defaults — LAN-only movie PVR. No VPN.
+# Skeleton: minimal install + service; flesh out indexers/download clients via
+# the Radarr UI (it talks to Prowlarr + qBittorrent on download-vpn over LAN).
+radarr_user: media
+radarr_group: media
+radarr_group_gid: 13000
+radarr_install_dir: /opt/Radarr
+radarr_data_dir: /var/lib/radarr
+radarr_media_dir: /mnt/media
+radarr_downloads_dir: /mnt/downloads
+# Web UI port from terraform constants (no hardcoded port).
+radarr_web_port: "{{ terraform_data.constants.media_ports.radarr_web }}"
+radarr_tarball_url: >-
+  https://radarr.servarr.com/v1/update/master/updatefile?os=linux&runtime=netcore&arch=x64
+radarr_manage_services: true

--- a/roles/radarr/handlers/main.yml
+++ b/roles/radarr/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Restart radarr
+  ansible.builtin.systemd:
+    name: radarr.service
+    state: restarted
+    daemon_reload: true
+  when: radarr_manage_services

--- a/roles/radarr/meta/main.yml
+++ b/roles/radarr/meta/main.yml
@@ -1,0 +1,14 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: Radarr movie PVR (LAN-only, no VPN) — minimal install skeleton.
+  license: MIT
+  min_ansible_version: "2.16"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+
+dependencies: []

--- a/roles/radarr/tasks/main.yml
+++ b/roles/radarr/tasks/main.yml
@@ -1,0 +1,72 @@
+---
+# radarr — minimal LAN-only install (skeleton).
+
+- name: Install Radarr prerequisites
+  ansible.builtin.apt:
+    name:
+      - curl
+      - ca-certificates
+      - sqlite3
+      - libicu-dev
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Create media group
+  ansible.builtin.group:
+    name: "{{ radarr_group }}"
+    gid: "{{ radarr_group_gid }}"
+    system: true
+    state: present
+
+- name: Create radarr service user
+  ansible.builtin.user:
+    name: "{{ radarr_user }}"
+    group: "{{ radarr_group }}"
+    system: true
+    shell: /usr/sbin/nologin
+    home: "{{ radarr_data_dir }}"
+    create_home: false
+    state: present
+
+- name: Ensure radarr data + media directories exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ radarr_user }}"
+    group: "{{ radarr_group }}"
+    mode: "2775"
+  loop:
+    - "{{ radarr_data_dir }}"
+    - "{{ radarr_media_dir }}"
+
+- name: Check if Radarr is already installed
+  ansible.builtin.stat:
+    path: "{{ radarr_install_dir }}/Radarr"
+  register: radarr_bin
+
+- name: Download + extract Radarr
+  ansible.builtin.unarchive:
+    src: "{{ radarr_tarball_url }}"
+    dest: /opt
+    remote_src: true
+    owner: "{{ radarr_user }}"
+    group: "{{ radarr_group }}"
+  when: not radarr_bin.stat.exists
+
+- name: Deploy Radarr systemd unit
+  ansible.builtin.template:
+    src: radarr.service.j2
+    dest: /etc/systemd/system/radarr.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart radarr
+
+- name: Enable + start Radarr
+  ansible.builtin.systemd:
+    name: radarr.service
+    state: started
+    enabled: true
+    daemon_reload: true
+  when: radarr_manage_services

--- a/roles/radarr/templates/radarr.service.j2
+++ b/roles/radarr/templates/radarr.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Radarr (Movie PVR)
+Documentation=https://wiki.servarr.com/radarr
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ radarr_user }}
+Group={{ radarr_group }}
+ExecStart={{ radarr_install_dir }}/Radarr -nobrowser -data={{ radarr_data_dir }}
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/sonarr/README.md
+++ b/roles/sonarr/README.md
@@ -1,0 +1,40 @@
+# sonarr
+
+Sonarr TV-series PVR, LAN-only (no VPN). Skeleton role: minimal native install
+plus a systemd service. Indexers and the download client are wired up in the
+Sonarr UI after deploy — it reaches Prowlarr + qBittorrent on the
+`download-vpn` LXC over the LAN.
+
+## Installation
+
+Provisioned by the `sonarr` LXC in `terraform-proxmox` (pve2, `tank/media` +
+`tank/downloads` bind-mounts). Deploy via this repo:
+
+```bash
+ansible-playbook -i inventory/hosts.yml playbooks/site.yml --tags sonarr
+```
+
+## Requirements
+
+- Debian-based LXC.
+- `tank/media` + `tank/downloads` bind-mounted at `/mnt/media` and
+  `/mnt/downloads`.
+
+## Key variables
+
+Web UI port comes from terraform (`terraform_data.constants.media_ports.sonarr_web`).
+See `defaults/main.yml`.
+
+- `sonarr_install_dir` — install location (default `/opt/Sonarr`).
+- `sonarr_data_dir` — app data (default `/var/lib/sonarr`).
+- `sonarr_web_port` — web UI port (terraform-derived).
+
+## Usage
+
+```yaml
+- name: Configure Sonarr
+  hosts: sonarr_group
+  become: true
+  roles:
+    - role: sonarr
+```

--- a/roles/sonarr/defaults/main.yml
+++ b/roles/sonarr/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+# sonarr role defaults — LAN-only TV PVR. No VPN.
+# Skeleton: minimal install + service; flesh out indexers/download clients via
+# the Sonarr UI (it talks to Prowlarr + qBittorrent on download-vpn over LAN).
+sonarr_user: media
+sonarr_group: media
+sonarr_group_gid: 13000
+sonarr_install_dir: /opt/Sonarr
+sonarr_data_dir: /var/lib/sonarr
+sonarr_media_dir: /mnt/media
+sonarr_downloads_dir: /mnt/downloads
+# Web UI port from terraform constants (no hardcoded port).
+sonarr_web_port: "{{ terraform_data.constants.media_ports.sonarr_web }}"
+sonarr_tarball_url: >-
+  https://services.sonarr.tv/v1/download/main/latest?version=4&os=linux&arch=x64
+sonarr_manage_services: true

--- a/roles/sonarr/handlers/main.yml
+++ b/roles/sonarr/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Restart sonarr
+  ansible.builtin.systemd:
+    name: sonarr.service
+    state: restarted
+    daemon_reload: true
+  when: sonarr_manage_services

--- a/roles/sonarr/meta/main.yml
+++ b/roles/sonarr/meta/main.yml
@@ -1,0 +1,14 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: Sonarr TV PVR (LAN-only, no VPN) — minimal install skeleton.
+  license: MIT
+  min_ansible_version: "2.16"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+
+dependencies: []

--- a/roles/sonarr/tasks/main.yml
+++ b/roles/sonarr/tasks/main.yml
@@ -1,0 +1,72 @@
+---
+# sonarr — minimal LAN-only install (skeleton).
+
+- name: Install Sonarr prerequisites
+  ansible.builtin.apt:
+    name:
+      - curl
+      - ca-certificates
+      - sqlite3
+      - libicu-dev
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Create media group
+  ansible.builtin.group:
+    name: "{{ sonarr_group }}"
+    gid: "{{ sonarr_group_gid }}"
+    system: true
+    state: present
+
+- name: Create sonarr service user
+  ansible.builtin.user:
+    name: "{{ sonarr_user }}"
+    group: "{{ sonarr_group }}"
+    system: true
+    shell: /usr/sbin/nologin
+    home: "{{ sonarr_data_dir }}"
+    create_home: false
+    state: present
+
+- name: Ensure sonarr data + media directories exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ sonarr_user }}"
+    group: "{{ sonarr_group }}"
+    mode: "2775"
+  loop:
+    - "{{ sonarr_data_dir }}"
+    - "{{ sonarr_media_dir }}"
+
+- name: Check if Sonarr is already installed
+  ansible.builtin.stat:
+    path: "{{ sonarr_install_dir }}/Sonarr"
+  register: sonarr_bin
+
+- name: Download + extract Sonarr
+  ansible.builtin.unarchive:
+    src: "{{ sonarr_tarball_url }}"
+    dest: /opt
+    remote_src: true
+    owner: "{{ sonarr_user }}"
+    group: "{{ sonarr_group }}"
+  when: not sonarr_bin.stat.exists
+
+- name: Deploy Sonarr systemd unit
+  ansible.builtin.template:
+    src: sonarr.service.j2
+    dest: /etc/systemd/system/sonarr.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart sonarr
+
+- name: Enable + start Sonarr
+  ansible.builtin.systemd:
+    name: sonarr.service
+    state: started
+    enabled: true
+    daemon_reload: true
+  when: sonarr_manage_services

--- a/roles/sonarr/templates/sonarr.service.j2
+++ b/roles/sonarr/templates/sonarr.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Sonarr (TV PVR)
+Documentation=https://wiki.servarr.com/sonarr
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ sonarr_user }}
+Group={{ sonarr_group }}
+ExecStart={{ sonarr_install_dir }}/Sonarr -nobrowser -data={{ sonarr_data_dir }}
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/secrets.enc.yaml
+++ b/secrets.enc.yaml
@@ -4,9 +4,17 @@
 #ENC[AES256_GCM,data:DHkdJaSQjsedpqY2rrn/TrbRiQoAssg6pAnNQhl6H+lCoewSMzaHGYtKK4gUeHHIFmvw+eKqVD0oHkh4yxvdRlkG,iv:I9Zq+JxiX4TTnhIHmWFfJ39ANE92eQ32OvcLtum9rmU=,tag:YmJGx1uDQOnDw23hMDRyag==,type:comment]
 #ENC[AES256_GCM,data:4/PfNrBLMQkiggZc51qttISS4Bo9GFivuXgDes10UHmViz8dMFweDrhw/4BzYMKZ07LJ41Y6pQ5ZPfqek5nUgK8l9Xg=,iv:WjXM9Tfho1wMTavVA058F9B9dSrLlviR/U5AI08BAHk=,tag:LwtHtsXMy3ufznMRTIAEWw==,type:comment]
 OPENPROJECT_SECRET_KEY_BASE: ENC[AES256_GCM,data:PXKMGU0jwSVESZtKVo0Ekl52ly5qAmwUfGx+yOrZ9E0XhoI0LKSReg2JxCcZGbe6WPDLeJxerlcJ8xcqHDaEewGvRay7SY0pM5636h63XSQdIrgj1KXd2S6rSFPDPlNZuYYBW+TgwkCNNKPPDg2ztyGFdB29mlpOVA14Mq0JD7U=,iv:vn/GbkwD7vnktaPmGr+e2mi2zDXnKctUAf878oovMfU=,tag:YKQ9MGW8lFNWWgElJpVH9g==,type:str]
+PROTON_WG_PRIVATE_KEY: ENC[AES256_GCM,data:GSl72FVb+iA+zRZjsyXqaT5XxaeeuhPOtfb3t8j2pbRfixLTqJSXlbALh1g=,iv:LX2wiVg949bUl+m4YjIRi72o56F6fPhWB3ei/EkcIvo=,tag:SKK5rn3MdYFMva5Ex7ZGqQ==,type:str]
+PROTON_WG_ADDRESS: ENC[AES256_GCM,data:w1Vzmvj2luOyiTzeQI3iBjTOxxnfBFCfVmtShHXOFA==,iv:lTxrxi9a6+zp5WMRX1h1PGN/Mbf/iVW2mrceT2RS7hk=,tag:Of2mG+chOOr6gqoUhFNfRQ==,type:str]
+PROTON_WG_DNS: ENC[AES256_GCM,data:ef0KYKPLkZ4LYQQjKY5aYJRalvS/oe8Y,iv:5vTBvRGoQ9mlme5J8WsGc6N2HmIX88nmXgWm8wQ0Fhg=,tag:y7QXtE1Ql8A8miDw4YcEDQ==,type:str]
+PROTON_WG_PEER_PUBLIC_KEY: ENC[AES256_GCM,data:cV9I4Wo2k5Z3jCLpw9qI09/0FwopGBJrkkRfuBIOWsNBmX7N+E/SP/RGJLM=,iv:fNLEnWd2mosgUgDLMVgw9pMEe3apdTt7Exb8pdwDatA=,tag:MwTNHS9NMeYFd5XXWwBiRA==,type:str]
+PROTON_WG_ENDPOINT: ENC[AES256_GCM,data:/3pHsUBsyus86kX4Y1+Y4Ays,iv:rYgUPkPkUgJuLZg7vOdh4njN1s2E4Z7GJb6OSMFplaE=,tag:U9Vc6pL7sfdCnaCWc9h69w==,type:str]
+QBITTORRENT_ADMIN_PASSWORD: ENC[AES256_GCM,data:UdFePfBFva9H5NvYcuZmVU17oFX3S/Nhvw28hVlqUaI=,iv:OgOjCbXbgs1RUL8TEJ7cE/DaBcGJYHn9kTIryfPSlp8=,tag:dX4umptNxrP/F6+ETXC+DQ==,type:str]
+DOWNLOAD_VPN_HEALTHCHECK_URL: ""
 sops:
     age:
-        - enc: |
+        - recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
+          enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFUkpCZlhUbU9EVjgyTkhJ
             NitiTlZOd2QvdnE4Y3VUdjIzaldNbXhGT21RCkd5TWhEQ1I5dDh3dUhCUmNobUIr
@@ -14,8 +22,7 @@ sops:
             Z3RhQjhBZWZzNGhHQ1g0QytpbStoTDQKifyhMCeddKVDkstLc1Jmz2FirNYsq4gc
             yB3E157iHA3Qn3eYx7vfSFrviMIZFhWdAsVZ821y/cDXeUfG0yU33g==
             -----END AGE ENCRYPTED FILE-----
-          recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
-    lastmodified: "2026-05-13T22:33:03Z"
-    mac: ENC[AES256_GCM,data:sFIUq3Ur+U/7FK3cfJGo60Zavw7xhnDPUapgN2ECBWOWxIy8Ma8t4CYahVlWFRiqd5Osuqtw9Y8MHGf+jLXOChpHBBgr0x826sbQVXmoBiyAh8uJ9ua6z4n3JwI8w/pADpDfX+aXC6sraqd2N5GalLoKNjkdptbvhIVUz9YBnPo=,iv:yrZiXRvM9tNhQtFRhEfAFs/d8VBv2RRAYeRPshO5jZE=,tag:wqYtSgHqElgIcfe9eYQ8/Q==,type:str]
+    lastmodified: "2026-05-29T13:23:40Z"
+    mac: ENC[AES256_GCM,data:vu7P1+fevrhXqEltDkesRun4XKRjXtBfwj3gfF8djRkY8W/ohBMw0MKmYQqz8RjQ2p8qEdGeEVfmufmNFybnb/+AK4GHE2aXJ7q2RWR2vGZj4c2zZbz9d/INijZbQTyyFGcVIpqAN5SohWa2ylo+SnLSTFRpk9mgN0HpdyyPFC0=,iv:eAouFxfO1q2IKxKXPgLOVXkpxILcY3xvRj47Ssx+4eU=,tag:uzSfMpUqAbKevO7IHh8MHA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.0

--- a/secrets.enc.yaml.example
+++ b/secrets.enc.yaml.example
@@ -64,3 +64,27 @@ OPENPROJECT_SECRET_KEY_BASE: your-128-char-hex-secret-here
 INFISICAL_ENCRYPTION_KEY: your-base64-32-byte-encryption-key-here
 INFISICAL_AUTH_SECRET: your-base64-32-byte-auth-secret-here
 INFISICAL_DB_PASSWORD: your-base64-24-byte-db-password-here
+
+# download_vpn (qBittorrent + Prowlarr behind Proton WireGuard)
+# Copy these from your Proton WireGuard config file (Proton account ->
+# Downloads -> WireGuard configuration). Proton issues a DUAL-STACK config:
+# the Address line contains an IPv4 AND an IPv6 address. The role keeps only
+# the IPv4 half and kills IPv6 entirely, so either paste the full Address as
+# Proton gives it or just the IPv4 entry — both work.
+#
+#   [Interface] PrivateKey  -> PROTON_WG_PRIVATE_KEY
+#   [Interface] Address     -> PROTON_WG_ADDRESS  (e.g. "10.2.0.2/32,fd00::.../128")
+#   [Interface] DNS         -> PROTON_WG_DNS      (e.g. "10.2.0.1")
+#   [Peer]      PublicKey   -> PROTON_WG_PEER_PUBLIC_KEY
+#   [Peer]      Endpoint    -> PROTON_WG_ENDPOINT (e.g. "host.protonvpn.net:51820")
+PROTON_WG_PRIVATE_KEY: your-proton-wireguard-private-key-here
+PROTON_WG_ADDRESS: "10.2.0.2/32"
+PROTON_WG_DNS: "10.2.0.1"
+PROTON_WG_PEER_PUBLIC_KEY: your-proton-server-public-key-here
+PROTON_WG_ENDPOINT: "your-proton-endpoint-host:51820"
+# qBittorrent WebUI admin password (used by the role to set the password and
+# by the NAT-PMP keeper + validator to authenticate to the WebUI API).
+QBITTORRENT_ADMIN_PASSWORD: your-strong-qbittorrent-password-here
+# Optional: healthchecks deadman ping URL for the runtime killswitch validator.
+# Leave empty to skip the deadman ping (ntfy alerts still fire on breach).
+DOWNLOAD_VPN_HEALTHCHECK_URL: ""

--- a/tests/inventory_load/terraform_inventory.json
+++ b/tests/inventory_load/terraform_inventory.json
@@ -6,7 +6,13 @@
       "hostname": "haproxy",
       "ansible_connection": "community.proxmox.proxmox_pct_remote",
       "ansible_pct_vmid": 175,
-      "tags": ["terraform", "container", "haproxy", "pipeline", "infrastructure"],
+      "tags": [
+        "terraform",
+        "container",
+        "haproxy",
+        "pipeline",
+        "infrastructure"
+      ],
       "node": "pve",
       "pool_id": "homelab"
     },
@@ -16,7 +22,14 @@
       "hostname": "cribl-edge-01",
       "ansible_connection": "community.proxmox.proxmox_pct_remote",
       "ansible_pct_vmid": 180,
-      "tags": ["terraform", "container", "cribl", "edge", "pipeline", "logging"],
+      "tags": [
+        "terraform",
+        "container",
+        "cribl",
+        "edge",
+        "pipeline",
+        "logging"
+      ],
       "node": "pve",
       "pool_id": "homelab"
     },
@@ -26,17 +39,26 @@
       "hostname": "cribl-edge-02",
       "ansible_connection": "community.proxmox.proxmox_pct_remote",
       "ansible_pct_vmid": 181,
-      "tags": ["terraform", "container", "cribl", "edge", "pipeline", "logging"],
+      "tags": [
+        "terraform",
+        "container",
+        "cribl",
+        "edge",
+        "pipeline",
+        "logging"
+      ],
       "node": "pve",
       "pool_id": "homelab"
     },
     "mssql": {
-      "vmid": 210,
-      "ip": "192.168.0.210",
+      "vmid": 130,
+      "ip": "192.168.0.130",
       "hostname": "mssql",
       "ansible_connection": "community.proxmox.proxmox_pct_remote",
-      "ansible_pct_vmid": 210,
-      "tags": ["database"],
+      "ansible_pct_vmid": 130,
+      "tags": [
+        "database"
+      ],
       "node": "pve",
       "pool_id": "homelab"
     },
@@ -46,7 +68,14 @@
       "hostname": "cribl-stream-01",
       "ansible_connection": "community.proxmox.proxmox_pct_remote",
       "ansible_pct_vmid": 182,
-      "tags": ["terraform", "container", "cribl", "stream", "pipeline", "logging"],
+      "tags": [
+        "terraform",
+        "container",
+        "cribl",
+        "stream",
+        "pipeline",
+        "logging"
+      ],
       "node": "pve",
       "pool_id": "homelab"
     },
@@ -56,7 +85,14 @@
       "hostname": "cribl-stream-02",
       "ansible_connection": "community.proxmox.proxmox_pct_remote",
       "ansible_pct_vmid": 183,
-      "tags": ["terraform", "container", "cribl", "stream", "pipeline", "logging"],
+      "tags": [
+        "terraform",
+        "container",
+        "cribl",
+        "stream",
+        "pipeline",
+        "logging"
+      ],
       "node": "pve",
       "pool_id": "homelab"
     },
@@ -66,7 +102,12 @@
       "hostname": "apt-cacher-ng",
       "ansible_connection": "community.proxmox.proxmox_pct_remote",
       "ansible_pct_vmid": 106,
-      "tags": ["apt-cache", "container", "infrastructure", "terraform"],
+      "tags": [
+        "apt-cache",
+        "container",
+        "infrastructure",
+        "terraform"
+      ],
       "node": "pve",
       "pool_id": "infrastructure"
     },
@@ -76,7 +117,13 @@
       "hostname": "qdrant",
       "ansible_connection": "community.proxmox.proxmox_pct_remote",
       "ansible_pct_vmid": 165,
-      "tags": ["terraform", "container", "vectordb", "ai", "docker"],
+      "tags": [
+        "terraform",
+        "container",
+        "vectordb",
+        "ai",
+        "docker"
+      ],
       "node": "pve",
       "pool_id": "ai"
     },
@@ -86,7 +133,12 @@
       "hostname": "llamaindex",
       "ansible_connection": "community.proxmox.proxmox_pct_remote",
       "ansible_pct_vmid": 166,
-      "tags": ["terraform", "container", "ai", "rag"],
+      "tags": [
+        "terraform",
+        "container",
+        "ai",
+        "rag"
+      ],
       "node": "pve",
       "pool_id": "ai"
     },
@@ -96,7 +148,12 @@
       "hostname": "mailpit",
       "ansible_connection": "community.proxmox.proxmox_pct_remote",
       "ansible_pct_vmid": 110,
-      "tags": ["terraform", "container", "smtp", "notifications"],
+      "tags": [
+        "terraform",
+        "container",
+        "smtp",
+        "notifications"
+      ],
       "node": "pve",
       "pool_id": "homelab"
     },
@@ -106,7 +163,12 @@
       "hostname": "ntfy",
       "ansible_connection": "community.proxmox.proxmox_pct_remote",
       "ansible_pct_vmid": 111,
-      "tags": ["terraform", "container", "push", "notifications"],
+      "tags": [
+        "terraform",
+        "container",
+        "push",
+        "notifications"
+      ],
       "node": "pve",
       "pool_id": "homelab"
     },
@@ -116,9 +178,81 @@
       "hostname": "openproject",
       "ansible_connection": "community.proxmox.proxmox_pct_remote",
       "ansible_pct_vmid": 140,
-      "tags": ["terraform", "container", "openproject", "projects", "docker"],
+      "tags": [
+        "terraform",
+        "container",
+        "openproject",
+        "projects",
+        "docker"
+      ],
       "node": "pve",
       "pool_id": "infrastructure"
+    },
+    "download-vpn": {
+      "vmid": 210,
+      "ip": "192.168.0.210",
+      "hostname": "download-vpn",
+      "ansible_connection": "community.proxmox.proxmox_pct_remote",
+      "ansible_pct_vmid": 210,
+      "tags": [
+        "terraform",
+        "container",
+        "media",
+        "download",
+        "vpn",
+        "torrent",
+        "indexer"
+      ],
+      "node": "pve2",
+      "pool_id": "media"
+    },
+    "sonarr": {
+      "vmid": 211,
+      "ip": "192.168.0.211",
+      "hostname": "sonarr",
+      "ansible_connection": "community.proxmox.proxmox_pct_remote",
+      "ansible_pct_vmid": 211,
+      "tags": [
+        "terraform",
+        "container",
+        "media",
+        "sonarr",
+        "pvr"
+      ],
+      "node": "pve2",
+      "pool_id": "media"
+    },
+    "radarr": {
+      "vmid": 212,
+      "ip": "192.168.0.212",
+      "hostname": "radarr",
+      "ansible_connection": "community.proxmox.proxmox_pct_remote",
+      "ansible_pct_vmid": 212,
+      "tags": [
+        "terraform",
+        "container",
+        "media",
+        "radarr",
+        "pvr"
+      ],
+      "node": "pve2",
+      "pool_id": "media"
+    },
+    "plex": {
+      "vmid": 213,
+      "ip": "192.168.0.213",
+      "hostname": "plex",
+      "ansible_connection": "community.proxmox.proxmox_pct_remote",
+      "ansible_pct_vmid": 213,
+      "tags": [
+        "terraform",
+        "container",
+        "media",
+        "plex",
+        "streaming"
+      ],
+      "node": "pve2",
+      "pool_id": "media"
     }
   },
   "vms": {},
@@ -128,7 +262,13 @@
       "ip": "192.168.0.250",
       "hostname": "docker-host",
       "ansible_connection": "ssh",
-      "tags": ["terraform", "cribl", "docker", "logging", "swarm"],
+      "tags": [
+        "terraform",
+        "cribl",
+        "docker",
+        "logging",
+        "swarm"
+      ],
       "node": "pve",
       "pool_id": "homelab"
     }
@@ -170,6 +310,13 @@
     "vector_db_ports": {
       "qdrant_http": 6333,
       "qdrant_grpc": 6334
+    },
+    "media_ports": {
+      "qbittorrent_web": 8080,
+      "prowlarr_web": 9696,
+      "sonarr_web": 8989,
+      "radarr_web": 7878,
+      "plex_web": 32400
     }
   },
   "domain": "jacobpevans.com",

--- a/tests/inventory_load/terraform_inventory.schema.json
+++ b/tests/inventory_load/terraform_inventory.schema.json
@@ -223,6 +223,18 @@
           },
           "required": ["qdrant_http", "qdrant_grpc"],
           "additionalProperties": false
+        },
+        "media_ports": {
+          "type": "object",
+          "properties": {
+            "qbittorrent_web": {"type": "integer", "minimum": 1, "maximum": 65535},
+            "prowlarr_web": {"type": "integer", "minimum": 1, "maximum": 65535},
+            "sonarr_web": {"type": "integer", "minimum": 1, "maximum": 65535},
+            "radarr_web": {"type": "integer", "minimum": 1, "maximum": 65535},
+            "plex_web": {"type": "integer", "minimum": 1, "maximum": 65535}
+          },
+          "required": ["qbittorrent_web", "prowlarr_web"],
+          "additionalProperties": false
         }
       }
     }

--- a/tests/inventory_load/verify_inventory.yml
+++ b/tests/inventory_load/verify_inventory.yml
@@ -207,6 +207,51 @@
           openproject_group should contain 'openproject' (openproject tag);
           got {{ groups['openproject_group'] | default([]) }}
 
+    - name: Verify download-vpn is in download_vpn_group (vpn tag)
+      ansible.builtin.assert:
+        that:
+          - groups['download_vpn_group'] is defined
+          - "'download-vpn' in groups['download_vpn_group']"
+          # Must NOT leak into other media groups.
+          - "'download-vpn' not in (groups['sonarr_group'] | default([]))"
+        fail_msg: >-
+          download_vpn_group should contain 'download-vpn' (vpn tag);
+          got {{ groups['download_vpn_group'] | default([]) }}
+
+    - name: Verify sonarr/radarr/plex are in their groups
+      ansible.builtin.assert:
+        that:
+          - "'sonarr' in (groups['sonarr_group'] | default([]))"
+          - "'radarr' in (groups['radarr_group'] | default([]))"
+          - "'plex' in (groups['plex_group'] | default([]))"
+        fail_msg: >-
+          media app groups misassigned —
+          sonarr_group={{ groups['sonarr_group'] | default([]) }},
+          radarr_group={{ groups['radarr_group'] | default([]) }},
+          plex_group={{ groups['plex_group'] | default([]) }}
+
+    - name: Verify all four media guests are in media_group
+      ansible.builtin.assert:
+        that:
+          - groups['media_group'] is defined
+          - "'download-vpn' in groups['media_group']"
+          - "'sonarr' in groups['media_group']"
+          - "'radarr' in groups['media_group']"
+          - "'plex' in groups['media_group']"
+        fail_msg: >-
+          media_group should contain all four media guests (media tag);
+          got {{ groups['media_group'] | default([]) }}
+
+    - name: Verify media_ports constant is present
+      ansible.builtin.assert:
+        that:
+          - terraform_data.constants.media_ports is defined
+          - terraform_data.constants.media_ports.qbittorrent_web == 8080
+          - terraform_data.constants.media_ports.prowlarr_web == 9696
+        fail_msg: >-
+          terraform_data.constants.media_ports missing or incorrect —
+          expected qbittorrent_web: 8080, prowlarr_web: 9696
+
     - name: Display group membership summary
       ansible.builtin.debug:
         msg: |


### PR DESCRIPTION
VPN-locked media downloader (qBittorrent + Prowlarr) as an LXC on pve2 with a fail-closed nftables killswitch (no VPN = zero egress, v4 AND v6) and 3-layer validation: molecule verify, deploy-time validate.yml (fails the play on any non-VPN egress), and a runtime systemd-timer validator that stops qBittorrent + alerts on any breach. Secrets via SOPS (placeholders only; real Proton config injected separately). Pairs with provisioning in dryvist/terraform-proxmox#327. Refs dryvist/terraform-proxmox#327.