### PR TITLE
fix(inventory-schema): make port registries extensible

### DIFF
--- a/tests/inventory_load/tofu_inventory.schema.json
+++ b/tests/inventory_load/tofu_inventory.schema.json
@@ -206,7 +206,7 @@
             "apt_cacher_ng": {"type": "integer", "minimum": 1, "maximum": 65535}
           },
           "required": ["haproxy_stats", "splunk_web", "splunk_hec", "splunk_mgmt", "cribl_edge_api", "cribl_stream_api"],
-          "additionalProperties": false
+          "additionalProperties": {"type": "integer", "minimum": 1, "maximum": 65535}
         },
         "syslog_ports": {
           "type": "object",
@@ -218,7 +218,7 @@
             "windows": {"type": "integer", "minimum": 1, "maximum": 65535}
           },
           "required": ["unifi", "palo_alto", "cisco_asa", "linux", "windows"],
-          "additionalProperties": false
+          "additionalProperties": {"type": "integer", "minimum": 1, "maximum": 65535}
         },
         "netflow_ports": {
           "type": "object",
@@ -226,7 +226,7 @@
             "unifi": {"type": "integer", "minimum": 1, "maximum": 65535}
           },
           "required": ["unifi"],
-          "additionalProperties": false
+          "additionalProperties": {"type": "integer", "minimum": 1, "maximum": 65535}
         },
         "notification_ports": {
           "type": "object",
@@ -236,7 +236,7 @@
             "ntfy_http": {"type": "integer", "minimum": 1, "maximum": 65535}
           },
           "required": ["mailpit_smtp", "mailpit_web", "ntfy_http"],
-          "additionalProperties": false
+          "additionalProperties": {"type": "integer", "minimum": 1, "maximum": 65535}
         },
         "vector_db_ports": {
           "type": "object",
@@ -245,7 +245,7 @@
             "qdrant_grpc": {"type": "integer", "minimum": 1, "maximum": 65535}
           },
           "required": ["qdrant_http", "qdrant_grpc"],
-          "additionalProperties": false
+          "additionalProperties": {"type": "integer", "minimum": 1, "maximum": 65535}
         },
         "media_ports": {
           "type": "object",
@@ -258,7 +258,7 @@
             "seerr_web": {"type": "integer", "minimum": 1, "maximum": 65535}
           },
           "required": ["qbittorrent_web", "prowlarr_web"],
-          "additionalProperties": false
+          "additionalProperties": {"type": "integer", "minimum": 1, "maximum": 65535}
         }
       }
     }


### PR DESCRIPTION
## What
The `constants.*_ports` registries are a growing map, but the schema pinned them with `additionalProperties:false` + a fixed enum — so the tofu inventory-sync gate broke as soon as new ports landed (`ollama_api`/`open_webui_web` from the LLM ingress, plus ~15 others already present: `pihole_web`, `technitium_web`, `minio_*`, `idrac_kvm_*`, …).

## Fix
Relax `additionalProperties` from `false` to `{type: integer, 1..65535}` on all six port registries (service/syslog/netflow/notification/vector_db/media), keeping each registry's `required` core ports. The live `ansible_inventory` output now passes validation.

Unblocks the inventory sync after the homelab VLAN-segmentation apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)