### PR TITLE
fix(jellyseerr): complete owner + service registration automatically

### DIFF
--- a/roles/jellyseerr/defaults/main.yml
+++ b/roles/jellyseerr/defaults/main.yml
@@ -63,6 +63,11 @@ jellyseerr_plex_hostname: >-
 jellyseerr_plex_port: "{{ terraform_data.constants.media_ports.plex_web }}"
 jellyseerr_plex_use_ssl: false
 
+# When true (default), the play FAILS if a Plex token is available but Jellyseerr
+# still has no owner after sign-in (registration could not complete) — surfacing a
+# broken setup instead of silently leaving the wizard. Set false to keep non-fatal.
+jellyseerr_require_registration: true
+
 # --- Test / orchestration toggle ---------------------------------------------
 # When false (Molecule), the role renders all config (compose, settings.json
 # seed) but skips the live Docker build/run + Jellyseerr API registration that

--- a/roles/jellyseerr/tasks/register.yml
+++ b/roles/jellyseerr/tasks/register.yml
@@ -100,14 +100,30 @@
       {{ (jellyseerr_owner_probe.status == 200)
          or (jellyseerr_owner_probe2.status | default(0) == 200) }}
 
-- name: Note that Jellyseerr registration is skipped (no owner — claim Plex first)
+# A token WAS available but the owner still does not exist => registration truly
+# failed (invalid/expired token, sign-in error). Fail loudly instead of silently
+# leaving Jellyseerr at its setup wizard. Gated by jellyseerr_require_registration.
+- name: Fail when a Plex token was available but the owner could not be created
+  ansible.builtin.fail:
+    msg: >-
+      Jellyseerr owner sign-in FAILED despite a Plex token being available
+      (sign-in HTTP {{ jellyseerr_owner_signin.status | default('n/a') }}). The
+      Plex token (PLEX_TOKEN / PlexOnlineToken) is likely invalid or expired —
+      fix it and re-run. Leaving Jellyseerr at its setup wizard is not acceptable.
+  when:
+    - not (jellyseerr_registration_ready | bool)
+    - jellyseerr_plex_effective_token | length > 0
+    - jellyseerr_require_registration | bool
+
+- name: Note that Jellyseerr registration is skipped (no Plex token to create an owner)
   ansible.builtin.debug:
     msg: >-
-      Jellyseerr service registration SKIPPED — the app has no admin owner yet and
-      no Plex token was available to create one. Claim Plex so Preferences.xml has
-      a PlexOnlineToken (or set PLEX_TOKEN), then re-run; or finish setup in the
-      Jellyseerr UI (Sign in with Plex). Non-fatal.
-  when: not (jellyseerr_registration_ready | bool)
+      Jellyseerr service registration SKIPPED — the app has no admin owner and no
+      Plex token was available to create one. Set PLEX_TOKEN in SOPS (or claim Plex
+      so Preferences.xml has a PlexOnlineToken), then re-run. Non-fatal.
+  when:
+    - not (jellyseerr_registration_ready | bool)
+    - jellyseerr_plex_effective_token | length == 0
 
 # --- Service registration (only once an owner exists) ------------------------
 
@@ -365,3 +381,34 @@
           Jellyseerr Plex link: server-settings HTTP
           {{ jellyseerr_plex_settings.status | default('n/a') }}. If not 200/201,
           finish the link once in the Jellyseerr UI (Settings -> Plex).
+
+# --- Finalize setup (flip `initialized` → no setup wizard) -------------------
+# The owner + servers can all be configured while settings.main.initialized is
+# still unset, so the UI keeps showing the first-run wizard. The wizard's final
+# "Finish Setup" button POSTs /api/v1/settings/initialize; do the same so the app
+# comes up fully set up. Idempotent — re-calling just returns the settings.
+- name: Finalize Jellyseerr setup (mark initialized, skip the wizard)
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ jellyseerr_web_port }}/api/v1/settings/initialize"
+    method: POST
+    headers:
+      X-Api-Key: "{{ jellyseerr_api_key }}"
+    status_code: [200, 201]
+  register: jellyseerr_initialize
+  changed_when: jellyseerr_initialize.status in [200, 201]
+  failed_when: false
+  no_log: true
+  when: jellyseerr_registration_ready | bool
+
+- name: Assert Jellyseerr finished initialization (no wizard left)
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ jellyseerr_web_port }}/api/v1/settings/public"
+    method: GET
+    status_code: 200
+  register: jellyseerr_public
+  changed_when: false
+  failed_when: >-
+    jellyseerr_require_registration | bool
+    and jellyseerr_registration_ready | bool
+    and not (jellyseerr_public.json.initialized | default(false) | bool)
+  when: jellyseerr_registration_ready | bool

--- a/roles/jellyseerr/templates/settings.json.j2
+++ b/roles/jellyseerr/templates/settings.json.j2
@@ -20,7 +20,8 @@
     "applicationUrl": "",
     "csrfProtection": false,
     "defaultPermissions": 32,
-    "mediaServerType": 1
+    "mediaServerType": 1,
+    "initialized": true
   },
   "plex": {
     "name": "",

--- a/secrets.enc.yaml
+++ b/secrets.enc.yaml
@@ -11,6 +11,7 @@ RADARR_API_KEY: ENC[AES256_GCM,data:7u6ekKu9478406WXxP/0+L7IyED+dqU1+gMZCGv7Iko=
 PROWLARR_API_KEY: ENC[AES256_GCM,data:c0Ufcx+weQyWfhxObJKGnKmd2NmRnSLNXJlh4iZqO9A=,iv:kgpd0mjPHBj4FKgUfQZMpZ7iM8FNVCJI4s4NAqAcc7U=,tag:TsWCs7IUhpGges9qpKaxWQ==,type:str]
 JELLYSEERR_API_KEY: ENC[AES256_GCM,data:DAarsxYGbjfjpUYReZVzzFc32ThmH5+DJwKYxRSmpEY=,iv:/qR5cvto63QgaPbnWeMxPf7b1Tp5gjgK+/tolvSQyhw=,tag:TMJbeRh2oaKCubXHY2pXFw==,type:str]
 PLEX_CLAIM_TOKEN: ENC[AES256_GCM,data:EL74JqtcF7PLOvYHWOPWAkO8wTxZNxdNLvM=,iv:71eD4jhgRyjSXXYPekjxOqb1IkR7wMfF8iUd1+kkHM4=,tag:dW/vOlHJ3uQwnuxg1reMPw==,type:str]
+PLEX_TOKEN: ENC[AES256_GCM,data:KLX08kSX65wwqvwKbFrmm82c++k=,iv:SCZ0t+v6cvLCzjrBaDSdW4LFw0KxWKoGrr5s0mOTTKQ=,tag:owwha29J5b3UA3jDQn2azg==,type:str]
 sops:
     age:
         - recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
@@ -22,7 +23,7 @@ sops:
             Z3RhQjhBZWZzNGhHQ1g0QytpbStoTDQKifyhMCeddKVDkstLc1Jmz2FirNYsq4gc
             yB3E157iHA3Qn3eYx7vfSFrviMIZFhWdAsVZ821y/cDXeUfG0yU33g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-01T23:23:49Z"
-    mac: ENC[AES256_GCM,data:ppLHhAR0zQKStgxfIHnZ8GDqAJ+74PJJoCfp+ZeGbpReeaRKzuSIpisuCEfgSZBw4flbKH316T1b+4gJdBqhdLSAFl4VmYEmCdRPWKEktsdpyG9u7pyMgXV65MjNRN/hIYqQr7aWqMVB/u6Fj5bkGsvYqPr7ggsILlLSKkyCuNY=,iv:RcTqWwAMMccoUqz1K+4IeUSf4QNurCdqZWPtu2kXzkw=,tag:8/oqBJdram6RDBKuOoqzJw==,type:str]
+    lastmodified: "2026-06-02T21:52:14Z"
+    mac: ENC[AES256_GCM,data:9uahsACzPwr2dhHeOUWQHvV0W4yc4hRfQfiBIk9gxji28r1RSmIY+tMgjlP+JV166bM675YnafkWqQrY2uyoI8HjnpyvmZhSbb4VnVf3NUtMFqL2TSO5vr98jLV4XM6eKtW7O2rkH1EtqAl+IbAmNIkn7MUWkhuRfLIWUR1Waz8=,iv:xh9VTZf6EnUOoYIls5cNZ/qrbXbf68gpC0GrlfToeSE=,tag:HkCMN0fgwdOC/CA8hZ/6lQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.0


### PR DESCRIPTION
## Problem

Jellyseerr (LXC 211) deployed but was **stuck at its first-run setup wizard**. The `jellyseerr` role's `register.yml` had two gaps:

1. Owner sign-in needs a Plex account token, but the only source was a *fragile delegated read* of Plex's `Preferences.xml`. When that read came back empty (e.g. the inventory's plex-host connection was unavailable), owner sign-in was **silently skipped** → no admin owner → wizard.
2. Even once servers were configured, the role **never finalized setup**, so `settings.main.initialized` stayed unset and the wizard kept showing.

## Fix (fully automated, idempotent)

- Add **`PLEX_TOKEN`** (long-lived Plex account token) to SOPS `secrets.enc.yaml`, which `register.yml` already prefers as the override — removing the fragile `Preferences.xml` dependency.
- `register.yml` now POSTs **`/api/v1/settings/initialize`** to finalize setup, then **asserts `initialized == true`** (fail-loud).
- **Fail loudly** when a token is present but the owner still can't be created (invalid/expired token) instead of silently leaving the wizard — gated by new `jellyseerr_require_registration` (default `true`).
- Seed `settings.json` with `initialized: true` for fresh installs.

## Verified live (LXC 211)

Targeted converge (`--tags jellyseerr`) → `failed=0`. Post-state via the Jellyseerr API:
- owner present; `plex.ip` set with **2 libraries** synced
- **Sonarr + Radarr** each registered (1 server)
- `GET /api/v1/settings/public` → **`initialized: true`** (no wizard)

ansible-lint (production profile) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)