### PR TITLE
feat(media): add deterministic servarr API keys to SOPS for self-wiring

### DIFF
--- a/secrets.enc.yaml
+++ b/secrets.enc.yaml
@@ -11,6 +11,10 @@ PROTON_WG_PEER_PUBLIC_KEY: ENC[AES256_GCM,data:cV9I4Wo2k5Z3jCLpw9qI09/0FwopGBJrk
 PROTON_WG_ENDPOINT: ENC[AES256_GCM,data:/3pHsUBsyus86kX4Y1+Y4Ays,iv:rYgUPkPkUgJuLZg7vOdh4njN1s2E4Z7GJb6OSMFplaE=,tag:U9Vc6pL7sfdCnaCWc9h69w==,type:str]
 QBITTORRENT_ADMIN_PASSWORD: ENC[AES256_GCM,data:UdFePfBFva9H5NvYcuZmVU17oFX3S/Nhvw28hVlqUaI=,iv:OgOjCbXbgs1RUL8TEJ7cE/DaBcGJYHn9kTIryfPSlp8=,tag:dX4umptNxrP/F6+ETXC+DQ==,type:str]
 DOWNLOAD_VPN_HEALTHCHECK_URL: ""
+SONARR_API_KEY: ENC[AES256_GCM,data:ilchuo1ESF4LAwmqrMSh2Eb3G8e/TreSUCVZvIu3R4g=,iv:uWZ27T9Ov0T0iNzsck9e5GvF9lTjGNwwZQOFAxdwneo=,tag:Yi/N86qrNrc+PuUazwLSnQ==,type:str]
+RADARR_API_KEY: ENC[AES256_GCM,data:7u6ekKu9478406WXxP/0+L7IyED+dqU1+gMZCGv7Iko=,iv:QjjcDjEET7k3V8BiwCZ6Asoal5lNBAUlv0uMj3fmfHM=,tag:9AbNawvgFG8MqaAeYqxvbw==,type:str]
+PROWLARR_API_KEY: ENC[AES256_GCM,data:c0Ufcx+weQyWfhxObJKGnKmd2NmRnSLNXJlh4iZqO9A=,iv:kgpd0mjPHBj4FKgUfQZMpZ7iM8FNVCJI4s4NAqAcc7U=,tag:TsWCs7IUhpGges9qpKaxWQ==,type:str]
+JELLYSEERR_API_KEY: ENC[AES256_GCM,data:DAarsxYGbjfjpUYReZVzzFc32ThmH5+DJwKYxRSmpEY=,iv:/qR5cvto63QgaPbnWeMxPf7b1Tp5gjgK+/tolvSQyhw=,tag:TMJbeRh2oaKCubXHY2pXFw==,type:str]
 sops:
     age:
         - recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
@@ -22,7 +26,7 @@ sops:
             Z3RhQjhBZWZzNGhHQ1g0QytpbStoTDQKifyhMCeddKVDkstLc1Jmz2FirNYsq4gc
             yB3E157iHA3Qn3eYx7vfSFrviMIZFhWdAsVZ821y/cDXeUfG0yU33g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-29T13:23:40Z"
-    mac: ENC[AES256_GCM,data:vu7P1+fevrhXqEltDkesRun4XKRjXtBfwj3gfF8djRkY8W/ohBMw0MKmYQqz8RjQ2p8qEdGeEVfmufmNFybnb/+AK4GHE2aXJ7q2RWR2vGZj4c2zZbz9d/INijZbQTyyFGcVIpqAN5SohWa2ylo+SnLSTFRpk9mgN0HpdyyPFC0=,iv:eAouFxfO1q2IKxKXPgLOVXkpxILcY3xvRj47Ssx+4eU=,tag:uzSfMpUqAbKevO7IHh8MHA==,type:str]
+    lastmodified: "2026-05-31T16:28:32Z"
+    mac: ENC[AES256_GCM,data:DitXsJ6yMWUKwKONoVkLPVAoUw+FJpiNRw/usAxEDhoi1K6FN9pD6VPjheH6vLZhUg9jT4sOVFjvLBSWarQIdlpi7wNgbKq0kGQI1fKN7eoyjMEwlwe66C7VhNUMQaen5ooL0jeWAeP1kVpeYx5Y56VIf1gZK6M+yQi9QzqtXMg=,iv:FgvYMn4Jjy3t/yJNl64TNQxb8U/sBK2bW6nMaWAOhTk=,tag:m+MW/TQ4cnisjtuxuGVFlw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.0


### PR DESCRIPTION
Adds four age-encrypted, deterministic API keys to `secrets.enc.yaml` so the `servarr_wiring` and `jellyseerr` roles can converge. Both roles fail-closed (assert) without these.

## Keys added (top-level, `type:str` ENC)

- `SONARR_API_KEY`
- `RADARR_API_KEY`
- `PROWLARR_API_KEY`
- `JELLYSEERR_API_KEY`

## Why deterministic

The keys are seeded into SOPS so they are known *before* converge rather than auto-generated per-app. This makes Prowlarr<->Sonarr/Radarr registration and Jellyseerr cross-wiring idempotent — each role reads its key via `lookup('env', ...)` under `sops exec-env`.

## Secrets discipline

Each value was generated with `openssl rand -hex 16` into a shell variable and written via non-interactive `sops set` — never echoed, never printed. Verified by:

- presence (`yq has()` after decrypt) = true for all four
- raw-file `ENC[` count increased by exactly 4 (13 -> 17)
- negative plaintext grep of each generated value against the raw file = zero matches

No plaintext key material appears in the diff, commit, or this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)