### PR TITLE
refactor(inventory-schema): thin to required-keys + types, allow extension

### DIFF
--- a/tests/inventory_load/tofu_inventory.schema.json
+++ b/tests/inventory_load/tofu_inventory.schema.json
@@ -4,7 +4,7 @@
   "description": "Schema for the tofu_inventory.json output consumed by ansible-proxmox-apps",
   "type": "object",
   "required": ["containers", "vms", "docker_vms", "splunk_vm", "constants", "ingress", "host_services", "nodes", "node_storage", "domain"],
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "containers": {
       "type": "object",
@@ -65,7 +65,7 @@
       "items": {
         "type": "object",
         "required": ["name", "ip", "port"],
-        "additionalProperties": false,
+        "additionalProperties": true,
         "properties": {
           "name": { "type": "string", "minLength": 1 },
           "ip": { "type": "string", "pattern": "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$" },
@@ -87,7 +87,7 @@
     "container_entry": {
       "type": "object",
       "required": ["vmid", "ip", "hostname", "ansible_connection", "tags", "node", "ansible_pct_vmid"],
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "vmid": {
           "type": "integer",
@@ -128,7 +128,7 @@
     "vm_entry": {
       "type": "object",
       "required": ["vmid", "ip", "hostname", "ansible_connection", "tags", "node"],
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "vmid": {
           "type": "integer",
@@ -165,7 +165,7 @@
     "splunk_entry": {
       "type": "object",
       "required": ["vmid", "ip", "hostname", "ansible_connection", "node"],
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "vmid": {
           "type": "integer",
@@ -192,7 +192,7 @@
     "constants": {
       "type": "object",
       "required": ["service_ports", "syslog_ports", "netflow_ports", "notification_ports", "vector_db_ports", "media_ports"],
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "service_ports": {
           "type": "object",


### PR DESCRIPTION
## Why
The inventory schema is a bespoke tofu→ansible contract (no off-the-shelf schema fits). Its real job is to **reject a partial/broken inventory** before it clobbers the downstream repos. But it was over-strict — every object used `additionalProperties: false` + a hand-maintained field enum, so any new container field / ingress key / top-level output / port broke the sync (twice tonight).

## What
Flip the six object-level `additionalProperties` from `false`→`true` (top-level, container/vm/splunk entries, ingress items, constants). The `required` lists and per-field **types** stay — that **is** the completeness guard.

## Verified
- Live `ansible_inventory` output passes.
- A partial inventory (missing a required key) still **fails** (guard intact).
- New fields/services/ports can no longer break the sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)