### PR TITLE
feat(openbao): add OpenBao secrets-manager role (Raft node 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,12 @@ secrets.dec.yaml
 .vault-pass*
 .vault-password*
 
+# OpenBao break-glass material (recovery shares, root token, AppRole creds).
+# Written 0600 on the controller under playbook_dir by the openbao role's
+# init.yml; transcribe to paper / load into Doppler, then securely delete.
+.openbao-recovery-*.json
+.openbao-approle-*.json
+
 # IDE
 .vscode/
 .idea/

--- a/inventory/load_tofu.yml
+++ b/inventory/load_tofu.yml
@@ -149,6 +149,11 @@
               else []
             ) +
             (
+              ['openbao_group']
+              if 'openbao' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
               ['technitium_dns_group']
               if 'dns' in (item.value.tags | default([]))
               else []

--- a/molecule/openbao/converge.yml
+++ b/molecule/openbao/converge.yml
@@ -1,0 +1,27 @@
+---
+# Molecule converge playbook — runs the openbao role against the test container.
+# Under Docker, the systemd start, health-wait, and bootstrap phases are skipped
+# by the role's `ansible_virtualization_type != 'docker'` guards, so converge
+# exercises install + user/dir creation + config templating only.
+
+- name: Converge
+  hosts: all
+  become: true
+  gather_facts: true
+
+  vars:
+    # Normally derived from container_ip (Terraform inventory). Supply a stub so
+    # the listener/api_addr render in the container test.
+    container_ip: "192.168.20.210"
+    # KMS + unseal creds are injected from Doppler/SOPS at runtime; stub them so
+    # the config + env templates render. The service never starts under Docker,
+    # so these are inert placeholders.
+    openbao_kms_key_id: "arn:aws:kms:us-east-1:000000000000:key/00000000-0000-0000-0000-000000000000"
+    openbao_kms_region: "us-east-1"
+    openbao_unseal_aws_access_key_id: "AKIAEXAMPLEEXAMPLE00"
+    openbao_unseal_aws_secret_access_key: "examplesecretexamplesecretexamplesecret0"
+
+  tasks:
+    - name: Include openbao role
+      ansible.builtin.include_role:
+        name: openbao

--- a/molecule/openbao/molecule.yml
+++ b/molecule/openbao/molecule.yml
@@ -1,0 +1,53 @@
+---
+# Molecule scenario for the openbao role.
+# CI-only gate: local runs are known-broken in this repo (see AGENTS.md /
+# project memory). Do not run locally.
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: openbao-test
+    # No stable version tags published; geerlingguy only ships :latest.
+    image: geerlingguy/docker-debian12-ansible:latest
+    privileged: true
+    command: ""
+    pre_build_image: true
+    tmpfs:
+      - /run
+      - /run/lock
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    groups:
+      - openbao_group
+      - lxc_containers
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
+
+verifier:
+  name: ansible
+
+scenario:
+  name: openbao
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - cleanup
+    - destroy

--- a/molecule/openbao/prepare.yml
+++ b/molecule/openbao/prepare.yml
@@ -1,0 +1,32 @@
+---
+# Molecule preparation playbook — set up the test container before the role.
+
+- name: Prepare
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Wait for container to be ready
+      ansible.builtin.wait_for_connection:
+        timeout: 30
+
+    - name: Gather facts
+      ansible.builtin.setup:
+
+    - name: Update apt cache (Debian/Ubuntu)
+      ansible.builtin.apt:
+        update_cache: true
+      register: _apt_update_result
+      until: _apt_update_result is succeeded
+      retries: 3
+      delay: 10
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Install base packages for the openbao role
+      ansible.builtin.apt:
+        name:
+          - ca-certificates
+          - jq
+        state: present
+      when: ansible_facts['os_family'] == 'Debian'

--- a/molecule/openbao/verify.yml
+++ b/molecule/openbao/verify.yml
@@ -1,0 +1,98 @@
+---
+# Molecule verification playbook — validates install + config without a live
+# OpenBao (the service does not start under Docker).
+
+- name: Verify
+  hosts: all
+  become: true
+  gather_facts: true
+
+  vars:
+    openbao_user: openbao
+    openbao_data_dir: /opt/openbao/data
+    openbao_config_dir: /etc/openbao
+    openbao_config_file: /etc/openbao/openbao.hcl
+    openbao_env_file: /etc/openbao/openbao.env
+
+  tasks:
+    - name: Check the bao binary is installed
+      ansible.builtin.stat:
+        path: /usr/bin/bao
+      register: bao_bin
+
+    - name: Assert the bao binary exists
+      ansible.builtin.assert:
+        that:
+          - bao_bin.stat.exists
+        fail_msg: "bao binary not found at /usr/bin/bao"
+
+    - name: Check the openbao system user exists
+      ansible.builtin.command:
+        cmd: "id {{ openbao_user }}"
+      register: bao_user
+      changed_when: false
+      failed_when: bao_user.rc != 0
+
+    - name: Check the data directory exists with 0700
+      ansible.builtin.stat:
+        path: "{{ openbao_data_dir }}"
+      register: bao_data
+
+    - name: Assert the data directory is 0700 and owned by openbao
+      ansible.builtin.assert:
+        that:
+          - bao_data.stat.exists
+          - bao_data.stat.isdir
+          - bao_data.stat.mode == '0700'
+          - bao_data.stat.pw_name == openbao_user
+        fail_msg: "Data dir missing or wrong perms/owner: {{ bao_data.stat | default({}) }}"
+
+    - name: Check the rendered config exists
+      ansible.builtin.stat:
+        path: "{{ openbao_config_file }}"
+      register: bao_cfg
+
+    - name: Assert the config exists
+      ansible.builtin.assert:
+        that:
+          - bao_cfg.stat.exists
+        fail_msg: "openbao.hcl was not rendered"
+
+    - name: Read the rendered config
+      ansible.builtin.slurp:
+        src: "{{ openbao_config_file }}"
+      register: bao_cfg_content
+
+    - name: Assert the config has the expected stanzas
+      ansible.builtin.assert:
+        that:
+          - "'storage \"raft\"' in (bao_cfg_content.content | b64decode)"
+          - "'seal \"awskms\"' in (bao_cfg_content.content | b64decode)"
+          - "'listener \"tcp\"' in (bao_cfg_content.content | b64decode)"
+          # Listener must bind the VLAN IP, never 0.0.0.0.
+          - "'0.0.0.0' not in (bao_cfg_content.content | b64decode)"
+          - "'192.168.20.210:8200' in (bao_cfg_content.content | b64decode)"
+        fail_msg: "openbao.hcl missing expected stanzas or bound to 0.0.0.0"
+
+    - name: Check the env file exists with 0600
+      ansible.builtin.stat:
+        path: "{{ openbao_env_file }}"
+      register: bao_env
+
+    - name: Assert the env file is 0600
+      ansible.builtin.assert:
+        that:
+          - bao_env.stat.exists
+          - bao_env.stat.mode == '0600'
+        fail_msg: "openbao.env missing or not 0600 ({{ bao_env.stat.mode | default('absent') }})"
+
+    - name: Check the systemd unit was installed
+      ansible.builtin.stat:
+        path: /etc/systemd/system/openbao.service
+      register: bao_unit
+
+    - name: Assert the systemd unit exists
+      ansible.builtin.assert:
+        that:
+          - bao_unit.stat.exists
+        fail_msg: "openbao.service unit not installed"

--- a/roles/openbao/README.md
+++ b/roles/openbao/README.md
@@ -1,0 +1,183 @@
+# openbao
+
+Installs and bootstraps [OpenBao](https://openbao.org/) — a native single Go
+binary on Debian (no Docker). Storage is integrated **Raft**; the master key is
+sealed/unsealed automatically via **AWS KMS**. After the service is live the
+role enables a KV v2 mount, writes a Terraform policy, and creates a Terraform
+AppRole.
+
+This node is **Raft node 1 of a planned 3-node cluster**. Additional nodes join
+later via `bao operator raft join <api_addr of node 1>`; this role establishes
+the leader and the bootstrap state the other nodes replicate.
+
+## Apply order (important)
+
+This role brings OpenBao live **before** anything that reads secrets from it.
+In particular, the `terraform-proxmox` `vault-secrets` unit (which authenticates
+with the Terraform AppRole created here) cannot run until this role has
+initialized OpenBao and the operator has loaded `VAULT_ROLE_ID` /
+`VAULT_SECRET_ID` into the tier-0 store. Sequence:
+
+1. `aws-infra` — provision the KMS CMK + scoped unseal IAM user (out of band).
+2. `terraform-proxmox` — provision the OpenBao LXC (VMID/IP/firewall).
+3. **this role** — install + init OpenBao, mint the Terraform AppRole.
+4. Operator — transcribe recovery shares to paper; load AppRole creds into
+   Doppler.
+5. `terraform-proxmox` `vault-secrets` — now able to authenticate.
+
+## Installation
+
+The role lives in this repository under `roles/openbao/`. Reference it from a
+playbook in the `roles:` block — no Galaxy install needed:
+
+```yaml
+- hosts: openbao_group
+  become: true
+  roles:
+    - role: openbao
+```
+
+Host membership in `openbao_group` is driven by the Terraform-exported
+inventory: an LXC container tagged `openbao` is placed in `openbao_group` by
+`inventory/load_tofu.yml` (add the tag-to-group mapping there alongside the
+existing ones). The node's VLAN IP arrives as the `container_ip` hostvar.
+
+## Usage
+
+Wire the role into a play targeting `openbao_group`, with the KMS key and unseal
+credentials injected from Doppler/SOPS at runtime:
+
+```yaml
+- name: Deploy OpenBao
+  hosts: openbao_group
+  become: true
+  roles:
+    - role: openbao
+```
+
+Run it through the repo's credentialed wrapper so the `OPENBAO_*` env vars are
+present:
+
+```sh
+doppler run -- ansible-playbook playbooks/openbao.yml
+```
+
+On the **first** run the play initializes OpenBao and writes the break-glass
+files to the controller (see below). On every subsequent run it is a no-op:
+install is skipped (version already present) and the bootstrap steps short-
+circuit on their existence checks.
+
+## API
+
+The role is variable-driven; see `defaults/main.yml` for the authoritative list
+and the table above for the common knobs. There are no other entry points — the
+two-file task split (`tasks/main.yml` install/config, `tasks/init.yml`
+bootstrap) is internal. `init.yml` is gated on a non-Docker
+`ansible_virtualization_type` so molecule converge exercises install + templating
+without a live OpenBao.
+
+## How it reads the inventory
+
+- **`openbao_bind_address`** resolves to `container_ip` (LXC) → `ansible_host`
+  (VM) → `ansible_default_ipv4.address`. The listener binds to this VLAN IP,
+  never `0.0.0.0`.
+- **`openbao_node_id`** defaults to `inventory_hostname` (stable Raft id).
+- **`openbao_api_addr` / `openbao_cluster_addr`** are built from the bind
+  address and the API/cluster ports.
+
+## Variables
+
+See `defaults/main.yml` for the authoritative list and inline rationale.
+Highlights:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `openbao_version` | `2.5.4` | Pinned upstream release. Bumps follow the repo pinning/Renovate convention — change it here only, never hardcode elsewhere. |
+| `openbao_user` / `openbao_group` | `openbao` | System account the service runs as. |
+| `openbao_data_dir` | `/opt/openbao/data` | Raft data, `0700`, owned by `openbao`. |
+| `openbao_config_dir` | `/etc/openbao` | Config + env file. |
+| `openbao_api_port` | `8200` | API listener port. |
+| `openbao_cluster_port` | `8201` | Raft cluster port. |
+| `openbao_kv_mount` | `secret` | KV v2 mount path. |
+| `openbao_homelab_path` | `homelab` | Subtree the Terraform policy may read/write. |
+| `openbao_kms_key_id` | env `OPENBAO_KMS_KEY_ID` | CMK for auto-unseal. |
+| `openbao_kms_region` | env `OPENBAO_KMS_REGION` (→ `us-east-1`) | KMS region. |
+| `openbao_unseal_aws_access_key_id` | env | Scoped unseal IAM key (runtime only). |
+| `openbao_unseal_aws_secret_access_key` | env | Scoped unseal IAM secret (runtime only). |
+| `openbao_recovery_shares` / `_threshold` | `5` / `3` | Recovery-key split for `operator init`. |
+| `openbao_enable_mlock` | `true` | mlock secrets out of swap (needs `CAP_IPC_LOCK`). |
+
+AWS unseal credentials and the KMS key id are **never hardcoded or committed**.
+They are injected at runtime from Doppler (`iac-conf-mgmt`) or SOPS into the
+environment, read via `lookup('env', ...)`, and land in the `0600`
+`openbao.env` systemd `EnvironmentFile` (root:openbao).
+
+## Break-glass handling (read this)
+
+With AWS-KMS auto-unseal, `bao operator init` produces **recovery** shares plus
+an initial **root token**. These are the only break-glass path if KMS ever
+becomes unavailable, so they are treated as paper secrets:
+
+- On the run that initializes OpenBao, the role writes the recovery shares +
+  root token to `.openbao-recovery-<host>.json` and the Terraform AppRole
+  `role_id`/`secret_id` to `.openbao-approle-<host>.json`, **both `0600`, on the
+  Ansible controller, under `playbook_dir`**.
+- Every `bao` invocation that touches this material runs with `no_log: true`.
+- The role prints a **loud warning** telling the operator to transcribe the
+  recovery shares to paper (split across custodians, stored offline), load the
+  AppRole creds into Doppler, then **securely delete** both files.
+- Nothing secret is ever written into the repo or onto the target host.
+
+**Gitignore these controller files.** The repo `.gitignore` already excludes
+`.env*` and `*.secrets.yml`; add the break-glass globs if not covered:
+
+```gitignore
+.openbao-recovery-*.json
+.openbao-approle-*.json
+```
+
+After transcription:
+
+```sh
+doppler secrets set VAULT_ADDR=http://<node-vlan-ip>:8200
+doppler secrets set VAULT_ROLE_ID=<role_id>
+doppler secrets set VAULT_SECRET_ID=<secret_id>
+shred -u <playbook_dir>/.openbao-recovery-<host>.json
+shred -u <playbook_dir>/.openbao-approle-<host>.json
+```
+
+## Idempotency
+
+- The `.deb` is checksum-verified against the upstream `checksums-linux.txt`
+  before install; `apt` skips a re-install when the version is already present.
+- `tasks/init.yml` parses `bao status -format=json` and **only initializes when
+  `initialized == false`**. The KV mount, policy, AppRole auth method, and the
+  AppRole itself are each guarded by an existence check, so re-runs are no-ops.
+- AppRole `role_id`/`secret_id` are surfaced **only on the initializing run**,
+  so re-running never silently mints new credentials.
+
+## TLS
+
+`tls_disable = 1` today: TLS terminates at Traefik on the internal VLAN in front
+of OpenBao. End-to-end TLS (listener-native certs, `api_addr` → `https://`) is a
+later hardening step noted inline in `templates/openbao.hcl.j2`.
+
+## Testing
+
+`molecule/openbao/` scaffolds a converge + verify scenario matching the repo
+convention. Molecule is a **CI-only gate** here and is known-broken for local
+runs — do not run it locally. The systemd-dependent tasks (enable/start, health
+wait, and the entire bootstrap phase) are gated on
+`ansible_virtualization_type != 'docker'` so the container converge exercises
+install + templating without needing a live OpenBao.
+
+## Contributing
+
+Pair any change to this role with a `molecule test` run in CI (the local gate is
+known-broken). Update this README and the variable table whenever a variable is
+added, removed, or changes default. Keep the OpenBao version bump flowing through
+`openbao_version` + Renovate — never scatter the version across files.
+
+## License
+
+Apache-2.0 — same as the parent repository.

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -1,0 +1,100 @@
+---
+# OpenBao single-binary secrets manager — role defaults.
+#
+# OpenBao is a native Go binary on Debian; no Docker. This role installs the
+# upstream .deb (checksum-verified), renders a Raft + AWS-KMS-auto-unseal
+# config, runs it under systemd, and (in init.yml) bootstraps the cluster and
+# the Terraform AppRole.
+
+# --- Version ----------------------------------------------------------------
+# Pinned to a known-good upstream release. Version bumps follow the repo's
+# pinning convention (Renovate keeps the .deb/checksums pin fresh; see
+# renovate.json and AGENTS.md "Version management"). Do NOT scatter the
+# version across multiple files — change it here only.
+openbao_version: "2.5.4"
+
+# --- Download (checksum-verified .deb from GitHub releases) ------------------
+# The controller stages the .deb + the release checksums file, verifies the
+# SHA256, then the .deb is installed on the target. This mirrors the minio
+# role's controller-staging pattern so containers in the outbound-internal
+# firewall group (RFC1918-only egress) don't need direct egress to GitHub.
+openbao_release_base_url: "https://github.com/openbao/openbao/releases/download"
+openbao_deb_filename: "openbao_{{ openbao_version }}_linux_amd64.deb"
+openbao_deb_url: >-
+  {{ openbao_release_base_url }}/v{{ openbao_version }}/{{ openbao_deb_filename }}
+# SHA256SUMS-format file ("<digest>  <filename>" per line) for the linux build.
+openbao_checksums_filename: "checksums-linux.txt"
+openbao_checksums_url: >-
+  {{ openbao_release_base_url }}/v{{ openbao_version }}/{{ openbao_checksums_filename }}
+
+# --- System user / group ----------------------------------------------------
+openbao_user: openbao
+openbao_group: openbao
+
+# --- Paths ------------------------------------------------------------------
+openbao_data_dir: /opt/openbao/data
+openbao_config_dir: /etc/openbao
+openbao_config_file: "{{ openbao_config_dir }}/openbao.hcl"
+# EnvironmentFile holding the AWS unseal creds for the systemd unit (0600).
+openbao_env_file: "{{ openbao_config_dir }}/openbao.env"
+# CLI talks to the local node over loopback by default for bootstrap tasks.
+openbao_install_dir: /usr/bin
+
+# --- Listener / cluster ports -----------------------------------------------
+openbao_api_port: 8200
+openbao_cluster_port: 8201
+
+# --- Node identity & addresses ----------------------------------------------
+# Raft node_id: stable per-node identifier. Defaults to the inventory hostname.
+openbao_node_id: "{{ inventory_hostname }}"
+# The node's VLAN IP. LXC hosts expose this as `container_ip` (set by
+# inventory/load_tofu.yml from the Terraform-exported inventory). Fall back to
+# ansible_host (VMs) so the role works on either. The listener binds to THIS
+# address, never 0.0.0.0 — TLS terminates at Traefik on the internal VLAN.
+openbao_bind_address: >-
+  {{ container_ip | default(ansible_host) | default(ansible_default_ipv4.address) }}
+# Advertised addresses other nodes / clients use to reach this node.
+# tls_disable=1 today (Traefik fronts TLS), so api_addr is http://. End-to-end
+# TLS is a later hardening step — see templates/openbao.hcl.j2.
+openbao_api_addr: "http://{{ openbao_bind_address }}:{{ openbao_api_port }}"
+openbao_cluster_addr: "https://{{ openbao_bind_address }}:{{ openbao_cluster_port }}"
+
+# --- Seal: AWS KMS auto-unseal ----------------------------------------------
+# The KMS key + scoped IAM user are provisioned out-of-band (aws-infra repo).
+# The key id and region identify the CMK; the AWS creds below are injected at
+# runtime from Doppler/SOPS (NOT hardcoded, NOT committed) and land in the
+# 0600 EnvironmentFile so only the openbao process and root can read them.
+openbao_kms_key_id: "{{ lookup('env', 'OPENBAO_KMS_KEY_ID') }}"
+openbao_kms_region: "{{ lookup('env', 'OPENBAO_KMS_REGION') | default('us-east-1', true) }}"
+# Dedicated unseal IAM creds — scoped to kms:Encrypt/Decrypt/DescribeKey on the
+# single CMK above. Sourced from Doppler (iac-conf-mgmt) or SOPS at runtime.
+openbao_unseal_aws_access_key_id: "{{ lookup('env', 'OPENBAO_UNSEAL_AWS_ACCESS_KEY_ID') }}"
+openbao_unseal_aws_secret_access_key: "{{ lookup('env', 'OPENBAO_UNSEAL_AWS_SECRET_ACCESS_KEY') }}"
+
+# --- KV / policy / AppRole ---------------------------------------------------
+openbao_kv_mount: secret
+# Path prefix that the terraform policy is allowed to read/write under the
+# KV v2 mount. Resolves to secret/data/homelab/* + secret/metadata/homelab/*.
+openbao_homelab_path: homelab
+openbao_terraform_policy_name: terraform
+openbao_terraform_approle_name: terraform
+
+# --- Break-glass / bootstrap output (controller-side, never committed) -------
+# init.yml writes recovery shares + root token (and later the AppRole creds) to
+# 0600 files UNDER playbook_dir ON THE CONTROLLER, then prints a LOUD warning to
+# transcribe to paper and delete. These paths are gitignored (see role README).
+openbao_recovery_shares: 5
+openbao_recovery_threshold: 3
+openbao_recovery_file: "{{ playbook_dir }}/.openbao-recovery-{{ inventory_hostname }}.json"
+openbao_approle_file: "{{ playbook_dir }}/.openbao-approle-{{ inventory_hostname }}.json"
+
+# --- systemd hardening -------------------------------------------------------
+# OpenBao mlock()s memory to keep secrets out of swap; that needs CAP_IPC_LOCK.
+# Set to false ONLY if the platform cannot grant the capability (then add
+# disable_mlock=true to the config) — see templates.
+openbao_enable_mlock: true
+openbao_service_state: started
+openbao_service_enabled: true
+
+# --- UI ----------------------------------------------------------------------
+openbao_enable_ui: true

--- a/roles/openbao/handlers/main.yml
+++ b/roles/openbao/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Restart openbao
+  ansible.builtin.systemd:
+    name: openbao
+    state: restarted
+    daemon_reload: true
+  when: ansible_virtualization_type | default('') != 'docker'

--- a/roles/openbao/meta/main.yml
+++ b/roles/openbao/meta/main.yml
@@ -1,0 +1,17 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: Deploy OpenBao secrets manager (Raft + AWS-KMS auto-unseal)
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+  galaxy_tags:
+    - openbao
+    - vault
+    - secrets
+    - raft
+dependencies: []

--- a/roles/openbao/tasks/init.yml
+++ b/roles/openbao/tasks/init.yml
@@ -1,0 +1,282 @@
+---
+# OpenBao bootstrap — initialize the cluster, then provision the KV mount,
+# the terraform policy, and the terraform AppRole. Every step is guarded so
+# re-runs are no-ops: nothing here is created if it already exists, and the
+# break-glass material is only emitted on the run that actually initializes.
+#
+# Break-glass safety: recovery shares + root token (and the AppRole creds) are
+# written ONLY to 0600 files on the Ansible CONTROLLER under playbook_dir, and a
+# LOUD warning tells the operator to transcribe to paper and delete the file.
+# These values are NEVER written into the repo or onto the target host, and the
+# `bao` invocations that touch them run with no_log: true.
+
+# All CLI calls target the local node over its advertised api_addr.
+# `bao status` exit codes: 0 = unsealed, 2 = sealed, 1 = error. For an
+# uninitialized node the command still exits 0/2 with "initialized": false in
+# the JSON body, so we parse the body rather than trust the exit code alone.
+- name: Read OpenBao status
+  ansible.builtin.command:
+    cmd: bao status -format=json
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+  register: openbao_status_raw
+  changed_when: false
+  failed_when: openbao_status_raw.rc not in [0, 2]
+
+- name: Parse OpenBao status
+  ansible.builtin.set_fact:
+    openbao_status: "{{ openbao_status_raw.stdout | from_json }}"
+
+# --- Initialization (only when not yet initialized) -------------------------
+- name: Initialize OpenBao (recovery keys via KMS auto-unseal)
+  ansible.builtin.command:
+    cmd: >-
+      bao operator init
+      -recovery-shares={{ openbao_recovery_shares }}
+      -recovery-threshold={{ openbao_recovery_threshold }}
+      -format=json
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+  register: openbao_init_raw
+  no_log: true
+  changed_when: true
+  when: not openbao_status.initialized
+
+- name: Capture init result
+  ansible.builtin.set_fact:
+    openbao_init: "{{ openbao_init_raw.stdout | from_json }}"
+  no_log: true
+  when: not openbao_status.initialized
+
+# Break-glass: write recovery shares + root token to a 0600 file ON THE
+# CONTROLLER (gitignored), then shout at the operator to move it to paper.
+- name: Write break-glass recovery material to controller (0600)
+  ansible.builtin.copy:
+    content: "{{ openbao_init | to_nice_json }}\n"
+    dest: "{{ openbao_recovery_file }}"
+    mode: "0600"
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  no_log: true
+  when: not openbao_status.initialized
+
+- name: WARN — transcribe recovery material to paper, then delete the file
+  ansible.builtin.debug:
+    msg: >-
+      ============================================================
+      OpenBao on {{ inventory_hostname }} was just INITIALIZED.
+      Recovery shares + the initial root token were written to:
+        {{ openbao_recovery_file }}
+      (0600, on this controller, gitignored). TRANSCRIBE the
+      recovery shares to PAPER, store them offline split across
+      custodians, then SECURELY DELETE this file. It is the ONLY
+      break-glass path if KMS auto-unseal ever fails. Do NOT
+      commit it. Do NOT leave it on disk.
+      ============================================================
+  when: not openbao_status.initialized
+
+# Root token: from this run's init output, or (on re-runs) the operator must
+# provide BAO_TOKEN out-of-band. We only proceed with the post-init
+# provisioning below when we actually hold a root token from THIS run.
+- name: Set the bootstrap token for provisioning
+  ansible.builtin.set_fact:
+    openbao_bootstrap_token: "{{ openbao_init.root_token }}"
+  no_log: true
+  when: not openbao_status.initialized
+
+# --- KV v2 mount (add-if-missing) -------------------------------------------
+- name: List enabled secrets engines
+  ansible.builtin.command:
+    cmd: bao secrets list -format=json
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  register: openbao_mounts_raw
+  no_log: true
+  changed_when: false
+  when: openbao_bootstrap_token is defined
+
+- name: Enable KV v2 at the configured mount
+  ansible.builtin.command:
+    cmd: "bao secrets enable -path={{ openbao_kv_mount }} -version=2 kv"
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  no_log: true
+  changed_when: true
+  when:
+    - openbao_bootstrap_token is defined
+    - (openbao_kv_mount ~ '/') not in (openbao_mounts_raw.stdout | from_json).keys()
+
+# --- terraform policy (write-if-missing) ------------------------------------
+- name: Render the terraform policy to the controller
+  ansible.builtin.template:
+    src: terraform-policy.hcl.j2
+    dest: "/tmp/openbao-terraform-policy-{{ inventory_hostname }}.hcl"
+    mode: "0600"
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  changed_when: false
+  when: openbao_bootstrap_token is defined
+
+- name: List existing policies
+  ansible.builtin.command:
+    cmd: bao policy list -format=json
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  register: openbao_policies_raw
+  no_log: true
+  changed_when: false
+  when: openbao_bootstrap_token is defined
+
+- name: Write the terraform policy
+  ansible.builtin.command:
+    cmd: >-
+      bao policy write {{ openbao_terraform_policy_name }}
+      /tmp/openbao-terraform-policy-{{ inventory_hostname }}.hcl
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  no_log: true
+  changed_when: true
+  when:
+    - openbao_bootstrap_token is defined
+    - openbao_terraform_policy_name not in (openbao_policies_raw.stdout | from_json)
+
+- name: Remove the rendered policy from the controller
+  ansible.builtin.file:
+    path: "/tmp/openbao-terraform-policy-{{ inventory_hostname }}.hcl"
+    state: absent
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  changed_when: false
+  when: openbao_bootstrap_token is defined
+
+# --- AppRole auth method (add-if-missing) -----------------------------------
+- name: List enabled auth methods
+  ansible.builtin.command:
+    cmd: bao auth list -format=json
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  register: openbao_auth_raw
+  no_log: true
+  changed_when: false
+  when: openbao_bootstrap_token is defined
+
+- name: Enable the AppRole auth method
+  ansible.builtin.command:
+    cmd: bao auth enable approle
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  no_log: true
+  changed_when: true
+  when:
+    - openbao_bootstrap_token is defined
+    - "'approle/' not in (openbao_auth_raw.stdout | from_json).keys()"
+
+# --- terraform AppRole (add-if-missing) -------------------------------------
+- name: Check whether the terraform AppRole already exists
+  ansible.builtin.command:
+    cmd: "bao read -format=json auth/approle/role/{{ openbao_terraform_approle_name }}"
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  register: openbao_approle_check
+  no_log: true
+  changed_when: false
+  failed_when: false
+  when: openbao_bootstrap_token is defined
+
+- name: Create the terraform AppRole bound to the terraform policy
+  ansible.builtin.command:
+    cmd: >-
+      bao write auth/approle/role/{{ openbao_terraform_approle_name }}
+      token_policies={{ openbao_terraform_policy_name }}
+      token_ttl=1h token_max_ttl=4h secret_id_ttl=0
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  no_log: true
+  changed_when: true
+  when:
+    - openbao_bootstrap_token is defined
+    - openbao_approle_check.rc is defined
+    - openbao_approle_check.rc != 0
+
+# Surface role_id + a fresh secret_id only when we just created the AppRole on
+# THIS (initializing) run, so re-runs never mint new credentials silently.
+- name: Read the terraform AppRole role_id
+  ansible.builtin.command:
+    cmd: "bao read -format=json auth/approle/role/{{ openbao_terraform_approle_name }}/role-id"
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  register: openbao_role_id_raw
+  no_log: true
+  changed_when: false
+  when:
+    - openbao_bootstrap_token is defined
+    - not openbao_status.initialized
+
+- name: Generate a terraform AppRole secret_id
+  ansible.builtin.command:
+    cmd: "bao write -f -format=json auth/approle/role/{{ openbao_terraform_approle_name }}/secret-id"
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  register: openbao_secret_id_raw
+  no_log: true
+  changed_when: true
+  when:
+    - openbao_bootstrap_token is defined
+    - not openbao_status.initialized
+
+- name: Write AppRole break-glass material to controller (0600)
+  ansible.builtin.copy:
+    content: |
+      {
+        "vault_addr": "{{ openbao_api_addr }}",
+        "role_id": "{{ (openbao_role_id_raw.stdout | from_json).data.role_id }}",
+        "secret_id": "{{ (openbao_secret_id_raw.stdout | from_json).data.secret_id }}"
+      }
+    dest: "{{ openbao_approle_file }}"
+    mode: "0600"
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  no_log: true
+  when:
+    - openbao_bootstrap_token is defined
+    - not openbao_status.initialized
+
+- name: INSTRUCT — load the terraform AppRole creds into Doppler, then delete
+  ansible.builtin.debug:
+    msg: >-
+      ============================================================
+      terraform AppRole created on {{ inventory_hostname }}.
+      role_id + secret_id were written to:
+        {{ openbao_approle_file }}
+      (0600, on this controller, gitignored). Load them into the
+      tier-0 secret store, then SECURELY DELETE the file:
+        doppler secrets set VAULT_ADDR={{ openbao_api_addr }}
+        doppler secrets set VAULT_ROLE_ID=<role_id from file>
+        doppler secrets set VAULT_SECRET_ID=<secret_id from file>
+      Do NOT commit this file. Do NOT leave it on disk.
+      ============================================================
+  when:
+    - openbao_bootstrap_token is defined
+    - not openbao_status.initialized

--- a/roles/openbao/tasks/main.yml
+++ b/roles/openbao/tasks/main.yml
@@ -1,0 +1,189 @@
+---
+# OpenBao install + configure. Native single Go binary on Debian; no Docker.
+# Idempotent and safe to re-run. Bootstrap (init/unseal/AppRole) is delegated
+# to tasks/init.yml, included after the service is up.
+
+# --- Phase 1: prerequisites --------------------------------------------------
+- name: Install OpenBao prerequisites
+  ansible.builtin.apt:
+    name:
+      - ca-certificates
+      - jq
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+# --- Phase 2: system user / group -------------------------------------------
+- name: Create openbao system group
+  ansible.builtin.group:
+    name: "{{ openbao_group }}"
+    system: true
+    state: present
+
+- name: Create openbao system user
+  ansible.builtin.user:
+    name: "{{ openbao_user }}"
+    group: "{{ openbao_group }}"
+    system: true
+    shell: /usr/sbin/nologin
+    home: "{{ openbao_data_dir }}"
+    create_home: false
+    state: present
+
+# --- Phase 3: directories ----------------------------------------------------
+- name: Create OpenBao config directory
+  ansible.builtin.file:
+    path: "{{ openbao_config_dir }}"
+    state: directory
+    owner: root
+    group: "{{ openbao_group }}"
+    mode: "0750"
+
+- name: Create OpenBao data directory (0700, owned by openbao)
+  ansible.builtin.file:
+    path: "{{ openbao_data_dir }}"
+    state: directory
+    owner: "{{ openbao_user }}"
+    group: "{{ openbao_group }}"
+    mode: "0700"
+
+# --- Phase 4: download + verify the .deb on the controller -------------------
+# Mirrors the minio role: stage on the controller (unrestricted egress), verify
+# the SHA256 against the upstream checksums file, then copy to the target. LXC
+# hosts in the outbound-internal firewall group cannot reach GitHub directly.
+#
+# ansible_become: false on the delegated tasks is REQUIRED — Ansible inherits
+# the play's become: true on delegated tasks regardless of task-level become,
+# which fails with "sudo: a password is required" on the controller.
+- name: Stage OpenBao release checksums on controller
+  ansible.builtin.get_url:
+    url: "{{ openbao_checksums_url }}"
+    dest: "/tmp/openbao-{{ openbao_version }}-checksums-linux.txt"
+    mode: "0644"
+    force: true
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  run_once: true
+
+- name: Read the expected SHA256 for the amd64 .deb
+  ansible.builtin.set_fact:
+    openbao_deb_sha256: >-
+      {{ (lookup('file', '/tmp/openbao-' ~ openbao_version ~ '-checksums-linux.txt')
+          | regex_search('([0-9a-f]{64})\s+' ~ (openbao_deb_filename | regex_escape), '\1')
+          | first) }}
+  run_once: true
+
+- name: Assert a checksum was found for the .deb
+  ansible.builtin.assert:
+    that:
+      - openbao_deb_sha256 is defined
+      - openbao_deb_sha256 | length == 64
+    fail_msg: >-
+      Could not find a SHA256 for {{ openbao_deb_filename }} in the upstream
+      checksums file. Did the asset naming change for v{{ openbao_version }}?
+  run_once: true
+
+- name: Stage the OpenBao .deb on controller (checksum-verified)
+  ansible.builtin.get_url:
+    url: "{{ openbao_deb_url }}"
+    dest: "/tmp/{{ openbao_deb_filename }}"
+    checksum: "sha256:{{ openbao_deb_sha256 }}"
+    mode: "0644"
+    force: true
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  run_once: true
+
+- name: Copy the OpenBao .deb to the target
+  ansible.builtin.copy:
+    src: "/tmp/{{ openbao_deb_filename }}"
+    dest: "/tmp/{{ openbao_deb_filename }}"
+    owner: root
+    group: root
+    mode: "0644"
+
+# --- Phase 5: install the package -------------------------------------------
+# Installing the upstream .deb pulls in the `bao` binary. The package also ships
+# its own openbao user/unit; we override the config + unit below so the role
+# stays the single source of truth (User/Group already created above match).
+- name: Install OpenBao package
+  ansible.builtin.apt:
+    deb: "/tmp/{{ openbao_deb_filename }}"
+    state: present
+
+- name: Remove the staged .deb from the target
+  ansible.builtin.file:
+    path: "/tmp/{{ openbao_deb_filename }}"
+    state: absent
+
+# --- Phase 6: configuration --------------------------------------------------
+- name: Render OpenBao server config
+  ansible.builtin.template:
+    src: openbao.hcl.j2
+    dest: "{{ openbao_config_file }}"
+    owner: root
+    group: "{{ openbao_group }}"
+    mode: "0640"
+  notify: Restart openbao
+
+- name: Render OpenBao AWS unseal EnvironmentFile
+  ansible.builtin.template:
+    src: openbao.env.j2
+    dest: "{{ openbao_env_file }}"
+    owner: root
+    group: "{{ openbao_group }}"
+    mode: "0600"
+  no_log: true
+  notify: Restart openbao
+
+- name: Install OpenBao systemd unit
+  ansible.builtin.template:
+    src: openbao.service.j2
+    dest: /etc/systemd/system/openbao.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart openbao
+
+# --- Phase 7: enable + start -------------------------------------------------
+# Skipped under Docker so the role can be molecule-tested in containers without
+# a functional systemd init; the init/bootstrap phase is likewise gated.
+- name: Enable and start OpenBao
+  ansible.builtin.systemd:
+    name: openbao
+    state: "{{ openbao_service_state }}"
+    enabled: "{{ openbao_service_enabled }}"
+    daemon_reload: true
+  when: ansible_virtualization_type | default('') != 'docker'
+
+# Flush so the restart handler fires before init.yml probes the live socket.
+- name: Apply any pending OpenBao restart before bootstrap
+  ansible.builtin.meta: flush_handlers
+
+# --- Phase 8: wait for the API ----------------------------------------------
+# A sealed-but-up OpenBao still answers /v1/sys/health with 200/429/501/503.
+# With KMS auto-unseal it should reach 200 (initialized+unsealed) on re-runs,
+# or 501 (not initialized) on the very first run. Any of those means the
+# listener is accepting connections, which is all we need before init.yml.
+- name: Wait for the OpenBao listener to accept connections
+  ansible.builtin.uri:
+    url: "{{ openbao_api_addr }}/v1/sys/health"
+    method: GET
+    status_code: [200, 429, 472, 473, 501, 503]
+  register: openbao_health
+  until: openbao_health.status is defined
+  retries: 10
+  delay: 3
+  changed_when: false
+  when: ansible_virtualization_type | default('') != 'docker'
+
+# --- Phase 9: bootstrap (idempotent) ----------------------------------------
+- name: Bootstrap OpenBao (init, KV, policy, AppRole)
+  ansible.builtin.include_tasks: init.yml
+  when: ansible_virtualization_type | default('') != 'docker'

--- a/roles/openbao/templates/openbao.env.j2
+++ b/roles/openbao/templates/openbao.env.j2
@@ -1,0 +1,7 @@
+{{ ansible_managed | comment }}
+# AWS KMS auto-unseal credentials for OpenBao (systemd EnvironmentFile).
+# Rendered 0600 root:openbao — never commit these values.
+# Scoped to kms:Encrypt/Decrypt/DescribeKey on a single CMK (see aws-infra).
+AWS_ACCESS_KEY_ID={{ openbao_unseal_aws_access_key_id }}
+AWS_SECRET_ACCESS_KEY={{ openbao_unseal_aws_secret_access_key }}
+AWS_REGION={{ openbao_kms_region }}

--- a/roles/openbao/templates/openbao.hcl.j2
+++ b/roles/openbao/templates/openbao.hcl.j2
@@ -1,0 +1,46 @@
+{{ ansible_managed | comment }}
+# OpenBao server configuration — Raft storage + AWS-KMS auto-unseal.
+# Rendered by the openbao Ansible role. Do not edit manually.
+
+# Integrated Raft storage. This node is node 1 of a planned 3-node cluster;
+# additional nodes join via `bao operator raft join` against this api_addr.
+storage "raft" {
+  path    = "{{ openbao_data_dir }}"
+  node_id = "{{ openbao_node_id }}"
+}
+
+# Auto-unseal via AWS KMS. With awskms seal, `bao operator init` produces
+# RECOVERY keys (not classic unseal keys); the KMS CMK unwraps the root key on
+# every start, so the process self-unseals without operator key entry.
+# Region + key_id identify the CMK; the AWS creds are delivered to the process
+# via the systemd EnvironmentFile ({{ openbao_env_file }}), never inlined here.
+seal "awskms" {
+  region     = "{{ openbao_kms_region }}"
+  kms_key_id = "{{ openbao_kms_key_id }}"
+}
+
+# Listener bound to THIS node's VLAN IP, never 0.0.0.0.
+# tls_disable = 1: TLS terminates at Traefik on the internal VLAN in front of
+# OpenBao. End-to-end TLS (listener-native certs) is a later hardening step —
+# when added, drop tls_disable and point tls_cert_file/tls_key_file at the
+# node cert, and flip openbao_api_addr to https://.
+listener "tcp" {
+  address     = "{{ openbao_bind_address }}:{{ openbao_api_port }}"
+  tls_disable = 1
+}
+
+# Addresses advertised to clients and peer Raft nodes.
+api_addr     = "{{ openbao_api_addr }}"
+cluster_addr = "{{ openbao_cluster_addr }}"
+
+{% if openbao_enable_mlock %}
+# mlock() keeps the in-memory root/encryption keys out of swap. The systemd
+# unit grants CAP_IPC_LOCK so this succeeds without running as root.
+disable_mlock = false
+{% else %}
+# mlock disabled: the platform could not grant CAP_IPC_LOCK. Secrets may touch
+# swap — ensure swap is disabled or encrypted on this host.
+disable_mlock = true
+{% endif %}
+
+ui = {{ openbao_enable_ui | ternary('true', 'false') }}

--- a/roles/openbao/templates/openbao.service.j2
+++ b/roles/openbao/templates/openbao.service.j2
@@ -1,0 +1,40 @@
+{{ ansible_managed | comment }}
+# OpenBao server systemd unit. Rendered by the openbao Ansible role.
+
+[Unit]
+Description=OpenBao secrets manager
+Documentation=https://openbao.org/docs/
+Requires=network-online.target
+After=network-online.target
+# Re-read config on reload without a full restart (SIGHUP).
+ConditionFileNotEmpty={{ openbao_config_file }}
+
+[Service]
+User={{ openbao_user }}
+Group={{ openbao_group }}
+# AWS KMS unseal credentials (0600, root:openbao). Keeping them in an
+# EnvironmentFile rather than the unit keeps them out of `systemctl show`.
+EnvironmentFile={{ openbao_env_file }}
+{% if openbao_enable_mlock %}
+# CAP_IPC_LOCK lets OpenBao mlock() its memory (disable_mlock=false in config)
+# without running as root.
+AmbientCapabilities=CAP_IPC_LOCK
+CapabilityBoundingSet=CAP_IPC_LOCK CAP_SYSLOG
+{% endif %}
+ExecStart={{ openbao_install_dir }}/bao server -config={{ openbao_config_file }}
+ExecReload=/bin/kill --signal HUP $MAINPID
+KillSignal=SIGINT
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+LimitNOFILE=65536
+# Hardening
+ProtectSystem=full
+ProtectHome=read-only
+PrivateTmp=yes
+PrivateDevices=yes
+NoNewPrivileges=yes
+ReadWritePaths={{ openbao_data_dir }}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/openbao/templates/terraform-policy.hcl.j2
+++ b/roles/openbao/templates/terraform-policy.hcl.j2
@@ -1,0 +1,12 @@
+{{ ansible_managed | comment }}
+# OpenBao policy for the Terraform/Terragrunt AppRole.
+# Grants read/write on the homelab subtree of the KV v2 mount only.
+# KV v2 splits data and metadata paths, so both are listed explicitly.
+
+path "{{ openbao_kv_mount }}/data/{{ openbao_homelab_path }}/*" {
+  capabilities = ["create", "read", "update", "delete"]
+}
+
+path "{{ openbao_kv_mount }}/metadata/{{ openbao_homelab_path }}/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}


### PR DESCRIPTION
# OpenBao secrets-manager role (Raft node 1)

## What

Configuration management for the self-hosted **OpenBao** secrets manager —
companion to the terraform-proxmox IaC
(`Refs: dryvist/terraform-proxmox#386`). This role brings OpenBao live so the
Terraform `vault-secrets` unit can then push/read secrets.

## Changes

- **`roles/openbao`** — installs OpenBao (checksum-verified `.deb`,
  version-pinned via a single var), renders Raft storage + AWS-KMS auto-unseal
  - a VLAN-bound listener (TLS terminates at Traefik; end-to-end TLS is a later
  hardening step), and a hardened systemd unit.
- **`tasks/init.yml`** — initializes the node, enables KV v2, and creates a
  least-privilege `terraform` policy + AppRole. Every step is idempotent
  (add-if-missing); credentials are surfaced only on the run that initializes.
- **`inventory/load_tofu.yml`** — maps the `openbao` tag to `openbao_group` so
  the role targets the LXC.
- **`molecule/openbao`** — scenario scaffolded to convention (CI-only gate;
  known-broken locally, so not run here).

## Break-glass safety

Recovery shares, the root token, and the AppRole `role_id`/`secret_id` are
written `0600` to **gitignored files on the Ansible controller**, under
`no_log`, with a loud warning to transcribe to paper / load into Doppler and
then securely delete. Nothing secret is written into the repo or onto the
target host.

## Operator notes

- The `openbao1` LXC must exist (terraform-proxmox PR + the operator-local
  `deployment.json` entry) before this role runs.
- After init: transcribe recovery shares offline, and load
  `VAULT_ADDR` / `VAULT_ROLE_ID` / `VAULT_SECRET_ID` into Doppler for the
  `vault-secrets` Terraform unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
