### PR TITLE
fix(ci): repoint release-please caller to org-native reusable workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,4 +1,3 @@
----
 name: Release Please
 
 on:
@@ -12,6 +11,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
+    uses: dryvist/.github/.github/workflows/_release-please.yml@main
     secrets:
-      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+      GH_ACTION_RELEASE_PLEASE_PRIVATE_KEY: ${{ secrets.GH_ACTION_RELEASE_PLEASE_PRIVATE_KEY }}


### PR DESCRIPTION
Point at dryvist/.github/_release-please.yml (org-owned, org release App) instead of the cross-account JacobPEvans-personal reusable. Passes the org-level GH_ACTION_RELEASE_PLEASE_PRIVATE_KEY secret.

Refs: dryvist/terraform-github#6

🤖 Generated with [Claude Code](https://claude.com/claude-code)