### PR TITLE
feat(plex): switch to Plex v2 apt repo (ed25519) for Debian 13

### DIFF
--- a/roles/plex/defaults/main.yml
+++ b/roles/plex/defaults/main.yml
@@ -8,8 +8,13 @@ plex_group_gid: 13000
 plex_media_dir: /mnt/media
 # Web UI / server port from terraform constants (no hardcoded port).
 plex_web_port: "{{ terraform_data.constants.media_ports.plex_web }}"
-# Official Plex apt repo (public channel).
-plex_apt_key_url: https://downloads.plex.tv/plex-keys/PlexSign.key
-plex_apt_repo: "deb https://downloads.plex.tv/repo/deb public main"
+# Official Plex apt repo — v2 (ed25519 key, repo.plex.tv).
+# Required on Debian 13 (trixie): apt-via-Sequoia (sqv) rejects the legacy
+# RSA/SHA-1 PlexSign key as of 2026-02-01. The v2 key/repo are the official
+# Plex replacement documented at:
+#   https://support.plex.tv/articles/235974187-enable-repository-updating-for-supported-linux-server-distributions/
+plex_apt_key_url: https://downloads.plex.tv/plex-keys/PlexSign.v2.key
+plex_apt_keyring_path: /etc/apt/keyrings/plexmediaserver.v2.asc
+plex_apt_repo: "deb [signed-by={{ plex_apt_keyring_path }}] https://repo.plex.tv/deb/ public main"
 plex_package: plexmediaserver
 plex_manage_services: true

--- a/roles/plex/tasks/main.yml
+++ b/roles/plex/tasks/main.yml
@@ -18,10 +18,31 @@
     system: true
     state: present
 
-- name: Add Plex apt signing key
+- name: Ensure /etc/apt/keyrings exists
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+
+# Plex moved repos in Plex Media Server 1.43.0 (v2 key, ed25519, repo.plex.tv).
+# The legacy RSA/SHA-1 PlexSign.key fails on Debian 13 (sqv) after 2026-02-01.
+# Strip any stale v1 artifacts before installing the v2 key/repo so apt does
+# not keep refusing updates on hosts that previously used the old layout.
+- name: Remove legacy Plex v1 apt keyring (if present)
+  ansible.builtin.file:
+    path: /etc/apt/keyrings/plex.asc
+    state: absent
+
+- name: Remove legacy Plex v1 apt repo file (if present)
+  ansible.builtin.file:
+    path: /etc/apt/sources.list.d/plexmediaserver.list
+    state: absent
+  register: plex_legacy_repo
+
+- name: Add Plex apt signing key (v2, ed25519)
   ansible.builtin.get_url:
     url: "{{ plex_apt_key_url }}"
-    dest: /etc/apt/keyrings/plex.asc
+    dest: "{{ plex_apt_keyring_path }}"
     mode: "0644"
 
 - name: Add Plex apt repository
@@ -31,11 +52,15 @@
     state: present
   register: plex_repo
 
+- name: Refresh apt cache after Plex repo changes
+  ansible.builtin.apt:
+    update_cache: true
+  when: plex_repo is changed or plex_legacy_repo is changed
+
 - name: Install Plex Media Server
   ansible.builtin.apt:
     name: "{{ plex_package }}"
     state: present
-    update_cache: "{{ plex_repo is changed }}"
 
 - name: Ensure plex user is in the media group (read tank/media)
   ansible.builtin.user:


### PR DESCRIPTION
## Problem

LXC 213 (`plex`, Debian 13 / trixie) can't run `apt-get update`:

```
Err:5 https://downloads.plex.tv/repo/deb public InRelease
  Sub-process /usr/bin/sqv returned an error code (1), error message is:
  Signing key on CD665CBA0E2F88B7373F7CB997203C7B3ADCA79D is not bound:
  No binding signature at time 2025-09-22T18:33:03Z
  because: Policy rejected non-revocation signature (PositiveCertification)
  requiring second pre-image resistance
  because: SHA1 is not considered secure since 2026-02-01T00:00:00Z
```

Debian 13 ships APT backed by Sequoia (`sqv`). Sequoia's default policy
rejects RSA self-bindings hashed with SHA-1 as of 2026-02-01. The legacy
Plex repo key (`CD66...A79D`, RSA-4096 from 2015) is bound that way, so
every Debian 13 host that uses `downloads.plex.tv/repo/deb` is wedged.

## Fix

Plex has shipped an official replacement: a new ed25519 key and a new
repo at `repo.plex.tv`, documented in the Plex Linux repo support
article. The role now uses both.

- `defaults/main.yml`:
  - `plex_apt_key_url` → `https://downloads.plex.tv/plex-keys/PlexSign.v2.key`
  - `plex_apt_keyring_path` → `/etc/apt/keyrings/plexmediaserver.v2.asc`
  - `plex_apt_repo` → `deb [signed-by=...] https://repo.plex.tv/deb/ public main`
- `tasks/main.yml`:
  - Ensure `/etc/apt/keyrings/` exists.
  - Explicitly remove legacy `plex.asc` and `plexmediaserver.list` before
    installing the v2 layout (so hosts that previously failed are unstuck).
  - Run a dedicated `apt update` step gated on changes (the prior
    inline `update_cache:` on the install task was getting skipped).

## Verification

Applied the v2 config live on LXC 213 (matches what this role will do):

```
$ apt-get update
Hit:1 http://deb.debian.org/debian trixie InRelease
Hit:2 http://security.debian.org trixie-security InRelease
Get:4 https://repo.plex.tv/deb public InRelease [4069 B]
Get:5 https://repo.plex.tv/deb public/main amd64 Packages [393 B]
Reading package lists... Done

$ apt-get install -y --dry-run plexmediaserver
Inst plexmediaserver (1.43.2.10687-563d026ea Plex Media Server Repository:public [amd64])
```

`sqv` accepts the v2 InRelease (Hash: SHA256, ed25519 signature) without
complaint.

## Evidence the legacy repo is unchanged

- `https://downloads.plex.tv/plex-keys/PlexSign.key` — same RSA key,
  fingerprint `CD66...A79D`, same 3072-byte file. Plex has not re-signed.
- `https://downloads.plex.tv/repo/deb/dists/public/InRelease` — last
  signed 2025-09-22 by the same key, still SHA-1 self-bound.

So this is **not** a transient — the legacy repo is permanently broken
on trixie and Plex's published fix is to move to the v2 repo.

## References

- Plex Linux repo support article: https://support.plex.tv/articles/235974187-enable-repository-updating-for-supported-linux-server-distributions/
- Plex forum (Plex-acknowledged): https://forums.plex.tv/t/debian-13-apt-sequoia-will-reject-plex-repo-key-after-2026-02-01-key-not-bound-sha-1/930245