### PR TITLE
feat(media): split movies and shows into separate ZFS datasets

### DIFF
--- a/roles/jellyseerr/defaults/main.yml
+++ b/roles/jellyseerr/defaults/main.yml
@@ -43,8 +43,9 @@ jellyseerr_radarr_port: "{{ terraform_data.constants.media_ports.radarr_web }}"
 jellyseerr_radarr_api_key: "{{ lookup('env', 'RADARR_API_KEY') | default('', true) }}"
 jellyseerr_radarr_use_ssl: false
 
-# Root folders inside the *arr LXCs (bind-mounted /tank datasets there).
-jellyseerr_sonarr_root_folder: "/mnt/media/tv"
+# Root folders inside the *arr LXCs. movies + shows are separate ZFS datasets
+# mounted under /mnt/media (Sonarr -> shows, Radarr -> movies).
+jellyseerr_sonarr_root_folder: "/mnt/media/shows"
 jellyseerr_radarr_root_folder: "/mnt/media/movies"
 
 # Plex registration needs an ACCOUNT-scoped Plex token (X-Plex-Token). Rather than

--- a/roles/plex/README.md
+++ b/roles/plex/README.md
@@ -63,7 +63,7 @@ be supplied: it works in whichever state the server is in.
 
 1. **Claimed server** — discovers the account token (`PlexOnlineToken`) from
    `Preferences.xml`, then `GET /library/sections` and `POST` only the missing
-   sections (`Movies` → `/mnt/media/movies`, `TV` → `/mnt/media/tv`).
+   sections (`Movies` → `/mnt/media/movies`, `Shows` → `/mnt/media/shows`).
 2. **Unclaimed server** — the local API accepts unauthenticated localhost
    requests, so the sections are created **token-free**; they persist after you
    later claim it.

--- a/roles/plex/defaults/main.yml
+++ b/roles/plex/defaults/main.yml
@@ -7,12 +7,12 @@ plex_user: plex
 plex_group: media
 plex_group_gid: 13000
 plex_media_dir: /mnt/media
-# Media library roots scaffolded under plex_media_dir (movies + tv). The actual
-# library "add" against the Plex API can be done later; these just guarantee the
-# directories Plex (and the *arr apps) expect exist with the right ownership.
+# Media library roots scaffolded under plex_media_dir (movies + shows). movies and
+# shows are SEPARATE ZFS datasets (independent quotas/snapshots), mounted under
+# plex_media_dir; these entries just guarantee the dirs exist with right ownership.
 plex_library_subdirs:
   - movies
-  - tv
+  - shows
 # Web UI / server port from terraform constants (no hardcoded port).
 plex_web_port: "{{ terraform_data.constants.media_ports.plex_web }}"
 
@@ -32,9 +32,9 @@ plex_libraries:
     agent: tv.plex.agents.movie
     scanner: Plex Movie
     language: en-US
-  - name: TV
+  - name: Shows
     type: show
-    location: "{{ plex_media_dir }}/tv"
+    location: "{{ plex_media_dir }}/shows"
     agent: tv.plex.agents.series
     scanner: Plex TV Series
     language: en-US

--- a/roles/servarr_wiring/README.md
+++ b/roles/servarr_wiring/README.md
@@ -29,7 +29,7 @@ together over the LAN.
 4. **Sonarr/Radarr → qBittorrent download client** — adds qBittorrent (host =
    `download-vpn`, port = `media_ports.qbittorrent_web`, category `tv` /
    `movies`) to each PVR, again schema-driven.
-5. **Root folders** — ensures `/mnt/media/tv` (Sonarr) and `/mnt/media/movies`
+5. **Root folders** — ensures `/mnt/media/shows` (Sonarr) and `/mnt/media/movies`
    (Radarr).
 6. **Completed-download handling** — enables it globally on each PVR.
 

--- a/roles/servarr_wiring/defaults/main.yml
+++ b/roles/servarr_wiring/defaults/main.yml
@@ -7,7 +7,7 @@
 #      wiring keys are known before converge — never auto-generated).
 #   2. Wires Prowlarr -> Sonarr/Radarr Applications (full sync).
 #   3. Wires Sonarr/Radarr -> qBittorrent download client (on download-vpn).
-#   4. Ensures root folders (/mnt/media/tv, /mnt/media/movies).
+#   4. Ensures root folders (/mnt/media/shows, /mnt/media/movies).
 #   5. Ensures a default quality profile exists.
 #
 # All API config is idempotent (GET-then-POST/PUT). No bespoke scripts: this is
@@ -49,8 +49,10 @@ servarr_wiring_qbittorrent_username: admin
 servarr_wiring_qbittorrent_password: "{{ lookup('env', 'QBITTORRENT_ADMIN_PASSWORD') | default('', true) }}"
 
 # --- Wiring parameters -------------------------------------------------------
-# Root folders inside the *arr LXCs (bind-mounted /tank datasets).
-servarr_wiring_sonarr_root_folder: "/mnt/media/tv"
+# Root folders inside the *arr LXCs. movies + shows are SEPARATE ZFS datasets
+# mounted under /mnt/media (so each has its own quota/snapshots); Sonarr imports
+# TV to shows, Radarr imports movies to movies.
+servarr_wiring_sonarr_root_folder: "/mnt/media/shows"
 servarr_wiring_radarr_root_folder: "/mnt/media/movies"
 # qBittorrent categories per app.
 servarr_wiring_sonarr_category: "tv"

--- a/roles/servarr_wiring/tasks/download_client.yml
+++ b/roles/servarr_wiring/tasks/download_client.yml
@@ -1,6 +1,6 @@
 ---
 # Per-app (Sonarr / Radarr) wiring, included once per app with _arr_* vars:
-#   - ensure the Root Folder exists (/mnt/media/tv or /mnt/media/movies)
+#   - ensure the Root Folder exists (/mnt/media/shows or /mnt/media/movies)
 #   - ensure the qBittorrent download client exists (host=download-vpn,
 #     port=media_ports.qbittorrent_web, category=tv|movies)
 #   - ensure completed-download handling is enabled


### PR DESCRIPTION
## What

Movies and TV shows now live on **independent ZFS datasets** `rpool/data/media/{movies,shows}` (each with its own quota + snapshots) instead of a single `media` dataset. This PR aligns the app configs with that layout.

## Live cutover already applied (production)

The datasets were created and the 47 GB of existing TV content migrated live, with **zero download interruption** and the VPN killswitch intact throughout:
- created `media/shows` + `media/movies` datasets; rsync-mirrored TV content into `shows`, verified, removed the old copy
- Sonarr: all 9 series repointed to `/mnt/media/shows` via `series/editor` (`moveFiles=false`) — **no re-download**
- Plex: replaced the `TV`→`/mnt/media/tv` library with `Shows`→`/mnt/media/shows`; `Movies` unchanged
- qBittorrent kept downloading throughout (Proton exit IP, ~38 MB/s)

## Config changes (so a converge stays consistent)

- `plex`: library `TV` → `Shows` at `/mnt/media/shows`
- `servarr_wiring` + `jellyseerr`: Sonarr root folder → `/mnt/media/shows`
- docs/comments updated

No bind-mount changes needed — Proxmox propagates the ZFS child datasets into the LXCs under `/mnt/media` automatically. ansible-lint (production profile) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)