### PR TITLE
fix(ollama): join GPU device-owning groups by runtime stat, not fixed GIDs

### DIFF
--- a/roles/ollama/README.md
+++ b/roles/ollama/README.md
@@ -21,8 +21,9 @@ Ordering: `terraform-proxmox` (LXC shell) → `ansible-proxmox` (GPU passthrough
   the install pipe + ROCm tarball overlay both require them).
 - Installs Ollama via the official script (creates the `ollama` user + systemd unit).
 - Overlays the **ROCm runtime** tarball (the installer ships CPU/NVIDIA libs only).
-- Creates `render`/`video` groups at the host GIDs and adds `ollama` to them so the
-  service can open `/dev/kfd` + `/dev/dri`.
+- Adds `ollama` to whatever groups own the passed-in GPU device nodes (resolved at
+  runtime via `stat`), so the service can open `/dev/kfd` + `/dev/dri` regardless of
+  how the host GIDs map to container group names.
 - Writes a systemd env drop-in (`OLLAMA_HOST`, `OLLAMA_MODELS`,
   `HSA_OVERRIDE_GFX_VERSION=10.3.0` for gfx1030, flash-attention, keep-alive).
 - Stages the **Hermes 4 14B** Q4_K_M GGUF as a local file (downloads from

--- a/roles/ollama/defaults/main.yml
+++ b/roles/ollama/defaults/main.yml
@@ -27,11 +27,13 @@ ollama_flash_attention: "1"
 ollama_keep_alive: "30m"
 ollama_num_parallel: "1"
 
-# GPU device groups the ollama user must join to open /dev/kfd + /dev/dri.
-# GIDs match the host (privileged CT): render=104, video=44 (verified live).
-ollama_gpu_groups:
-  - { name: render, gid: 104 }
-  - { name: video, gid: 44 }
+# GPU device nodes passed into the container by ansible-proxmox lxc_gpu_features.
+# The role stats these at runtime and adds the ollama user to whatever groups own
+# them, so device access works regardless of how host GIDs map to container groups.
+ollama_gpu_device_nodes:
+  - /dev/kfd
+  - /dev/dri/card0
+  - /dev/dri/renderD128
 
 # Model: Hermes 4 14B (Qwen3 base) Q4_K_M GGUF, aliased to `hermes4`.
 # The GGUF is staged as a local file (one ~8.4 GB blob) and registered via

--- a/roles/ollama/tasks/main.yml
+++ b/roles/ollama/tasks/main.yml
@@ -31,19 +31,31 @@
     executable: /bin/bash
   notify: Restart ollama
 
-- name: Ensure GPU device groups exist with the host GIDs
-  ansible.builtin.group:
-    name: "{{ item.name }}"
-    gid: "{{ item.gid }}"
-    state: present
-  loop: "{{ ollama_gpu_groups }}"
-  loop_control:
-    label: "{{ item.name }} ({{ item.gid }})"
+# ansible-proxmox (lxc_gpu_features) binds the device nodes in with the HOST's
+# group GIDs (e.g. render=104, video=44). Those rarely match the container's own
+# render/video groups (here render=992), and the host GID may already be owned by
+# an unrelated container group (here 104=postdrop). So instead of forcing group
+# GIDs — which collides — add the ollama user to whatever groups actually own the
+# device nodes, resolved at runtime from the files themselves.
+- name: Stat the GPU device nodes to learn their owning groups
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  loop: "{{ ollama_gpu_device_nodes }}"
+  register: ollama_gpu_dev_stat
 
-- name: Add the ollama user to the GPU device groups
+- name: Assert the GPU device nodes are present (passed in by lxc_gpu_features)
+  ansible.builtin.assert:
+    that:
+      - ollama_gpu_dev_stat.results | rejectattr('stat.exists') | list | length == 0
+    fail_msg: >-
+      One or more GPU device nodes are missing in this container
+      ({{ ollama_gpu_device_nodes | join(', ') }}). Run ansible-proxmox
+      lxc_gpu_features against this CT first.
+
+- name: Add the ollama user to the GPU device-owning groups
   ansible.builtin.user:
     name: "{{ ollama_user }}"
-    groups: "{{ ollama_gpu_groups | map(attribute='name') | list }}"
+    groups: "{{ ollama_gpu_dev_stat.results | map(attribute='stat.gr_name') | list | unique }}"
     append: true
   notify: Restart ollama
 


### PR DESCRIPTION
## What

Replaces the brittle "create container groups `render`=104 / `video`=44" step with a runtime `stat` of the GPU device nodes, then adds the `ollama` user to whatever groups actually own them.

## Why

A live converge on CT 167 (`hermes-infer`) failed:

```
TASK [ollama : Ensure GPU device groups exist with the host GIDs]
fatal: [hermes-infer] (item=render (104)) => "groupmod: GID '104' already exists"
```

On CT 167 the passed-in device nodes are owned by host GIDs that don't line up with the container's groups:

| Node | GID | Container group |
| --- | --- | --- |
| `/dev/dri/card0` | 44 | `video` |
| `/dev/kfd`, `/dev/dri/renderD128` | 104 | `postdrop` (unrelated) |

The container's own `render` group is GID 992, and GID 104 is already taken by `postdrop`, so forcing `render`=104 collides. Membership is GID-based in Linux DAC, so the fix is simply to put `ollama` in whatever group owns each node.

## Change

- `tasks/main.yml`: `stat` the device nodes → assert present → add `ollama` to `stat.gr_name | unique`.
- `defaults/main.yml`: `ollama_gpu_groups` (name/gid) → `ollama_gpu_device_nodes` (paths).
- `README.md`: behaviour bullet updated.

## Verification

- `ansible-lint roles/ollama/` passes at the **production** profile (0 failures).
- Re-run against CT 167 after merge; confirm `id ollama` includes the device GIDs and `ollama list` registers `hermes4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)