### PR TITLE
fix(open_webui): install sudo for become_user privilege drop

### DIFF
--- a/roles/open_webui/README.md
+++ b/roles/open_webui/README.md
@@ -16,8 +16,9 @@ Requires `OPEN_WEBUI_SECRET_KEY` in Doppler/SOPS (generate once: `openssl rand -
 
 ## What it does
 
-- Creates an `open-webui` system user, installs `curl`/`ca-certificates` (a
-  minimal LXC template lacks them and the uv installer needs curl), then **uv**.
+- Creates an `open-webui` system user, installs `curl`/`ca-certificates`/`sudo`
+  (a minimal LXC template lacks them — curl for the uv installer, sudo for the
+  `become_user` privilege drop), then **uv**.
 - Installs Open WebUI into a venv (`/opt/open-webui/venv`) and runs it via a
   dedicated systemd unit (`open-webui serve`), data in `DATA_DIR=/var/lib/open-webui`.
 - Renders `/etc/open-webui.env` with the **reverse-proxy-correct** settings Open

--- a/roles/open_webui/tasks/main.yml
+++ b/roles/open_webui/tasks/main.yml
@@ -19,13 +19,15 @@
     shell: /usr/sbin/nologin
     create_home: true
 
-# A minimal LXC template ships without curl; the uv installer is fetched via
-# `curl | sh`, so install it (plus CA certs for the TLS fetch) first.
-- name: Install uv installer prerequisites
+# A minimal LXC template ships without curl or sudo: the uv installer is fetched
+# via `curl | sh`, and the venv/pip tasks below drop to the open-webui user with
+# become_user, which uses sudo (the default become_method). Install both first.
+- name: Install role prerequisites (uv installer + privilege drop)
   ansible.builtin.apt:
     name:
       - curl
       - ca-certificates
+      - sudo
     state: present
     update_cache: true
     cache_valid_time: 3600


### PR DESCRIPTION
## What
Adds `sudo` to the `open_webui` role's apt prerequisites.

## Why
The venv/pip tasks use `become_user: open-webui`, which Ansible performs via `sudo` (default `become_method`). The minimal LXC template lacks sudo, so a live converge on CT 168 failed:

```
TASK [open_webui : Create the Open WebUI virtualenv]
fatal: [hermes-chat]: "/bin/sh: 1: sudo: not found"
```

`sudo` handles `-u <nologin-user>` correctly (unlike `su`), so it's the right tool for the privilege drop.

## Verification
- `ansible-lint roles/open_webui/` passes at the **production** profile.
- Re-run against CT 168 after merge → venv + Open WebUI install + `/health` 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)