### PR TITLE
refactor(download_vpn): rename Proton WG vars to IFACE_/PEER_ scheme matching .conf structure

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,3 +1,4 @@
+---
 name: Release Please
 
 on:

--- a/molecule/download_vpn/molecule.yml
+++ b/molecule/download_vpn/molecule.yml
@@ -35,11 +35,13 @@ provisioner:
       interpreter_python: auto_silent
       roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
   env:
-    PROTON_WG_PRIVATE_KEY: "${PROTON_WG_PRIVATE_KEY:-QHk0aVZ2c2tleVRFU1Rvbmx5Tk9UcmVhbGtleQ==}"
-    PROTON_WG_ADDRESS: "${PROTON_WG_ADDRESS:-10.2.0.2/32}"
-    PROTON_WG_ENDPOINT: "${PROTON_WG_ENDPOINT:-203.0.113.7:51820}"
+    # IFACE/PEER prefixes mirror the [Interface]/[Peer] sections of the
+    # .conf Proton issues. DNS is a stable tunnel constant (10.2.0.1)
+    # baked into the role defaults — not exposed as an env var.
+    PROTON_WG_IFACE_PRIVATE_KEY: "${PROTON_WG_IFACE_PRIVATE_KEY:-QHk0aVZ2c2tleVRFU1Rvbmx5Tk9UcmVhbGtleQ==}"
+    PROTON_WG_IFACE_ADDRESS: "${PROTON_WG_IFACE_ADDRESS:-10.2.0.2/32}"
+    PROTON_WG_PEER_ENDPOINT: "${PROTON_WG_PEER_ENDPOINT:-192.168.0.7:51820}"
     PROTON_WG_PEER_PUBLIC_KEY: "${PROTON_WG_PEER_PUBLIC_KEY:-cGVlclRFU1RwdWJsaWNrZXlOT1RyZWFsa2V5MDA=}"
-    PROTON_WG_DNS: "${PROTON_WG_DNS:-10.2.0.1}"
     QBITTORRENT_ADMIN_PASSWORD: "${QBITTORRENT_ADMIN_PASSWORD:-molecule-test-pass}"
 
 verifier:

--- a/roles/download_vpn/README.md
+++ b/roles/download_vpn/README.md
@@ -56,10 +56,13 @@ sops exec-env secrets.enc.yaml 'doppler run -- ansible-playbook \
 ## Requirements
 
 - Debian-based unprivileged LXC with `/dev/net/tun` and `nesting`/`keyctl`.
-- Proton WireGuard config delivered via SOPS (see repo
-  `secrets.enc.yaml.example`): `PROTON_WG_PRIVATE_KEY`, `PROTON_WG_ADDRESS`,
-  `PROTON_WG_ENDPOINT`, `PROTON_WG_PEER_PUBLIC_KEY`, `PROTON_WG_DNS`,
-  `QBITTORRENT_ADMIN_PASSWORD`.
+- Proton WireGuard config delivered via Doppler runtime env (variable names
+  mirror the `.conf` `[Interface]`/`[Peer]` sections so a fresh Proton
+  download maps 1:1): `PROTON_WG_IFACE_PRIVATE_KEY`,
+  `PROTON_WG_IFACE_ADDRESS`, `PROTON_WG_PEER_PUBLIC_KEY`,
+  `PROTON_WG_PEER_ENDPOINT`. Proton's tunnel DNS resolver `10.2.0.1` is a
+  stable constant and is hardcoded in `defaults/main.yml` (not a secret).
+  `QBITTORRENT_ADMIN_PASSWORD` is delivered via SOPS.
 - `tank/downloads` + `tank/media` bind-mounted at `/mnt/downloads` and
   `/mnt/media`.
 

--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -27,17 +27,22 @@ download_vpn_media_dir: /mnt/media
 # --- WireGuard (Proton) ------------------------------------------------------
 download_vpn_wg_interface: wg0
 download_vpn_wg_config_path: /etc/wireguard/wg0.conf
-# Proton WireGuard parameters — sourced from SOPS env (see
-# secrets.enc.yaml.example). NEVER hardcode key material or the endpoint.
-download_vpn_wg_private_key: "{{ lookup('env', 'PROTON_WG_PRIVATE_KEY') }}"
+# Proton WireGuard parameters — sourced from Doppler runtime env. Variable
+# names mirror the [Interface]/[Peer] section structure of the .conf Proton
+# issues, so a fresh download maps 1:1 to env vars. NEVER hardcode key
+# material or the endpoint.
+download_vpn_wg_private_key: "{{ lookup('env', 'PROTON_WG_IFACE_PRIVATE_KEY') }}"
 # Tunnel interface address(es). Proton issues a dual-stack pair
 # ("10.2.0.2/32,fd00::.../128"). We keep the full value for the wg0 Address line
 # but rely on kernel IPv6 disable + nft ip6 DROP so the v6 half cannot leak.
-download_vpn_wg_address: "{{ lookup('env', 'PROTON_WG_ADDRESS') }}"
-download_vpn_wg_dns: "{{ lookup('env', 'PROTON_WG_DNS') }}"
+download_vpn_wg_address: "{{ lookup('env', 'PROTON_WG_IFACE_ADDRESS') }}"
+# Proton's WireGuard DNS resolver is a stable tunnel-side constant
+# (10.2.0.1), not a per-user secret — matches download_vpn_natpmp_gateway
+# below. Hardcoded so the .conf-derived env contract stays IFACE/PEER-only.
+download_vpn_wg_dns: "10.2.0.1"
 # Proton server public key + "host:port" endpoint.
 download_vpn_wg_peer_public_key: "{{ lookup('env', 'PROTON_WG_PEER_PUBLIC_KEY') }}"
-download_vpn_wg_endpoint: "{{ lookup('env', 'PROTON_WG_ENDPOINT') }}"
+download_vpn_wg_endpoint: "{{ lookup('env', 'PROTON_WG_PEER_ENDPOINT') }}"
 # AllowedIPs deliberately routes ONLY IPv4 default via the tunnel. We do NOT
 # add ::/0 — IPv6 is killed at the kernel, so adding a v6 default route would
 # only create a path the killswitch then has to fight. IPv4 default through

--- a/secrets.enc.yaml
+++ b/secrets.enc.yaml
@@ -4,11 +4,6 @@
 #ENC[AES256_GCM,data:DHkdJaSQjsedpqY2rrn/TrbRiQoAssg6pAnNQhl6H+lCoewSMzaHGYtKK4gUeHHIFmvw+eKqVD0oHkh4yxvdRlkG,iv:I9Zq+JxiX4TTnhIHmWFfJ39ANE92eQ32OvcLtum9rmU=,tag:YmJGx1uDQOnDw23hMDRyag==,type:comment]
 #ENC[AES256_GCM,data:4/PfNrBLMQkiggZc51qttISS4Bo9GFivuXgDes10UHmViz8dMFweDrhw/4BzYMKZ07LJ41Y6pQ5ZPfqek5nUgK8l9Xg=,iv:WjXM9Tfho1wMTavVA058F9B9dSrLlviR/U5AI08BAHk=,tag:LwtHtsXMy3ufznMRTIAEWw==,type:comment]
 OPENPROJECT_SECRET_KEY_BASE: ENC[AES256_GCM,data:PXKMGU0jwSVESZtKVo0Ekl52ly5qAmwUfGx+yOrZ9E0XhoI0LKSReg2JxCcZGbe6WPDLeJxerlcJ8xcqHDaEewGvRay7SY0pM5636h63XSQdIrgj1KXd2S6rSFPDPlNZuYYBW+TgwkCNNKPPDg2ztyGFdB29mlpOVA14Mq0JD7U=,iv:vn/GbkwD7vnktaPmGr+e2mi2zDXnKctUAf878oovMfU=,tag:YKQ9MGW8lFNWWgElJpVH9g==,type:str]
-PROTON_WG_PRIVATE_KEY: ENC[AES256_GCM,data:GSl72FVb+iA+zRZjsyXqaT5XxaeeuhPOtfb3t8j2pbRfixLTqJSXlbALh1g=,iv:LX2wiVg949bUl+m4YjIRi72o56F6fPhWB3ei/EkcIvo=,tag:SKK5rn3MdYFMva5Ex7ZGqQ==,type:str]
-PROTON_WG_ADDRESS: ENC[AES256_GCM,data:w1Vzmvj2luOyiTzeQI3iBjTOxxnfBFCfVmtShHXOFA==,iv:lTxrxi9a6+zp5WMRX1h1PGN/Mbf/iVW2mrceT2RS7hk=,tag:Of2mG+chOOr6gqoUhFNfRQ==,type:str]
-PROTON_WG_DNS: ENC[AES256_GCM,data:ef0KYKPLkZ4LYQQjKY5aYJRalvS/oe8Y,iv:5vTBvRGoQ9mlme5J8WsGc6N2HmIX88nmXgWm8wQ0Fhg=,tag:y7QXtE1Ql8A8miDw4YcEDQ==,type:str]
-PROTON_WG_PEER_PUBLIC_KEY: ENC[AES256_GCM,data:cV9I4Wo2k5Z3jCLpw9qI09/0FwopGBJrkkRfuBIOWsNBmX7N+E/SP/RGJLM=,iv:fNLEnWd2mosgUgDLMVgw9pMEe3apdTt7Exb8pdwDatA=,tag:MwTNHS9NMeYFd5XXWwBiRA==,type:str]
-PROTON_WG_ENDPOINT: ENC[AES256_GCM,data:/3pHsUBsyus86kX4Y1+Y4Ays,iv:rYgUPkPkUgJuLZg7vOdh4njN1s2E4Z7GJb6OSMFplaE=,tag:U9Vc6pL7sfdCnaCWc9h69w==,type:str]
 QBITTORRENT_ADMIN_PASSWORD: ENC[AES256_GCM,data:UdFePfBFva9H5NvYcuZmVU17oFX3S/Nhvw28hVlqUaI=,iv:OgOjCbXbgs1RUL8TEJ7cE/DaBcGJYHn9kTIryfPSlp8=,tag:dX4umptNxrP/F6+ETXC+DQ==,type:str]
 DOWNLOAD_VPN_HEALTHCHECK_URL: ""
 SONARR_API_KEY: ENC[AES256_GCM,data:ilchuo1ESF4LAwmqrMSh2Eb3G8e/TreSUCVZvIu3R4g=,iv:uWZ27T9Ov0T0iNzsck9e5GvF9lTjGNwwZQOFAxdwneo=,tag:Yi/N86qrNrc+PuUazwLSnQ==,type:str]
@@ -26,7 +21,7 @@ sops:
             Z3RhQjhBZWZzNGhHQ1g0QytpbStoTDQKifyhMCeddKVDkstLc1Jmz2FirNYsq4gc
             yB3E157iHA3Qn3eYx7vfSFrviMIZFhWdAsVZ821y/cDXeUfG0yU33g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-31T16:28:32Z"
-    mac: ENC[AES256_GCM,data:DitXsJ6yMWUKwKONoVkLPVAoUw+FJpiNRw/usAxEDhoi1K6FN9pD6VPjheH6vLZhUg9jT4sOVFjvLBSWarQIdlpi7wNgbKq0kGQI1fKN7eoyjMEwlwe66C7VhNUMQaen5ooL0jeWAeP1kVpeYx5Y56VIf1gZK6M+yQi9QzqtXMg=,iv:FgvYMn4Jjy3t/yJNl64TNQxb8U/sBK2bW6nMaWAOhTk=,tag:m+MW/TQ4cnisjtuxuGVFlw==,type:str]
+    lastmodified: "2026-06-01T14:31:13Z"
+    mac: ENC[AES256_GCM,data:PIO/9Z8isLSQeXJuELFrsFhDJxPkzcfL4s/QM0jd52GNymk7Cr7qhtohfwrhZFETNxlfvmsw95Tp4wccD8fbFgBq6wXP41tXcCbJzgPz/BzKTT98cKqK5wkbHfVB/I+w1ftZfluZr4Dg5EirrdGcGs2t+YJSDVXgyuyxP2KEZ+o=,iv:e5WkEUYFwG5nzmvawK+yZTcXMciDj7f7sJ4U1IzB5K0=,tag:Qp0LFUpm5YqVT7qNMNSDqg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.0

--- a/secrets.enc.yaml.example
+++ b/secrets.enc.yaml.example
@@ -66,22 +66,23 @@ INFISICAL_AUTH_SECRET: your-base64-32-byte-auth-secret-here
 INFISICAL_DB_PASSWORD: your-base64-24-byte-db-password-here
 
 # download_vpn (qBittorrent + Prowlarr behind Proton WireGuard)
-# Copy these from your Proton WireGuard config file (Proton account ->
-# Downloads -> WireGuard configuration). Proton issues a DUAL-STACK config:
-# the Address line contains an IPv4 AND an IPv6 address. The role keeps only
-# the IPv4 half and kills IPv6 entirely, so either paste the full Address as
-# Proton gives it or just the IPv4 entry — both work.
 #
-#   [Interface] PrivateKey  -> PROTON_WG_PRIVATE_KEY
-#   [Interface] Address     -> PROTON_WG_ADDRESS  (e.g. "10.2.0.2/32,fd00::.../128")
-#   [Interface] DNS         -> PROTON_WG_DNS      (e.g. "10.2.0.1")
+# Proton WireGuard credentials live in Doppler (NOT SOPS) — the role reads
+# them via lookup('env', ...). Variable names mirror the .conf section
+# structure Proton ships, so copying values out of the downloaded .conf
+# into Doppler is mechanical:
+#
+#   [Interface] PrivateKey  -> PROTON_WG_IFACE_PRIVATE_KEY
+#   [Interface] Address     -> PROTON_WG_IFACE_ADDRESS  (e.g. "10.2.0.2/32,fd00::.../128")
 #   [Peer]      PublicKey   -> PROTON_WG_PEER_PUBLIC_KEY
-#   [Peer]      Endpoint    -> PROTON_WG_ENDPOINT (e.g. "host.protonvpn.net:51820")
-PROTON_WG_PRIVATE_KEY: your-proton-wireguard-private-key-here
-PROTON_WG_ADDRESS: "10.2.0.2/32"
-PROTON_WG_DNS: "10.2.0.1"
-PROTON_WG_PEER_PUBLIC_KEY: your-proton-server-public-key-here
-PROTON_WG_ENDPOINT: "your-proton-endpoint-host:51820"
+#   [Peer]      Endpoint    -> PROTON_WG_PEER_ENDPOINT  (e.g. "host.protonvpn.net:51820")
+#
+# Proton issues a DUAL-STACK config: the Address line contains an IPv4 AND
+# an IPv6 address. The role keeps only the IPv4 half and kills IPv6 entirely
+# — paste the full Address as Proton gives it or just the IPv4 entry, either
+# works. The [Interface] DNS resolver (10.2.0.1) is a stable Proton tunnel
+# constant hardcoded in defaults/main.yml; not an env var.
+#
 # qBittorrent WebUI admin password (used by the role to set the password and
 # by the NAT-PMP keeper + validator to authenticate to the WebUI API).
 QBITTORRENT_ADMIN_PASSWORD: your-strong-qbittorrent-password-here


### PR DESCRIPTION
## Summary

Two commits, both narrowly scoped:

### 1. `refactor(download_vpn)` — main change

Rename the four Proton WireGuard env-var names the `download_vpn` role
reads so they mirror the `[Interface]` / `[Peer]` section structure of
the `.conf` file Proton ships. A fresh `.conf` download now maps 1:1
to Doppler keys:

| .conf section | Old name | New name |
| --- | --- | --- |
| `[Interface] PrivateKey` | `PROTON_WG_PRIVATE_KEY` | `PROTON_WG_IFACE_PRIVATE_KEY` |
| `[Interface] Address` | `PROTON_WG_ADDRESS` | `PROTON_WG_IFACE_ADDRESS` |
| `[Peer] PublicKey` | `PROTON_WG_PEER_PUBLIC_KEY` | `PROTON_WG_PEER_PUBLIC_KEY` (unchanged; value rotated) |
| `[Peer] Endpoint` | `PROTON_WG_ENDPOINT` | `PROTON_WG_PEER_ENDPOINT` |

Doppler now owns the live values (already populated in
`iac-conf-mgmt/prd`). The old SOPS-resident copies are removed from
`secrets.enc.yaml` so the two stores cannot drift.

### 2. `ci(release-please)` — CI unblock side fix

ansible-lint 26.4.0 (latest, which CI installs unpinned) now enforces
`yaml[document-start]` across `.github/workflows/`. The
`release-please.yml` workflow predates this rule and was missing the
leading `---` marker. Every PR opened against this repo right now
trips the same failure regardless of content. One-character fix.

## DNS handling — chose Option B

Hardcoded `download_vpn_wg_dns: "10.2.0.1"` as a default in
`roles/download_vpn/defaults/main.yml`. Rationale:

1. The Proton tunnel DNS resolver is a stable constant, not a per-user
   secret.
2. The role already hardcodes the matching
   `download_vpn_natpmp_gateway: "10.2.0.1"` a few lines below.
3. The user moved IFACE/PEER values to Doppler but explicitly did NOT
   add `PROTON_WG_DNS`. Keeping it in SOPS would split the contract
   across both stores for one constant value.
4. Removes one SOPS key entirely; the `.conf`-derived env contract
   stays IFACE/PEER-only.

## SOPS cleanup

`sops unset` removed five keys from `secrets.enc.yaml`:
`PROTON_WG_PRIVATE_KEY`, `PROTON_WG_ADDRESS`, `PROTON_WG_DNS`,
`PROTON_WG_PEER_PUBLIC_KEY`, `PROTON_WG_ENDPOINT`. The file is still
`AES256_GCM` encrypted at rest. `QBITTORRENT_ADMIN_PASSWORD`,
`SONARR_API_KEY`, `RADARR_API_KEY`, `PROWLARR_API_KEY`,
`JELLYSEERR_API_KEY`, `OPENPROJECT_SECRET_KEY_BASE`, and
`DOWNLOAD_VPN_HEALTHCHECK_URL` are untouched.

## Files touched

- `roles/download_vpn/defaults/main.yml` — env-var lookups renamed; DNS hardcoded.
- `roles/download_vpn/README.md` — document the Doppler-sourced contract.
- `secrets.enc.yaml.example` — replace the Proton-WG SOPS block with a
  comment-only block explaining the Doppler contract.
- `secrets.enc.yaml` — five keys removed (encrypted-at-rest preserved).
- `molecule/download_vpn/molecule.yml` — matching env-var rename; drop
  `PROTON_WG_DNS` (role now hardcodes it).
- `.github/workflows/release-please.yml` — add `---` doc-start (CI unblock).

## Validation

- Local `yamllint` on all touched YAML — clean.
- Local `ansible-lint --offline roles/download_vpn/` (profile
  `production`) — clean.
- CI `Molecule (download_vpn)` — green (verifies the role still renders
  end-to-end with the new env-var names).
- CI `Molecule (qdrant)`, `(llamaindex)`, `Template Rendering Tests`,
  full `Ansible Lint / *` suite — green.
- `grep -rnE 'PROTON_WG_(PRIVATE_KEY|ADDRESS|ENDPOINT|DNS)\b' .` — zero
  surviving references to the old names anywhere in the repo.
- `grep -rnE 'PROTON_WG_(IFACE_|PEER_)' .` — refs present in role
  defaults, README, and molecule scenario only (no SOPS keys — Doppler
  is single source).

## Test plan

- [ ] CI re-runs Ansible Lint green after the doc-start fix.
- [ ] On next converge against the `download_vpn` LXC, the
  Doppler-injected env vars resolve into `wg0.conf` and `wg-quick up wg0`
  succeeds against the rotated Proton credentials.
- [ ] Killswitch validator (`tasks/validate.yml`) re-passes end-to-end
  post-converge.

Assisted-by: Claude:claude-opus-4-7