### PR TITLE
feat(traefik): support HTTPS backends with self-signed certs

### DIFF
--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -84,8 +84,10 @@
 
 # Build the routers from the single tofu-owned ingress table
 # (tofu_data.ingress via traefik_ingress_routes): a list of {name, ip, port}
-# with the backend IP already resolved by tofu (cidrhost). The template just
-# needs name/fqdn/backend, so it stays dumb (and fixture-testable).
+# with the backend IP already resolved by tofu (cidrhost). Items may carry an
+# optional scheme (default http) and insecure_tls (default false) for backends
+# that serve HTTPS with a self-signed cert (e.g. Splunk Web). The template just
+# needs name/fqdn/backend/insecure_tls, so it stays dumb (and fixture-testable).
 - name: Build Traefik routers from the inventory ingress table
   ansible.builtin.set_fact:
     traefik_routes: >-
@@ -93,7 +95,8 @@
         traefik_routes | default([]) + [{
           'name': item.name,
           'fqdn': item.name ~ '.' ~ traefik_base_domain,
-          'backend': 'http://' ~ item.ip ~ ':' ~ item.port
+          'backend': (item.scheme | default('http')) ~ '://' ~ item.ip ~ ':' ~ item.port,
+          'insecure_tls': item.insecure_tls | default(false)
         }]
       }}
   loop: "{{ traefik_ingress_routes }}"

--- a/roles/traefik/templates/dynamic.yml.j2
+++ b/roles/traefik/templates/dynamic.yml.j2
@@ -40,7 +40,19 @@ http:
         passHostHeader: true
         servers:
           - url: "{{ route.backend }}"
+{% if route.insecure_tls | default(false) %}
+        serversTransport: insecure-backend
+{% endif %}
 {% endfor %}
+{% if traefik_routes | selectattr('insecure_tls', 'defined') | selectattr('insecure_tls') | list | length > 0 %}
+
+  serversTransports:
+    # Backends serving HTTPS with a self-signed cert (e.g. Splunk Web). Traefik
+    # terminates the public wildcard cert and re-encrypts to the backend; the
+    # backend cert is not chain-verifiable, so skip verification for these only.
+    insecure-backend:
+      insecureSkipVerify: true
+{% endif %}
 {% if traefik_dashboard_enabled %}
 
   middlewares:

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1049,6 +1049,8 @@
     traefik_routes:
       - { name: plex, fqdn: "plex.pve.example.com", backend: "http://192.0.2.10:32400" }
       - { name: seerr, fqdn: "seerr.pve.example.com", backend: "http://192.0.2.11:5055" }
+      # HTTPS backend with a self-signed cert (e.g. Splunk Web) -> insecure_tls.
+      - { name: splunk, fqdn: "splunk.pve.example.com", backend: "https://192.0.2.12:8000", insecure_tls: true }
     _template_dir: "../../roles/traefik/templates"
 
   tasks:
@@ -1118,6 +1120,21 @@
         fail_msg: >-
           dynamic.yml.j2 missing a router/service, the wildcard SAN, or the
           usersFile-secured dashboard.
+
+    - name: Assert HTTPS backend gets an https URL + insecure-backend serversTransport
+      ansible.builtin.assert:
+        that:
+          # The https backend keeps its scheme through to the service URL.
+          - _traefik_dynamic_yaml.http.services.splunk.loadBalancer.servers[0].url == "https://192.0.2.12:8000"
+          # Only the insecure_tls route references the shared transport...
+          - _traefik_dynamic_yaml.http.services.splunk.loadBalancer.serversTransport == "insecure-backend"
+          - "'serversTransport' not in _traefik_dynamic_yaml.http.services.plex.loadBalancer"
+          # ...and that transport skips verification of the self-signed cert.
+          - _traefik_dynamic_yaml.http.serversTransports['insecure-backend'].insecureSkipVerify | bool
+        fail_msg: >-
+          dynamic.yml.j2 did not honor scheme/insecure_tls: the https backend
+          lost its scheme, the serversTransport was missing or leaked onto an
+          http service, or insecureSkipVerify was not set.
 
     - name: Render traefik ACME EnvironmentFile to /tmp
       ansible.builtin.template:


### PR DESCRIPTION
## Why

The Traefik ingress route builder hardcoded `http://` for every backend (`roles/traefik/tasks/main.yml`). A backend that serves **HTTPS** — Splunk Web, with a self-signed cert — would 502 behind Traefik.

## What

- Honor an optional per-route `scheme` (default `http`) and `insecure_tls` (default `false`) from the tofu ingress table.
- Build the backend URL with the given scheme.
- When `insecure_tls` is set, attach a shared `insecure-backend` `serversTransport` (`insecureSkipVerify: true`) so Traefik terminates the public wildcard cert and re-encrypts to the self-signed backend without failing verification.

## Compatibility

Absent keys render **byte-identical** to before (verified — existing fixture assertions unchanged). Adds a template-render assertion covering the https/insecure path.

## Validation

`ansible-playbook tests/template_render/verify_templates.yml` passes (`ok=110, failed=0`).

Refs: dryvist/terraform-proxmox (splunk ingress `scheme=https`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)