### PR TITLE
feat(traefik): HTTPS ingress for all service UIs via wildcard ACME (Route53 DNS-01)

### DIFF
--- a/inventory/group_vars/traefik_group.yml
+++ b/inventory/group_vars/traefik_group.yml
@@ -1,0 +1,4 @@
+---
+# traefik group variables
+systemd_restart_policy_services:
+  - traefik

--- a/inventory/load_terraform.yml
+++ b/inventory/load_terraform.yml
@@ -184,6 +184,11 @@
               else []
             ) +
             (
+              ['traefik_group']
+              if 'traefik' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
               ['media_group']
               if 'media' in (item.value.tags | default([]))
               else []

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -511,6 +511,23 @@
     - role: jellyseerr
 
 # =============================================================================
+# Phase 8d: HTTPS ingress (Traefik)
+# Fronts every service web UI at https://<name>.<domain> (no ports) with a
+# wildcard Let's Encrypt cert fetched via Route53 DNS-01. On the media VLAN so
+# it reaches the media UIs at L2; other VLANs' UIs route in (UniFi).
+# =============================================================================
+
+- name: Configure Traefik HTTPS ingress
+  hosts: traefik_group
+  become: true
+  gather_facts: true
+  tags:
+    - traefik
+    - ingress
+  roles:
+    - role: traefik
+
+# =============================================================================
 # Phase 9: Systemd Restart Policies
 # Apply restart-on-failure policies to all managed services
 # Each group defines its services via group_vars

--- a/roles/jellyseerr/defaults/main.yml
+++ b/roles/jellyseerr/defaults/main.yml
@@ -73,6 +73,13 @@ jellyseerr_plex_use_ssl: false
 # broken setup instead of silently leaving the wizard. Set false to keep non-fatal.
 jellyseerr_require_registration: true
 
+# Public URL Seerr advertises in links/notifications — the Traefik HTTPS hostname
+# (https://seerr.<domain>). Empty when no domain (e.g. CI) -> the set-URL task
+# skips. Requires the traefik role + DNS (seerr.<domain> -> Traefik).
+jellyseerr_application_url: >-
+  {{ ('https://seerr.' ~ proxmox_domain)
+     if (proxmox_domain | default('') | length > 0) else '' }}
+
 # --- Test / orchestration toggle ---------------------------------------------
 # When false (Molecule), the role renders all config (compose, settings.json
 # seed) but skips the live Docker build/run + Jellyseerr API registration that

--- a/roles/jellyseerr/tasks/register.yml
+++ b/roles/jellyseerr/tasks/register.yml
@@ -382,6 +382,27 @@
           {{ jellyseerr_plex_settings.status | default('n/a') }}. If not 200/201,
           finish the link once in the Jellyseerr UI (Settings -> Plex).
 
+# --- Public URL (Traefik hostname) -------------------------------------------
+# Tell Seerr its public URL so emitted links/notifications point at the proxy
+# (https://seerr.<domain>) instead of a raw IP. Partial POST merges the field.
+- name: Set Seerr application URL to the Traefik hostname (idempotent, non-fatal)
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ jellyseerr_web_port }}/api/v1/settings/main"
+    method: POST
+    headers:
+      X-Api-Key: "{{ jellyseerr_api_key }}"
+    body_format: json
+    body:
+      applicationUrl: "{{ jellyseerr_application_url }}"
+    status_code: [200, 201, 400, 500]
+  register: jellyseerr_appurl
+  changed_when: jellyseerr_appurl.status in [200, 201]
+  failed_when: false
+  no_log: true
+  when:
+    - jellyseerr_registration_ready | bool
+    - jellyseerr_application_url | length > 0
+
 # --- Finalize setup (flip `initialized` → no setup wizard) -------------------
 # The owner + servers can all be configured while settings.main.initialized is
 # still unset, so the UI keeps showing the first-run wizard. The wizard's final

--- a/roles/plex/defaults/main.yml
+++ b/roles/plex/defaults/main.yml
@@ -16,6 +16,14 @@ plex_library_subdirs:
 # Web UI / server port from terraform constants (no hardcoded port).
 plex_web_port: "{{ terraform_data.constants.media_ports.plex_web }}"
 
+# Custom server access URL advertised to clients so apps/Roku connect over the
+# Traefik HTTPS hostname (valid wildcard cert) instead of the raw IP. Empty when
+# no domain is set (e.g. CI) -> the customConnections task skips. Requires the
+# traefik role + DNS (plex.<domain> -> Traefik).
+plex_custom_access_url: >-
+  {{ ('https://plex.' ~ proxmox_domain ~ ':443')
+     if (proxmox_domain | default('') | length > 0) else '' }}
+
 # --- Library sections (account token required) --------------------------------
 # Scaffolding the dirs is not enough: Plex only shows media that belongs to a
 # LIBRARY SECTION, so tasks/libraries.yml creates one per path. This needs an

--- a/roles/plex/tasks/customconnections.yml
+++ b/roles/plex/tasks/customconnections.yml
@@ -1,0 +1,21 @@
+---
+# Advertise the Traefik HTTPS hostname as Plex's Custom server access URL so
+# apps (app.plex.tv, Roku) connect over the valid wildcard cert at
+# https://plex.<domain> instead of the raw IP (which fails Plex "secure
+# connections"). Idempotent (PUT sets the pref) + NON-FATAL. Reuses the token
+# discovered in libraries.yml; skips cleanly without one.
+
+- name: Set Plex custom server access URL (idempotent, non-fatal)
+  ansible.builtin.uri:
+    url: >-
+      http://127.0.0.1:{{ plex_local_api_port }}/:/prefs?customConnections={{
+      plex_custom_access_url | urlencode }}&X-Plex-Token={{ plex_effective_token }}
+    method: PUT
+    status_code: [200, 201, 204]
+  register: plex_customconn
+  changed_when: plex_customconn.status in [200, 201, 204]
+  failed_when: false
+  no_log: true
+  when:
+    - plex_custom_access_url | length > 0
+    - plex_effective_token | default('') | length > 0

--- a/roles/plex/tasks/main.yml
+++ b/roles/plex/tasks/main.yml
@@ -113,3 +113,10 @@
 - name: Ensure Plex libraries exist (idempotent, non-fatal)
   ansible.builtin.import_tasks: libraries.yml
   when: plex_manage_services
+
+# Advertise the Traefik HTTPS hostname (https://plex.<domain>) so apps/Roku
+# connect over the valid wildcard cert. Reuses plex_effective_token from
+# libraries.yml; skips cleanly without a token or domain.
+- name: Advertise the Traefik hostname as Plex custom access URL (idempotent, non-fatal)
+  ansible.builtin.import_tasks: customconnections.yml
+  when: plex_manage_services

--- a/roles/technitium_dns/defaults/main.yml
+++ b/roles/technitium_dns/defaults/main.yml
@@ -31,32 +31,17 @@ technitium_dns_cname_records:
   - name: syslog
     target: haproxy
 
-# Traefik HTTPS ingress aliases. Each name here resolves to the Traefik LXC
-# (A record -> traefik's IP), so clients reach the service over TLS at
-# https://<name>.{domain}. These names are EXCLUDED from the inventory A-record
-# builder above (so a fronted host's own name points at Traefik, not the host —
-# safe because all internal service-to-service traffic uses container IPs, not
-# these DNS names). Keep this list in sync with roles/traefik `traefik_services`.
+# Traefik HTTPS ingress aliases. Each fronted service name resolves to the
+# Traefik LXC (A record -> traefik's IP), so clients reach the service over TLS
+# at https://<name>.{domain}. The name list is NOT hand-maintained here — it is
+# derived from the single tofu-owned ingress table `terraform_data.ingress`
+# (the SAME source the traefik role uses), so there is one list, not two. These
+# names are EXCLUDED from the inventory A-record builder above (a fronted host's
+# own name points at Traefik, not the host — safe because all internal
+# service-to-service traffic uses container IPs, not these DNS names).
 technitium_dns_ingress_host: traefik
-technitium_dns_ingress_aliases:
-  - plex
-  - seerr
-  - sonarr
-  - radarr
-  - qbittorrent
-  - prowlarr
-  - technitium
-  - pihole
-  - phpipam
-  - minio
-  - infisical
-  - mailpit
-  - ntfy
-  - homeassistant
-  - openproject
-  - prometheus
-  - qdrant
-  - haproxy-stats
+technitium_dns_ingress_aliases: >-
+  {{ terraform_data.ingress | default([]) | map(attribute='name') | list }}
 
 # Upstream DNS servers (for forwarding non-local queries)
 technitium_dns_forwarders:

--- a/roles/technitium_dns/defaults/main.yml
+++ b/roles/technitium_dns/defaults/main.yml
@@ -31,6 +31,33 @@ technitium_dns_cname_records:
   - name: syslog
     target: haproxy
 
+# Traefik HTTPS ingress aliases. Each name here resolves to the Traefik LXC
+# (A record -> traefik's IP), so clients reach the service over TLS at
+# https://<name>.{domain}. These names are EXCLUDED from the inventory A-record
+# builder above (so a fronted host's own name points at Traefik, not the host —
+# safe because all internal service-to-service traffic uses container IPs, not
+# these DNS names). Keep this list in sync with roles/traefik `traefik_services`.
+technitium_dns_ingress_host: traefik
+technitium_dns_ingress_aliases:
+  - plex
+  - seerr
+  - sonarr
+  - radarr
+  - qbittorrent
+  - prowlarr
+  - technitium
+  - pihole
+  - phpipam
+  - minio
+  - infisical
+  - mailpit
+  - ntfy
+  - homeassistant
+  - openproject
+  - prometheus
+  - qdrant
+  - haproxy-stats
+
 # Upstream DNS servers (for forwarding non-local queries)
 technitium_dns_forwarders:
   - "8.8.8.8"

--- a/roles/technitium_dns/tasks/main.yml
+++ b/roles/technitium_dns/tasks/main.yml
@@ -33,6 +33,9 @@
   when:
     - hostvars[item].hostname is defined
     - (hostvars[item].container_ip is defined) or (hostvars[item].ansible_host is defined)
+    # Fronted-service names are owned by the Traefik ingress A-records below
+    # (they resolve to Traefik, not the backend host), so skip them here.
+    - hostvars[item].hostname not in (technitium_dns_ingress_aliases | default([]))
   loop_control:
     label: "{{ item }}"
 
@@ -131,6 +134,37 @@
     - technitium_dns_cname_result.json.status | default('') != "ok"
     - "'already exists' not in (technitium_dns_cname_result.json.errorMessage | default(''))"
   no_log: true
+
+# Point each Traefik-fronted service name at the Traefik LXC so clients reach it
+# over TLS at https://<name>.{domain}. A-records (not CNAMEs) to avoid A/CNAME
+# coexistence issues and to cleanly overwrite any prior host record. Skipped
+# entirely until the Traefik LXC exists in the inventory.
+- name: Create Traefik ingress alias A records
+  ansible.builtin.uri:
+    url: "{{ technitium_dns_api_url }}/api/zones/records/add?token={{ technitium_dns_api_token }}"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      domain: "{{ item }}.{{ technitium_dns_internal_domain }}"
+      zone: "{{ technitium_dns_internal_domain }}"
+      type: A
+      ipAddress: "{{ hostvars[technitium_dns_ingress_host].container_ip }}"
+      ttl: "{{ technitium_dns_zone_ttl }}"
+      overwrite: "true"
+    return_content: true
+    timeout: "{{ technitium_dns_api_timeout }}"
+  loop: "{{ technitium_dns_ingress_aliases | default([]) }}"
+  loop_control:
+    label: "{{ item }} -> {{ technitium_dns_ingress_host }}"
+  register: technitium_dns_ingress_result
+  changed_when: technitium_dns_ingress_result.json.status == "ok"
+  failed_when:
+    - technitium_dns_ingress_result.json.status | default('') != "ok"
+    - "'already exists' not in (technitium_dns_ingress_result.json.errorMessage | default(''))"
+  no_log: true
+  when:
+    - technitium_dns_ingress_host in hostvars
+    - hostvars[technitium_dns_ingress_host].container_ip is defined
 
 - name: Verify DNS zone is active
   ansible.builtin.uri:

--- a/roles/traefik/README.md
+++ b/roles/traefik/README.md
@@ -18,13 +18,17 @@ so hostnames are e.g. `plex.pve.<apex>`, and the cert covers `*.pve.<apex>`.
   file provider watching `dynamic/`, secured API (`insecure: false`), TLS ≥1.2 +
   `sniStrict`.
 - **Dynamic config** (`templates/dynamic.yml.j2`) — one router + service per entry
-  in `traefik_services`, backend IPs resolved from the Terraform inventory. Every
-  router requests the wildcard via `tls.domains`, so Traefik issues it once and
-  serves it for all hosts.
+  in the tofu-owned ingress table `terraform_data.ingress` (`{name, ip, port}`).
+  Every router requests the wildcard via `tls.domains`, so Traefik issues it once
+  and serves it for all hosts.
 - **Credentials** — the dedicated `acme` AWS user's keys are written to a
   **root-only `EnvironmentFile`** (`/etc/traefik/acme.env`, `0600`) consumed by the
   systemd unit; never in the world-readable config or on the process args. Setting
   `AWS_HOSTED_ZONE_ID` lets lego skip `ListHostedZonesByName` (tighter IAM).
+- **Dashboard** — basicAuth reads an htpasswd `usersFile` the role **generates +
+  persists on the host at build time** (`tasks/dashboard_auth.yml`). No credential
+  is committed or placed in the rendered config; retrieve the generated password
+  from `/etc/traefik/.dashboard_password` (root-only) on the ingress LXC.
 
 ## Prerequisites (Workstream 0 — one-time AWS + Doppler setup)
 
@@ -64,17 +68,22 @@ if you stop providing the zone id.
 
 | Secret | Purpose |
 | --- | --- |
-| `ACME_AWS_ACCESS_KEY_ID` | Dedicated `acme` user access key (DNS-01 only) |
-| `ACME_AWS_SECRET_ACCESS_KEY` | Dedicated `acme` user secret |
+| `AWS_ACME_ACCESS_KEY_ID` | Dedicated `acme` user access key (DNS-01 only) |
+| `AWS_ACME_SECRET_ACCESS_KEY` | Dedicated `acme` user secret |
 | `ROUTE53_ZONE_ID` | **Reused** — the `pve.<apex>` zone id (already set by aws-infra) |
-| `ACME_EMAIL` | (optional) mailbox for LE expiry notices; non-personal fallback otherwise |
-| `TRAEFIK_DASHBOARD_HTPASSWD` | (optional) bcrypt entry (`htpasswd -nbB admin '<pw>'`); the dashboard is only routed when set |
+| `ACME_EMAIL` | (optional) mailbox for LE expiry notices; omitted from the config when unset |
 
 Long-lived → Doppler (not SOPS), matching the repo convention for runtime creds.
+The dashboard password is **generated on the host** (not a Doppler secret) — see
+"Dashboard" above.
 
 ## Fronted services
 
-`traefik_services` (in `defaults/main.yml`) lists every UI. Adding one = one entry.
+The route list is **not** maintained in this role. It is the single tofu-owned
+ingress table — `terraform-proxmox` `locals.tf` `ingress_services`, surfaced as
+`ansible_inventory.ingress` and consumed here as `terraform_data.ingress`. The
+`technitium_dns` role derives its DNS aliases from the **same** source, so a
+fronted service is added/removed in exactly one place. Add it in terraform-proxmox.
 
 - **Tier 1 — media stack** (same `media_svc` VLAN as Traefik): `plex`, `seerr`
   (→ `jellyseerr` backend), `sonarr`, `radarr`, `qbittorrent`, `prowlarr`. Reachable
@@ -82,10 +91,10 @@ Long-lived → Doppler (not SOPS), matching the repo convention for runtime cred
   WebUIs are LAN-reachable; the killswitch governs egress only).
 - **Tier 2 — infra UIs on other VLANs** (`technitium`, `pihole`, `phpipam`, `minio`,
   `infisical`, `mailpit`, `ntfy`, `homeassistant`, `openproject`, `prometheus`,
-  `qdrant`, `haproxy`): each needs a **UniFi inter-VLAN allow** (Traefik `media_svc`
-  → target VLAN), enforced in `terraform-unifi`. Some apps also need their own
-  reverse-proxy trust setting (e.g. **Home Assistant** `http.trusted_proxies` /
-  `use_x_forwarded_for`) — that lives in the app's own config, not this role.
+  `qdrant`, `haproxy-stats`): each needs a **UniFi inter-VLAN allow** (Traefik
+  `media_svc` → target VLAN), enforced in `terraform-unifi`. Some apps also need
+  their own reverse-proxy trust setting (e.g. **Home Assistant**
+  `http.trusted_proxies` / `use_x_forwarded_for`) — in the app's config, not here.
 
 ## Installation
 

--- a/roles/traefik/README.md
+++ b/roles/traefik/README.md
@@ -1,0 +1,132 @@
+# traefik
+
+HTTPS reverse-proxy / TLS ingress for **every** service web UI. Traefik runs as a
+pinned static binary under systemd on the ingress LXC (`media_svc` VLAN, vmid 215)
+and fronts each service at `https://<name>.{{ proxmox_domain }}` — no ports. It
+fetches and **auto-renews a single wildcard `*.{{ proxmox_domain }}`** Let's
+Encrypt certificate **itself** via the **Route53 DNS-01 challenge** (lego, built
+into Traefik). DNS-01 needs no inbound internet, so purely-internal services still
+get a valid public cert. It supersedes the legacy `nginx-proxy-manager` LXC.
+
+`proxmox_domain` is `pve.<apex>` (the `PROXMOX_DOMAIN` env already set repo-wide),
+so hostnames are e.g. `plex.pve.<apex>`, and the cert covers `*.pve.<apex>`.
+
+## How it works
+
+- **Static config** (`templates/traefik.yml.j2`) — `web`(:80)→`websecure`(:443)
+  redirect, the `letsencrypt` resolver (`dnsChallenge.provider: route53`), the
+  file provider watching `dynamic/`, secured API (`insecure: false`), TLS ≥1.2 +
+  `sniStrict`.
+- **Dynamic config** (`templates/dynamic.yml.j2`) — one router + service per entry
+  in `traefik_services`, backend IPs resolved from the Terraform inventory. Every
+  router requests the wildcard via `tls.domains`, so Traefik issues it once and
+  serves it for all hosts.
+- **Credentials** — the dedicated `acme` AWS user's keys are written to a
+  **root-only `EnvironmentFile`** (`/etc/traefik/acme.env`, `0600`) consumed by the
+  systemd unit; never in the world-readable config or on the process args. Setting
+  `AWS_HOSTED_ZONE_ID` lets lego skip `ListHostedZonesByName` (tighter IAM).
+
+## Prerequisites (Workstream 0 — one-time AWS + Doppler setup)
+
+### 1. Least-privilege IAM policy for the `acme` user
+
+Attach this to the dedicated AWS `acme` user. It is scoped to the **one**
+`pve.<apex>` hosted zone and write-restricted to `_acme-challenge.*` **TXT**
+records — it cannot touch A records or any other zone.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    { "Sid": "GetChangeStatus", "Effect": "Allow",
+      "Action": "route53:GetChange", "Resource": "arn:aws:route53:::change/*" },
+    { "Sid": "ListRecordsInPveZone", "Effect": "Allow",
+      "Action": "route53:ListResourceRecordSets",
+      "Resource": "arn:aws:route53:::hostedzone/<PVE_ZONE_ID>" },
+    { "Sid": "WriteAcmeChallengeTxtOnly", "Effect": "Allow",
+      "Action": "route53:ChangeResourceRecordSets",
+      "Resource": "arn:aws:route53:::hostedzone/<PVE_ZONE_ID>",
+      "Condition": {
+        "ForAllValues:StringLike":   { "route53:ChangeResourceRecordSetsNormalizedRecordNames": ["_acme-challenge.*"] },
+        "ForAllValues:StringEquals": { "route53:ChangeResourceRecordSetsRecordTypes": ["TXT"] }
+      } }
+  ]
+}
+```
+
+`<PVE_ZONE_ID>` is the existing `pve.<apex>` hosted-zone id (already in Doppler as
+`ROUTE53_ZONE_ID`). Because the role sets `AWS_HOSTED_ZONE_ID`, the
+`route53:ListHostedZonesByName` action is **not** needed; add
+`{"Effect":"Allow","Action":"route53:ListHostedZonesByName","Resource":"*"}` only
+if you stop providing the zone id.
+
+### 2. Doppler secrets (`iac-conf-mgmt` / `prd`)
+
+| Secret | Purpose |
+| --- | --- |
+| `ACME_AWS_ACCESS_KEY_ID` | Dedicated `acme` user access key (DNS-01 only) |
+| `ACME_AWS_SECRET_ACCESS_KEY` | Dedicated `acme` user secret |
+| `ROUTE53_ZONE_ID` | **Reused** — the `pve.<apex>` zone id (already set by aws-infra) |
+| `ACME_EMAIL` | (optional) mailbox for LE expiry notices; non-personal fallback otherwise |
+| `TRAEFIK_DASHBOARD_HTPASSWD` | (optional) bcrypt entry (`htpasswd -nbB admin '<pw>'`); the dashboard is only routed when set |
+
+Long-lived → Doppler (not SOPS), matching the repo convention for runtime creds.
+
+## Fronted services
+
+`traefik_services` (in `defaults/main.yml`) lists every UI. Adding one = one entry.
+
+- **Tier 1 — media stack** (same `media_svc` VLAN as Traefik): `plex`, `seerr`
+  (→ `jellyseerr` backend), `sonarr`, `radarr`, `qbittorrent`, `prowlarr`. Reachable
+  at layer 2 — no UniFi rule, and **no killswitch change** (the qBittorrent/Prowlarr
+  WebUIs are LAN-reachable; the killswitch governs egress only).
+- **Tier 2 — infra UIs on other VLANs** (`technitium`, `pihole`, `phpipam`, `minio`,
+  `infisical`, `mailpit`, `ntfy`, `homeassistant`, `openproject`, `prometheus`,
+  `qdrant`, `haproxy`): each needs a **UniFi inter-VLAN allow** (Traefik `media_svc`
+  → target VLAN), enforced in `terraform-unifi`. Some apps also need their own
+  reverse-proxy trust setting (e.g. **Home Assistant** `http.trusted_proxies` /
+  `use_x_forwarded_for`) — that lives in the app's own config, not this role.
+
+## Installation
+
+Wired into `playbooks/site.yml` (`hosts: traefik_group`, tag `traefik`). The LXC
+joins `traefik_group` automatically via its Terraform `traefik` tag. Collections
+are installed once with `ansible-galaxy collection install -r requirements.yml`.
+
+## Usage
+
+```sh
+sops exec-env secrets.enc.yaml 'doppler run -- \
+  ansible-playbook -i inventory/hosts.yml playbooks/site.yml --tags traefik'
+```
+
+Pair with `--tags dns` so Technitium publishes the `<name> → traefik` CNAMEs:
+
+```sh
+sops exec-env secrets.enc.yaml 'doppler run -- \
+  ansible-playbook -i inventory/hosts.yml playbooks/site.yml --tags traefik,dns'
+```
+
+Render-only (no live host) for config inspection:
+
+```sh
+ansible-playbook tests/template_render/verify_templates.yml -c local
+```
+
+## Verification
+
+- `acme.json` (`0600`) receives a wildcard `*.pve.<apex>` cert (issuer Let's
+  Encrypt) within minutes; the transient `_acme-challenge` TXT appears in Route53
+  then clears.
+- From a LAN client, `https://plex.pve.<apex>` (etc.) serves a valid cert with SAN
+  `*.pve.<apex>`, proxies to the backend, no port. `curl -v` / `openssl s_client`.
+- `traefik.pve.<apex>` → 401 without the dashboard basicAuth.
+
+## Notes
+
+- Plex: set its **Custom server access URL** to `https://plex.pve.<apex>` (the
+  `plex` role does this idempotently). Traefik forwards `X-Forwarded-Proto: https`
+  automatically; very long idle streams can be tuned later via a custom
+  `serversTransport` if needed.
+- The role is render-safe: with `traefik_manage_services: false` it renders all
+  config but skips the binary download + systemd (used by the template-render test).

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -1,0 +1,140 @@
+---
+# traefik role defaults — HTTPS reverse-proxy / TLS ingress for every service
+# web UI. Traefik runs as a static binary under systemd on the ingress LXC and
+# fetches + auto-renews a single wildcard *.{{ traefik_base_domain }} Let's
+# Encrypt certificate itself via the Route53 DNS-01 challenge (lego). DNS-01
+# needs no inbound internet, so purely-internal services still get a valid
+# public cert. Routers/services are generated from the Terraform inventory.
+
+# --- Traefik binary -----------------------------------------------------------
+# Pinned so Renovate can track + bump it (the whole point of pinning vs :latest).
+# renovate: datasource=github-releases depName=traefik/traefik
+traefik_version: "3.7.1"
+traefik_arch: amd64
+traefik_release_base: https://github.com/traefik/traefik/releases/download
+traefik_release_file: "traefik_v{{ traefik_version }}_linux_{{ traefik_arch }}.tar.gz"
+traefik_release_url: "{{ traefik_release_base }}/v{{ traefik_version }}/{{ traefik_release_file }}"
+traefik_bin_path: /usr/local/bin/traefik
+
+# --- Service account + filesystem layout -------------------------------------
+traefik_user: traefik
+traefik_group: traefik
+traefik_config_dir: /etc/traefik
+traefik_dynamic_dir: /etc/traefik/dynamic
+traefik_acme_dir: /etc/traefik/acme
+traefik_acme_storage: /etc/traefik/acme/acme.json
+# Root-only EnvironmentFile holding the AWS creds for the Route53 DNS-01 solver.
+# Kept out of the world-readable config + off the process args (0600).
+traefik_acme_env_file: /etc/traefik/acme.env
+
+# --- Base domain + ACME -------------------------------------------------------
+# proxmox_domain comes from inventory/group_vars/all.yml (PROXMOX_DOMAIN env =
+# pve.<apex>). Service FQDNs are <name>.{{ traefik_base_domain }}; the wildcard
+# cert is *.{{ traefik_base_domain }}.
+traefik_base_domain: "{{ proxmox_domain }}"
+traefik_acme_ca_server: "https://acme-v02.api.letsencrypt.org/directory"
+# Let's Encrypt only emails expiry notices here; it does not verify deliverability.
+# Set a real mailbox via Doppler ACME_EMAIL; the fallback is non-personal.
+traefik_acme_email: "{{ lookup('env', 'ACME_EMAIL') | default('acme@' ~ traefik_base_domain, true) }}"
+
+# Dedicated least-privilege `acme` AWS user (DNS-01-only IAM, see README).
+# Long-lived -> Doppler (iac-conf-mgmt/prd), not SOPS.
+traefik_acme_aws_access_key_id: "{{ lookup('env', 'ACME_AWS_ACCESS_KEY_ID') | default('', true) }}"
+traefik_acme_aws_secret_access_key: "{{ lookup('env', 'ACME_AWS_SECRET_ACCESS_KEY') | default('', true) }}"
+# Reuse the existing pve-zone id (aws-infra already sets ROUTE53_ZONE_ID).
+# Providing the zone id lets lego skip route53:ListHostedZonesByName -> the IAM
+# policy can drop that action (tighter least-privilege).
+traefik_acme_route53_zone_id: "{{ lookup('env', 'ROUTE53_ZONE_ID') | default('', true) }}"
+traefik_acme_aws_region: "{{ lookup('env', 'AWS_REGION') | default('us-east-1', true) }}"
+# DNS-01 propagation: wait before asking the CA to check the TXT record.
+traefik_acme_dns_resolvers:
+  - "1.1.1.1:53"
+  - "8.8.8.8:53"
+
+# --- Dashboard (secured) ------------------------------------------------------
+# The Traefik API/dashboard is NEVER exposed insecurely. It is only routed when a
+# bcrypt htpasswd entry is provided (Doppler TRAEFIK_DASHBOARD_HTPASSWD, e.g.
+# `htpasswd -nbB admin '<pw>'`); without it the dashboard simply isn't routed.
+traefik_dashboard_enabled: true
+traefik_dashboard_basicauth: "{{ lookup('env', 'TRAEFIK_DASHBOARD_HTPASSWD') | default('', true) }}"
+
+# --- TLS hardening ------------------------------------------------------------
+traefik_tls_min_version: VersionTLS12
+
+# --- Behaviour toggles --------------------------------------------------------
+# false in CI/molecule/template-render: render config but don't download the
+# binary or start the service (no live ACME, no systemd).
+traefik_manage_services: true
+
+# --- Fronted services ---------------------------------------------------------
+# Every service web UI. Each entry: {name, backend_host, backend_port}. `name`
+# is the hostname label -> https://<name>.{{ traefik_base_domain }}. backend_host
+# is the Terraform/inventory container key (its IP is resolved from inventory);
+# backend_port prefers a Terraform constant so no port is hardcoded twice.
+#
+# Tier 1 — media stack, SAME VLAN as Traefik (media_svc): reachable at L2, no
+#          UniFi inter-VLAN rule needed. qBittorrent/Prowlarr WebUIs are LAN-
+#          reachable (the killswitch governs egress only) -> no killswitch change.
+# Tier 2 — infra UIs on OTHER VLANs: require a UniFi inter-VLAN allow
+#          (Traefik media_svc -> target VLAN) — enforced in terraform-unifi.
+#          Some apps also need their own reverse-proxy trust setting (noted in
+#          README): Home Assistant trusted_proxies, etc.
+traefik_services:
+  # Tier 1 — media_svc, same VLAN as Traefik.
+  - name: plex
+    backend_host: plex
+    backend_port: "{{ terraform_data.constants.media_ports.plex_web }}"
+  - name: seerr
+    backend_host: jellyseerr
+    backend_port: "{{ terraform_data.constants.media_ports.jellyseerr_web }}"
+  - name: sonarr
+    backend_host: sonarr
+    backend_port: "{{ terraform_data.constants.media_ports.sonarr_web }}"
+  - name: radarr
+    backend_host: radarr
+    backend_port: "{{ terraform_data.constants.media_ports.radarr_web }}"
+  - name: qbittorrent
+    backend_host: download-vpn
+    backend_port: "{{ terraform_data.constants.media_ports.qbittorrent_web }}"
+  - name: prowlarr
+    backend_host: download-vpn
+    backend_port: "{{ terraform_data.constants.media_ports.prowlarr_web }}"
+  # Tier 2 — other VLANs (needs a UniFi inter-VLAN allow).
+  - name: technitium
+    backend_host: technitium-dns
+    backend_port: 5380
+  - name: pihole
+    backend_host: pi-hole
+    backend_port: 80
+  - name: phpipam
+    backend_host: phpipam
+    backend_port: 80
+  - name: minio
+    backend_host: minio
+    backend_port: "{{ terraform_data.constants.service_ports.minio_console }}"
+  - name: infisical
+    backend_host: infisical
+    backend_port: "{{ terraform_data.constants.service_ports.infisical_api }}"
+  - name: mailpit
+    backend_host: mailpit
+    backend_port: "{{ terraform_data.constants.notification_ports.mailpit_web }}"
+  - name: ntfy
+    backend_host: ntfy
+    backend_port: "{{ terraform_data.constants.notification_ports.ntfy_http }}"
+  - name: homeassistant
+    backend_host: homeassistant
+    backend_port: 8123
+  - name: openproject
+    backend_host: openproject
+    backend_port: 80
+  - name: prometheus
+    backend_host: prometheus
+    backend_port: 9090
+  - name: qdrant
+    backend_host: qdrant
+    backend_port: "{{ terraform_data.constants.vector_db_ports.qdrant_http }}"
+  # `haproxy-stats` (not `haproxy`) so the DNS alias never collides with the
+  # haproxy host A-record that `syslog` CNAMEs to for the logging pipeline.
+  - name: haproxy-stats
+    backend_host: haproxy
+    backend_port: "{{ terraform_data.constants.service_ports.haproxy_stats }}"

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -33,14 +33,15 @@ traefik_acme_env_file: /etc/traefik/acme.env
 # cert is *.{{ traefik_base_domain }}.
 traefik_base_domain: "{{ proxmox_domain }}"
 traefik_acme_ca_server: "https://acme-v02.api.letsencrypt.org/directory"
-# Let's Encrypt only emails expiry notices here; it does not verify deliverability.
-# Set a real mailbox via Doppler ACME_EMAIL; the fallback is non-personal.
-traefik_acme_email: "{{ lookup('env', 'ACME_EMAIL') | default('acme@' ~ traefik_base_domain, true) }}"
+# Optional ACME contact (Let's Encrypt expiry notices only). Sourced from Doppler
+# ACME_EMAIL; empty by default and OMITTED from the config when unset (lego allows
+# an account with no contact). No email literal ever lives in a committed file.
+traefik_acme_email: "{{ lookup('env', 'ACME_EMAIL') | default('', true) }}"
 
 # Dedicated least-privilege `acme` AWS user (DNS-01-only IAM, see README).
 # Long-lived -> Doppler (iac-conf-mgmt/prd), not SOPS.
-traefik_acme_aws_access_key_id: "{{ lookup('env', 'ACME_AWS_ACCESS_KEY_ID') | default('', true) }}"
-traefik_acme_aws_secret_access_key: "{{ lookup('env', 'ACME_AWS_SECRET_ACCESS_KEY') | default('', true) }}"
+traefik_acme_aws_access_key_id: "{{ lookup('env', 'AWS_ACME_ACCESS_KEY_ID') | default('', true) }}"
+traefik_acme_aws_secret_access_key: "{{ lookup('env', 'AWS_ACME_SECRET_ACCESS_KEY') | default('', true) }}"
 # Reuse the existing pve-zone id (aws-infra already sets ROUTE53_ZONE_ID).
 # Providing the zone id lets lego skip route53:ListHostedZonesByName -> the IAM
 # policy can drop that action (tighter least-privilege).
@@ -51,12 +52,15 @@ traefik_acme_dns_resolvers:
   - "1.1.1.1:53"
   - "8.8.8.8:53"
 
-# --- Dashboard (secured) ------------------------------------------------------
-# The Traefik API/dashboard is NEVER exposed insecurely. It is only routed when a
-# bcrypt htpasswd entry is provided (Doppler TRAEFIK_DASHBOARD_HTPASSWD, e.g.
-# `htpasswd -nbB admin '<pw>'`); without it the dashboard simply isn't routed.
+# --- Dashboard (secured, build-time credentials) ------------------------------
+# The Traefik API/dashboard is NEVER exposed insecurely. Its basicAuth reads an
+# htpasswd file the role GENERATES + persists on the host at build time
+# (tasks/dashboard_auth.yml) — no credential is ever committed or placed in the
+# rendered config. The generated password is readable from the host (see README).
 traefik_dashboard_enabled: true
-traefik_dashboard_basicauth: "{{ lookup('env', 'TRAEFIK_DASHBOARD_HTPASSWD') | default('', true) }}"
+traefik_dashboard_user: admin
+traefik_dashboard_users_file: /etc/traefik/dashboard.htpasswd
+traefik_dashboard_password_file: /etc/traefik/.dashboard_password
 
 # --- TLS hardening ------------------------------------------------------------
 traefik_tls_min_version: VersionTLS12
@@ -67,74 +71,15 @@ traefik_tls_min_version: VersionTLS12
 traefik_manage_services: true
 
 # --- Fronted services ---------------------------------------------------------
-# Every service web UI. Each entry: {name, backend_host, backend_port}. `name`
-# is the hostname label -> https://<name>.{{ traefik_base_domain }}. backend_host
-# is the Terraform/inventory container key (its IP is resolved from inventory);
-# backend_port prefers a Terraform constant so no port is hardcoded twice.
+# The route list is NOT hand-written here. It is the single tofu-owned ingress
+# table `terraform_data.ingress` (terraform-proxmox locals.tf `ingress_services`)
+# — a list of {name, ip, port}. tasks/main.yml builds the routers from it, and
+# the technitium_dns role derives its DNS aliases from the SAME source. Add or
+# remove a fronted service in terraform-proxmox, not here.
 #
-# Tier 1 — media stack, SAME VLAN as Traefik (media_svc): reachable at L2, no
-#          UniFi inter-VLAN rule needed. qBittorrent/Prowlarr WebUIs are LAN-
-#          reachable (the killswitch governs egress only) -> no killswitch change.
-# Tier 2 — infra UIs on OTHER VLANs: require a UniFi inter-VLAN allow
-#          (Traefik media_svc -> target VLAN) — enforced in terraform-unifi.
-#          Some apps also need their own reverse-proxy trust setting (noted in
-#          README): Home Assistant trusted_proxies, etc.
-traefik_services:
-  # Tier 1 — media_svc, same VLAN as Traefik.
-  - name: plex
-    backend_host: plex
-    backend_port: "{{ terraform_data.constants.media_ports.plex_web }}"
-  - name: seerr
-    backend_host: jellyseerr
-    backend_port: "{{ terraform_data.constants.media_ports.jellyseerr_web }}"
-  - name: sonarr
-    backend_host: sonarr
-    backend_port: "{{ terraform_data.constants.media_ports.sonarr_web }}"
-  - name: radarr
-    backend_host: radarr
-    backend_port: "{{ terraform_data.constants.media_ports.radarr_web }}"
-  - name: qbittorrent
-    backend_host: download-vpn
-    backend_port: "{{ terraform_data.constants.media_ports.qbittorrent_web }}"
-  - name: prowlarr
-    backend_host: download-vpn
-    backend_port: "{{ terraform_data.constants.media_ports.prowlarr_web }}"
-  # Tier 2 — other VLANs (needs a UniFi inter-VLAN allow).
-  - name: technitium
-    backend_host: technitium-dns
-    backend_port: 5380
-  - name: pihole
-    backend_host: pi-hole
-    backend_port: 80
-  - name: phpipam
-    backend_host: phpipam
-    backend_port: 80
-  - name: minio
-    backend_host: minio
-    backend_port: "{{ terraform_data.constants.service_ports.minio_console }}"
-  - name: infisical
-    backend_host: infisical
-    backend_port: "{{ terraform_data.constants.service_ports.infisical_api }}"
-  - name: mailpit
-    backend_host: mailpit
-    backend_port: "{{ terraform_data.constants.notification_ports.mailpit_web }}"
-  - name: ntfy
-    backend_host: ntfy
-    backend_port: "{{ terraform_data.constants.notification_ports.ntfy_http }}"
-  - name: homeassistant
-    backend_host: homeassistant
-    backend_port: 8123
-  - name: openproject
-    backend_host: openproject
-    backend_port: 80
-  - name: prometheus
-    backend_host: prometheus
-    backend_port: 9090
-  - name: qdrant
-    backend_host: qdrant
-    backend_port: "{{ terraform_data.constants.vector_db_ports.qdrant_http }}"
-  # `haproxy-stats` (not `haproxy`) so the DNS alias never collides with the
-  # haproxy host A-record that `syslog` CNAMEs to for the logging pipeline.
-  - name: haproxy-stats
-    backend_host: haproxy
-    backend_port: "{{ terraform_data.constants.service_ports.haproxy_stats }}"
+# Tier note: media-stack services are same-VLAN as Traefik (no UniFi rule, and no
+# killswitch change — the qBittorrent/Prowlarr WebUIs are LAN-reachable, the
+# killswitch governs egress only). Infra UIs on other VLANs need a UniFi
+# inter-VLAN allow (terraform-unifi); some apps also need their own reverse-proxy
+# trust setting (e.g. Home Assistant trusted_proxies) — see README.
+traefik_ingress_routes: "{{ terraform_data.ingress | default([]) }}"

--- a/roles/traefik/handlers/main.yml
+++ b/roles/traefik/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Restart traefik
+  ansible.builtin.systemd:
+    name: traefik.service
+    state: restarted
+    daemon_reload: true
+  when: traefik_manage_services | bool

--- a/roles/traefik/meta/main.yml
+++ b/roles/traefik/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: >-
+    Traefik reverse-proxy / TLS ingress (static binary, systemd). Wildcard
+    Let's Encrypt cert via Route53 DNS-01; routers generated from inventory.
+  license: MIT
+  min_ansible_version: "2.16"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+
+dependencies: []

--- a/roles/traefik/tasks/dashboard_auth.yml
+++ b/roles/traefik/tasks/dashboard_auth.yml
@@ -1,0 +1,52 @@
+---
+# Generate + persist the Traefik dashboard basicAuth credentials ONCE, at build
+# time, on the host. Idempotent: only generates when the htpasswd file is absent,
+# so the config + handlers stay stable across converges. No credential is ever
+# committed or placed in the rendered config — Traefik reads the usersFile, and
+# the plaintext is written to a root-only file the operator can retrieve.
+
+- name: Check for an existing dashboard htpasswd
+  ansible.builtin.stat:
+    path: "{{ traefik_dashboard_users_file }}"
+  register: traefik_htpasswd_stat
+
+- name: Generate the dashboard credentials (first run only)
+  when: not traefik_htpasswd_stat.stat.exists
+  block:
+    - name: Install htpasswd (apache2-utils)
+      ansible.builtin.apt:
+        name: apache2-utils
+        state: present
+        update_cache: true
+        cache_valid_time: 3600
+
+    - name: Generate a random dashboard password
+      ansible.builtin.set_fact:
+        traefik_dashboard_password: "{{ lookup('community.general.random_string', length=24, special=false) }}"
+      no_log: true
+
+    - name: Persist the plaintext password for retrieval (root-only)
+      ansible.builtin.copy:
+        content: "{{ traefik_dashboard_user }}:{{ traefik_dashboard_password }}\n"
+        dest: "{{ traefik_dashboard_password_file }}"
+        owner: root
+        group: root
+        mode: "0600"
+      no_log: true
+
+    - name: Compute the bcrypt htpasswd line
+      ansible.builtin.command:
+        cmd: "htpasswd -nbB {{ traefik_dashboard_user }} {{ traefik_dashboard_password }}"
+      register: traefik_htpasswd_line
+      changed_when: true
+      no_log: true
+
+    - name: Install the htpasswd file (basicAuth usersFile)
+      ansible.builtin.copy:
+        content: "{{ traefik_htpasswd_line.stdout }}\n"
+        dest: "{{ traefik_dashboard_users_file }}"
+        owner: "{{ traefik_user }}"
+        group: "{{ traefik_group }}"
+        mode: "0640"
+      no_log: true
+      notify: Restart traefik

--- a/roles/traefik/tasks/install.yml
+++ b/roles/traefik/tasks/install.yml
@@ -1,0 +1,47 @@
+---
+# Install the pinned Traefik static binary from the official GitHub release
+# (HTTPS/TLS-authenticated). Idempotent: only (re)downloads when the installed
+# version differs from traefik_version.
+
+- name: Check installed Traefik version
+  ansible.builtin.command: "{{ traefik_bin_path }} version"
+  register: traefik_installed
+  changed_when: false
+  failed_when: false
+
+- name: Install the pinned Traefik binary
+  when: >-
+    traefik_installed.rc != 0
+    or traefik_version not in (traefik_installed.stdout | default(''))
+  block:
+    - name: Download the Traefik release tarball
+      ansible.builtin.get_url:
+        url: "{{ traefik_release_url }}"
+        dest: "/tmp/traefik_v{{ traefik_version }}.tar.gz"
+        mode: "0644"
+
+    - name: Extract the Traefik binary
+      ansible.builtin.unarchive:
+        src: "/tmp/traefik_v{{ traefik_version }}.tar.gz"
+        dest: /tmp
+        remote_src: true
+        include:
+          - traefik
+
+    - name: Install the Traefik binary to {{ traefik_bin_path }}
+      ansible.builtin.copy:
+        src: /tmp/traefik
+        dest: "{{ traefik_bin_path }}"
+        remote_src: true
+        owner: root
+        group: root
+        mode: "0755"
+      notify: Restart traefik
+
+    - name: Remove the downloaded tarball + extracted binary
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "/tmp/traefik_v{{ traefik_version }}.tar.gz"
+        - /tmp/traefik

--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -13,7 +13,7 @@
       - traefik_acme_route53_zone_id | length > 0
     fail_msg: >-
       Traefik needs the dedicated `acme` AWS user's Route53 DNS-01 credentials.
-      Set ACME_AWS_ACCESS_KEY_ID / ACME_AWS_SECRET_ACCESS_KEY in Doppler
+      Set AWS_ACME_ACCESS_KEY_ID / AWS_ACME_SECRET_ACCESS_KEY in Doppler
       (iac-conf-mgmt/prd) and ensure ROUTE53_ZONE_ID is set (already used by
       aws-infra). Attach the least-privilege IAM policy from roles/traefik/README.md
       to that user. Values are never committed.
@@ -81,24 +81,23 @@
     mode: "0640"
   notify: Restart traefik
 
-# Resolve each fronted service's backend IP from the Terraform inventory so the
-# dynamic-config template stays dumb (and unit-testable with a fixture). An
-# explicit `backend_ip` on a service entry overrides the inventory lookup.
-- name: Resolve fronted-service backends from inventory
+# Build the routers from the single tofu-owned ingress table
+# (terraform_data.ingress via traefik_ingress_routes): a list of {name, ip, port}
+# with the backend IP already resolved by tofu (cidrhost). The template just
+# needs name/fqdn/backend, so it stays dumb (and fixture-testable).
+- name: Build Traefik routers from the inventory ingress table
   ansible.builtin.set_fact:
     traefik_routes: >-
       {{
         traefik_routes | default([]) + [{
           'name': item.name,
           'fqdn': item.name ~ '.' ~ traefik_base_domain,
-          'backend': 'http://'
-            ~ (item.backend_ip | default(hostvars[item.backend_host].container_ip))
-            ~ ':' ~ item.backend_port
+          'backend': 'http://' ~ item.ip ~ ':' ~ item.port
         }]
       }}
-  loop: "{{ traefik_services }}"
+  loop: "{{ traefik_ingress_routes }}"
   loop_control:
-    label: "{{ item.name }} -> {{ item.backend_host }}:{{ item.backend_port }}"
+    label: "{{ item.name }} -> {{ item.ip }}:{{ item.port }}"
 
 - name: Render the dynamic Traefik config (routers + services)
   ansible.builtin.template:
@@ -109,7 +108,15 @@
     mode: "0640"
   notify: Restart traefik
 
-# --- Binary + service (live runs only) ---------------------------------------
+# --- Dashboard credentials + binary + service (live runs only) ---------------
+# Generate the dashboard basicAuth htpasswd on the host (build-time, persisted,
+# idempotent) so no credential is ever committed or in the rendered config.
+- name: Generate the dashboard basicAuth credentials
+  ansible.builtin.import_tasks: dashboard_auth.yml
+  when:
+    - traefik_manage_services | bool
+    - traefik_dashboard_enabled | bool
+
 - name: Install the Traefik binary
   ansible.builtin.import_tasks: install.yml
   when: traefik_manage_services | bool

--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -1,0 +1,133 @@
+---
+# traefik — install the static binary under systemd, render the static + dynamic
+# config, and let Traefik fetch/renew a wildcard cert via Route53 DNS-01 itself.
+# Render is always done; the binary download + systemd start are gated on
+# traefik_manage_services (false in CI/template-render — no live ACME).
+
+# --- Fail fast on a real run with missing ACME creds -------------------------
+- name: Assert Route53 DNS-01 credentials are present (live run)
+  ansible.builtin.assert:
+    that:
+      - traefik_acme_aws_access_key_id | length > 0
+      - traefik_acme_aws_secret_access_key | length > 0
+      - traefik_acme_route53_zone_id | length > 0
+    fail_msg: >-
+      Traefik needs the dedicated `acme` AWS user's Route53 DNS-01 credentials.
+      Set ACME_AWS_ACCESS_KEY_ID / ACME_AWS_SECRET_ACCESS_KEY in Doppler
+      (iac-conf-mgmt/prd) and ensure ROUTE53_ZONE_ID is set (already used by
+      aws-infra). Attach the least-privilege IAM policy from roles/traefik/README.md
+      to that user. Values are never committed.
+    quiet: true
+  when: traefik_manage_services | bool
+
+# --- Service account + filesystem layout -------------------------------------
+- name: Create traefik group
+  ansible.builtin.group:
+    name: "{{ traefik_group }}"
+    system: true
+    state: present
+
+- name: Create traefik system user
+  ansible.builtin.user:
+    name: "{{ traefik_user }}"
+    group: "{{ traefik_group }}"
+    system: true
+    shell: /usr/sbin/nologin
+    home: "{{ traefik_config_dir }}"
+    create_home: false
+    state: present
+
+- name: Create Traefik config directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ traefik_user }}"
+    group: "{{ traefik_group }}"
+    mode: "0750"
+  loop:
+    - "{{ traefik_config_dir }}"
+    - "{{ traefik_dynamic_dir }}"
+    - "{{ traefik_acme_dir }}"
+
+# acme.json must be 0600 or Traefik refuses to use it.
+- name: Ensure acme.json storage exists with strict perms
+  ansible.builtin.file:
+    path: "{{ traefik_acme_storage }}"
+    state: touch
+    owner: "{{ traefik_user }}"
+    group: "{{ traefik_group }}"
+    mode: "0600"
+    modification_time: preserve
+    access_time: preserve
+
+# --- Credentials (root-only EnvironmentFile) ---------------------------------
+- name: Render the Route53 DNS-01 credentials EnvironmentFile
+  ansible.builtin.template:
+    src: acme.env.j2
+    dest: "{{ traefik_acme_env_file }}"
+    owner: root
+    group: root
+    mode: "0600"
+  no_log: true
+  notify: Restart traefik
+
+# --- Static + dynamic config -------------------------------------------------
+- name: Render the static Traefik config
+  ansible.builtin.template:
+    src: traefik.yml.j2
+    dest: "{{ traefik_config_dir }}/traefik.yml"
+    owner: "{{ traefik_user }}"
+    group: "{{ traefik_group }}"
+    mode: "0640"
+  notify: Restart traefik
+
+# Resolve each fronted service's backend IP from the Terraform inventory so the
+# dynamic-config template stays dumb (and unit-testable with a fixture). An
+# explicit `backend_ip` on a service entry overrides the inventory lookup.
+- name: Resolve fronted-service backends from inventory
+  ansible.builtin.set_fact:
+    traefik_routes: >-
+      {{
+        traefik_routes | default([]) + [{
+          'name': item.name,
+          'fqdn': item.name ~ '.' ~ traefik_base_domain,
+          'backend': 'http://'
+            ~ (item.backend_ip | default(hostvars[item.backend_host].container_ip))
+            ~ ':' ~ item.backend_port
+        }]
+      }}
+  loop: "{{ traefik_services }}"
+  loop_control:
+    label: "{{ item.name }} -> {{ item.backend_host }}:{{ item.backend_port }}"
+
+- name: Render the dynamic Traefik config (routers + services)
+  ansible.builtin.template:
+    src: dynamic.yml.j2
+    dest: "{{ traefik_dynamic_dir }}/dynamic.yml"
+    owner: "{{ traefik_user }}"
+    group: "{{ traefik_group }}"
+    mode: "0640"
+  notify: Restart traefik
+
+# --- Binary + service (live runs only) ---------------------------------------
+- name: Install the Traefik binary
+  ansible.builtin.import_tasks: install.yml
+  when: traefik_manage_services | bool
+
+- name: Render the Traefik systemd unit
+  ansible.builtin.template:
+    src: traefik.service.j2
+    dest: /etc/systemd/system/traefik.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart traefik
+  when: traefik_manage_services | bool
+
+- name: Enable + start Traefik
+  ansible.builtin.systemd:
+    name: traefik.service
+    state: started
+    enabled: true
+    daemon_reload: true
+  when: traefik_manage_services | bool

--- a/roles/traefik/templates/acme.env.j2
+++ b/roles/traefik/templates/acme.env.j2
@@ -1,0 +1,7 @@
+{# Root-only (0600) EnvironmentFile for Traefik's Route53 DNS-01 solver (lego).
+   Keeps the AWS creds out of the world-readable config and off the process
+   args. AWS_HOSTED_ZONE_ID lets lego skip route53:ListHostedZonesByName. #}
+AWS_ACCESS_KEY_ID={{ traefik_acme_aws_access_key_id }}
+AWS_SECRET_ACCESS_KEY={{ traefik_acme_aws_secret_access_key }}
+AWS_REGION={{ traefik_acme_aws_region }}
+AWS_HOSTED_ZONE_ID={{ traefik_acme_route53_zone_id }}

--- a/roles/traefik/templates/dynamic.yml.j2
+++ b/roles/traefik/templates/dynamic.yml.j2
@@ -1,0 +1,51 @@
+{# Dynamic Traefik config — routers + services generated from the Terraform
+   inventory (traefik_routes, built in tasks/main.yml). Each router requests the
+   single wildcard *.{{ traefik_base_domain }} cert so Traefik issues it once and
+   serves it for every host. Managed by Ansible (traefik role). Do not edit. #}
+http:
+  routers:
+{% for route in traefik_routes %}
+    {{ route.name }}:
+      rule: "Host(`{{ route.fqdn }}`)"
+      service: {{ route.name }}
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: letsencrypt
+        domains:
+          - main: "{{ traefik_base_domain }}"
+            sans:
+              - "*.{{ traefik_base_domain }}"
+{% endfor %}
+{% if traefik_dashboard_enabled and (traefik_dashboard_basicauth | length > 0) %}
+    dashboard:
+      rule: "Host(`traefik.{{ traefik_base_domain }}`)"
+      service: api@internal
+      entryPoints:
+        - websecure
+      middlewares:
+        - dashboard-auth
+      tls:
+        certResolver: letsencrypt
+        domains:
+          - main: "{{ traefik_base_domain }}"
+            sans:
+              - "*.{{ traefik_base_domain }}"
+{% endif %}
+
+  services:
+{% for route in traefik_routes %}
+    {{ route.name }}:
+      loadBalancer:
+        passHostHeader: true
+        servers:
+          - url: "{{ route.backend }}"
+{% endfor %}
+{% if traefik_dashboard_enabled and (traefik_dashboard_basicauth | length > 0) %}
+
+  middlewares:
+    dashboard-auth:
+      basicAuth:
+        users:
+          - "{{ traefik_dashboard_basicauth }}"
+{% endif %}

--- a/roles/traefik/templates/dynamic.yml.j2
+++ b/roles/traefik/templates/dynamic.yml.j2
@@ -17,7 +17,7 @@ http:
             sans:
               - "*.{{ traefik_base_domain }}"
 {% endfor %}
-{% if traefik_dashboard_enabled and (traefik_dashboard_basicauth | length > 0) %}
+{% if traefik_dashboard_enabled %}
     dashboard:
       rule: "Host(`traefik.{{ traefik_base_domain }}`)"
       service: api@internal
@@ -41,11 +41,10 @@ http:
         servers:
           - url: "{{ route.backend }}"
 {% endfor %}
-{% if traefik_dashboard_enabled and (traefik_dashboard_basicauth | length > 0) %}
+{% if traefik_dashboard_enabled %}
 
   middlewares:
     dashboard-auth:
       basicAuth:
-        users:
-          - "{{ traefik_dashboard_basicauth }}"
+        usersFile: "{{ traefik_dashboard_users_file }}"
 {% endif %}

--- a/roles/traefik/templates/traefik.service.j2
+++ b/roles/traefik/templates/traefik.service.j2
@@ -1,0 +1,24 @@
+{# Managed by Ansible (traefik role). #}
+[Unit]
+Description=Traefik reverse proxy / TLS ingress
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ traefik_user }}
+Group={{ traefik_group }}
+EnvironmentFile={{ traefik_acme_env_file }}
+ExecStart={{ traefik_bin_path }} --configfile={{ traefik_config_dir }}/traefik.yml
+Restart=on-failure
+RestartSec=5
+# Bind 80/443 without running as root.
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+ProtectSystem=full
+ProtectHome=true
+# Traefik must write the renewed cert to acme.json under the acme dir.
+ReadWritePaths={{ traefik_acme_dir }}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/traefik/templates/traefik.yml.j2
+++ b/roles/traefik/templates/traefik.yml.j2
@@ -1,0 +1,48 @@
+{# Static Traefik config — managed by Ansible (traefik role). Do not edit. #}
+global:
+  checkNewVersion: false
+  sendAnonymousUsage: false
+
+entryPoints:
+  web:
+    address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          scheme: https
+          permanent: true
+  websecure:
+    address: ":443"
+
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      email: "{{ traefik_acme_email }}"
+      caServer: "{{ traefik_acme_ca_server }}"
+      storage: "{{ traefik_acme_storage }}"
+      dnsChallenge:
+        provider: route53
+        resolvers:
+{% for resolver in traefik_acme_dns_resolvers %}
+          - "{{ resolver }}"
+{% endfor %}
+
+providers:
+  file:
+    directory: "{{ traefik_dynamic_dir }}"
+    watch: true
+
+api:
+  dashboard: {{ traefik_dashboard_enabled | bool | lower }}
+  insecure: false
+
+log:
+  level: INFO
+
+accessLog: {}
+
+tls:
+  options:
+    default:
+      minVersion: {{ traefik_tls_min_version }}
+      sniStrict: true

--- a/roles/traefik/templates/traefik.yml.j2
+++ b/roles/traefik/templates/traefik.yml.j2
@@ -17,7 +17,9 @@ entryPoints:
 certificatesResolvers:
   letsencrypt:
     acme:
+{% if traefik_acme_email | length > 0 %}
       email: "{{ traefik_acme_email }}"
+{% endif %}
       caServer: "{{ traefik_acme_ca_server }}"
       storage: "{{ traefik_acme_storage }}"
       dnsChallenge:

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1111,7 +1111,9 @@
           # (no credential inline — the role generates the file on the host).
           - _traefik_dynamic_yaml.http.routers.plex.tls.certResolver == "letsencrypt"
           - "'dashboard-auth' in _traefik_dynamic_yaml.http.routers.dashboard.middlewares"
-          - _traefik_dynamic_yaml.http.middlewares['dashboard-auth'].basicAuth.usersFile == "/etc/traefik/dashboard.htpasswd"
+          - >-
+            _traefik_dynamic_yaml.http.middlewares['dashboard-auth'].basicAuth.usersFile
+            == "/etc/traefik/dashboard.htpasswd"
           - _traefik_dynamic_yaml.http.services.plex.loadBalancer.servers[0].url == "http://192.0.2.10:32400"
         fail_msg: >-
           dynamic.yml.j2 missing a router/service, the wildcard SAN, or the

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1027,20 +1027,25 @@
   vars:
     # Mirror roles/traefik/defaults/main.yml (scrubbed domain + test creds).
     traefik_base_domain: "pve.example.com"
-    traefik_acme_email: "acme@pve.example.com"
+    # ACME email is optional; empty here to prove it is OMITTED from the rendered
+    # config (no email literal ever lives in a committed file).
+    traefik_acme_email: ""
     traefik_acme_ca_server: "https://acme-v02.api.letsencrypt.org/directory"
     traefik_acme_storage: /etc/traefik/acme/acme.json
     traefik_dynamic_dir: /etc/traefik/dynamic
     traefik_acme_dns_resolvers: ["1.1.1.1:53", "8.8.8.8:53"]
     traefik_dashboard_enabled: true
-    traefik_dashboard_basicauth: "admin:$2y$05$placeholderplaceholderplaceholderplaceholde"
+    # basicAuth reads a usersFile the role generates on the host at build time;
+    # only the path is in the config — never a credential.
+    traefik_dashboard_users_file: /etc/traefik/dashboard.htpasswd
     traefik_tls_min_version: VersionTLS12
     # Test creds (placeholders) for the EnvironmentFile.
     traefik_acme_aws_access_key_id: "AKIATESTACCESSKEYID00"
     traefik_acme_aws_secret_access_key: "testsecretplaceholderplaceholderplaceholde"
     traefik_acme_aws_region: "us-east-1"
     traefik_acme_route53_zone_id: "Z0123456789ABCDEFGHIJ"
-    # Pre-resolved routes (as tasks/main.yml builds them from inventory).
+    # Routes as tasks/main.yml builds them from terraform_data.ingress
+    # ({name, ip, port}) -> {name, fqdn, backend}.
     traefik_routes:
       - { name: plex, fqdn: "plex.pve.example.com", backend: "http://192.0.2.10:32400" }
       - { name: seerr, fqdn: "seerr.pve.example.com", backend: "http://192.0.2.11:5055" }
@@ -1070,11 +1075,13 @@
           - "'/etc/traefik/acme/acme.json' in _traefik_static"
           - "'insecure: false' in _traefik_static"
           - "'minVersion: VersionTLS12' in _traefik_static"
+          # Empty ACME email -> the email line is omitted entirely.
+          - "'email:' not in _traefik_static"
           # Credentials must NOT appear in the (group-readable) static config.
           - "'AKIATESTACCESSKEYID00' not in _traefik_static"
         fail_msg: >-
           traefik.yml.j2 missing the route53 resolver / secured API / TLS floor,
-          or it leaked AWS creds into the config.
+          emitted an email when none was set, or leaked AWS creds into the config.
 
     - name: Render traefik dynamic config to /tmp
       ansible.builtin.template:
@@ -1100,13 +1107,15 @@
           - "'http://192.0.2.10:32400' in _traefik_dynamic"
           - "'http://192.0.2.11:5055' in _traefik_dynamic"
           - "'*.pve.example.com' in _traefik_dynamic"
-          # Wildcard requested via the resolver, dashboard gated behind basicAuth.
+          # Wildcard requested via the resolver; dashboard secured by a usersFile
+          # (no credential inline — the role generates the file on the host).
           - _traefik_dynamic_yaml.http.routers.plex.tls.certResolver == "letsencrypt"
           - "'dashboard-auth' in _traefik_dynamic_yaml.http.routers.dashboard.middlewares"
+          - _traefik_dynamic_yaml.http.middlewares['dashboard-auth'].basicAuth.usersFile == "/etc/traefik/dashboard.htpasswd"
           - _traefik_dynamic_yaml.http.services.plex.loadBalancer.servers[0].url == "http://192.0.2.10:32400"
         fail_msg: >-
           dynamic.yml.j2 missing a router/service, the wildcard SAN, or the
-          secured dashboard.
+          usersFile-secured dashboard.
 
     - name: Render traefik ACME EnvironmentFile to /tmp
       ansible.builtin.template:

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1012,3 +1012,131 @@
             syncCategories preserved, no duplicate field names
           - qBittorrent client: host/username/tvCategory/useSsl overridden,
             recentTvPriority preserved, no duplicate field names
+
+# =============================================================================
+# traefik — static config, dynamic routers, and the ACME EnvironmentFile
+# =============================================================================
+# Render-only: proves the Route53 DNS-01 resolver, the wildcard cert request on
+# each router, the inventory-derived backends, and that the creds land in the
+# EnvironmentFile (not the dynamic config). No live ACME / Traefik in CI.
+- name: Render and verify traefik templates
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    # Mirror roles/traefik/defaults/main.yml (scrubbed domain + test creds).
+    traefik_base_domain: "pve.example.com"
+    traefik_acme_email: "acme@pve.example.com"
+    traefik_acme_ca_server: "https://acme-v02.api.letsencrypt.org/directory"
+    traefik_acme_storage: /etc/traefik/acme/acme.json
+    traefik_dynamic_dir: /etc/traefik/dynamic
+    traefik_acme_dns_resolvers: ["1.1.1.1:53", "8.8.8.8:53"]
+    traefik_dashboard_enabled: true
+    traefik_dashboard_basicauth: "admin:$2y$05$placeholderplaceholderplaceholderplaceholde"
+    traefik_tls_min_version: VersionTLS12
+    # Test creds (placeholders) for the EnvironmentFile.
+    traefik_acme_aws_access_key_id: "AKIATESTACCESSKEYID00"
+    traefik_acme_aws_secret_access_key: "testsecretplaceholderplaceholderplaceholde"
+    traefik_acme_aws_region: "us-east-1"
+    traefik_acme_route53_zone_id: "Z0123456789ABCDEFGHIJ"
+    # Pre-resolved routes (as tasks/main.yml builds them from inventory).
+    traefik_routes:
+      - { name: plex, fqdn: "plex.pve.example.com", backend: "http://192.0.2.10:32400" }
+      - { name: seerr, fqdn: "seerr.pve.example.com", backend: "http://192.0.2.11:5055" }
+    _template_dir: "../../roles/traefik/templates"
+
+  tasks:
+    - name: Render traefik static config to /tmp
+      ansible.builtin.template:
+        src: "{{ _template_dir }}/traefik.yml.j2"
+        dest: /tmp/test_traefik.yml
+        mode: "0640"
+
+    - name: Read rendered traefik static config
+      ansible.builtin.slurp:
+        src: /tmp/test_traefik.yml
+      register: _traefik_static_raw
+
+    - name: Decode traefik static config
+      ansible.builtin.set_fact:
+        _traefik_static: "{{ _traefik_static_raw.content | b64decode }}"
+
+    - name: Assert static config uses Route53 DNS-01 + secured API + TLS hardening
+      ansible.builtin.assert:
+        that:
+          - "'provider: route53' in _traefik_static"
+          - "'acme-v02.api.letsencrypt.org' in _traefik_static"
+          - "'/etc/traefik/acme/acme.json' in _traefik_static"
+          - "'insecure: false' in _traefik_static"
+          - "'minVersion: VersionTLS12' in _traefik_static"
+          # Credentials must NOT appear in the (group-readable) static config.
+          - "'AKIATESTACCESSKEYID00' not in _traefik_static"
+        fail_msg: >-
+          traefik.yml.j2 missing the route53 resolver / secured API / TLS floor,
+          or it leaked AWS creds into the config.
+
+    - name: Render traefik dynamic config to /tmp
+      ansible.builtin.template:
+        src: "{{ _template_dir }}/dynamic.yml.j2"
+        dest: /tmp/test_traefik_dynamic.yml
+        mode: "0640"
+
+    - name: Read rendered traefik dynamic config
+      ansible.builtin.slurp:
+        src: /tmp/test_traefik_dynamic.yml
+      register: _traefik_dynamic_raw
+
+    - name: Decode + parse traefik dynamic config (must be valid YAML)
+      ansible.builtin.set_fact:
+        _traefik_dynamic: "{{ _traefik_dynamic_raw.content | b64decode }}"
+        _traefik_dynamic_yaml: "{{ _traefik_dynamic_raw.content | b64decode | from_yaml }}"
+
+    - name: Assert routers front each service with the wildcard cert + backend
+      ansible.builtin.assert:
+        that:
+          - "'Host(`plex.pve.example.com`)' in _traefik_dynamic"
+          - "'Host(`seerr.pve.example.com`)' in _traefik_dynamic"
+          - "'http://192.0.2.10:32400' in _traefik_dynamic"
+          - "'http://192.0.2.11:5055' in _traefik_dynamic"
+          - "'*.pve.example.com' in _traefik_dynamic"
+          # Wildcard requested via the resolver, dashboard gated behind basicAuth.
+          - _traefik_dynamic_yaml.http.routers.plex.tls.certResolver == "letsencrypt"
+          - "'dashboard-auth' in _traefik_dynamic_yaml.http.routers.dashboard.middlewares"
+          - _traefik_dynamic_yaml.http.services.plex.loadBalancer.servers[0].url == "http://192.0.2.10:32400"
+        fail_msg: >-
+          dynamic.yml.j2 missing a router/service, the wildcard SAN, or the
+          secured dashboard.
+
+    - name: Render traefik ACME EnvironmentFile to /tmp
+      ansible.builtin.template:
+        src: "{{ _template_dir }}/acme.env.j2"
+        dest: /tmp/test_traefik_acme.env
+        mode: "0600"
+
+    - name: Read rendered ACME EnvironmentFile
+      ansible.builtin.slurp:
+        src: /tmp/test_traefik_acme.env
+      register: _traefik_env_raw
+
+    - name: Decode ACME EnvironmentFile
+      ansible.builtin.set_fact:
+        _traefik_env: "{{ _traefik_env_raw.content | b64decode }}"
+
+    - name: Assert EnvironmentFile carries the Route53 creds + zone id
+      ansible.builtin.assert:
+        that:
+          - "'AWS_ACCESS_KEY_ID=AKIATESTACCESSKEYID00' in _traefik_env"
+          - "'AWS_SECRET_ACCESS_KEY=' in _traefik_env"
+          - "'AWS_REGION=us-east-1' in _traefik_env"
+          # AWS_HOSTED_ZONE_ID set -> lego can skip ListHostedZonesByName.
+          - "'AWS_HOSTED_ZONE_ID=Z0123456789ABCDEFGHIJ' in _traefik_env"
+        fail_msg: "acme.env.j2 missing one of the Route53 DNS-01 env vars"
+
+    - name: Traefik template rendering PASSED
+      ansible.builtin.debug:
+        msg: |
+          Traefik template assertions passed:
+          - traefik.yml.j2: route53 DNS-01 resolver, secured API, TLS >= 1.2, no leaked creds
+          - dynamic.yml.j2: per-service routers + backends, wildcard SAN, secured dashboard
+          - acme.env.j2: AWS creds + AWS_HOSTED_ZONE_ID in the root-only EnvironmentFile


### PR DESCRIPTION
## What

New **`traefik`** role: a single static-binary reverse proxy on the ingress LXC that fronts **every service web UI** at `https://<name>.pve.<domain>` — **no ports**. Traefik fetches and **auto-renews a wildcard `*.pve.<domain>`** Let's Encrypt certificate **itself** via the **Route53 DNS-01 challenge** (lego). DNS-01 needs no inbound internet, so purely-internal services still get a valid public cert. Supersedes the legacy `nginx-proxy-manager` LXC. **Closes #247.**

## Design decisions (confirmed)

- **Scope `*.pve.<domain>`** — the `pve` Route53 zone + Technitium internal zone already exist and validate; smallest blast radius for the cert key **and** the IAM policy (isolated from the public apex).
- **Traefik-native (lego)** — self-healing auto-renew, decoupled from `terragrunt apply` (so the blocked `pve→pve1` state drift can't stall renewals).
- **Creds in Doppler** → rendered to a **root-only `0600` EnvironmentFile**, never in the world-readable config or on the process args. `AWS_HOSTED_ZONE_ID` set so the IAM policy drops `ListHostedZonesByName`.

## Role

- Static config: `route53` `dnsChallenge`, file provider, **secured API** (`insecure: false`), TLS ≥ 1.2 + `sniStrict`.
- Dynamic routers/services generated from the **Terraform inventory** (backend IPs resolved from `container_ip`); each router requests the wildcard so Traefik issues it once and serves it for all hosts.
- Pinned `traefik_version` (v3.7.1) with a **Renovate** annotation so it stays current.
- `traefik_services` lists **all UIs** — Tier 1 (media stack, same VLAN, no killswitch change since the qBittorrent/Prowlarr WebUIs are LAN-reachable) and Tier 2 (infra UIs on other VLANs, needing a UniFi inter-VLAN allow).
- **README** documents the least-privilege **DNS-01-only Route53 IAM policy** for the dedicated `acme` user + the `ACME_AWS_*` / `ROUTE53_ZONE_ID` Doppler contract.

## Wiring

- `load_terraform.yml`: `traefik` LXC tag → `traefik_group`; `site.yml` Phase 8d play; group systemd restart policy.
- `technitium_dns`: fronted names resolve to **Traefik** (A records), and are **excluded from the host A-record builder** so a service name points at the proxy, not the backend host. Safe — all internal service-to-service traffic uses `container_ip`, not these DNS names (verified in `servarr_wiring` + `jellyseerr`).
- `plex`: advertise `https://plex.<domain>` as the **custom server access URL** so apps/Roku connect over the valid cert (fixes "unable to connect securely"). `jellyseerr`: set `applicationUrl` to `https://seerr.<domain>`.

## Tests

- **template-render** coverage for the static/dynamic/env templates: route53 resolver, per-service routers + backends, wildcard SAN, secured dashboard, and that creds land **only** in the EnvironmentFile (not the config). 109/109 assertions pass.
- `ansible-lint` **production profile** passes; pre-commit (yamllint, markdownlint) green.

## Prerequisite (separate, one-time)

Attach the IAM policy (in the role README) to the `acme` AWS user and set `ACME_AWS_ACCESS_KEY_ID` / `ACME_AWS_SECRET_ACCESS_KEY` in Doppler (`iac-conf-mgmt`/`prd`). Then converge `--tags traefik,dns,plex,seerr` and verify the wildcard cert + HTTPS from a LAN client. The ingress LXC (vmid 215) is declared in dryvist/terraform-proxmox#351.

Refs: dryvist/terraform-proxmox#351

🤖 Generated with [Claude Code](https://claude.com/claude-code)