### PR TITLE
fix(ollama): install curl/ca-certificates/zstd before Ollama install

### DIFF
--- a/roles/ollama/README.md
+++ b/roles/ollama/README.md
@@ -17,6 +17,8 @@ Ordering: `terraform-proxmox` (LXC shell) → `ansible-proxmox` (GPU passthrough
 
 ## What it does
 
+- Installs `curl`, `ca-certificates`, `zstd` (a minimal LXC template lacks them;
+  the install pipe + ROCm tarball overlay both require them).
 - Installs Ollama via the official script (creates the `ollama` user + systemd unit).
 - Overlays the **ROCm runtime** tarball (the installer ships CPU/NVIDIA libs only).
 - Creates `render`/`video` groups at the host GIDs and adds `ollama` to them so the

--- a/roles/ollama/tasks/main.yml
+++ b/roles/ollama/tasks/main.yml
@@ -3,6 +3,18 @@
 # Prereqs (upstream): ansible-proxmox lxc_gpu_features has bound /dev/kfd +
 # /dev/dri into this CT. We only need the ollama user to be able to use them.
 
+# A minimal LXC template ships without curl/zstd; the install.sh pipe and the
+# ROCm tarball overlay (curl | tar --use-compress-program=unzstd) both need them.
+- name: Install Ollama install/overlay prerequisites
+  ansible.builtin.apt:
+    name:
+      - curl
+      - ca-certificates
+      - zstd
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
 - name: Install Ollama (creates the ollama user + systemd unit)
   ansible.builtin.shell:
     cmd: "set -o pipefail && curl -fsSL {{ ollama_install_url }} | sh"


### PR DESCRIPTION
## What

Adds an apt prerequisite step to the `ollama` role that installs `curl`, `ca-certificates`, and `zstd` before the Ollama install + ROCm overlay.

## Why

On a fresh/minimal LXC template these binaries are absent. A live converge against CT 167 (`hermes-infer`) failed:

```
TASK [ollama : Install Ollama (creates the ollama user + systemd unit)]
fatal: [hermes-infer]: FAILED! => rc=127, "curl: command not found"
```

Both install steps depend on them:
- `curl -fsSL https://ollama.com/install.sh | sh`
- `curl -fsSL <rocm tarball> | tar -x --use-compress-program=unzstd -C /usr` (zstd → `unzstd`)

## Verification

- `ansible-lint roles/ollama/` passes at the **production** profile (0 failures).
- Re-run of the `ollama` play against CT 167 will be performed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)