### PR TITLE
fix(ollama): create systemd drop-in dir before env override

### DIFF
--- a/roles/ollama/tasks/main.yml
+++ b/roles/ollama/tasks/main.yml
@@ -70,6 +70,16 @@
     - "{{ ollama_models_dir }}"
     - "{{ ollama_import_dir }}"
 
+# The Ollama installer ships ollama.service but not a drop-in dir; create it
+# so the environment override below has somewhere to land.
+- name: Ensure the Ollama systemd drop-in directory exists
+  ansible.builtin.file:
+    path: /etc/systemd/system/ollama.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
 - name: Deploy Ollama systemd environment drop-in
   ansible.builtin.template:
     src: ollama-env.conf.j2


### PR DESCRIPTION
## What
Adds a `file: state=directory` step creating `/etc/systemd/system/ollama.service.d` before the env-override template.

## Why
The official Ollama installer creates `ollama.service` but not its `.d` drop-in directory. A live converge on CT 167 failed:

```
TASK [ollama : Deploy Ollama systemd environment drop-in]
fatal: [hermes-infer]: "Destination directory /etc/systemd/system/ollama.service.d does not exist"
```

## Verification
- `ansible-lint roles/ollama/` passes at the **production** profile.
- Re-run against CT 167 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)