### PR TITLE
feat: local Hermes LLM — ollama + open_webui roles

### DIFF
--- a/inventory/group_vars/ollama_group.yml
+++ b/inventory/group_vars/ollama_group.yml
@@ -1,0 +1,6 @@
+---
+# Restart-on-failure for Ollama is applied by the shared systemd_restart_policy
+# role (site.yml Phase 9), keeping restart policy DRY across the repo rather than
+# hardcoding Restart= in the unit drop-in.
+systemd_restart_policy_services:
+  - ollama

--- a/inventory/group_vars/open_webui_group.yml
+++ b/inventory/group_vars/open_webui_group.yml
@@ -1,0 +1,5 @@
+---
+# Restart-on-failure for Open WebUI, applied by the shared systemd_restart_policy
+# role (site.yml Phase 9) — keeps restart policy DRY rather than hardcoded in the unit.
+systemd_restart_policy_services:
+  - open-webui

--- a/inventory/load_tofu.yml
+++ b/inventory/load_tofu.yml
@@ -124,6 +124,16 @@
               else []
             ) +
             (
+              ['ollama_group']
+              if 'ollama' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
+              ['open_webui_group']
+              if 'open-webui' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
               ['apt_cacher_group']
               if 'apt-cache' in (item.value.tags | default([]))
               else []

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -399,6 +399,35 @@
     - role: llamaindex
 
 # =============================================================================
+# Phase 8a: Local LLM — Ollama inference (AMD ROCm) + Open WebUI chat
+# Ollama (CT 167, RX 6800) serves Hermes 4 14B; Open WebUI (CT 168) is the chat
+# front-end. Open WebUI is fronted by Traefik at https://llm.<subdomain>
+# (Phase 8d); Ollama stays internal on the ai VLAN.
+# =============================================================================
+
+- name: Configure Ollama LLM inference (AMD ROCm)
+  hosts: ollama_group
+  become: true
+  gather_facts: true
+  tags:
+    - ollama
+    - llm
+    - ai
+  roles:
+    - role: ollama
+
+- name: Configure Open WebUI chat front-end
+  hosts: open_webui_group
+  become: true
+  gather_facts: true
+  tags:
+    - open_webui
+    - llm
+    - ai
+  roles:
+    - role: open_webui
+
+# =============================================================================
 # Phase 8b: OpenProject Community Edition
 # Project management web app — Docker all-in-one in LXC (bundles postgres,
 # memcached, web, worker). Reachable on container_ip:80 internally; DNS A

--- a/roles/ollama/README.md
+++ b/roles/ollama/README.md
@@ -1,0 +1,54 @@
+# ollama
+
+Deploys **Ollama** as the local LLM inference server on an AMD **ROCm** GPU,
+inside an LXC (CT 167 `hermes-infer`, RX 6800), and provisions **Hermes 4 14B**.
+
+## Installation
+
+Ships with the `ansible-proxmox-apps` repo; no external install. The container is
+provisioned by `terraform-proxmox` and the GPU device nodes (`/dev/kfd`,
+`/dev/dri`) are passed in by `ansible-proxmox` (role `lxc_gpu_features`) — both
+must be in place first. This role is wired into `playbooks/site.yml` against the
+`ollama_group` (containers tagged `ollama` in the tofu inventory). Tools come
+from the repo's Nix dev shell (`direnv allow`).
+
+Ordering: `terraform-proxmox` (LXC shell) → `ansible-proxmox` (GPU passthrough) →
+**this role** (Ollama + ROCm + model) → `open_webui` (chat UI).
+
+## What it does
+
+- Installs Ollama via the official script (creates the `ollama` user + systemd unit).
+- Overlays the **ROCm runtime** tarball (the installer ships CPU/NVIDIA libs only).
+- Creates `render`/`video` groups at the host GIDs and adds `ollama` to them so the
+  service can open `/dev/kfd` + `/dev/dri`.
+- Writes a systemd env drop-in (`OLLAMA_HOST`, `OLLAMA_MODELS`,
+  `HSA_OVERRIDE_GFX_VERSION=10.3.0` for gfx1030, flash-attention, keep-alive).
+- Pulls **Hermes 4 14B** Q4_K_M GGUF from HuggingFace and aliases it to `hermes4`.
+- Restart-on-failure is applied by the shared `systemd_restart_policy` role via
+  `group_vars/ollama_group.yml`.
+
+## Key variables (`defaults/main.yml`)
+
+| Var | Default | Purpose |
+| --- | --- | --- |
+| `ollama_api_port` | `tofu_data.constants.service_ports.ollama_api` | API port (no hardcode) |
+| `ollama_models_dir` | `/var/lib/ollama` | Model store (120 GB local-zfs vol) |
+| `ollama_hsa_override_gfx_version` | `10.3.0` | RX 6800 / Navi 21 / gfx1030 |
+| `ollama_model_name` | `hermes4` | Local alias |
+| `ollama_model_source` | `hf.co/bartowski/NousResearch_Hermes-4-14B-GGUF:Q4_K_M` | GGUF source |
+
+## Usage
+
+```bash
+# Deploy (after terraform + ansible-proxmox GPU passthrough)
+env -u DOPPLER_PROJECT -u DOPPLER_CONFIG -u DOPPLER_ENVIRONMENT doppler run -- \
+  ./scripts/run-ansible.sh playbooks/site.yml --limit hermes-infer --tags ollama,ai
+```
+
+## Verify
+
+```bash
+pct exec 167 -- rocminfo | grep -i gfx            # GPU visible to ROCm
+pct exec 167 -- ollama run hermes4 "say hi"        # GPU inference (watch radeontop)
+curl http://10.0.40.167:11434/v1/models            # OpenAI-compatible endpoint
+```

--- a/roles/ollama/defaults/main.yml
+++ b/roles/ollama/defaults/main.yml
@@ -1,0 +1,39 @@
+---
+# ollama role defaults — Ollama LLM inference with AMD ROCm, in an LXC (CT 167).
+#
+# GPU device nodes (/dev/kfd, /dev/dri) are passed into the container UPSTREAM by
+# ansible-proxmox (role lxc_gpu_features); this role assumes they already exist
+# and makes the `ollama` service user able to open them. Install uses the
+# official script (which creates the `ollama` user + systemd unit), then overlays
+# the ROCm runtime for AMD GPUs. Restart-on-failure is applied DRY by the
+# shared systemd_restart_policy role via group_vars (Phase 9), not here.
+
+ollama_install_url: "https://ollama.com/install.sh"
+# AMD ROCm runtime overlay (the installer ships CPU/NVIDIA libs only).
+ollama_rocm_tarball_url: "https://ollama.com/download/ollama-linux-amd64-rocm.tar.zst"
+
+ollama_user: ollama
+# Active-model store — backed by the 120 GB local-zfs mount on CT 167.
+ollama_models_dir: /var/lib/ollama
+
+# Bind all interfaces so hermes-chat (Open WebUI) + Traefik reach it on the ai VLAN.
+# Port comes from the tofu ports registry (no hardcoded ports — see ip-addressing rule).
+ollama_api_port: "{{ tofu_data.constants.service_ports.ollama_api }}"
+ollama_listen: "0.0.0.0:{{ ollama_api_port }}"
+
+# AMD RX 6800 = Navi 21 / gfx1030; ROCm needs the gfx-version override for this card.
+ollama_hsa_override_gfx_version: "10.3.0"
+ollama_flash_attention: "1"
+ollama_keep_alive: "30m"
+ollama_num_parallel: "1"
+
+# GPU device groups the ollama user must join to open /dev/kfd + /dev/dri.
+# GIDs match the host (privileged CT): render=104, video=44 (verified live).
+ollama_gpu_groups:
+  - { name: render, gid: 104 }
+  - { name: video, gid: 44 }
+
+# Model: Hermes 4 14B (Qwen3 base) Q4_K_M GGUF, pulled directly from HF and
+# aliased to `hermes4`. Ollama pulls GGUF from HuggingFace via the hf.co/ ref.
+ollama_model_name: hermes4
+ollama_model_source: "hf.co/bartowski/NousResearch_Hermes-4-14B-GGUF:Q4_K_M"

--- a/roles/ollama/handlers/main.yml
+++ b/roles/ollama/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart ollama
+  ansible.builtin.systemd:
+    name: ollama
+    state: restarted
+    daemon_reload: true

--- a/roles/ollama/tasks/main.yml
+++ b/roles/ollama/tasks/main.yml
@@ -1,0 +1,108 @@
+---
+# Ollama LLM inference (AMD ROCm) in an LXC. Idempotent; safe to re-run.
+# Prereqs (upstream): ansible-proxmox lxc_gpu_features has bound /dev/kfd +
+# /dev/dri into this CT. We only need the ollama user to be able to use them.
+
+- name: Install Ollama (creates the ollama user + systemd unit)
+  ansible.builtin.shell:
+    cmd: "set -o pipefail && curl -fsSL {{ ollama_install_url }} | sh"
+    creates: /usr/local/bin/ollama
+  args:
+    executable: /bin/bash
+
+# The installer ships CPU/NVIDIA libs; overlay the ROCm runtime for the RX 6800.
+- name: Install the ROCm runtime overlay (AMD GPU)
+  ansible.builtin.shell:
+    cmd: "set -o pipefail && curl -fsSL {{ ollama_rocm_tarball_url }} | tar -x --use-compress-program=unzstd -C /usr"
+    creates: /usr/lib/ollama/rocm
+  args:
+    executable: /bin/bash
+  notify: Restart ollama
+
+- name: Ensure GPU device groups exist with the host GIDs
+  ansible.builtin.group:
+    name: "{{ item.name }}"
+    gid: "{{ item.gid }}"
+    state: present
+  loop: "{{ ollama_gpu_groups }}"
+  loop_control:
+    label: "{{ item.name }} ({{ item.gid }})"
+
+- name: Add the ollama user to the GPU device groups
+  ansible.builtin.user:
+    name: "{{ ollama_user }}"
+    groups: "{{ ollama_gpu_groups | map(attribute='name') | list }}"
+    append: true
+  notify: Restart ollama
+
+- name: Create the models directory
+  ansible.builtin.file:
+    path: "{{ ollama_models_dir }}"
+    state: directory
+    owner: "{{ ollama_user }}"
+    group: "{{ ollama_user }}"
+    mode: "0750"
+
+- name: Deploy Ollama systemd environment drop-in
+  ansible.builtin.template:
+    src: ollama-env.conf.j2
+    dest: /etc/systemd/system/ollama.service.d/10-environment.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart ollama
+
+- name: Enable and start Ollama
+  ansible.builtin.systemd:
+    name: ollama
+    state: started
+    enabled: true
+    daemon_reload: true
+
+- name: Flush handlers so the environment + GPU groups apply before model pull
+  ansible.builtin.meta: flush_handlers
+
+# --- model provisioning (Hermes 4 14B) ---
+
+- name: List installed Ollama models
+  ansible.builtin.command: ollama list
+  register: ollama_model_list
+  changed_when: false
+  retries: 10
+  delay: 3
+  until: ollama_model_list.rc == 0
+
+- name: Pull + alias Hermes 4 14B  # ~9 GB; only when absent
+  when: ollama_model_name not in ollama_model_list.stdout
+  block:
+    - name: Pull the Hermes 4 14B GGUF from HuggingFace
+      ansible.builtin.command:
+        cmd: "ollama pull {{ ollama_model_source }}"
+      changed_when: true
+
+    - name: Render the Modelfile (alias + params)
+      ansible.builtin.template:
+        src: Modelfile.j2
+        dest: "{{ ollama_models_dir }}/Modelfile.{{ ollama_model_name }}"
+        owner: "{{ ollama_user }}"
+        group: "{{ ollama_user }}"
+        mode: "0640"
+
+    - name: "Create the Ollama model {{ ollama_model_name }}"
+      ansible.builtin.command:
+        cmd: "ollama create {{ ollama_model_name }} -f {{ ollama_models_dir }}/Modelfile.{{ ollama_model_name }}"
+      changed_when: true
+
+# --- verify ---
+
+- name: Verify Ollama service is active
+  ansible.builtin.systemd:
+    name: ollama
+  register: ollama_service_state
+  failed_when: ollama_service_state.status.ActiveState != 'active'
+
+- name: Verify the model is registered
+  ansible.builtin.command: ollama list
+  register: ollama_verify_list
+  changed_when: false
+  failed_when: ollama_model_name not in ollama_verify_list.stdout

--- a/roles/ollama/templates/Modelfile.j2
+++ b/roles/ollama/templates/Modelfile.j2
@@ -1,0 +1,8 @@
+{{ ansible_managed | comment }}
+# Hermes 4 14B (Qwen3 base). The bartowski GGUF embeds the ChatML chat template,
+# tool-calling, and <think> reasoning in its metadata, so no TEMPLATE override is
+# needed here — overriding it would risk breaking tool-calling.
+FROM {{ ollama_model_source }}
+
+# Context window — bounded to fit the RX 6800's 16 GB alongside the Q4 weights.
+PARAMETER num_ctx 8192

--- a/roles/ollama/templates/ollama-env.conf.j2
+++ b/roles/ollama/templates/ollama-env.conf.j2
@@ -1,0 +1,9 @@
+{{ ansible_managed | comment }}
+# Ollama service environment (managed by the ollama role). ROCm/AMD on CT 167.
+[Service]
+Environment="OLLAMA_HOST={{ ollama_listen }}"
+Environment="OLLAMA_MODELS={{ ollama_models_dir }}"
+Environment="OLLAMA_FLASH_ATTENTION={{ ollama_flash_attention }}"
+Environment="OLLAMA_KEEP_ALIVE={{ ollama_keep_alive }}"
+Environment="OLLAMA_NUM_PARALLEL={{ ollama_num_parallel }}"
+Environment="HSA_OVERRIDE_GFX_VERSION={{ ollama_hsa_override_gfx_version }}"

--- a/roles/open_webui/README.md
+++ b/roles/open_webui/README.md
@@ -1,0 +1,51 @@
+# open_webui
+
+Deploys **Open WebUI** (CT 168 `hermes-chat`) as the chat front-end for the local
+LLM, talking to **Ollama** (CT 167) and fronted by **Traefik** at
+`https://llm.<PROXMOX_SUBDOMAIN>` (e.g. `https://llm.pve.jacobpevans.com`).
+
+## Installation
+
+Ships with the `ansible-proxmox-apps` repo; no external install. The container is
+provisioned by `terraform-proxmox`. This role is wired into `playbooks/site.yml`
+against the `open_webui_group` (containers tagged `open-webui` in the tofu
+inventory) and runs over the `proxmox_pct_remote` connection. Tools come from the
+repo's Nix dev shell (`direnv allow`). Deploy after the `ollama` role (its backend).
+
+Requires `OPEN_WEBUI_SECRET_KEY` in Doppler/SOPS (generate once: `openssl rand -hex 32`).
+
+## What it does
+
+- Creates an `open-webui` system user and installs **uv**.
+- Installs Open WebUI into a venv (`/opt/open-webui/venv`) and runs it via a
+  dedicated systemd unit (`open-webui serve`), data in `DATA_DIR=/var/lib/open-webui`.
+- Renders `/etc/open-webui.env` with the **reverse-proxy-correct** settings Open
+  WebUI requires behind HTTPS: `OLLAMA_BASE_URL` (→ CT 167, from inventory),
+  `WEBUI_URL`/`CORS_ALLOW_ORIGIN` (= the Traefik URL, from `PROXMOX_SUBDOMAIN`),
+  secure cookies, `ENABLE_WEBSOCKET_SUPPORT`, stable `WEBUI_SECRET_KEY`.
+- Restart-on-failure via the shared `systemd_restart_policy` role (`group_vars`).
+
+## Key variables (`defaults/main.yml`)
+
+| Var | Default | Purpose |
+| --- | --- | --- |
+| `open_webui_port` | `tofu_data.constants.service_ports.open_webui_web` | Listen port (no hardcode) |
+| `open_webui_ollama_base_url` | `http://<hermes-infer ip>:<ollama_api>` | Backend (from inventory) |
+| `open_webui_hostname` | `llm.{{ PROXMOX_SUBDOMAIN }}` | Public FQDN via Traefik |
+| `open_webui_data_dir` | `/var/lib/open-webui` | Persistent data |
+| `open_webui_secret_key` | `OPEN_WEBUI_SECRET_KEY` (Doppler/SOPS) | Stable JWT/encryption key |
+
+## Usage
+
+```bash
+env -u DOPPLER_PROJECT -u DOPPLER_CONFIG -u DOPPLER_ENVIRONMENT \
+  sops exec-env secrets.enc.yaml 'doppler run -- \
+  ./scripts/run-ansible.sh playbooks/site.yml --limit hermes-chat --tags open_webui,ai'
+```
+
+## Verify
+
+```bash
+pct exec 168 -- curl -fsS http://127.0.0.1:8080/health   # service up (LAN)
+# then browse https://llm.<subdomain> (after the Traefik ingress entry is live)
+```

--- a/roles/open_webui/defaults/main.yml
+++ b/roles/open_webui/defaults/main.yml
@@ -1,0 +1,27 @@
+---
+# open_webui role defaults — Open WebUI chat front-end (CT 168 hermes-chat).
+# Talks to Ollama (CT 167) and is fronted by Traefik at https://llm.<subdomain>.
+# Native install via uv into a venv + systemd (no Docker). Restart-on-failure is
+# applied DRY by the shared systemd_restart_policy role (Phase 9) via group_vars.
+
+open_webui_user: open-webui
+open_webui_home: /opt/open-webui
+open_webui_venv: /opt/open-webui/venv
+open_webui_data_dir: /var/lib/open-webui   # persistent DB/config (DATA_DIR)
+open_webui_python: "3.11"
+open_webui_uv_install_url: "https://astral.sh/uv/install.sh"
+
+open_webui_listen_host: "0.0.0.0"
+# Port + backend come from the tofu ports registry / inventory (no hardcodes).
+open_webui_port: "{{ tofu_data.constants.service_ports.open_webui_web }}"
+open_webui_ollama_base_url: >-
+  http://{{ hostvars['hermes-infer'].container_ip }}:{{ tofu_data.constants.service_ports.ollama_api }}
+
+# Public URL via Traefik — derived from the PROXMOX_SUBDOMAIN var (pve.<apex>),
+# never hardcoded. Matches the `llm` ingress entry in terraform-proxmox locals.tf.
+open_webui_hostname: "llm.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
+open_webui_url: "https://{{ open_webui_hostname }}"
+
+# Stable secret key for JWT/data encryption — generate once (openssl rand -hex 32),
+# store in Doppler/SOPS. Must NOT change between runs or sessions invalidate.
+open_webui_secret_key: "{{ lookup('env', 'OPEN_WEBUI_SECRET_KEY') }}"

--- a/roles/open_webui/handlers/main.yml
+++ b/roles/open_webui/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart open-webui
+  ansible.builtin.systemd:
+    name: open-webui
+    state: restarted
+    daemon_reload: true

--- a/roles/open_webui/tasks/main.yml
+++ b/roles/open_webui/tasks/main.yml
@@ -1,0 +1,85 @@
+---
+# Open WebUI native install (uv venv + systemd) in CT 168. Idempotent.
+
+- name: Assert the Open WebUI secret key is provided
+  ansible.builtin.assert:
+    that:
+      - open_webui_secret_key | length >= 32
+    fail_msg: >-
+      OPEN_WEBUI_SECRET_KEY is unset/too short. Generate once with
+      `openssl rand -hex 32` and store it in Doppler (iac-conf-mgmt/prd) or SOPS.
+    quiet: true
+  no_log: true
+
+- name: Create the open-webui system user
+  ansible.builtin.user:
+    name: "{{ open_webui_user }}"
+    home: "{{ open_webui_home }}"
+    system: true
+    shell: /usr/sbin/nologin
+    create_home: true
+
+- name: Install uv (Python venv/package manager)
+  ansible.builtin.shell:
+    cmd: "set -o pipefail && curl -LsSf {{ open_webui_uv_install_url }} | env UV_INSTALL_DIR=/usr/local/bin sh"
+    creates: /usr/local/bin/uv
+  args:
+    executable: /bin/bash
+
+- name: Create the persistent data directory
+  ansible.builtin.file:
+    path: "{{ open_webui_data_dir }}"
+    state: directory
+    owner: "{{ open_webui_user }}"
+    group: "{{ open_webui_user }}"
+    mode: "0750"
+
+- name: Create the Open WebUI virtualenv
+  ansible.builtin.command:
+    cmd: "uv venv --python {{ open_webui_python }} {{ open_webui_venv }}"
+    creates: "{{ open_webui_venv }}/bin/python"
+  become: true
+  become_user: "{{ open_webui_user }}"
+
+- name: Install/upgrade Open WebUI into the venv
+  ansible.builtin.command:
+    cmd: "uv pip install --python {{ open_webui_venv }}/bin/python --upgrade open-webui"
+  become: true
+  become_user: "{{ open_webui_user }}"
+  register: open_webui_pip
+  changed_when: "'Installed' in open_webui_pip.stdout or 'Prepared' in open_webui_pip.stdout"
+
+- name: Deploy the Open WebUI environment file
+  ansible.builtin.template:
+    src: open-webui.env.j2
+    dest: /etc/open-webui.env
+    owner: root
+    group: "{{ open_webui_user }}"
+    mode: "0640"
+  no_log: true
+  notify: Restart open-webui
+
+- name: Deploy the Open WebUI systemd unit
+  ansible.builtin.template:
+    src: open-webui.service.j2
+    dest: /etc/systemd/system/open-webui.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart open-webui
+
+- name: Enable and start Open WebUI
+  ansible.builtin.systemd:
+    name: open-webui
+    state: started
+    enabled: true
+    daemon_reload: true
+
+- name: Verify Open WebUI is healthy
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ open_webui_port }}/health"
+    status_code: 200
+  register: open_webui_health
+  retries: 30
+  delay: 5
+  until: open_webui_health.status == 200

--- a/roles/open_webui/templates/open-webui.env.j2
+++ b/roles/open_webui/templates/open-webui.env.j2
@@ -1,0 +1,13 @@
+{{ ansible_managed | comment }}
+# Open WebUI runtime config. Reverse-proxy-correct values are REQUIRED behind
+# Traefik HTTPS (sessions/websockets break without them) — per Open WebUI docs.
+DATA_DIR={{ open_webui_data_dir }}
+OLLAMA_BASE_URL={{ open_webui_ollama_base_url }}
+WEBUI_URL={{ open_webui_url }}
+WEBUI_SECRET_KEY={{ open_webui_secret_key }}
+CORS_ALLOW_ORIGIN={{ open_webui_url }}
+WEBUI_SESSION_COOKIE_SECURE=true
+WEBUI_AUTH_COOKIE_SECURE=true
+WEBUI_SESSION_COOKIE_SAME_SITE=lax
+WEBUI_AUTH_COOKIE_SAME_SITE=lax
+ENABLE_WEBSOCKET_SUPPORT=true

--- a/roles/open_webui/templates/open-webui.service.j2
+++ b/roles/open_webui/templates/open-webui.service.j2
@@ -1,0 +1,17 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Open WebUI (LLM chat front-end)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ open_webui_user }}
+Group={{ open_webui_user }}
+WorkingDirectory={{ open_webui_home }}
+EnvironmentFile=/etc/open-webui.env
+ExecStart={{ open_webui_venv }}/bin/open-webui serve --host {{ open_webui_listen_host }} --port {{ open_webui_port }}
+# Restart policy is managed by the systemd_restart_policy role (99-restart-policy.conf).
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
Two roles for the GPU-served local LLM on pve1 (containers already created by terraform-proxmox; GPU passed through by ansible-proxmox `lxc_gpu_features`).

- **`ollama`** (CT 167, group `ollama_group` ← tag `ollama`): official installer + **AMD ROCm runtime overlay**; adds the `ollama` user to `render`/`video` (to open passed-through `/dev/kfd`+`/dev/dri`); systemd env drop-in (`OLLAMA_HOST`/`MODELS`, `HSA_OVERRIDE_GFX_VERSION=10.3.0` for gfx1030, flash-attention); pulls **Hermes 4 14B** Q4_K_M GGUF → `hermes4`.
- **`open_webui`** (CT 168, group `open_webui_group` ← tag `open-webui`): `uv` venv + systemd; reverse-proxy-correct env required behind Traefik HTTPS (`WEBUI_URL`/`CORS_ALLOW_ORIGIN` from `PROXMOX_SUBDOMAIN`, secure cookies, websockets, stable `WEBUI_SECRET_KEY`); points at Ollama via inventory.

Wired into `load_tofu.yml` + `site.yml`; restart policy via the shared `systemd_restart_policy` role. Ports + IPs come from `tofu_data` (no hardcodes).

## Follow-ups (not in this PR)
- terraform-proxmox PR: `ollama_api` + `open_webui_web` in `pipeline_constants.service_ports`, and the one `llm` `ingress_services` entry.
- Repoint Traefik/Technitium base domain to `PROXMOX_SUBDOMAIN` (separate fix).
- `OPEN_WEBUI_SECRET_KEY` → Doppler/SOPS.

## Test plan
- [x] `ansible-lint` clean (production profile)
- [ ] Live: run `--tags ollama` (CT 167) → `rocminfo` + `hermes4` inference on GPU; run `--tags open_webui` (CT 168) → LAN `/health`; then Traefik → `https://llm.pve.jacobpevans.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)