### PR TITLE
feat(zot_registry): self-hosted Zot registry + docker mirror client config

### DIFF
--- a/inventory/group_vars/registry_group.yml
+++ b/inventory/group_vars/registry_group.yml
@@ -1,0 +1,3 @@
+---
+systemd_restart_policy_services:
+  - zot

--- a/inventory/load_terraform.yml
+++ b/inventory/load_terraform.yml
@@ -129,6 +129,11 @@
               else []
             ) +
             (
+              ['registry_group']
+              if 'registry' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
               ['minio_group']
               if 'minio' in (item.value.tags | default([]))
               else []

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -56,6 +56,64 @@
         state: absent
 
 # =============================================================================
+# Phase 0-zot: Zot OCI Registry
+# Self-hosted pull-through cache (docker.io/ghcr.io/quay.io) and private
+# registry. Deployed early — before any docker app roles — so firewalled
+# docker hosts can pull through it. Pairs with the terraform registry LXC 109.
+# =============================================================================
+
+- name: Deploy Zot registry
+  hosts: registry_group
+  become: true
+  gather_facts: true
+  tags:
+    - zot
+    - registry
+    - lxc
+  roles:
+    - role: zot_registry
+
+- name: Configure Docker registry mirror on LXC containers
+  hosts: lxc_containers:!registry_group
+  become: true
+  gather_facts: false
+  tags:
+    - registry_mirror
+    - docker
+    - lxc
+  handlers:
+    - name: Restart docker
+      ansible.builtin.systemd:
+        name: docker
+        state: restarted
+  tasks:
+    # This play is the single owner of /etc/docker/daemon.json on docker LXCs.
+    # roles/idrac_kvm_docker no longer writes the storage-driver here (removed
+    # on a separate branch) to avoid two writers fighting over the same file.
+    - name: Configure Docker registry mirror
+      when:
+        - "'registry' in hostvars"
+        - "'docker' in (host_tags | default([]))"
+      vars:
+        _registry_ip: "{{ hostvars['registry']['container_ip'] }}"
+        _registry_port: >-
+          {{ hostvars['localhost']['terraform_data']
+             ['constants']['service_ports']['registry']
+             | default(5000) }}
+      ansible.builtin.copy:
+        dest: /etc/docker/daemon.json
+        content: |
+          {
+            "registry-mirrors": ["http://{{ _registry_ip }}:{{ _registry_port }}"],
+            "insecure-registries": ["{{ _registry_ip }}:{{ _registry_port }}"],
+            "storage-driver": "fuse-overlayfs"
+          }
+        owner: root
+        group: root
+        mode: '0644'
+      notify: Restart docker
+
+# =============================================================================
 # Phase 0a: NTP Time Synchronization Baseline
 # Runs after apt-cacher-ng is up and the apt proxy is configured, so LXC
 # containers with outbound-internal firewall (cribl_edge, cribl_stream)

--- a/roles/zot_registry/README.md
+++ b/roles/zot_registry/README.md
@@ -1,0 +1,90 @@
+# Zot Registry Role
+
+Installs and configures [Zot](https://zotregistry.dev), a lightweight
+OCI-native container registry, on a Debian LXC. Zot serves two roles at once:
+
+- **Pull-through cache** for the public registries (`docker.io`, `ghcr.io`,
+  `quay.io`) via the `sync` extension with `onDemand` caching. The first pull
+  of an image fetches it from upstream and caches it locally; subsequent pulls
+  are served from local storage.
+- **Private registry** for images built and pushed in the homelab. Pushed
+  images live alongside the cached upstream content under
+  `{{ zot_storage_dir }}`.
+
+This unblocks firewalled Docker hosts (e.g. LXC containers with
+`output_policy=DROP`) that cannot reach the internet directly: they point at
+this registry as a `registry-mirror` and pull everything through it.
+
+## Requirements
+
+- Debian-based host (bookworm/trixie)
+- Outbound internet access on the registry host (to reach the upstream
+  registries it caches). The registry LXC runs with `output_policy=ACCEPT`.
+
+## Role Variables
+
+See `defaults/main.yml` for all variables.
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `zot_registry_version` | `v2.1.17` | Pinned project-zot/zot release tag |
+| `zot_registry_port` | `5000` | HTTP listen port |
+| `zot_registry_bind_address` | `0.0.0.0` | HTTP bind address |
+| `zot_registry_storage_dir` | `/opt/zot/storage` | Image/blob storage (100G mount) |
+| `zot_registry_config_dir` | `/etc/zot` | Config directory |
+| `zot_registry_user` | `zot` | System user/group |
+| `zot_registry_upstream_registries` | docker.io, ghcr.io, quay.io | Pull-through upstreams |
+
+## Installation
+
+Add the host to the `registry_group` (via the `registry` Terraform tag) and run
+the deploy play in `playbooks/site.yml`, or apply the role directly:
+
+```yaml
+- name: Deploy Zot registry
+  hosts: registry_group
+  become: true
+  roles:
+    - zot_registry
+```
+
+## Usage
+
+### Client Configuration (Docker mirror)
+
+Firewalled Docker hosts pull through this registry. Configure their
+`/etc/docker/daemon.json` (HTTP-only in v1, so the registry must be listed as
+insecure):
+
+```json
+{
+  "registry-mirrors": ["http://<registry-ip>:5000"],
+  "insecure-registries": ["<registry-ip>:5000"]
+}
+```
+
+Then `systemctl restart docker`. This is applied automatically by the
+"Configure Docker registry mirror on LXC containers" play in
+`playbooks/site.yml`.
+
+### Pushing private images
+
+```bash
+docker tag myapp:latest <registry-ip>:5000/myapp:latest
+docker push <registry-ip>:5000/myapp:latest
+```
+
+## TLS (follow-up)
+
+v1 is **HTTP only** — no TLS. Clients must trust it via `insecure-registries`.
+A follow-up should front Zot with TLS (HAProxy termination or native zot TLS
+config under `http.tls`) and drop the insecure-registry client entries once a
+trusted certificate is in place.
+
+## Dependencies
+
+None.
+
+## License
+
+Apache-2.0

--- a/roles/zot_registry/defaults/main.yml
+++ b/roles/zot_registry/defaults/main.yml
@@ -1,0 +1,40 @@
+---
+# Zot OCI registry role defaults
+
+# Pinned upstream release. Bump deliberately; see project-zot/zot releases.
+zot_registry_version: v2.1.17
+
+# Service configuration
+zot_registry_port: 5000
+zot_registry_bind_address: "0.0.0.0"
+
+# Filesystem layout
+zot_registry_install_dir: /usr/local/bin
+zot_registry_storage_dir: /opt/zot/storage
+zot_registry_config_dir: /etc/zot
+
+# System user
+zot_registry_user: zot
+zot_registry_group: zot
+
+# Binary download (GitHub release asset). The linux-amd64 build is a static
+# binary; the matching .md5 file alongside it provides the checksum.
+zot_registry_binary_name: zot-linux-amd64
+zot_registry_binary_url: >-
+  https://github.com/project-zot/zot/releases/download/{{ zot_registry_version }}/{{ zot_registry_binary_name }}
+zot_registry_binary_checksum_url: >-
+  https://github.com/project-zot/zot/releases/download/{{ zot_registry_version }}/{{ zot_registry_binary_name }}.md5
+
+# Logging
+zot_registry_log_level: info
+
+# Pull-through cache upstreams. Each entry becomes one sync registry with
+# onDemand caching enabled. docker.io must use on-demand only (Docker Hub
+# rate-limits pulls and has no catalog listing, so polled mirroring is unsafe).
+zot_registry_upstream_registries:
+  - name: docker.io
+    url: https://registry-1.docker.io
+  - name: ghcr.io
+    url: https://ghcr.io
+  - name: quay.io
+    url: https://quay.io

--- a/roles/zot_registry/handlers/main.yml
+++ b/roles/zot_registry/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Restart zot
+  ansible.builtin.systemd:
+    name: zot
+    state: restarted
+    daemon_reload: true
+  when: ansible_service_mgr == 'systemd'

--- a/roles/zot_registry/meta/main.yml
+++ b/roles/zot_registry/meta/main.yml
@@ -1,0 +1,17 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: Deploy Zot OCI registry as a pull-through cache and private registry
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+  galaxy_tags:
+    - zot
+    - registry
+    - oci
+    - docker
+dependencies: []

--- a/roles/zot_registry/tasks/main.yml
+++ b/roles/zot_registry/tasks/main.yml
@@ -1,0 +1,111 @@
+---
+# Zot OCI registry installation and configuration
+#
+# The registry LXC has output_policy=ACCEPT (unrestricted egress), so the
+# binary and its checksum are fetched directly on the target — no controller
+# staging is needed (contrast with the minio role, whose hosts are egress
+# restricted).
+
+# Phase 1: System user
+- name: Create zot system group
+  ansible.builtin.group:
+    name: "{{ zot_registry_group }}"
+    system: true
+    state: present
+
+- name: Create zot system user
+  ansible.builtin.user:
+    name: "{{ zot_registry_user }}"
+    group: "{{ zot_registry_group }}"
+    system: true
+    shell: /usr/sbin/nologin
+    home: "{{ zot_registry_storage_dir }}"
+    create_home: false
+    state: present
+
+# Phase 2: Directories
+- name: Create zot storage directory
+  ansible.builtin.file:
+    path: "{{ zot_registry_storage_dir }}"
+    state: directory
+    owner: "{{ zot_registry_user }}"
+    group: "{{ zot_registry_group }}"
+    mode: "0750"
+
+- name: Create zot config directory
+  ansible.builtin.file:
+    path: "{{ zot_registry_config_dir }}"
+    state: directory
+    owner: "{{ zot_registry_user }}"
+    group: "{{ zot_registry_group }}"
+    mode: "0750"
+
+# Phase 3: Download binary
+# Fetch the published .md5 so get_url can verify the binary and re-download
+# only when the pinned version changes (idempotent across runs).
+- name: Fetch zot binary checksum
+  ansible.builtin.uri:
+    url: "{{ zot_registry_binary_checksum_url }}"
+    return_content: true
+  register: zot_registry_checksum_response
+  changed_when: false
+
+- name: Download zot binary
+  ansible.builtin.get_url:
+    url: "{{ zot_registry_binary_url }}"
+    dest: "{{ zot_registry_install_dir }}/zot"
+    checksum: "md5:{{ zot_registry_checksum_response.content.split() | first }}"
+    owner: root
+    group: root
+    mode: "0755"
+  notify: Restart zot
+
+# Phase 4: Configuration
+- name: Deploy zot configuration
+  ansible.builtin.template:
+    src: config.json.j2
+    dest: "{{ zot_registry_config_dir }}/config.json"
+    owner: root
+    group: "{{ zot_registry_group }}"
+    mode: "0640"
+    # zot ships a config linter; validate the rendered file before install so a
+    # malformed config.json never reaches the running service.
+    validate: "{{ zot_registry_install_dir }}/zot verify %s"
+  notify: Restart zot
+
+- name: Deploy zot systemd unit file
+  ansible.builtin.template:
+    src: zot.service.j2
+    dest: /etc/systemd/system/zot.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart zot
+
+# Phase 5: Enable and start service
+- name: Enable and start zot service
+  ansible.builtin.systemd:
+    name: zot
+    state: started
+    enabled: true
+    daemon_reload: true
+  when: ansible_service_mgr == 'systemd'
+
+# Phase 6: Health check
+- name: Wait for zot registry API to be ready
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ zot_registry_port }}/v2/"
+    status_code: 200
+  register: zot_registry_health
+  until: zot_registry_health.status == 200
+  retries: 10
+  delay: 3
+  changed_when: false
+  when: ansible_service_mgr == 'systemd'
+
+- name: Display zot registry access information
+  ansible.builtin.debug:
+    msg:
+      - "Zot registry is running on port {{ zot_registry_port }}"
+      - "Registry API: http://{{ container_ip | default(inventory_hostname) }}:{{ zot_registry_port }}/v2/"
+      - "Pull-through cache upstreams: {{ zot_registry_upstream_registries | map(attribute='name') | join(', ') }}"

--- a/roles/zot_registry/templates/config.json.j2
+++ b/roles/zot_registry/templates/config.json.j2
@@ -1,0 +1,38 @@
+{
+  "distSpecVersion": "1.1.0",
+  "storage": {
+    "rootDirectory": "{{ zot_registry_storage_dir }}",
+    "gc": true
+  },
+  "http": {
+    "address": "{{ zot_registry_bind_address }}",
+    "port": "{{ zot_registry_port }}"
+  },
+  "log": {
+    "level": "{{ zot_registry_log_level }}"
+  },
+  "extensions": {
+    "search": {
+      "enable": true
+    },
+    "sync": {
+      "enable": true,
+      "registries": [
+{% for upstream in zot_registry_upstream_registries %}
+        {
+          "urls": [
+            "{{ upstream.url }}"
+          ],
+          "onDemand": true,
+          "tlsVerify": true,
+          "content": [
+            {
+              "prefix": "**"
+            }
+          ]
+        }{{ "," if not loop.last else "" }}
+{% endfor %}
+      ]
+    }
+  }
+}

--- a/roles/zot_registry/templates/zot.service.j2
+++ b/roles/zot_registry/templates/zot.service.j2
@@ -1,0 +1,17 @@
+[Unit]
+Description=Zot OCI Registry
+Documentation=https://zotregistry.dev
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ zot_registry_user }}
+Group={{ zot_registry_group }}
+ExecStart={{ zot_registry_install_dir }}/zot serve {{ zot_registry_config_dir }}/config.json
+Restart=on-failure
+RestartSec=10
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add a zot_registry Ansible role and two site.yml plays for the new registry
LXC (vmid 109, 10.0.1.109:5000). Zot serves as both a pull-through cache for
docker.io/ghcr.io/quay.io (sync extension, onDemand) and a private registry
for homelab-built images pushed over HTTP.

The client play writes /etc/docker/daemon.json on docker-tagged LXCs with
registry-mirrors + insecure-registries pointing at the registry, plus the
fuse-overlayfs storage driver. This unblocks firewalled docker hosts that
cannot reach the internet directly — they pull everything through the mirror.
This play is now the single owner of daemon.json on docker LXCs.

Pairs with the terraform registry LXC 109 PR. HTTP only in v1 (no TLS);
clients trust it via insecure-registries — TLS is a follow-up.

Assisted-by: Claude <noreply@anthropic.com>
