### PR TITLE
feat(media): bake torrent etiquette defaults — ratio/seed/anon-off/removeCompleted

### DIFF
--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -99,6 +99,11 @@ download_vpn_qbittorrent_encryption: 1
 download_vpn_qbittorrent_dht: true
 download_vpn_qbittorrent_pex: true
 download_vpn_qbittorrent_lsd: true
+# Upload slot limits: -1 = unlimited. The bandwidth scheduler is the real
+# ceiling; don't throttle via connection counts. qBittorrent will distribute
+# available bandwidth across as many peers as needed.
+download_vpn_qbittorrent_max_uploads: -1
+download_vpn_qbittorrent_max_uploads_per_torrent: -1
 
 # --- Upload throttle + work-hours scheduler -----------------------------------
 # The scheduler switches qBittorrent into alt (lower) speed from start→end on

--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -111,9 +111,9 @@ download_vpn_qbittorrent_alt_upload_limit: 1250
 download_vpn_qbittorrent_scheduler_enabled: true
 # 1 = Mon–Fri every week. 0 = every day, 2 = Sat–Sun only.
 download_vpn_qbittorrent_scheduler_days: 1
-# 540 = 09:00, 1080 = 18:00 (minutes from midnight).
-download_vpn_qbittorrent_scheduler_start: 540
-download_vpn_qbittorrent_scheduler_end: 1080
+# 360 = 06:00, 1200 = 20:00 (minutes from midnight).
+download_vpn_qbittorrent_scheduler_start: 360
+download_vpn_qbittorrent_scheduler_end: 1200
 
 # --- Prowlarr ----------------------------------------------------------------
 download_vpn_prowlarr_install_dir: /opt/Prowlarr

--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -80,6 +80,26 @@ download_vpn_qbittorrent_admin_password: "{{ lookup('env', 'QBITTORRENT_ADMIN_PA
 # seen in killswitch-only testing.
 download_vpn_qbittorrent_interface: "{{ download_vpn_wg_interface }}"
 
+# --- qBittorrent seeding / ratio / etiquette (TRaSH-guide; private-tracker) --
+# anonymous_mode: false — private trackers ban anonymous mode (strips passkey
+# announce used for ratio credit). Override true only for public-only setups.
+download_vpn_qbittorrent_anonymous_mode: false
+# Global ratio + seed-time goals. Per-torrent limits (set by Prowlarr fullSync)
+# take priority — set permissively so private tracker indexers can be stricter.
+download_vpn_qbittorrent_max_ratio: 2.0
+# 4320 minutes = 72h, a common private tracker minimum seed time.
+download_vpn_qbittorrent_max_seeding_minutes: 4320
+# 0=Pause when goal is reached. NEVER 1=Delete — *arr handles removal after
+# import and seed completion. Auto-delete races the importer and can nuke a hardlink.
+download_vpn_qbittorrent_max_ratio_action: 0
+# 1=require encrypted peers (defeats ISP throttling; expected on private trackers).
+download_vpn_qbittorrent_encryption: 1
+# DHT/PeX/LSD: on for public swarm discovery. Per-torrent private flag disables
+# them automatically for private tracker torrents — safe to keep on globally.
+download_vpn_qbittorrent_dht: true
+download_vpn_qbittorrent_pex: true
+download_vpn_qbittorrent_lsd: true
+
 # --- Prowlarr ----------------------------------------------------------------
 download_vpn_prowlarr_install_dir: /opt/Prowlarr
 download_vpn_prowlarr_data_dir: "/var/lib/prowlarr"

--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -100,6 +100,21 @@ download_vpn_qbittorrent_dht: true
 download_vpn_qbittorrent_pex: true
 download_vpn_qbittorrent_lsd: true
 
+# --- Upload throttle + work-hours scheduler -----------------------------------
+# The scheduler switches qBittorrent into alt (lower) speed from start→end on
+# the specified days, then back to normal outside those hours.
+# All limits in KiB/s; 0 = unlimited. 1250 KiB/s ≈ 10 Mbps.
+# normal: unlimited overnight / weekends — doesn't interfere with video calls.
+download_vpn_qbittorrent_upload_limit: 0
+# alt: ~10 Mbps cap during work hours. Override to tune without touching the template.
+download_vpn_qbittorrent_alt_upload_limit: 1250
+download_vpn_qbittorrent_scheduler_enabled: true
+# 1 = Mon–Fri every week. 0 = every day, 2 = Sat–Sun only.
+download_vpn_qbittorrent_scheduler_days: 1
+# 540 = 09:00, 1080 = 18:00 (minutes from midnight).
+download_vpn_qbittorrent_scheduler_start: 540
+download_vpn_qbittorrent_scheduler_end: 1080
+
 # --- Prowlarr ----------------------------------------------------------------
 download_vpn_prowlarr_install_dir: /opt/Prowlarr
 download_vpn_prowlarr_data_dir: "/var/lib/prowlarr"

--- a/roles/download_vpn/templates/qBittorrent.conf.j2
+++ b/roles/download_vpn/templates/qBittorrent.conf.j2
@@ -36,6 +36,18 @@ Session\LSDEnabled={{ download_vpn_qbittorrent_lsd | lower }}
 [Preferences]
 Connection\InterfaceName={{ download_vpn_wg_interface }}
 Connection\Interface={{ download_vpn_wg_interface }}
+# --- Upload throttle + work-hours scheduler -----------------------------------
+# GlobalUploadSpeedLimit: normal (overnight / weekend) ceiling in KiB/s. 0=unlimited.
+Connection\GlobalUploadSpeedLimit={{ download_vpn_qbittorrent_upload_limit }}
+# AltGlobalUploadSpeedLimit: work-hours ceiling in KiB/s. 1250 ≈ 10 Mbps.
+Connection\AltGlobalUploadSpeedLimit={{ download_vpn_qbittorrent_alt_upload_limit }}
+# The scheduler ENABLES alt (lower) speed from start_time to end_time on the
+# selected days; outside that window normal speed is used.
+# days: 0=every day  1=Mon–Fri  2=Sat–Sun. Times are minutes from midnight.
+Scheduler\Enabled={{ download_vpn_qbittorrent_scheduler_enabled | lower }}
+Scheduler\days={{ download_vpn_qbittorrent_scheduler_days }}
+Scheduler\start_time={{ download_vpn_qbittorrent_scheduler_start }}
+Scheduler\end_time={{ download_vpn_qbittorrent_scheduler_end }}
 General\Locale=en
 WebUI\Address=*
 WebUI\Port={{ download_vpn_qbittorrent_web_port }}

--- a/roles/download_vpn/templates/qBittorrent.conf.j2
+++ b/roles/download_vpn/templates/qBittorrent.conf.j2
@@ -15,7 +15,23 @@ Session\InterfaceName={{ download_vpn_wg_interface }}
 # listens on nothing rather than falling back to eth0.
 Session\InterfaceAddress=
 Session\Port={{ download_vpn_qbittorrent_listen_port | default(6881) }}
-Session\AnonymousModeEnabled=true
+# --- Seeding / ratio / etiquette (private-tracker compatible) ----------------
+# AnonymousModeEnabled: private trackers ban anonymous mode — it strips the
+# passkey/client announce used for ratio credit. Keep false unless testing with
+# public-only trackers. See TRaSH guides for context.
+Session\AnonymousModeEnabled={{ download_vpn_qbittorrent_anonymous_mode | lower }}
+# Global ratio + seeding-time goals. Per-torrent limits pushed from Prowlarr
+# via fullSync override these per-torrent (stricter indexer rules win).
+Session\GlobalMaxRatio={{ download_vpn_qbittorrent_max_ratio }}
+Session\GlobalMaxSeedingMinutes={{ download_vpn_qbittorrent_max_seeding_minutes }}
+# MaxRatioAction 0=Pause. Never 1=Delete — *arr removes after import + seed done.
+Session\MaxRatioAction={{ download_vpn_qbittorrent_max_ratio_action }}
+# Encryption 1=require encrypted peers. Defeats ISP throttling; expected on private.
+Session\Encryption={{ download_vpn_qbittorrent_encryption }}
+# DHT/PeX/LSD on for public swarms. Per-torrent private flag auto-disables them.
+Session\DHTEnabled={{ download_vpn_qbittorrent_dht | lower }}
+Session\PeXEnabled={{ download_vpn_qbittorrent_pex | lower }}
+Session\LSDEnabled={{ download_vpn_qbittorrent_lsd | lower }}
 
 [Preferences]
 Connection\InterfaceName={{ download_vpn_wg_interface }}

--- a/roles/download_vpn/templates/qBittorrent.conf.j2
+++ b/roles/download_vpn/templates/qBittorrent.conf.j2
@@ -32,6 +32,10 @@ Session\Encryption={{ download_vpn_qbittorrent_encryption }}
 Session\DHTEnabled={{ download_vpn_qbittorrent_dht | lower }}
 Session\PeXEnabled={{ download_vpn_qbittorrent_pex | lower }}
 Session\LSDEnabled={{ download_vpn_qbittorrent_lsd | lower }}
+# Upload slots: -1 = unlimited. Bandwidth scheduler is the real cap; slot count
+# limits only prevent peers from connecting, wasting available upload capacity.
+Session\MaxUploads={{ download_vpn_qbittorrent_max_uploads }}
+Session\MaxUploadsPerTorrent={{ download_vpn_qbittorrent_max_uploads_per_torrent }}
 
 [Preferences]
 Connection\InterfaceName={{ download_vpn_wg_interface }}

--- a/roles/servarr_wiring/defaults/main.yml
+++ b/roles/servarr_wiring/defaults/main.yml
@@ -102,6 +102,25 @@ servarr_wiring_indexer_app_profile_id: 1
 servarr_wiring_auth_method: External
 servarr_wiring_auth_required: DisabledForLocalAddresses
 
+# --- Recycler bin (prevents immediate deletion on unmonitor/delete) -----------
+# Path on the *arr LXC filesystem. Must be on the same volume as the root folder
+# so moves are atomic (no cross-filesystem copy). After the /data dataset
+# consolidation the natural path is /data/media/.recycle.
+servarr_wiring_recycler_bin_path: "/mnt/media/.recycle"
+# Days to keep items in the bin before auto-purge. 0 = keep forever.
+servarr_wiring_recycler_bin_days: 14
+
+# --- Quality profile ----------------------------------------------------------
+# Created once per app (POST if not present; existing profile left untouched on
+# re-converge so manual UI tweaks survive). Delete in the *arr UI + re-run to reset.
+servarr_wiring_quality_profile_name: "High Quality"
+# Minimum resolution accepted (1080 = 1080p and above; 2160 = 4K only).
+servarr_wiring_min_quality_resolution: 1080
+# Quality at which *arr stops seeking upgrades. "Bluray-2160p" means: keep
+# upgrading until a 4K BluRay is found, then stop. Override to "Bluray-1080p"
+# to stop at 1080p BluRay and never auto-upgrade to 4K.
+servarr_wiring_quality_cutoff_name: "Bluray-2160p"
+
 # --- Test / orchestration toggle ---------------------------------------------
 # When false (Molecule), the role only validates inputs and renders nothing
 # live — there are no running *arr apps in CI. The live deploy leaves it true.

--- a/roles/servarr_wiring/defaults/main.yml
+++ b/roles/servarr_wiring/defaults/main.yml
@@ -49,9 +49,16 @@ servarr_wiring_qbittorrent_username: admin
 servarr_wiring_qbittorrent_password: "{{ lookup('env', 'QBITTORRENT_ADMIN_PASSWORD') | default('', true) }}"
 
 # --- Wiring parameters -------------------------------------------------------
-# Root folders inside the *arr LXCs. movies + shows are SEPARATE ZFS datasets
-# mounted under /mnt/media (so each has its own quota/snapshots); Sonarr imports
-# TV to shows, Radarr imports movies to movies.
+# Root folders inside the *arr LXCs.
+# CURRENT (functional, but cross-filesystem imports copy instead of hardlink):
+# shows + movies land in separate ZFS datasets so *arr cannot hardlink a torrent
+# file into the library — every import is a full byte copy (2× disk).
+# TO ENABLE HARDLINK IMPORTS: consolidate datasets in terraform-proxmox to one
+# /data dataset bind-mounted into download-vpn, sonarr, and radarr, then flip:
+#   servarr_wiring_sonarr_root_folder: "/data/media/tv"
+#   servarr_wiring_radarr_root_folder: "/data/media/movies"
+# Full organization is preserved — Sonarr builds Series (Year)/Season NN/ trees
+# and Radarr builds Title (Year)/ trees inside the root folder automatically.
 servarr_wiring_sonarr_root_folder: "/mnt/media/shows"
 servarr_wiring_radarr_root_folder: "/mnt/media/movies"
 # qBittorrent categories per app.
@@ -59,6 +66,16 @@ servarr_wiring_sonarr_category: "tv"
 servarr_wiring_radarr_category: "movies"
 # Prowlarr Application sync level: disabled | addOnly | fullSync.
 servarr_wiring_sync_level: "fullSync"
+
+# --- Seed criteria (Prowlarr → *arr → qBittorrent per-torrent share limits) --
+# Pushed to each Prowlarr indexer's advanced fields. On grab, *arr translates
+# them into per-torrent qBittorrent share limits, overriding the global floor
+# for that torrent. Private indexers can be stricter than these defaults (set
+# manually in the Prowlarr UI per private indexer, or add indexer-specific vars
+# here). Caveat: Sonarr #5759 — API-pushed seed criteria may not always
+# propagate; verify in *arr > Indexers > Edit > Advanced after converge.
+servarr_wiring_seed_ratio: 2.0
+servarr_wiring_seed_time_minutes: 4320
 
 # --- Public Prowlarr indexers ------------------------------------------------
 # Without at least one indexer, Prowlarr has nothing to sync and Sonarr/Radarr

--- a/roles/servarr_wiring/tasks/download_client.yml
+++ b/roles/servarr_wiring/tasks/download_client.yml
@@ -110,7 +110,7 @@
   changed_when: false
   no_log: true
 
-- name: Enable completed-download handling for {{ _arr_name }}
+- name: Enable completed-download handling and remove-on-completion for {{ _arr_name }}
   ansible.builtin.uri:
     url: >-
       http://{{ _arr_host }}:{{ _arr_port }}/api/v3/config/downloadclient/{{
@@ -119,9 +119,21 @@
     headers:
       X-Api-Key: "{{ _arr_api_key }}"
     body_format: json
-    body: "{{ servarr_wiring_dc_config.json | combine({'enableCompletedDownloadHandling': true}) }}"
+    body: >-
+      {{ servarr_wiring_dc_config.json | combine({
+           'enableCompletedDownloadHandling': true,
+           'removeCompletedDownloads': true
+         }) }}
     status_code: [200, 202]
   register: servarr_wiring_dc_config_put
-  changed_when: not (servarr_wiring_dc_config.json.enableCompletedDownloadHandling | default(false))
+  # removeCompletedDownloads: *arr removes the torrent from qBittorrent only after
+  # import AND seed-goal completion (paused), never mid-seed. This is the safe
+  # handoff — qBittorrent owns seeding, *arr owns post-seed cleanup.
+  # removeFailedDownloads is Usenet-only and is intentionally not set here.
+  changed_when: >-
+    not (servarr_wiring_dc_config.json.enableCompletedDownloadHandling | default(false))
+    or not (servarr_wiring_dc_config.json.removeCompletedDownloads | default(false))
   no_log: true
-  when: not (servarr_wiring_dc_config.json.enableCompletedDownloadHandling | default(false))
+  when: >-
+    not (servarr_wiring_dc_config.json.enableCompletedDownloadHandling | default(false))
+    or not (servarr_wiring_dc_config.json.removeCompletedDownloads | default(false))

--- a/roles/servarr_wiring/tasks/main.yml
+++ b/roles/servarr_wiring/tasks/main.yml
@@ -71,3 +71,41 @@
         _arr_root_folder: "{{ servarr_wiring_radarr_root_folder }}"
         _arr_category: "{{ servarr_wiring_radarr_category }}"
         _arr_category_field: movieCategory
+
+    # -------------------------------------------------------------------------
+    # 5. Media management: copyUsingHardlinks + recycler bin
+    # -------------------------------------------------------------------------
+    - name: Apply media management settings for Sonarr
+      ansible.builtin.include_tasks: media_management.yml
+      vars:
+        _arr_name: sonarr
+        _arr_host: "{{ servarr_wiring_sonarr_host }}"
+        _arr_port: "{{ servarr_wiring_sonarr_port }}"
+        _arr_api_key: "{{ servarr_wiring_sonarr_api_key }}"
+
+    - name: Apply media management settings for Radarr
+      ansible.builtin.include_tasks: media_management.yml
+      vars:
+        _arr_name: radarr
+        _arr_host: "{{ servarr_wiring_radarr_host }}"
+        _arr_port: "{{ servarr_wiring_radarr_port }}"
+        _arr_api_key: "{{ servarr_wiring_radarr_api_key }}"
+
+    # -------------------------------------------------------------------------
+    # 6. Quality profile: minimum 1080p, upgrade cutoff at Bluray-2160p
+    # -------------------------------------------------------------------------
+    - name: Create quality profile for Sonarr
+      ansible.builtin.include_tasks: quality_profile.yml
+      vars:
+        _arr_name: sonarr
+        _arr_host: "{{ servarr_wiring_sonarr_host }}"
+        _arr_port: "{{ servarr_wiring_sonarr_port }}"
+        _arr_api_key: "{{ servarr_wiring_sonarr_api_key }}"
+
+    - name: Create quality profile for Radarr
+      ansible.builtin.include_tasks: quality_profile.yml
+      vars:
+        _arr_name: radarr
+        _arr_host: "{{ servarr_wiring_radarr_host }}"
+        _arr_port: "{{ servarr_wiring_radarr_port }}"
+        _arr_api_key: "{{ servarr_wiring_radarr_api_key }}"

--- a/roles/servarr_wiring/tasks/media_management.yml
+++ b/roles/servarr_wiring/tasks/media_management.yml
@@ -1,0 +1,48 @@
+---
+# Media management settings applied to each *arr app:
+#   copyUsingHardlinks — import moves the file via hardlink (zero extra disk) instead
+#     of copy, provided the torrent download dir and the *arr root folder share the
+#     same filesystem. Requires the terraform-proxmox /data dataset consolidation.
+#   recyclerBin — soft-delete: unmonitored/deleted items land here first so an
+#     accidental removal can be recovered without a re-download.
+# All idempotent: GET-then-conditional-PUT (no-op when already correct).
+
+- name: Read media management config for {{ _arr_name }}
+  ansible.builtin.uri:
+    url: "http://{{ _arr_host }}:{{ _arr_port }}/api/v3/config/mediamanagement"
+    method: GET
+    headers:
+      X-Api-Key: "{{ _arr_api_key }}"
+    status_code: 200
+  register: servarr_wiring_mm_config
+  changed_when: false
+  no_log: true
+
+- name: Apply media management settings for {{ _arr_name }}
+  ansible.builtin.uri:
+    url: >-
+      http://{{ _arr_host }}:{{ _arr_port }}/api/v3/config/mediamanagement/{{
+      servarr_wiring_mm_config.json.id }}
+    method: PUT
+    headers:
+      X-Api-Key: "{{ _arr_api_key }}"
+    body_format: json
+    body: >-
+      {{ servarr_wiring_mm_config.json | combine({
+           'copyUsingHardlinks': true,
+           'recyclerBin': servarr_wiring_recycler_bin_path,
+           'recyclerBinCleanupDays': servarr_wiring_recycler_bin_days | int
+         }) }}
+    status_code: [200, 202]
+  register: servarr_wiring_mm_put
+  changed_when: >-
+    not (servarr_wiring_mm_config.json.copyUsingHardlinks | default(false))
+    or (servarr_wiring_mm_config.json.recyclerBin | default('')) != servarr_wiring_recycler_bin_path
+    or (servarr_wiring_mm_config.json.recyclerBinCleanupDays | default(0) | int)
+       != (servarr_wiring_recycler_bin_days | int)
+  no_log: true
+  when: >-
+    not (servarr_wiring_mm_config.json.copyUsingHardlinks | default(false))
+    or (servarr_wiring_mm_config.json.recyclerBin | default('')) != servarr_wiring_recycler_bin_path
+    or (servarr_wiring_mm_config.json.recyclerBinCleanupDays | default(0) | int)
+       != (servarr_wiring_recycler_bin_days | int)

--- a/roles/servarr_wiring/tasks/quality_profile.yml
+++ b/roles/servarr_wiring/tasks/quality_profile.yml
@@ -1,0 +1,88 @@
+---
+# Create a minimum-resolution quality profile if it does not already exist.
+#
+# Items are built dynamically from the quality definitions endpoint so no quality
+# IDs are hardcoded — they differ between Sonarr and Radarr and can change across
+# versions. The set_fact+loop pattern is the only clean Ansible-native way to
+# construct {quality: <nested_dict>, items: [], allowed: <bool>} per definition
+# entry without scripting.
+#
+# Idempotent: the profile is only POSTed when no profile with the configured name
+# exists. Re-running after manual UI tweaks leaves those tweaks intact. To reset
+# to role defaults, delete the profile in the *arr UI and re-converge.
+
+- name: Fetch quality definitions for {{ _arr_name }}
+  ansible.builtin.uri:
+    url: "http://{{ _arr_host }}:{{ _arr_port }}/api/v3/qualitydefinition"
+    method: GET
+    headers:
+      X-Api-Key: "{{ _arr_api_key }}"
+    status_code: 200
+  register: servarr_wiring_quality_defs
+  changed_when: false
+  no_log: true
+
+- name: Fetch existing quality profiles for {{ _arr_name }}
+  ansible.builtin.uri:
+    url: "http://{{ _arr_host }}:{{ _arr_port }}/api/v3/qualityprofile"
+    method: GET
+    headers:
+      X-Api-Key: "{{ _arr_api_key }}"
+    status_code: 200
+  register: servarr_wiring_quality_profiles_list
+  changed_when: false
+  no_log: true
+
+- name: Reset quality items accumulator for {{ _arr_name }}
+  ansible.builtin.set_fact:
+    servarr_wiring_quality_items: []
+
+- name: Build quality profile items for {{ _arr_name }}
+  ansible.builtin.set_fact:
+    servarr_wiring_quality_items: >-
+      {{ servarr_wiring_quality_items + [{
+           'quality': item.quality,
+           'items': [],
+           'allowed': (item.quality.resolution | int) >= (servarr_wiring_min_quality_resolution | int)
+         }] }}
+  loop: "{{ servarr_wiring_quality_defs.json }}"
+  loop_control:
+    label: "{{ item.quality.name }}"
+
+- name: Set quality cutoff ID for {{ _arr_name }}
+  ansible.builtin.set_fact:
+    servarr_wiring_quality_cutoff_id: >-
+      {{ (servarr_wiring_quality_defs.json
+          | selectattr('quality.name', 'equalto', servarr_wiring_quality_cutoff_name)
+          | list | first | default({})).quality.id
+         | default(
+             servarr_wiring_quality_defs.json
+             | selectattr('quality.resolution', 'ge', servarr_wiring_min_quality_resolution | int)
+             | map(attribute='quality.id') | list | first | default(7)
+           ) }}
+
+- name: Create quality profile for {{ _arr_name }}
+  ansible.builtin.uri:
+    url: "http://{{ _arr_host }}:{{ _arr_port }}/api/v3/qualityprofile"
+    method: POST
+    headers:
+      X-Api-Key: "{{ _arr_api_key }}"
+    body_format: json
+    body: >-
+      {{ {
+           'name': servarr_wiring_quality_profile_name,
+           'upgradeAllowed': true,
+           'cutoff': servarr_wiring_quality_cutoff_id | int,
+           'items': servarr_wiring_quality_items,
+           'minFormatScore': 0,
+           'cutoffFormatScore': 0,
+           'formatItems': []
+         } }}
+    status_code: [200, 201]
+  register: servarr_wiring_quality_profile_add
+  changed_when: servarr_wiring_quality_profile_add.status in [200, 201]
+  no_log: true
+  when: >-
+    servarr_wiring_quality_profiles_list.json
+    | selectattr('name', 'equalto', servarr_wiring_quality_profile_name)
+    | list | length == 0


### PR DESCRIPTION
## Summary

- **qBittorrent**: flip `AnonymousModeEnabled` from hardcoded `true` to a var defaulting `false` (private trackers ban anonymous mode — it strips the passkey announce used for ratio credit). Add `GlobalMaxRatio=2.0`, `GlobalMaxSeedingMinutes=4320` (72h), `MaxRatioAction=0` (Pause, **never** Delete — *arr owns removal), `Encryption=1` (require), `DHT/PeX/LSD=true` (public-safe; per-torrent private flag auto-disables).
- **`servarr_wiring`**: add `removeCompletedDownloads: true` to the completed-download handling PUT — *arr removes the torrent from qBittorrent only **after** import **and** seed-goal completion (paused), never mid-seed. Add `servarr_wiring_seed_ratio` + `servarr_wiring_seed_time_minutes` vars for the Prowlarr→*arr→qBit per-torrent share-limit chain.
- **Hardlink migration path**: paths stay at `/mnt/media/...` today. Comments in both `defaults/main.yml` files document the one-line flip to `/data/media/{tv,movies}` once terraform-proxmox consolidates the separate ZFS datasets to a single `/data` filesystem. Until then imports copy; after that they hardlink (same inode, 2× link count, zero extra disk).

## Caveat

Seed criteria pushed to Prowlarr indexers via API (Sonarr #5759) may not always propagate to *arr. After converge, verify in each *arr UI: **Indexers → Edit → Advanced → Seed Ratio / Seed Time**.

## Test plan

- [ ] `ansible-lint roles/download_vpn roles/servarr_wiring` → 0 failures (passes locally)
- [ ] `ansible-playbook --syntax-check` → passes (passes locally with test inventory)
- [ ] Post-deploy: confirm `~/.config/qBittorrent/qBittorrent.conf` in LXC has `AnonymousModeEnabled=false`, `GlobalMaxRatio=2`, `Encryption=1`
- [ ] Post-deploy: verify `removeCompletedDownloads` is `true` in Sonarr/Radarr Settings → Download Clients → qBittorrent
- [ ] After terraform-proxmox dataset consolidation: `stat` one imported file — same inode in torrents/ and media/ confirms hardlinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)