### PR TITLE
feat(technitium_dns): native primary/secondary HA mode

### DIFF
--- a/.github/workflows/_molecule.yml
+++ b/.github/workflows/_molecule.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scenario: [default, qdrant, llamaindex, download_vpn, seerr]
+        scenario: [default, qdrant, llamaindex, download_vpn, seerr, technitium_dns]
 
     steps:
       - name: Checkout code
@@ -78,6 +78,9 @@ jobs:
           #                  built-in dummy fallbacks; services not started in CI)
           #   seerr       -> none (SEERR_API_KEY uses a built-in dummy
           #                  fallback; container not started in CI)
+          #   technitium_dns -> none (PROXMOX_DOMAIN/SUBDOMAIN +
+          #                  TECHNITIUM_DNS_API_TOKEN use built-in dummy
+          #                  fallbacks; technitium_dns_apply=false, no live API)
           QDRANT_API_KEY: ${{ steps.doppler.outputs.QDRANT_API_KEY }}
           MSSQL_SA_PASSWORD: ${{ steps.doppler.outputs.MSSQL_SA_PASSWORD }}
           QBITTORRENT_ADMIN_PASSWORD: ${{ steps.doppler.outputs.QBITTORRENT_ADMIN_PASSWORD }}

--- a/molecule/technitium_dns/converge.yml
+++ b/molecule/technitium_dns/converge.yml
@@ -1,0 +1,25 @@
+---
+# Molecule converge for technitium_dns.
+#
+# Runs the role with technitium_dns_apply=false: the role resolves the HA
+# topology (primary = lowest-vmid member), builds its A-record list, and gates
+# the record writes by role — but every live Technitium API call is skipped
+# (there is no DNS server in CI). verify.yml asserts the resolved facts. The two
+# instances exercise BOTH modes: technitium-1 (vmid 10) -> primary,
+# technitium-2 (vmid 11) -> secondary.
+
+- name: Converge
+  hosts: all
+  gather_facts: false
+
+  vars:
+    technitium_dns_apply: false
+    technitium_dns_host: "{{ container_ip | default(ansible_host) }}"
+    # Stand-in for the tofu-owned ingress table (load_tofu.yml provides it live).
+    tofu_data:
+      ingress: []
+
+  tasks:
+    - name: Include technitium_dns role
+      ansible.builtin.include_role:
+        name: technitium_dns

--- a/molecule/technitium_dns/molecule.yml
+++ b/molecule/technitium_dns/molecule.yml
@@ -1,0 +1,86 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
+
+driver:
+  name: docker
+
+# Two instances exercise BOTH HA modes without a live DNS server: technitium-1
+# (lowest vmid) resolves to the primary, technitium-2 to a secondary.
+platforms:
+  - name: technitium-1-test
+    # No stable version tags available; geerlingguy only publishes :latest
+    image: geerlingguy/docker-debian12-ansible:latest
+    privileged: true
+    command: ""
+    pre_build_image: true
+    tmpfs:
+      - /run
+      - /tmp
+      - /run/lock
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    groups:
+      - technitium_dns_group
+      - lxc_containers
+  - name: technitium-2-test
+    image: geerlingguy/docker-debian12-ansible:latest
+    privileged: true
+    command: ""
+    pre_build_image: true
+    tmpfs:
+      - /run
+      - /tmp
+      - /run/lock
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    groups:
+      - technitium_dns_group
+      - lxc_containers
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
+  # Per-host facts normally injected by load_tofu.yml. vmids 10/11 make
+  # technitium-1 the lowest-vmid (primary). IPs are RFC1918 placeholders.
+  inventory:
+    host_vars:
+      technitium-1-test:
+        proxmox_vmid: 10
+        container_ip: "192.168.5.10"
+        hostname: technitium-1
+      technitium-2-test:
+        proxmox_vmid: 11
+        container_ip: "192.168.5.11"
+        hostname: technitium-2
+  env:
+    # Non-correlated placeholder values only — never the real domain/subdomain.
+    # apply=false (converge/verify) means no live API call is ever made.
+    PROXMOX_DOMAIN: "${PROXMOX_DOMAIN:-example.net}"
+    PROXMOX_SUBDOMAIN: "${PROXMOX_SUBDOMAIN:-svc.example.net}"
+    TECHNITIUM_DNS_API_TOKEN: "${TECHNITIUM_DNS_API_TOKEN:-moleculetesttoken}"
+
+verifier:
+  name: ansible
+
+scenario:
+  name: technitium_dns
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - cleanup
+    - destroy

--- a/molecule/technitium_dns/prepare.yml
+++ b/molecule/technitium_dns/prepare.yml
@@ -1,0 +1,13 @@
+---
+# Molecule preparation for the technitium_dns scenario.
+# The role makes no live API calls in CI (technitium_dns_apply=false), so the
+# only setup needed is confirming the containers are reachable.
+
+- name: Prepare
+  hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Wait for container to be ready
+      ansible.builtin.wait_for_connection:
+        timeout: 30

--- a/molecule/technitium_dns/verify.yml
+++ b/molecule/technitium_dns/verify.yml
@@ -1,0 +1,58 @@
+---
+# Molecule verification for technitium_dns (no live DNS server).
+#
+# Re-runs the role with technitium_dns_apply=false to populate the derived facts,
+# then asserts the HA topology resolved correctly across the two-node group:
+#   - the primary is the lowest-vmid member (technitium-1 / .10);
+#   - each host's role matches its identity (primary vs secondary);
+#   - the secondary-IP list excludes the primary and includes the peer;
+#   - inventory A-records were built for both hosts.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+
+  vars:
+    technitium_dns_apply: false
+    technitium_dns_host: "{{ container_ip | default(ansible_host) }}"
+    tofu_data:
+      ingress: []
+
+  tasks:
+    - name: Re-run technitium_dns role to populate derived facts (no live API)
+      ansible.builtin.include_role:
+        name: technitium_dns
+
+    - name: Assert the primary is the lowest-vmid node (technitium-1 / .10)
+      ansible.builtin.assert:
+        that:
+          - technitium_dns_primary_ip == '192.168.5.10'
+        fail_msg: >-
+          Expected primary 192.168.5.10, got '{{ technitium_dns_primary_ip }}'.
+
+    - name: Assert this host's role matches its identity
+      ansible.builtin.assert:
+        that:
+          - >-
+            technitium_dns_role ==
+            ('primary' if container_ip == '192.168.5.10' else 'secondary')
+        fail_msg: >-
+          Role mismatch on {{ inventory_hostname }} ({{ container_ip }}):
+          got '{{ technitium_dns_role }}'.
+
+    - name: Assert the secondary-IP list excludes the primary and includes the peer
+      ansible.builtin.assert:
+        that:
+          - "'192.168.5.10' not in technitium_dns_secondary_ips"
+          - "'192.168.5.11' in technitium_dns_secondary_ips"
+        fail_msg: >-
+          Unexpected secondary IPs: {{ technitium_dns_secondary_ips }}.
+
+    - name: Assert inventory A-records were built for both hosts
+      ansible.builtin.assert:
+        that:
+          - technitium_dns_a_records | length >= 2
+          - "'technitium-1' in (technitium_dns_a_records | map(attribute='name') | list)"
+          - "'technitium-2' in (technitium_dns_a_records | map(attribute='name') | list)"
+        fail_msg: >-
+          A-records not built as expected: {{ technitium_dns_a_records }}.

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -178,7 +178,7 @@
 # =============================================================================
 
 - name: Configure Technitium DNS with internal A records
-  hosts: localhost
+  hosts: technitium_dns_group
   become: false
   gather_facts: false
   tags:
@@ -186,13 +186,15 @@
     - dns
 
   vars:
-    # Derive Technitium DNS host IP from gateway (VMID 103)
-    technitium_dns_host: "{{ lookup('env', 'PROXMOX_VE_GATEWAY') | regex_replace('\\.[0-9]+$', '.103') }}"
+    # Each instance configures its OWN Technitium API: the primary authors the
+    # zone + records and allows AXFR; the secondaries create a Secondary zone and
+    # replicate. API host = the instance's own container IP (matches the Phase 1a
+    # install play), so the role runs across the whole HA group.
+    technitium_dns_host: "{{ container_ip | default(ansible_host) }}"
     # group_vars/all.yml sets `ansible_become: true` (an inventory variable),
     # which Ansible applies via the connection layer and which overrides the
-    # play-level `become: false` keyword. The reliable way to disable become
-    # for this localhost-only play (which just hits HTTP APIs and never needs
-    # sudo) is to override the inventory variable directly via play vars.
+    # play-level `become: false` keyword. These tasks only hit HTTP APIs and
+    # never need sudo, so disable become via the inventory variable directly.
     ansible_become: false
 
   roles:

--- a/roles/technitium_dns/defaults/main.yml
+++ b/roles/technitium_dns/defaults/main.yml
@@ -56,5 +56,29 @@ technitium_dns_forwarders:
 technitium_dns_recursion: true
 technitium_dns_cache_enabled: true
 
+# --- HA: primary / secondary roles (native AXFR/IXFR zone transfer) -----------
+# The role runs across the whole technitium_dns_group. The PRIMARY authors the
+# zone + records and allows zone transfer (AXFR) to the secondaries; each
+# SECONDARY creates a Secondary zone (master = primary) and skips record writes
+# (records replicate via zone transfer). The primary is the lowest-vmid member
+# of the group (terraform pins technitium-1 to the lowest vmid). All three are
+# derived in tasks when left empty, so a single-node group degenerates to "this
+# host is its own primary" and behavior is UNCHANGED. No IP literal is committed.
+technitium_dns_role: ""            # auto: 'primary' | 'secondary'
+technitium_dns_primary_ip: ""      # auto: lowest-vmid member's container_ip
+technitium_dns_secondary_ips: []   # auto: group member IPs minus the primary
+# Protocol the secondaries use to pull the zone from the primary.
+technitium_dns_zone_transfer_protocol: "Tcp"
+
+# Existing zones discovered from the API at runtime. The default keeps the
+# technitium_dns_apply=false path (molecule/CI) from referencing an undefined
+# register when the discovery API call is skipped.
+technitium_dns_existing_zones: []
+
+# When false, skip every live Technitium API call and run only the fact-building
+# logic. Used by molecule/CI to exercise the role's branching without a live
+# server; always true in production.
+technitium_dns_apply: true
+
 # Timeout for API requests (seconds)
 technitium_dns_api_timeout: 30

--- a/roles/technitium_dns/tasks/main.yml
+++ b/roles/technitium_dns/tasks/main.yml
@@ -39,6 +39,43 @@
   loop_control:
     label: "{{ item }}"
 
+# --- Derive HA topology (primary = lowest-vmid technitium_dns_group member) ---
+# Build a {vmid, ip} list for the group so the primary is the lowest vmid
+# (terraform pins technitium-1 lowest). vmid is int-cast so it sorts numerically.
+# A single-node group yields one member, so that host becomes its own primary
+# and the prior single-node behavior is preserved.
+- name: Build Technitium group member list
+  ansible.builtin.set_fact:
+    technitium_dns_members: >-
+      {{
+        technitium_dns_members | default([]) +
+        [{
+          'vmid': hostvars[item].proxmox_vmid | default(0) | int,
+          'ip': hostvars[item].container_ip | default(hostvars[item].ansible_host)
+        }]
+      }}
+  loop: "{{ groups['technitium_dns_group'] | default([]) | reject('equalto', 'localhost') | list }}"
+  when: (hostvars[item].container_ip is defined) or (hostvars[item].ansible_host is defined)
+  loop_control:
+    label: "{{ item }}"
+
+- name: Resolve Technitium primary IP (lowest vmid)
+  ansible.builtin.set_fact:
+    technitium_dns_primary_ip: >-
+      {{ technitium_dns_primary_ip if (technitium_dns_primary_ip | length > 0)
+         else ((technitium_dns_members | default([]) | sort(attribute='vmid')
+                | map(attribute='ip') | list | first) | default(technitium_dns_host)) }}
+
+- name: Resolve Technitium role and secondary IPs
+  ansible.builtin.set_fact:
+    technitium_dns_role: >-
+      {{ technitium_dns_role if (technitium_dns_role | length > 0)
+         else ('primary' if technitium_dns_host == technitium_dns_primary_ip else 'secondary') }}
+    technitium_dns_secondary_ips: >-
+      {{ technitium_dns_secondary_ips if (technitium_dns_secondary_ips | length > 0)
+         else (technitium_dns_members | default([]) | map(attribute='ip')
+               | reject('equalto', technitium_dns_primary_ip) | list) }}
+
 # Technitium authenticates API calls via `?token=...` query parameter,
 # NOT via an X-Api-Token header. The header is silently ignored and
 # the server responds with "Parameter 'token' missing."
@@ -50,14 +87,16 @@
     timeout: "{{ technitium_dns_api_timeout }}"
   register: technitium_dns_zones_response
   changed_when: false
+  when: technitium_dns_apply | bool
   no_log: true
 
 - name: Parse existing zones
   ansible.builtin.set_fact:
     technitium_dns_existing_zones: >-
       {{ technitium_dns_zones_response.json.response.zones | default([]) | map(attribute='name') | list }}
+  when: technitium_dns_apply | bool
 
-- name: Create internal DNS zone
+- name: Create internal DNS zone (primary)
   ansible.builtin.uri:
     url: "{{ technitium_dns_api_url }}/api/zones/create?token={{ technitium_dns_api_token }}"
     method: POST
@@ -70,7 +109,34 @@
     status_code: [200, 400]
   register: technitium_dns_zone_create
   changed_when: technitium_dns_zone_create.json.status == "ok"
-  when: technitium_dns_internal_domain not in technitium_dns_existing_zones
+  when:
+    - technitium_dns_role == 'primary'
+    - technitium_dns_apply | bool
+    - technitium_dns_internal_domain not in technitium_dns_existing_zones
+  no_log: true
+
+# Secondaries replicate the zone from the primary via native AXFR/IXFR zone
+# transfer; they create a Secondary zone (master = primary) and skip all record
+# writes below. Only functions once the primary + secondary LXCs exist.
+- name: Create Secondary DNS zone (secondary)
+  ansible.builtin.uri:
+    url: "{{ technitium_dns_api_url }}/api/zones/create?token={{ technitium_dns_api_token }}"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      zone: "{{ technitium_dns_internal_domain }}"
+      type: "Secondary"
+      primaryNameServerAddresses: "{{ technitium_dns_primary_ip }}"
+      zoneTransferProtocol: "{{ technitium_dns_zone_transfer_protocol }}"
+    return_content: true
+    timeout: "{{ technitium_dns_api_timeout }}"
+    status_code: [200, 400]
+  register: technitium_dns_secondary_zone_create
+  changed_when: technitium_dns_secondary_zone_create.json.status == "ok"
+  when:
+    - technitium_dns_role == 'secondary'
+    - technitium_dns_apply | bool
+    - technitium_dns_internal_domain not in technitium_dns_existing_zones
   no_log: true
 
 - name: Get existing A records for zone
@@ -85,6 +151,9 @@
     timeout: "{{ technitium_dns_api_timeout }}"
   register: technitium_dns_existing_records
   changed_when: false
+  when:
+    - technitium_dns_role == 'primary'
+    - technitium_dns_apply | bool
   no_log: true
 
 - name: Create A records for infrastructure hosts
@@ -109,6 +178,9 @@
   failed_when:
     - technitium_dns_a_record_result.json.status | default('') != "ok"
     - "'already exists' not in (technitium_dns_a_record_result.json.errorMessage | default(''))"
+  when:
+    - technitium_dns_role == 'primary'
+    - technitium_dns_apply | bool
   no_log: true
 
 - name: Create CNAME records for service aliases
@@ -133,6 +205,9 @@
   failed_when:
     - technitium_dns_cname_result.json.status | default('') != "ok"
     - "'already exists' not in (technitium_dns_cname_result.json.errorMessage | default(''))"
+  when:
+    - technitium_dns_role == 'primary'
+    - technitium_dns_apply | bool
   no_log: true
 
 # Point each Traefik-fronted service name at the Traefik LXC so clients reach it
@@ -163,8 +238,32 @@
     - "'already exists' not in (technitium_dns_ingress_result.json.errorMessage | default(''))"
   no_log: true
   when:
+    - technitium_dns_role == 'primary'
+    - technitium_dns_apply | bool
     - technitium_dns_ingress_host in hostvars
     - hostvars[technitium_dns_ingress_host].container_ip is defined
+
+# Authorize the secondaries to pull the zone via AXFR. UseSpecifiedNetworkACL
+# restricts transfer to exactly the secondary IPs (default-deny otherwise).
+# No-op for a single-node group (no secondaries).
+- name: Allow AXFR zone transfer to secondaries (primary)
+  ansible.builtin.uri:
+    url: "{{ technitium_dns_api_url }}/api/zones/options/set?token={{ technitium_dns_api_token }}"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      zone: "{{ technitium_dns_internal_domain }}"
+      zoneTransfer: "UseSpecifiedNetworkACL"
+      zoneTransferNetworkACL: "{{ technitium_dns_secondary_ips | join(',') }}"
+    return_content: true
+    timeout: "{{ technitium_dns_api_timeout }}"
+  register: technitium_dns_axfr_result
+  changed_when: technitium_dns_axfr_result.json.status == "ok"
+  when:
+    - technitium_dns_role == 'primary'
+    - technitium_dns_apply | bool
+    - technitium_dns_secondary_ips | length > 0
+  no_log: true
 
 - name: Verify DNS zone is active
   ansible.builtin.uri:
@@ -177,4 +276,5 @@
   failed_when: >-
     technitium_dns_internal_domain not in
     (technitium_dns_final_zones.json.response.zones | default([]) | map(attribute='name') | list)
+  when: technitium_dns_apply | bool
   no_log: true


### PR DESCRIPTION
## What

Adds native Technitium **primary/secondary HA** via the server's own AXFR/IXFR
zone transfer — no keepalived, no VIP, no scripts. The role now runs across the
whole `technitium_dns_group`:

- **Primary** authors the zone + records and **allows zone transfer (AXFR)** to
  the secondary IPs (`/api/zones/options/set`, `UseSpecifiedNetworkACL`).
- **Secondary** creates a **Secondary zone** (`/api/zones/create` `type=Secondary`,
  `primaryNameServerAddresses=<primary>`) and **skips all record writes** — records
  replicate via zone transfer.
- `technitium_dns_role` / `technitium_dns_primary_ip` / `technitium_dns_secondary_ips`
  are **derived in-role** from the group (primary = lowest `proxmox_vmid`, matching
  terraform's `technitium-1`). No IP literal is committed.

## Targeting change

The Phase 1b config play moves from `hosts: localhost` (a single gateway-derived
`.103` API host — a single-node kludge) to `hosts: technitium_dns_group`, each
instance using its **own `container_ip`** as its API host.

## Additive / safe — single-node behavior unchanged

A single-host group degenerates to "this host is its own primary", so the prior
single-node behavior is preserved. Verified locally (`apply=false`, no live
server):

| Group | Result |
| --- | --- |
| 1 node (.103) | `role=primary`, `secondaries=[]`, records authored — unchanged |
| 3 nodes (vmid 10/11/12) | `.10`→primary (AXFR-allows `[.11,.12]`), `.11/.12`→secondary |

## Idempotency

Zone-create stays gated by the existing-zones pre-check; A/CNAME/ingress upserts
(`overwrite:true`) tolerate `already exists`; `options/set` AXFR-allow is
declarative; the secondary-zone create is gated by existing-zones. Re-converge is
a no-op.

## Testing

- **New `molecule/technitium_dns` scenario** (two nodes; `technitium_dns_apply=false`
  mocks the Technitium API) added to the CI matrix. Asserts primary/secondary
  resolution and inventory A-record building with **no live server**.
- `ansible-lint` (production profile) and `yamllint` pass; pre-commit clean.
- The HA derivation + single-node path were executed locally (apply=false) and
  assert green. Note: the **local** molecule runner cannot execute (a
  `molecule-plugins` 23.5.3 / ansible-core 2.21 broken-conditional in molecule's
  own `create.yml`/`destroy.yml` — it fails identically on every existing scenario,
  e.g. `seerr`); the molecule scenario runs in **CI**.

## Scope / sequencing

- Secondaries only **function** once `terraform-proxmox` #23 creates the 3 LXCs.
- This PR operates on the **current apex zone**. Narrowing to the subdomain and
  forwarding the apex to the gateway is the **next PR** (refactor; couples with a
  consumer-repoint PR).
- **Deferred credentialed verification** (after #23): AXFR sync on the secondaries
  (record counts match the primary), failover with the primary down, idempotent
  re-converge. Not gated here — there is no live server until #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
