### PR TITLE
fix(download_vpn): use wg-quick auto routing — drop recursive Table=off design

### DIFF
--- a/roles/download_vpn/templates/download-vpn-wg.service.j2
+++ b/roles/download_vpn/templates/download-vpn-wg.service.j2
@@ -8,11 +8,12 @@ Requires=download-vpn-killswitch.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-# wg-quick honours `Table = off` in the config, so it sets up the interface
-# and address but installs no routes. We then add ONLY the IPv4 default route
-# via wg0 — no IPv6 default route is ever created.
+# wg-quick honours `Table = auto` in wg0.conf: it installs the IPv4 default
+# route via wg0 *and* an fwmark + policy-routing table so wg's encapsulated
+# UDP to the Proton endpoint resolves via the original LAN default. Do not
+# add a manual `ip route replace default dev wg0` here — it would clobber
+# wg-quick's setup and recursively route the handshake back into the tunnel.
 ExecStart=/usr/bin/wg-quick up {{ download_vpn_wg_interface }}
-ExecStartPost=/sbin/ip -4 route replace default dev {{ download_vpn_wg_interface }}
 ExecStop=/usr/bin/wg-quick down {{ download_vpn_wg_interface }}
 Restart=on-failure
 RestartSec=5

--- a/roles/download_vpn/templates/wg0.conf.j2
+++ b/roles/download_vpn/templates/wg0.conf.j2
@@ -6,6 +6,14 @@
   on the Address line and set AllowedIPs to the IPv4 default route. IPv6 is
   disabled at the kernel + dropped by nftables, so we deliberately do NOT add
   ::/0 here — that would build a v6 default route the killswitch must fight.
+
+  Routing note: `Table = auto` is wg-quick's default. When AllowedIPs covers
+  0.0.0.0/0 it installs the v4 default route via wg0 *and* sets up an fwmark +
+  policy-routing table so wg's own encapsulated UDP to the Proton endpoint is
+  resolved against the original LAN default (not back through wg0). Setting
+  `Table = off` here breaks that — encapsulated UDP recursively routes into
+  wg0 and the handshake never completes. The killswitch (nftables) is what
+  enforces fail-closed, not the routing table choice.
 -#}
 [Interface]
 PrivateKey = {{ download_vpn_wg_private_key }}
@@ -13,10 +21,11 @@ Address = {{ download_vpn_wg_address_v4 }}
 {% if download_vpn_wg_dns | trim | length > 0 %}
 DNS = {{ download_vpn_wg_dns }}
 {% endif %}
-# Table = off keeps wg-quick from installing routes for us; the killswitch +
-# the explicit wg0 default route (added by the role) own routing so no v6
-# default route can sneak in.
-Table = off
+# Let wg-quick manage routing: it installs the v4 default via wg0 AND the
+# fwmark policy-routing table that keeps encapsulated UDP escaping via the
+# LAN gateway. The killswitch (nftables, default-drop) provides fail-closed
+# guarantees independently of routing.
+Table = auto
 
 [Peer]
 PublicKey = {{ download_vpn_wg_peer_public_key }}


### PR DESCRIPTION
## Summary

Fix a real bug in the `download_vpn` role that prevented the WireGuard
handshake from completing autonomously after deploy.

The previous design set `Table = off` in `wg0.conf` and added
`ip route replace default dev wg0` from the systemd unit's `ExecStartPost`.
That installed `wg0` as the only IPv4 default route but did NOT set up the
fwmark + policy-routing table that `wg-quick` normally creates. Result:
wg's own encapsulated UDP packets to the Proton endpoint were matched by
the `wg0` default and recursively routed back into the tunnel, so the
handshake never completed.

## Change

- `wg0.conf.j2`: `Table = off` -> `Table = auto`.
- `download-vpn-wg.service.j2`: remove the manual
  `ExecStartPost=/sbin/ip -4 route replace default dev wg0`.

With `Table = auto` (wg-quick's default) and `AllowedIPs = 0.0.0.0/0`,
wg-quick installs the v4 default via `wg0` AND sets up an fwmark + alt
policy-routing table so encapsulated UDP to the Proton endpoint escapes
via the original LAN default. This matches the manual fix that was
verified live on LXC 210 — handshake completes, apt over LAN works,
killswitch stays fail-closed.

## Safety

The fail-closed nftables killswitch is independent of routing:

- `output` chain policy = `drop` (covers v4 + v6).
- Only allows: `lo`, `ct state established,related`, the LAN subnet, UDP
  to the Proton endpoint, `oifname wg0`.
- `wg0` down -> no rule permits non-VPN egress -> traffic cut off
  instantly, exactly as before.

`validate.yml` assertions (default route via `wg0`, qBittorrent bound to
`wg0`, forced non-VPN egress refused, IPv6 egress refused) continue to
hold: wg-quick's `Table = auto` does install the v4 default via `wg0` in
the main table; encapsulated UDP rides a separate policy-routing table
via fwmark, which the assertion does not (and should not) inspect.

## Test plan

- [x] `ansible-lint` clean.
- [ ] CI molecule run.
- [ ] Live converge on LXC 210: tunnel comes up via systemd, handshake
  completes, `validate.yml` 7 assertions all PASS.
- [ ] Live kill-switch proof: `curl --interface wg0` succeeds (Proton IP);
  `curl --interface eth0` blocked; `systemctl stop download-vpn-wg.service`
  cascades qBittorrent down.