### PR TITLE
refactor: repoint internal service URLs to the DNS subdomain

### DIFF
--- a/roles/cribl_docker_stack/defaults/main.yml
+++ b/roles/cribl_docker_stack/defaults/main.yml
@@ -44,8 +44,10 @@ cribl_docker_stack_netflow_port: 2055
 cribl_docker_stack_edge_web_port: 9000
 cribl_docker_stack_stream_web_port: 9100
 
-# Internal domain for hostname resolution
-cribl_docker_stack_internal_domain: "{{ lookup('env', 'PROXMOX_DOMAIN') }}"
+# Internal domain for hostname resolution. Currently unconsumed (no template or
+# task references it), repointed to PROXMOX_SUBDOMAIN to match the DNS split
+# (Technitium is authoritative for the subdomain; the apex forwards to the gateway).
+cribl_docker_stack_internal_domain: "{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
 
 # Health check settings - lenient for slow startup and edge cases
 cribl_docker_stack_healthcheck_interval: "60s"

--- a/roles/infisical_docker/defaults/main.yml
+++ b/roles/infisical_docker/defaults/main.yml
@@ -31,10 +31,12 @@ infisical_docker_db_user: infisical
 # Restart policy applied to every service in the stack.
 infisical_docker_restart_policy: unless-stopped
 
-# Site URL composition. Auto-derived from inventory hostname + PROXMOX_DOMAIN.
-# Always HTTPS because the canonical access path is HAProxy → Infisical, and the
-# HAProxy frontend enforces TLS (see roles/haproxy → haproxy_http_frontends).
-infisical_docker_site_url: "https://{{ hostname }}.{{ lookup('env', 'PROXMOX_DOMAIN') }}"
+# Site URL composition. Auto-derived from inventory hostname + PROXMOX_SUBDOMAIN
+# (Technitium is authoritative for the subdomain; the apex now forwards to the
+# gateway, so <hostname>.<apex> would NXDOMAIN). Always HTTPS because the canonical
+# access path is HAProxy → Infisical, and the HAProxy frontend enforces TLS
+# (see roles/haproxy → haproxy_http_frontends).
+infisical_docker_site_url: "https://{{ hostname }}.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
 
 # Port pulled from the OpenTofu pipeline_constants (DRY: no port literal here).
 _infisical_docker_api_port_err: >-

--- a/roles/openproject_docker/defaults/main.yml
+++ b/roles/openproject_docker/defaults/main.yml
@@ -13,8 +13,9 @@ openproject_docker_data_dir: /opt/openproject
 openproject_docker_web_port: 80
 
 # FQDN used for cookie scoping and external URL generation.
-# Auto-derived from inventory hostname + PROXMOX_DOMAIN.
-openproject_docker_host_name: "{{ hostname }}.{{ lookup('env', 'PROXMOX_DOMAIN') }}"
+# Auto-derived from inventory hostname + PROXMOX_SUBDOMAIN (Technitium is
+# authoritative for the subdomain; <hostname>.<apex> would NXDOMAIN post-split).
+openproject_docker_host_name: "{{ hostname }}.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
 
 # HTTPS off by default — homelab serves plain HTTP over the trusted LAN.
 # Set to "true" when fronted by NPM/HAProxy with TLS termination.


### PR DESCRIPTION
> **Stacked on #320** (base branch `refactor/technitium-subdomain-zone`), which is
> stacked on #319. Review/merge those first.

## What

Once Technitium narrows to the subdomain and forwards the apex to the gateway
(#320), any service that advertises `<hostname>.<apex>` resolves **NXDOMAIN** — the
inventory A-records (including these service names) now live under the subdomain. So
the service-advertised URLs must follow:

| Var | Before | After |
| --- | --- | --- |
| `infisical_docker_site_url` | `https://<hostname>.<apex>` | `https://<hostname>.<PROXMOX_SUBDOMAIN>` |
| `openproject_docker_host_name` | `<hostname>.<apex>` | `<hostname>.<PROXMOX_SUBDOMAIN>` |
| `cribl_docker_stack_internal_domain` | `<apex>` | `<PROXMOX_SUBDOMAIN>` (currently unconsumed; repointed for consistency) |

## What deliberately stays on the apex

- OpenProject **email** vars (`smtp_domain`, `mail_from`, `admin_email`) — email
  identity, not internal DNS names.
- The generic `proxmox_domain` inventory var — **no consumers** (verified); left as-is.
- `technitium_dns_apex_domain` (#320) — used only to delete a stale apex zone.

All other service-to-service wiring already uses `container_ip` (haproxy,
`cribl_edge`, `cribl_stream`), so the in-repo blast radius is just these three
advertised URLs.

## Testing

`ansible-lint` (production) + `yamllint` pass; pre-commit clean. These are default-var
domain-label swaps in roles with no molecule scenario; no test asserts on the values.

## ⚠️ Apply-together coupling

Must merge close to and apply in the **SAME converge** as #320 (and the `tofu-unifi`
DHCP-DNS change + UniFi Local-DNS mirror) so no internal name NXDOMAINs mid-flight.

External consumers (UniFi-configured syslog senders, human bookmarks) and a
downstream-repo grep (`ansible-proxmox`, `ansible-splunk`, `int_homelab`) are tracked
in #321 — they must be repointed in the same window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
