### PR TITLE
fix(media): self-healing Jellyseerr wiring + idempotent non-fatal Plex claim

### DIFF
--- a/roles/jellyseerr/README.md
+++ b/roles/jellyseerr/README.md
@@ -66,13 +66,21 @@ it deterministically so downstream tooling knows it before the container runs:
 
 ## Service registration (Sonarr / Radarr / Plex)
 
-`tasks/register.yml` registers the `*arr` apps idempotently via the Jellyseerr
-settings API (GET-then-POST — the repo's house pattern, no bespoke scripts):
+`tasks/register.yml` registers the `*arr` apps idempotently and self-healingly
+via the Jellyseerr settings API (GET-then-PUT-always — the repo's house pattern,
+no bespoke scripts):
 
 - `GET /api/v1/settings/{radarr,sonarr}` to read existing servers.
 - Resolve the target app's first quality-profile id from its own
   `/api/v3/qualityprofile` (Jellyseerr requires `activeProfileId`).
 - `POST` the server only when no entry with that hostname exists yet.
+- `PUT /api/v1/settings/{radarr,sonarr}/{id}` to reconcile an existing entry
+  whenever its stored `apiKey`, `port`, or `useSsl` drifts from the SOPS-sourced
+  value. A converged host PUTs nothing; a SOPS key rotation re-syncs the entry.
+
+This makes the role re-runnable at **any** point: a rotated `SONARR_API_KEY` /
+`RADARR_API_KEY` is pushed into Jellyseerr's DB on the next converge instead of
+leaving a stale key behind a 401.
 
 Hostnames default to the media-stack LXC IPs from inventory; ports come from
 Terraform constants. Sonarr/Radarr registration is skipped if its API key is

--- a/roles/jellyseerr/tasks/register.yml
+++ b/roles/jellyseerr/tasks/register.yml
@@ -1,11 +1,18 @@
 ---
-# Idempotent Jellyseerr service registration via its settings API.
+# Idempotent, self-healing Jellyseerr service registration via its settings API.
 #
-# Pattern (matches the repo's house style — GET-then-POST, no bespoke scripts):
-#   1. GET the current Jellyseerr settings for each service type.
-#   2. Resolve the target *arr's first quality profile id (Jellyseerr requires
+# Pattern (GET-then-PUT-always — reconciles every converge, no bespoke scripts):
+#   1. GET the target *arr's first quality profile id (Jellyseerr requires
 #      activeProfileId on a Radarr/Sonarr server entry).
-#   3. POST the server only when no entry with the same hostname exists yet.
+#   2. GET the current Jellyseerr server entries for that service type.
+#   3. If no entry with the same hostname exists -> POST a new one.
+#      If an entry exists but its stored apiKey / port / useSsl drifts from the
+#      SOPS-sourced value -> PUT the update (PUT /api/v1/settings/{type}/{id}).
+#      If an entry exists and matches -> no change.
+#
+# Net effect: a SOPS key rotation (or any re-run) reconciles Jellyseerr's stored
+# credentials to the current SOPS values, so applying at ANY point re-syncs the
+# server entries instead of leaving a stale apiKey -> 401.
 #
 # All calls authenticate with the deterministic X-Api-Key. Plex registration is
 # skipped unless a Plex token is provided (documented manual step otherwise).
@@ -35,7 +42,17 @@
       changed_when: false
       no_log: true
 
-    - name: Add Radarr to Jellyseerr (idempotent)
+    - name: Resolve the existing Radarr entry for this hostname (if any)
+      ansible.builtin.set_fact:
+        jellyseerr_radarr_entry: >-
+          {{
+            (jellyseerr_radarr_existing.json
+             | selectattr('hostname', 'equalto', jellyseerr_radarr_hostname)
+             | list | first) | default({}, true)
+          }}
+      no_log: true
+
+    - name: Add Radarr to Jellyseerr (create — no entry yet)
       ansible.builtin.uri:
         url: "http://127.0.0.1:{{ jellyseerr_web_port }}/api/v1/settings/radarr"
         method: POST
@@ -62,10 +79,39 @@
       no_log: true
       when:
         - jellyseerr_radarr_profiles.json | length > 0
+        - jellyseerr_radarr_entry == {}
+
+    # Self-heal: PUT only when the stored entry drifts from the SOPS-sourced
+    # credentials/connection (apiKey rotation, port or SSL change). Comparing
+    # before PUT keeps the task idempotent — no change on a converged host. The
+    # PUT body preserves the entry's existing fields (combine) and overlays only
+    # the reconciled connection values, so unrelated settings are untouched.
+    - name: Update Radarr in Jellyseerr (reconcile drifted apiKey/port/ssl)
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ jellyseerr_web_port }}/api/v1/settings/radarr/{{ jellyseerr_radarr_entry.id }}"
+        method: PUT
+        headers:
+          X-Api-Key: "{{ jellyseerr_api_key }}"
+        body_format: json
+        body: >-
+          {{
+            jellyseerr_radarr_entry | combine({
+              'hostname': jellyseerr_radarr_hostname,
+              'port': jellyseerr_radarr_port | int,
+              'useSsl': jellyseerr_radarr_use_ssl,
+              'apiKey': jellyseerr_radarr_api_key
+            })
+          }}
+        status_code: [200, 201]
+      register: jellyseerr_radarr_update
+      changed_when: jellyseerr_radarr_update.status in [200, 201]
+      no_log: true
+      when:
+        - jellyseerr_radarr_entry != {}
         - >-
-          jellyseerr_radarr_existing.json
-          | selectattr('hostname', 'equalto', jellyseerr_radarr_hostname)
-          | list | length == 0
+          jellyseerr_radarr_entry.apiKey | default('') != jellyseerr_radarr_api_key
+          or (jellyseerr_radarr_entry.port | default(0) | int) != (jellyseerr_radarr_port | int)
+          or (jellyseerr_radarr_entry.useSsl | default(false) | bool) != (jellyseerr_radarr_use_ssl | bool)
 
 - name: Register Sonarr in Jellyseerr
   when: jellyseerr_sonarr_api_key | length > 0
@@ -92,7 +138,17 @@
       changed_when: false
       no_log: true
 
-    - name: Add Sonarr to Jellyseerr (idempotent)
+    - name: Resolve the existing Sonarr entry for this hostname (if any)
+      ansible.builtin.set_fact:
+        jellyseerr_sonarr_entry: >-
+          {{
+            (jellyseerr_sonarr_existing.json
+             | selectattr('hostname', 'equalto', jellyseerr_sonarr_hostname)
+             | list | first) | default({}, true)
+          }}
+      no_log: true
+
+    - name: Add Sonarr to Jellyseerr (create — no entry yet)
       ansible.builtin.uri:
         url: "http://127.0.0.1:{{ jellyseerr_web_port }}/api/v1/settings/sonarr"
         method: POST
@@ -118,10 +174,37 @@
       no_log: true
       when:
         - jellyseerr_sonarr_profiles.json | length > 0
+        - jellyseerr_sonarr_entry == {}
+
+    # Self-heal: PUT only when the stored entry drifts from the SOPS-sourced
+    # credentials/connection (apiKey rotation, port or SSL change). Body preserves
+    # the existing entry (combine) and overlays only the reconciled connection.
+    - name: Update Sonarr in Jellyseerr (reconcile drifted apiKey/port/ssl)
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ jellyseerr_web_port }}/api/v1/settings/sonarr/{{ jellyseerr_sonarr_entry.id }}"
+        method: PUT
+        headers:
+          X-Api-Key: "{{ jellyseerr_api_key }}"
+        body_format: json
+        body: >-
+          {{
+            jellyseerr_sonarr_entry | combine({
+              'hostname': jellyseerr_sonarr_hostname,
+              'port': jellyseerr_sonarr_port | int,
+              'useSsl': jellyseerr_sonarr_use_ssl,
+              'apiKey': jellyseerr_sonarr_api_key
+            })
+          }}
+        status_code: [200, 201]
+      register: jellyseerr_sonarr_update
+      changed_when: jellyseerr_sonarr_update.status in [200, 201]
+      no_log: true
+      when:
+        - jellyseerr_sonarr_entry != {}
         - >-
-          jellyseerr_sonarr_existing.json
-          | selectattr('hostname', 'equalto', jellyseerr_sonarr_hostname)
-          | list | length == 0
+          jellyseerr_sonarr_entry.apiKey | default('') != jellyseerr_sonarr_api_key
+          or (jellyseerr_sonarr_entry.port | default(0) | int) != (jellyseerr_sonarr_port | int)
+          or (jellyseerr_sonarr_entry.useSsl | default(false) | bool) != (jellyseerr_sonarr_use_ssl | bool)
 
 # Plex registration needs an account-scoped Plex token. Skipped (and surfaced as
 # a manual step in the README) unless PLEX_CLAIM_TOKEN is populated in SOPS.

--- a/roles/plex/README.md
+++ b/roles/plex/README.md
@@ -1,8 +1,10 @@
 # plex
 
-Plex Media Server, LAN-only (no VPN). Skeleton role: installs from Plex's
-official apt repo and enables the bundled systemd service. Library setup and
-server claim happen in the Plex web UI after deploy.
+Plex Media Server, LAN-only (no VPN). Installs from Plex's official apt repo,
+enables the bundled systemd service, scaffolds the `movies`/`tv` library roots,
+and claims the server idempotently and non-fatally from a SOPS-sourced claim
+token. Finishing the library "add" can still be done in the Plex web UI / API
+after deploy.
 
 ## Installation
 
@@ -24,8 +26,39 @@ Server port comes from terraform (`terraform_data.constants.media_ports.plex_web
 See `defaults/main.yml`.
 
 - `plex_media_dir` — media library root (default `/mnt/media`).
+- `plex_library_subdirs` — library subdirs scaffolded under it (`movies`, `tv`).
 - `plex_apt_repo` — Plex apt repository line.
 - `plex_web_port` — server/web UI port (terraform-derived).
+- `plex_claim_token` — Plex claim token, read from `PLEX_CLAIM_TOKEN` (SOPS env).
+- `plex_preferences_path` — `Preferences.xml` location (holds `PlexOnlineToken`).
+
+## Server claim (idempotent + non-fatal)
+
+`tasks/claim.yml` consumes a Plex claim token to link the server to your account,
+the standard headless apt-install claim flow:
+
+1. **Already claimed** — `Preferences.xml` has a non-empty `PlexOnlineToken` ⇒
+   skip.
+2. **Token present + valid** — exchange it at the local Plex API
+   (`POST http://127.0.0.1:32400/myplex/claim?token=…`) for the permanent token.
+3. **Token absent or expired** — log a clear reminder and **continue** (the play
+   never fails on a missing/stale token).
+
+> **Plex claim tokens expire ~4 minutes after generation**
+> ([plex.tv/claim](https://www.plex.tv/claim)). A token stored in SOPS is almost
+> always already stale by converge time. To automate the claim, generate a fresh
+> token and drop it into `PLEX_CLAIM_TOKEN` in `secrets.enc.yaml`
+> *immediately before* running the converge. Otherwise, claim once via the web
+> UI at `http://<lxc-ip>:<plex_web_port>/web`.
+
+## Secrets
+
+| Variable           | Purpose                                      | Source                  |
+| ------------------ | -------------------------------------------- | ----------------------- |
+| `PLEX_CLAIM_TOKEN` | Fresh Plex claim token to auto-claim the PMS | SOPS `secrets.enc.yaml` |
+
+`PLEX_CLAIM_TOKEN` is never committed. When unset or expired, the claim is
+skipped non-fatally and the server can be claimed in the Plex web UI instead.
 
 ## Usage
 
@@ -35,4 +68,11 @@ See `defaults/main.yml`.
   become: true
   roles:
     - role: plex
+```
+
+With the SOPS env loaded so `PLEX_CLAIM_TOKEN` reaches the role:
+
+```sh
+sops exec-env secrets.enc.yaml 'doppler run -- \
+  ansible-playbook playbooks/site.yml --tags plex'
 ```

--- a/roles/plex/defaults/main.yml
+++ b/roles/plex/defaults/main.yml
@@ -1,13 +1,37 @@
 ---
 # plex role defaults — LAN-only Plex Media Server. No VPN.
-# Skeleton: install from Plex's official apt repo + enable the service.
-# Library setup + claim happen in the Plex web UI after deploy.
+# Install from Plex's official apt repo, enable the service, and (idempotently +
+# non-fatally) claim the server from a SOPS-sourced claim token. Library content
+# add can still be finished in the Plex web UI / API after deploy.
 plex_user: plex
 plex_group: media
 plex_group_gid: 13000
 plex_media_dir: /mnt/media
+# Media library roots scaffolded under plex_media_dir (movies + tv). The actual
+# library "add" against the Plex API can be done later; these just guarantee the
+# directories Plex (and the *arr apps) expect exist with the right ownership.
+plex_library_subdirs:
+  - movies
+  - tv
 # Web UI / server port from terraform constants (no hardcoded port).
 plex_web_port: "{{ terraform_data.constants.media_ports.plex_web }}"
+
+# --- Server claim (account linking) ------------------------------------------
+# Plex claim tokens are account-scoped and EXPIRE ~4 minutes after generation
+# (https://www.plex.tv/claim), so a stored token is usually already stale. The
+# role consumes it idempotently AND non-fatally:
+#   - already claimed (Preferences.xml has PlexOnlineToken) -> skip
+#   - token present + still valid                           -> claim, then done
+#   - token absent or expired/invalid                       -> log + continue
+# Sourced from SOPS env (PLEX_CLAIM_TOKEN); never committed. Empty => skip.
+plex_claim_token: "{{ lookup('env', 'PLEX_CLAIM_TOKEN') | default('', true) }}"
+# Local Plex API for the claim exchange (loopback — the claim is submitted from
+# the server itself). 32400 is the fixed Plex Media Server API port.
+plex_local_api_port: 32400
+# Where apt-installed Plex persists Preferences.xml (holds PlexOnlineToken once
+# the server is claimed).
+plex_preferences_path: >-
+  /var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Preferences.xml
 # Official Plex apt repo — v2 (ed25519 key, repo.plex.tv).
 # Required on Debian 13 (trixie): apt-via-Sequoia (sqv) rejects the legacy
 # RSA/SHA-1 PlexSign key as of 2026-02-01. The v2 key/repo are the official

--- a/roles/plex/tasks/claim.yml
+++ b/roles/plex/tasks/claim.yml
@@ -1,0 +1,114 @@
+---
+# Idempotent + NON-FATAL Plex server claim.
+#
+# Plex claim tokens are account-scoped and expire ~4 minutes after generation
+# (https://www.plex.tv/claim), so a token stored in SOPS is usually already
+# stale by converge time. This task therefore NEVER fails the play on a missing
+# or expired token — it reconciles when it can and logs a clear next step when
+# it cannot:
+#   1. already claimed  (Preferences.xml has a non-empty PlexOnlineToken) -> skip
+#   2. token present     -> exchange it at the LOCAL Plex API for the permanent
+#                           token (the standard apt-install claim flow). A
+#                           rejected/expired token is logged, not fatal.
+#   3. token absent      -> log a reminder to provide a fresh PLEX_CLAIM_TOKEN
+#                           right before converge, or claim via the web UI.
+
+- name: Check whether Preferences.xml exists yet
+  ansible.builtin.stat:
+    path: "{{ plex_preferences_path }}"
+  register: plex_prefs_stat
+
+- name: Read Preferences.xml to detect an existing claim
+  ansible.builtin.slurp:
+    src: "{{ plex_preferences_path }}"
+  register: plex_prefs_raw
+  when: plex_prefs_stat.stat.exists
+  no_log: true
+
+# PlexOnlineToken="..." is present (and non-empty) once the server is claimed.
+- name: Determine if Plex is already claimed
+  ansible.builtin.set_fact:
+    plex_already_claimed: >-
+      {{
+        plex_prefs_stat.stat.exists
+        and (plex_prefs_raw.content | b64decode)
+            is search('PlexOnlineToken="[^"]+"')
+      }}
+  no_log: true
+
+- name: Report that Plex is already claimed (nothing to do)
+  ansible.builtin.debug:
+    msg: "Plex is already claimed (Preferences.xml has PlexOnlineToken) — skipping claim."
+  when: plex_already_claimed
+
+# A stable per-host client identifier keeps the claim attempt idempotent across
+# re-runs (Plex ties the claim to this id).
+- name: Build a stable X-Plex-Client-Identifier for this host
+  ansible.builtin.set_fact:
+    plex_client_identifier: "ansible-plex-{{ ansible_machine_id | default(inventory_hostname) }}"
+  when:
+    - not plex_already_claimed
+    - plex_claim_token | length > 0
+
+- name: Claim block (token present, not yet claimed)
+  when:
+    - not plex_already_claimed
+    - plex_claim_token | length > 0
+  block:
+    # Plex must be up to accept the claim. Short wait — non-fatal so a slow or
+    # down server still falls through to the reminder instead of aborting.
+    - name: Wait briefly for the local Plex API
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: "{{ plex_local_api_port }}"
+        timeout: 60
+      register: plex_api_wait
+      failed_when: false
+
+    # Exchange the claim token for the permanent account token. Submitted FROM
+    # the server to its own loopback API (the standard headless claim flow).
+    # NON-FATAL: an expired/invalid token returns 4xx — we record it and move on.
+    - name: Exchange the claim token at the local Plex API
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ plex_local_api_port }}/myplex/claim?token={{ plex_claim_token }}"
+        method: POST
+        headers:
+          X-Plex-Client-Identifier: "{{ plex_client_identifier }}"
+          Accept: application/json
+        status_code: [200, 201]
+      register: plex_claim_result
+      failed_when: false
+      changed_when: plex_claim_result.status in [200, 201]
+      no_log: true
+      when: plex_api_wait.state is defined and plex_api_wait.state == 'started'
+
+    - name: Report successful Plex claim
+      ansible.builtin.debug:
+        msg: "Plex server claimed successfully via PLEX_CLAIM_TOKEN."
+      when:
+        - plex_claim_result is defined
+        - plex_claim_result.status is defined
+        - plex_claim_result.status in [200, 201]
+
+    # The most common real-world outcome: the stored token had already expired.
+    - name: Report a non-fatal claim failure (token likely expired)
+      ansible.builtin.debug:
+        msg: >-
+          Plex NOT claimed: the local API rejected PLEX_CLAIM_TOKEN
+          (claim tokens expire ~4 min after generation). Provide a FRESH
+          PLEX_CLAIM_TOKEN in SOPS immediately before converge, or claim via the
+          Plex web UI at
+          http://{{ ansible_default_ipv4.address | default(inventory_hostname) }}:{{ plex_web_port }}/web.
+      when:
+        - plex_claim_result is defined
+        - not (plex_claim_result.status is defined and plex_claim_result.status in [200, 201])
+
+- name: Report that no claim token was provided (manual claim still pending)
+  ansible.builtin.debug:
+    msg: >-
+      Plex not claimed: no PLEX_CLAIM_TOKEN provided. Add a fresh token to SOPS
+      (secrets.enc.yaml) right before converge, or claim via the Plex web UI at
+      http://{{ ansible_default_ipv4.address | default(inventory_hostname) }}:{{ plex_web_port }}/web.
+  when:
+    - not plex_already_claimed
+    - plex_claim_token | length == 0

--- a/roles/plex/tasks/main.yml
+++ b/roles/plex/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
-# plex — minimal LAN-only install from the official Plex apt repo (skeleton).
+# plex — LAN-only install from the official Plex apt repo, then an idempotent +
+# non-fatal server claim from a SOPS-sourced PLEX_CLAIM_TOKEN.
 
 - name: Install Plex prerequisites
   ansible.builtin.apt:
@@ -79,10 +80,29 @@
     mode: "2775"
   failed_when: false
 
+# Scaffold the movies/tv library roots so Plex (and the *arr apps writing here)
+# have the expected directories. The library "add" against the Plex API can be
+# finished later via UI/API; this just guarantees the paths exist.
+- name: Scaffold Plex media library subdirectories
+  ansible.builtin.file:
+    path: "{{ plex_media_dir }}/{{ item }}"
+    state: directory
+    owner: "{{ plex_user }}"
+    group: "{{ plex_group }}"
+    mode: "2775"
+  loop: "{{ plex_library_subdirs }}"
+  failed_when: false
+
 - name: Enable + start Plex Media Server
   ansible.builtin.systemd:
     name: plexmediaserver.service
     state: started
     enabled: true
     daemon_reload: true
+  when: plex_manage_services
+
+# Idempotent + non-fatal server claim (see tasks/claim.yml). Only attempted on a
+# live host (plex_manage_services), since it talks to the running Plex API.
+- name: Claim the Plex server (idempotent, non-fatal)
+  ansible.builtin.import_tasks: claim.yml
   when: plex_manage_services

--- a/secrets.enc.yaml
+++ b/secrets.enc.yaml
@@ -10,6 +10,7 @@ SONARR_API_KEY: ENC[AES256_GCM,data:ilchuo1ESF4LAwmqrMSh2Eb3G8e/TreSUCVZvIu3R4g=
 RADARR_API_KEY: ENC[AES256_GCM,data:7u6ekKu9478406WXxP/0+L7IyED+dqU1+gMZCGv7Iko=,iv:QjjcDjEET7k3V8BiwCZ6Asoal5lNBAUlv0uMj3fmfHM=,tag:9AbNawvgFG8MqaAeYqxvbw==,type:str]
 PROWLARR_API_KEY: ENC[AES256_GCM,data:c0Ufcx+weQyWfhxObJKGnKmd2NmRnSLNXJlh4iZqO9A=,iv:kgpd0mjPHBj4FKgUfQZMpZ7iM8FNVCJI4s4NAqAcc7U=,tag:TsWCs7IUhpGges9qpKaxWQ==,type:str]
 JELLYSEERR_API_KEY: ENC[AES256_GCM,data:DAarsxYGbjfjpUYReZVzzFc32ThmH5+DJwKYxRSmpEY=,iv:/qR5cvto63QgaPbnWeMxPf7b1Tp5gjgK+/tolvSQyhw=,tag:TMJbeRh2oaKCubXHY2pXFw==,type:str]
+PLEX_CLAIM_TOKEN: ENC[AES256_GCM,data:EL74JqtcF7PLOvYHWOPWAkO8wTxZNxdNLvM=,iv:71eD4jhgRyjSXXYPekjxOqb1IkR7wMfF8iUd1+kkHM4=,tag:dW/vOlHJ3uQwnuxg1reMPw==,type:str]
 sops:
     age:
         - recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
@@ -21,7 +22,7 @@ sops:
             Z3RhQjhBZWZzNGhHQ1g0QytpbStoTDQKifyhMCeddKVDkstLc1Jmz2FirNYsq4gc
             yB3E157iHA3Qn3eYx7vfSFrviMIZFhWdAsVZ821y/cDXeUfG0yU33g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-01T14:31:13Z"
-    mac: ENC[AES256_GCM,data:PIO/9Z8isLSQeXJuELFrsFhDJxPkzcfL4s/QM0jd52GNymk7Cr7qhtohfwrhZFETNxlfvmsw95Tp4wccD8fbFgBq6wXP41tXcCbJzgPz/BzKTT98cKqK5wkbHfVB/I+w1ftZfluZr4Dg5EirrdGcGs2t+YJSDVXgyuyxP2KEZ+o=,iv:e5WkEUYFwG5nzmvawK+yZTcXMciDj7f7sJ4U1IzB5K0=,tag:Qp0LFUpm5YqVT7qNMNSDqg==,type:str]
+    lastmodified: "2026-06-01T23:23:49Z"
+    mac: ENC[AES256_GCM,data:ppLHhAR0zQKStgxfIHnZ8GDqAJ+74PJJoCfp+ZeGbpReeaRKzuSIpisuCEfgSZBw4flbKH316T1b+4gJdBqhdLSAFl4VmYEmCdRPWKEktsdpyG9u7pyMgXV65MjNRN/hIYqQr7aWqMVB/u6Fj5bkGsvYqPr7ggsILlLSKkyCuNY=,iv:RcTqWwAMMccoUqz1K+4IeUSf4QNurCdqZWPtu2kXzkw=,tag:8/oqBJdram6RDBKuOoqzJw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.0


### PR DESCRIPTION
## Summary

Two idempotency-hardening fixes so the media stack reconciles to source-of-truth on **any** converge, not just first run. User-flagged: "should just be able to apply at ANY point to sync."

### FIX 1 — Jellyseerr servarr wiring: GET-then-PUT-always

`roles/jellyseerr/tasks/register.yml` previously **POST-if-absent only** — once a Sonarr/Radarr server entry existed in Jellyseerr it never updated the stored `apiKey`. A SOPS key rotation (or re-run) left Jellyseerr's DB pointing at a stale key → 401.

Now each converge:
- `GET /api/v1/settings/{radarr,sonarr}` and resolve the entry for this hostname.
- `POST` only when no entry exists yet.
- `PUT /api/v1/settings/{radarr,sonarr}/{id}` when the stored `apiKey` / `port` / `useSsl` drifts from the SOPS-sourced value. Drift is compared **before** PUT, so a converged host is a no-op (idempotent). The PUT body uses `combine()` to overlay only the reconciled connection fields and preserve everything else (`activeProfileId`, root folder, etc.).

Net effect: every converge reconciles stored keys to SOPS — self-healing.

### FIX 2 — Plex claim: idempotent AND non-fatal

`roles/plex` was a skeleton (manual UI claim). It now consumes `PLEX_CLAIM_TOKEN` (SOPS env) via `tasks/claim.yml`:
- **already claimed** (`Preferences.xml` has `PlexOnlineToken`) → skip.
- **token present + valid** → exchange at the local Plex API (`POST http://127.0.0.1:32400/myplex/claim?token=…`) for the permanent token (standard headless claim flow).
- **token absent or expired** → log a clear reminder and **continue** — the play never fails.

> Plex claim tokens expire **~4 minutes** after generation, so a token stored in SOPS is usually already stale. The role documents generating a fresh token immediately before converge; otherwise claim once via the web UI. This is why the consumption is deliberately non-fatal.

Also scaffolds the `movies`/`tv` library roots under `/mnt/media`.

`PLEX_CLAIM_TOKEN` relocated into this repo's `secrets.enc.yaml` (the place the role actually reads). The `terraform-proxmox` `terraform.sops.json` copy is left untouched — noted as a later cleanup.

## Verification

- `ansible-lint` (production profile): **pass**, full repo (334 files) and both roles.
- `yamllint` + all pre-commit hooks: **pass**.
- Offline Jinja render test confirmed: stale entry → drift=True + merged body preserves profile fields; converged entry → drift=False (no PUT); `PlexOnlineToken` regex detection works both ways.
- `secrets.enc.yaml`: encrypted at rest (ENC count 12→13), `PLEX_CLAIM_TOKEN` round-trips to the same value as the terraform source (hash match), **no plaintext token** in the committed file.
- No committed `jacobpevans.com`, real `10.0.*`, or RFC5737 literals; only `127.0.0.1` loopback (the claim is submitted from the server to its own API).

## Notes for review

- No molecule scenarios exist for these roles in-repo; CI `_molecule.yml` / `_ansible-lint.yml` will run. The live Plex claim and Jellyseerr PUT only execute on a real host (`*_manage_services`) and cannot be exercised in static CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)