### PR TITLE
fix(download_vpn): add openresolv so wg-quick DNS= directive works on Debian 13 LXC

### DIFF
--- a/roles/download_vpn/tasks/main.yml
+++ b/roles/download_vpn/tasks/main.yml
@@ -55,6 +55,7 @@
   ansible.builtin.apt:
     name:
       - wireguard-tools
+      - openresolv  # provides /usr/sbin/resolvconf so wg-quick honours DNS=
       - nftables
       - "{{ download_vpn_qbittorrent_package }}"
       - natpmpc


### PR DESCRIPTION
## Why

\`wg-quick\` invokes \`/usr/sbin/resolvconf\` to apply the \`DNS=\` line from the WireGuard config. On Debian, \`/usr/sbin/resolvconf\` is provided by the **openresolv** package — NOT the \`resolvconf\` package (which is Ubuntu's). The default Debian 13 (trixie) LXC template ships neither, so \`wg0\` came up without DNS injection and qBittorrent could only reach hosts by IP.

A prior converge unblocked LXC 210 by hand (\`apt install openresolv\`); this codifies the package in the role's apt task so every future converge produces the same outcome on a fresh template.

## What

- \`roles/download_vpn/tasks/main.yml\`: add \`openresolv\` to the \"Install media + VPN + firewall packages\" apt task, with an inline comment pointing at the wg-quick dependency.

## Test

- \`ansible-lint roles/download_vpn/tasks/main.yml\` (profile production): passes, 0 failures / 0 warnings.
- No molecule scenario exists for \`download_vpn\`; CI runs the full repo-wide lint.

## Out of scope

- No defaults / molecule fixture changes — the role does not enumerate the package list anywhere else.