### PR TITLE
feat(media): migrate request app from deprecated Jellyseerr to Seerr

### DIFF
--- a/molecule/jellyseerr/verify.yml
+++ b/molecule/jellyseerr/verify.yml
@@ -15,7 +15,7 @@
   vars:
     jellyseerr_data_dir: /opt/jellyseerr
     jellyseerr_config_dir: /opt/jellyseerr/config
-    jellyseerr_image: "fallenbagel/jellyseerr:latest"
+    jellyseerr_image: "ghcr.io/seerr-team/seerr:v3.3.0"
     jellyseerr_container_name: jellyseerr
     # Must match molecule.yml provisioner.env JELLYSEERR_API_KEY default.
     jellyseerr_expected_api_key: "0123456789abcdef0123456789abcdef"

--- a/roles/jellyseerr/defaults/main.yml
+++ b/roles/jellyseerr/defaults/main.yml
@@ -5,7 +5,11 @@
 # run a single container via Compose, persist config to a host dir. Jellyseerr
 # is config-only (no /tank bind-mounts); it reaches Sonarr/Radarr/Plex over the
 # LAN. The web UI port comes from terraform constants (no hardcoded port).
-jellyseerr_image: "fallenbagel/jellyseerr:latest"
+# Seerr is the maintained successor to Jellyseerr/Overseerr (those two projects
+# merged into Seerr in Feb 2026; Jellyseerr is deprecated and no longer updated).
+# Pinned to a tag so it's reproducible AND Renovate can bump it. Seerr runs as the
+# node user (UID 1000) and auto-migrates an existing Jellyseerr config on first start.
+jellyseerr_image: "ghcr.io/seerr-team/seerr:v3.3.0"
 jellyseerr_container_name: jellyseerr
 jellyseerr_data_dir: /opt/jellyseerr
 # Host dir bind-mounted to the container's /app/config (settings.json, db).

--- a/roles/jellyseerr/tasks/main.yml
+++ b/roles/jellyseerr/tasks/main.yml
@@ -105,12 +105,14 @@
 # Data directories + config
 # =============================================================================
 
+# Seerr runs as the node user (UID 1000), so the config dir it reads/writes must
+# be owned by 1000 (Jellyseerr ran as root; the live migration chowned it).
 - name: Create Jellyseerr data + config directories
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    owner: root
-    group: root
+    owner: "1000"
+    group: "1000"
     mode: "0755"
   loop:
     - "{{ jellyseerr_data_dir }}"
@@ -132,8 +134,8 @@
   ansible.builtin.template:
     src: settings.json.j2
     dest: "{{ jellyseerr_config_dir }}/settings.json"
-    owner: root
-    group: root
+    owner: "1000"
+    group: "1000"
     mode: "0640"
   when: not jellyseerr_settings_seed_stat.stat.exists
   no_log: true

--- a/roles/jellyseerr/templates/docker-compose.yml.j2
+++ b/roles/jellyseerr/templates/docker-compose.yml.j2
@@ -5,6 +5,8 @@ services:
   jellyseerr:
     container_name: {{ jellyseerr_container_name }}
     image: {{ jellyseerr_image }}
+    # Seerr's image ships no init process; init: true reaps zombies (PID 1).
+    init: true
     restart: unless-stopped
     ports:
       - "{{ jellyseerr_bind_address }}:{{ jellyseerr_web_port }}:5055"

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -828,7 +828,7 @@
   vars:
     # Mirror roles/jellyseerr/defaults/main.yml (test stand-ins for the
     # SOPS-sourced API key and terraform_data ports).
-    jellyseerr_image: "fallenbagel/jellyseerr:latest"
+    jellyseerr_image: "ghcr.io/seerr-team/seerr:v3.3.0"
     jellyseerr_container_name: jellyseerr
     jellyseerr_bind_address: "0.0.0.0"
     jellyseerr_tz: "UTC"
@@ -857,7 +857,7 @@
     - name: Assert jellyseerr compose references image, port 5055, config mount
       ansible.builtin.assert:
         that:
-          - "'fallenbagel/jellyseerr:latest' in _jellyseerr_compose"
+          - "'ghcr.io/seerr-team/seerr:v3.3.0' in _jellyseerr_compose"
           - "'5055:5055' in _jellyseerr_compose"
           - "'/app/config' in _jellyseerr_compose"
         fail_msg: >-


### PR DESCRIPTION
## Why

**Jellyseerr and Overseerr were deprecated in Feb 2026** — the two teams merged into **[Seerr](https://github.com/seerr-team/seerr)** (11.5k★, actively maintained, v3.3.0 released today). Our container was **frozen on Jellyseerr 2.7.3** (~10 months old): the `:latest` tag never recreated the container and upstream stopped shipping. This is the root cause of the 'everything is on an old version' report for the request app.

## Change

- image → `ghcr.io/seerr-team/seerr:v3.3.0` — **pinned** so it's reproducible *and* Renovate's docker manager can bump it (a `:latest` tag is exactly what Renovate can't track)
- `init: true` (Seerr's image ships no init process)
- config dir + seed owned by **UID 1000** (Seerr runs as the `node` user, not root)

## Verified live (LXC 211)

Seerr auto-migrates the existing Jellyseerr DB on first start. Swapped on production with config backed up first:
- version **3.3.0**, container `Up`, healthy
- `initialized: true`; Plex configured, Sonarr + Radarr preserved (zero data loss)

Image vetted: official `seerr-team` org, 11,470★, not archived, pushed today.

Note: the role + paths are still named `jellyseerr` (config at `/opt/jellyseerr`); a full rename to `seerr` is a mechanical follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)