### PR TITLE
fix(technitium_dns): authenticate per node for HA secondaries

### DIFF
--- a/molecule/technitium_dns/molecule.yml
+++ b/molecule/technitium_dns/molecule.yml
@@ -67,6 +67,7 @@ provisioner:
     PROXMOX_SUBDOMAIN: "${PROXMOX_SUBDOMAIN:-svc.example.net}"
     PROXMOX_VE_GATEWAY: "${PROXMOX_VE_GATEWAY:-192.168.5.1}"
     TECHNITIUM_DNS_API_TOKEN: "${TECHNITIUM_DNS_API_TOKEN:-moleculetesttoken}"
+    TECHNITIUM_DNS_ADMIN_PASSWORD: "${TECHNITIUM_DNS_ADMIN_PASSWORD:-moleculetestpass}"
 
 verifier:
   name: ansible

--- a/roles/technitium_dns/defaults/main.yml
+++ b/roles/technitium_dns/defaults/main.yml
@@ -4,7 +4,13 @@
 # Technitium API endpoint (internal DNS server)
 technitium_dns_api_url: "http://{{ technitium_dns_host }}:5380"
 
-# API token from SOPS secrets (not in Doppler)
+# Per-host API auth. Technitium tokens are PER-INSTANCE, so one shared token only
+# authenticates the node that minted it — it cannot configure the HA secondaries.
+# The config role logs into EACH node's API with the shared admin password (set
+# identically on every member by technitium_install) to obtain that node's own
+# session token at runtime (see tasks/main.yml), which overrides the default below.
+technitium_dns_admin_user: admin
+technitium_dns_admin_password: "{{ lookup('env', 'TECHNITIUM_DNS_ADMIN_PASSWORD') }}"
 technitium_dns_api_token: "{{ lookup('env', 'TECHNITIUM_DNS_API_TOKEN') }}"
 
 # Authoritative zone = the homelab SUBDOMAIN only (a child zone). Technitium is

--- a/roles/technitium_dns/tasks/main.yml
+++ b/roles/technitium_dns/tasks/main.yml
@@ -5,15 +5,42 @@
 - name: Validate required variables
   ansible.builtin.assert:
     that:
-      - technitium_dns_api_token | length > 0
+      - technitium_dns_admin_password | length > 0
       - technitium_dns_zone | length > 0
       - technitium_dns_host is defined
     fail_msg: >-
-      Required variables not set. Check: (1) TECHNITIUM_DNS_API_TOKEN must be in Doppler
-      (add via: doppler secrets set TECHNITIUM_DNS_API_TOKEN='your-token-here' -p iac-conf-mgmt -c prd);
+      Required variables not set. Check: (1) TECHNITIUM_DNS_ADMIN_PASSWORD must be in Doppler
+      (add via: doppler secrets set TECHNITIUM_DNS_ADMIN_PASSWORD='<password>' -p iac-conf-mgmt -c prd);
       (2) PROXMOX_SUBDOMAIN is available via Doppler; (3) technitium_dns_host must be set in
       the play vars.
     quiet: true
+
+# Technitium API tokens are PER-INSTANCE — one shared token only authenticates the
+# node that minted it, so the HA secondaries could not be configured. Log into THIS
+# node's API with the shared admin password (technitium_install sets it identically
+# on every member) to obtain this node's OWN session token, and use it for every
+# API call below. Skipped under technitium_dns_apply=false (molecule/CI, no live API).
+- name: Authenticate to this node's Technitium API (per-host session token)
+  ansible.builtin.uri:
+    url: "{{ technitium_dns_api_url }}/api/user/login"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      user: "{{ technitium_dns_admin_user }}"
+      pass: "{{ technitium_dns_admin_password }}"
+    return_content: true
+    timeout: "{{ technitium_dns_api_timeout }}"
+  register: technitium_dns_login
+  changed_when: false
+  failed_when: technitium_dns_login.json.status | default('') != "ok"
+  when: technitium_dns_apply | bool
+  no_log: true
+
+- name: Use this node's session token for subsequent API calls
+  ansible.builtin.set_fact:
+    technitium_dns_api_token: "{{ technitium_dns_login.json.token }}"
+  when: technitium_dns_apply | bool
+  no_log: true
 
 - name: Build A records from inventory
   # Iterate over groups['all'] explicitly. Iterating `hostvars | dict2items`


### PR DESCRIPTION
## Why

The HA topology logic (PR #319) sets up primary/secondary correctly, but the config role authenticates **every** node with one shared `TECHNITIUM_DNS_API_TOKEN` against a per-host API URL. Technitium tokens are **per-instance** — that token only works on the node that minted it, so the secondaries' API calls (create Secondary zone, set forwarders) would fail auth. HA could never actually converge.

## What

- Log into **each** node's API with the shared admin password (`TECHNITIUM_DNS_ADMIN_PASSWORD`, set identically on every member by `technitium_install`) to obtain that node's **own** session token, then use it for all subsequent API calls.
- Skipped under `technitium_dns_apply=false` (molecule/CI — no live API). Single-node logs into itself → behavior unchanged.
- Assert now requires `TECHNITIUM_DNS_ADMIN_PASSWORD`; molecule gets a dummy fallback like the existing token.

## Validation

ansible-lint + the `technitium_dns` molecule scenario (exercises primary + secondary fact resolution; login is gated off in CI). This unblocks the terraform-proxmox 3-node Technitium HA build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)