### PR TITLE
fix(open_webui): install curl/ca-certificates before uv installer

### DIFF
--- a/roles/open_webui/README.md
+++ b/roles/open_webui/README.md
@@ -16,7 +16,8 @@ Requires `OPEN_WEBUI_SECRET_KEY` in Doppler/SOPS (generate once: `openssl rand -
 
 ## What it does
 
-- Creates an `open-webui` system user and installs **uv**.
+- Creates an `open-webui` system user, installs `curl`/`ca-certificates` (a
+  minimal LXC template lacks them and the uv installer needs curl), then **uv**.
 - Installs Open WebUI into a venv (`/opt/open-webui/venv`) and runs it via a
   dedicated systemd unit (`open-webui serve`), data in `DATA_DIR=/var/lib/open-webui`.
 - Renders `/etc/open-webui.env` with the **reverse-proxy-correct** settings Open

--- a/roles/open_webui/tasks/main.yml
+++ b/roles/open_webui/tasks/main.yml
@@ -19,6 +19,17 @@
     shell: /usr/sbin/nologin
     create_home: true
 
+# A minimal LXC template ships without curl; the uv installer is fetched via
+# `curl | sh`, so install it (plus CA certs for the TLS fetch) first.
+- name: Install uv installer prerequisites
+  ansible.builtin.apt:
+    name:
+      - curl
+      - ca-certificates
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
 - name: Install uv (Python venv/package manager)
   ansible.builtin.shell:
     cmd: "set -o pipefail && curl -LsSf {{ open_webui_uv_install_url }} | env UV_INSTALL_DIR=/usr/local/bin sh"


### PR DESCRIPTION
## What
Adds an apt prerequisite step (`curl`, `ca-certificates`) to the `open_webui` role before the uv installer.

## Why
Live converge on CT 168 (`hermes-chat`) failed:

```
TASK [open_webui : Install uv (Python venv/package manager)]
fatal: [hermes-chat]: rc=127, "curl: command not found"
```

Mirrors the same prerequisite fix already merged for the `ollama` role (#331).

## Verification
- `ansible-lint roles/open_webui/` passes at the **production** profile.
- Re-run against CT 168 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)