### PR TITLE
refactor(ollama): register Hermes 4 from local GGUF instead of HF pull

### DIFF
--- a/roles/ollama/README.md
+++ b/roles/ollama/README.md
@@ -23,7 +23,8 @@ Ordering: `terraform-proxmox` (LXC shell) → `ansible-proxmox` (GPU passthrough
   service can open `/dev/kfd` + `/dev/dri`.
 - Writes a systemd env drop-in (`OLLAMA_HOST`, `OLLAMA_MODELS`,
   `HSA_OVERRIDE_GFX_VERSION=10.3.0` for gfx1030, flash-attention, keep-alive).
-- Pulls **Hermes 4 14B** Q4_K_M GGUF from HuggingFace and aliases it to `hermes4`.
+- Stages the **Hermes 4 14B** Q4_K_M GGUF as a local file (downloads from
+  HuggingFace only when absent) and registers it as `hermes4` via `ollama create`.
 - Restart-on-failure is applied by the shared `systemd_restart_policy` role via
   `group_vars/ollama_group.yml`.
 
@@ -35,7 +36,9 @@ Ordering: `terraform-proxmox` (LXC shell) → `ansible-proxmox` (GPU passthrough
 | `ollama_models_dir` | `/var/lib/ollama` | Model store (120 GB local-zfs vol) |
 | `ollama_hsa_override_gfx_version` | `10.3.0` | RX 6800 / Navi 21 / gfx1030 |
 | `ollama_model_name` | `hermes4` | Local alias |
-| `ollama_model_source` | `hf.co/bartowski/NousResearch_Hermes-4-14B-GGUF:Q4_K_M` | GGUF source |
+| `ollama_gguf_filename` | `NousResearch_Hermes-4-14B-Q4_K_M.gguf` | Staged GGUF blob |
+| `ollama_import_dir` | `{{ ollama_models_dir }}/import` | GGUF staging dir (persistent vol) |
+| `ollama_gguf_url` | bartowski HF `resolve/main/<file>` | Download source (only if absent) |
 
 ## Usage
 

--- a/roles/ollama/defaults/main.yml
+++ b/roles/ollama/defaults/main.yml
@@ -33,7 +33,17 @@ ollama_gpu_groups:
   - { name: render, gid: 104 }
   - { name: video, gid: 44 }
 
-# Model: Hermes 4 14B (Qwen3 base) Q4_K_M GGUF, pulled directly from HF and
-# aliased to `hermes4`. Ollama pulls GGUF from HuggingFace via the hf.co/ ref.
+# Model: Hermes 4 14B (Qwen3 base) Q4_K_M GGUF, aliased to `hermes4`.
+# The GGUF is staged as a local file (one ~8.4 GB blob) and registered via
+# `ollama create` against a Modelfile whose FROM points at that file — this
+# avoids re-pulling 8+ GB from HuggingFace on every converge and survives a
+# container rebuild as long as the import dir is on the persistent volume.
 ollama_model_name: hermes4
-ollama_model_source: "hf.co/bartowski/NousResearch_Hermes-4-14B-GGUF:Q4_K_M"
+
+# Staging dir for the raw GGUF (on the 120 GB persistent volume, beside the
+# active model store). get_url downloads here only when the file is absent.
+ollama_import_dir: "{{ ollama_models_dir }}/import"
+ollama_gguf_filename: "NousResearch_Hermes-4-14B-Q4_K_M.gguf"
+ollama_gguf_path: "{{ ollama_import_dir }}/{{ ollama_gguf_filename }}"
+ollama_gguf_repo_url: "https://huggingface.co/bartowski/NousResearch_Hermes-4-14B-GGUF/resolve/main"
+ollama_gguf_url: "{{ ollama_gguf_repo_url }}/{{ ollama_gguf_filename }}"

--- a/roles/ollama/tasks/main.yml
+++ b/roles/ollama/tasks/main.yml
@@ -35,13 +35,16 @@
     append: true
   notify: Restart ollama
 
-- name: Create the models directory
+- name: Create the models + GGUF import directories
   ansible.builtin.file:
-    path: "{{ ollama_models_dir }}"
+    path: "{{ item }}"
     state: directory
     owner: "{{ ollama_user }}"
     group: "{{ ollama_user }}"
     mode: "0750"
+  loop:
+    - "{{ ollama_models_dir }}"
+    - "{{ ollama_import_dir }}"
 
 - name: Deploy Ollama systemd environment drop-in
   ansible.builtin.template:
@@ -72,13 +75,20 @@
   delay: 3
   until: ollama_model_list.rc == 0
 
-- name: Pull + alias Hermes 4 14B  # ~9 GB; only when absent
+- name: Register Hermes 4 14B from the local GGUF  # ~8.4 GB; only when absent
   when: ollama_model_name not in ollama_model_list.stdout
   block:
-    - name: Pull the Hermes 4 14B GGUF from HuggingFace
-      ansible.builtin.command:
-        cmd: "ollama pull {{ ollama_model_source }}"
-      changed_when: true
+    - name: Stage the Hermes 4 14B GGUF (download only if absent)
+      ansible.builtin.get_url:
+        url: "{{ ollama_gguf_url }}"
+        dest: "{{ ollama_gguf_path }}"
+        owner: "{{ ollama_user }}"
+        group: "{{ ollama_user }}"
+        mode: "0640"
+      register: ollama_gguf_download
+      until: ollama_gguf_download is succeeded
+      retries: 3
+      delay: 10
 
     - name: Render the Modelfile (alias + params)
       ansible.builtin.template:
@@ -88,7 +98,7 @@
         group: "{{ ollama_user }}"
         mode: "0640"
 
-    - name: "Create the Ollama model {{ ollama_model_name }}"
+    - name: "Create the local-GGUF Ollama model {{ ollama_model_name }}"
       ansible.builtin.command:
         cmd: "ollama create {{ ollama_model_name }} -f {{ ollama_models_dir }}/Modelfile.{{ ollama_model_name }}"
       changed_when: true

--- a/roles/ollama/templates/Modelfile.j2
+++ b/roles/ollama/templates/Modelfile.j2
@@ -2,7 +2,7 @@
 # Hermes 4 14B (Qwen3 base). The bartowski GGUF embeds the ChatML chat template,
 # tool-calling, and <think> reasoning in its metadata, so no TEMPLATE override is
 # needed here — overriding it would risk breaking tool-calling.
-FROM {{ ollama_model_source }}
+FROM {{ ollama_gguf_path }}
 
 # Context window — bounded to fit the RX 6800's 16 GB alongside the Q4 weights.
 PARAMETER num_ctx 8192


### PR DESCRIPTION
## What

Switches the `ollama` role from `ollama pull hf.co/...` to registering Hermes 4 14B from a **local GGUF file** staged on the container's persistent volume.

## Why

The 8.4 GB Q4_K_M GGUF is already downloaded on CT 167 (`/var/lib/ollama/import/`). Re-pulling 8+ GB from HuggingFace on every Ansible converge is slow and wasteful. Staging the blob once and registering it via `ollama create` against a Modelfile whose `FROM` points at the local file makes converges fast and idempotent, and survives a container rebuild as long as the volume persists.

## Changes

- `defaults/main.yml`: replace `ollama_model_source` (hf.co ref) with `ollama_import_dir` / `ollama_gguf_filename` / `ollama_gguf_path` / `ollama_gguf_url` (bartowski `resolve/main` source, used only when the file is absent).
- `tasks/main.yml`: create the import dir; replace the `ollama pull` step with an idempotent `get_url` (download-if-absent, retried) followed by `ollama create` from the local Modelfile.
- `templates/Modelfile.j2`: `FROM {{ ollama_gguf_path }}` (was the hf.co ref).
- `README.md`: updated behaviour bullet + variable table.

## Verification

- `ansible-lint roles/ollama/` passes at the **production** profile (0 failures).
- On CT 167 the GGUF already exists, so `get_url` is a no-op and `ollama create` registers `hermes4` from the staged file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)