### PR TITLE
feat(download_vpn): policy-route LAN web-UI replies for cross-subnet access

### DIFF
--- a/roles/download_vpn/README.md
+++ b/roles/download_vpn/README.md
@@ -26,6 +26,15 @@ outside the VPN:
 5. **Boot-safe ordering** — qBittorrent/Prowlarr/NAT-PMP units
    `Requires=`/`After=`/`BindsTo=` the killswitch + `wg0` units, so they can
    never start (or stay up) without the lock.
+6. **LAN web-UI reachability (reply-only)** — a connmark + dedicated routing
+   table (`download-vpn-lanroute.service` + `templates/mangle.nft.j2`) let
+   cross-subnet clients (e.g. the Traefik reverse proxy on the management VLAN)
+   reach the qBittorrent/Prowlarr web UIs. Inbound UI connections are marked and
+   only their **replies** are policy-routed back out the LAN NIC; app-initiated
+   flows are never marked, so they still egress via `wg0` (or are dropped). This
+   opens **no new egress path** — the killswitch guarantees above are unchanged,
+   and the `ct mark` guard keeps WireGuard's own fwmark on encapsulated UDP
+   intact so the tunnel is never recursively routed.
 
 ## Three validation layers (all mandatory)
 
@@ -36,8 +45,9 @@ outside the VPN:
   on every play. Asserts the killswitch is active, internet-bound IPv4 traffic
   routes via `wg0` (wg-quick `Table = auto` keeps the main-table default on the
   LAN NIC and routes the tunnel through a separate fwmark table), no IPv6 default
-  route exists, qBittorrent is bound to `wg0`, live VPN IPv4 egress works, and
-  forced non-VPN IPv4 + all IPv6 egress are refused. **Fails the play on any
+  route exists, qBittorrent is bound to `wg0`, live VPN IPv4 egress works,
+  forced non-VPN IPv4 + all IPv6 egress are refused, and the LAN-reply policy
+  routing is present (web UIs reachable cross-subnet). **Fails the play on any
   violation.**
 - **Runtime** — `download-vpn-validate.timer` (every ~2 min). Re-checks the
   above; on ANY breach it stops qBittorrent, alerts ntfy, and pings the

--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -66,6 +66,22 @@ download_vpn_lan_subnet: >-
 # only to pin a specific NIC.
 download_vpn_lan_interface: ""
 
+# LAN gateway (.1 of the container subnet) — the next hop the policy-routed web
+# UI replies use to reach cross-subnet clients (e.g. the Traefik VLAN). Derived
+# from the LAN subnet; override only for a non-.1 gateway.
+download_vpn_lan_gateway: >-
+  {{ download_vpn_lan_subnet | ansible.utils.ipaddr('1') | ansible.utils.ipaddr('address') }}
+
+# --- LAN-reply policy routing (cross-subnet web UI reachability) -------------
+# A connmark + dedicated routing table let cross-subnet clients (e.g. Traefik on
+# the management VLAN) reach the qBittorrent/Prowlarr web UIs: inbound web-UI
+# connections are marked, the mark is restored on their replies, and ONLY those
+# replies are routed out the LAN NIC. App-initiated egress is never marked, so it
+# still leaves via wg0 (or is dropped by the killswitch). Reply-only — opens no
+# new egress path. See templates/mangle.nft.j2 + download-vpn-lanroute.service.j2.
+download_vpn_lanroute_table: 100
+download_vpn_lanroute_mark: "0x1"
+
 # --- qBittorrent -------------------------------------------------------------
 download_vpn_qbittorrent_package: qbittorrent-nox
 download_vpn_qbittorrent_user: "{{ download_vpn_user }}"
@@ -173,6 +189,7 @@ download_vpn_manage_services: true
 
 # --- Deployed file paths (rarely overridden) --------------------------------
 download_vpn_nft_ruleset_path: /etc/nftables.d/download-vpn-killswitch.nft
+download_vpn_mangle_ruleset_path: /etc/nftables.d/download-vpn-lanroute.nft
 download_vpn_natpmp_script_path: /usr/local/bin/download-vpn-natpmp.sh
 download_vpn_natpmp_env_path: /etc/default/download-vpn-natpmp
 download_vpn_validator_script_path: /usr/local/bin/download-vpn-killswitch-validate.sh

--- a/roles/download_vpn/handlers/main.yml
+++ b/roles/download_vpn/handlers/main.yml
@@ -30,3 +30,10 @@
     state: restarted
     daemon_reload: true
   when: download_vpn_manage_services
+
+- name: Restart download-vpn lanroute
+  ansible.builtin.systemd:
+    name: download-vpn-lanroute.service
+    state: restarted
+    daemon_reload: true
+  when: download_vpn_manage_services

--- a/roles/download_vpn/tasks/main.yml
+++ b/roles/download_vpn/tasks/main.yml
@@ -179,6 +179,39 @@
     daemon_reload: true
   when: download_vpn_manage_services
 
+# --- Phase 5b: LAN-reply policy routing (cross-subnet web UI reachability) ---
+# Lets cross-subnet clients (Traefik on the management VLAN) reach the
+# qBittorrent/Prowlarr web UIs without opening any non-VPN egress: a connmark
+# marks inbound UI connections, the mark is restored on their replies, and only
+# those replies are policy-routed out the LAN NIC. App-initiated egress is never
+# marked, so it still leaves via wg0 (or is dropped by the killswitch).
+- name: Deploy LAN-reply connmark mangle ruleset
+  ansible.builtin.template:
+    src: mangle.nft.j2
+    dest: "{{ download_vpn_mangle_ruleset_path }}"
+    owner: root
+    group: root
+    mode: "0600"
+    validate: "/usr/sbin/nft -c -f %s"
+  notify: Restart download-vpn lanroute
+
+- name: Deploy LAN-reply policy-routing systemd unit
+  ansible.builtin.template:
+    src: download-vpn-lanroute.service.j2
+    dest: /etc/systemd/system/download-vpn-lanroute.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd
+
+- name: Enable + start LAN-reply policy routing
+  ansible.builtin.systemd:
+    name: download-vpn-lanroute.service
+    state: started
+    enabled: true
+    daemon_reload: true
+  when: download_vpn_manage_services
+
 # --- Phase 6: qBittorrent ----------------------------------------------------
 - name: Ensure qBittorrent config directory exists
   ansible.builtin.file:

--- a/roles/download_vpn/tasks/validate.yml
+++ b/roles/download_vpn/tasks/validate.yml
@@ -165,10 +165,44 @@
           IPv6 LEAK: egress over IPv6 succeeded
           ({{ download_vpn_v6_probe.stdout | trim }}). IPv6 must have no path.
 
+    # --- H. LAN-reply policy routing present (functional gate, not a leak) --
+    # Cross-subnet clients (e.g. Traefik) reach the web UIs only if the connmark
+    # mangle table + fwmark rule + table-default route are all in place. A missing
+    # route is a FUNCTIONAL failure (UIs unreachable), NOT a leak — checks A-G
+    # above already prove no egress escapes the VPN — but we still gate the deploy
+    # so a half-applied role is caught here rather than as a silent timeout.
+    - name: Read the LAN-reply policy-routing state
+      ansible.builtin.command:
+        cmd: "{{ item }}"
+      loop:
+        - nft list table inet vpn_lanroute
+        - ip rule show
+        - ip route show table {{ download_vpn_lanroute_table }}
+      register: download_vpn_lanroute_state
+      changed_when: false
+      failed_when: false
+
+    - name: Assert LAN-reply policy routing is in place
+      ansible.builtin.assert:
+        that:
+          - "'vpn_lanroute' in download_vpn_lanroute_state.results[0].stdout"
+          - "'fwmark ' ~ download_vpn_lanroute_mark in download_vpn_lanroute_state.results[1].stdout"
+          - "'lookup ' ~ download_vpn_lanroute_table in download_vpn_lanroute_state.results[1].stdout"
+          - "'default ' in download_vpn_lanroute_state.results[2].stdout"
+          - "'dev ' ~ download_vpn_lan_interface in download_vpn_lanroute_state.results[2].stdout"
+        fail_msg: >-
+          LAN-reply policy routing is incomplete — cross-subnet clients (e.g.
+          Traefik) cannot reach the qBittorrent/Prowlarr web UIs. Expected the
+          inet vpn_lanroute table, an `ip rule` for fwmark
+          {{ download_vpn_lanroute_mark }} -> table {{ download_vpn_lanroute_table }},
+          and a default route via {{ download_vpn_lan_interface }} in that table.
+        success_msg: "LAN-reply policy routing present (web UIs reachable cross-subnet)."
+
     - name: Report killswitch validation success
       ansible.builtin.debug:
         msg: >-
           download-vpn killswitch validated: nft DROP active; internet-bound IPv4
           routes via {{ download_vpn_wg_interface }} (Table=auto); no IPv6 default
           route; qBittorrent bound to {{ download_vpn_wg_interface }}; VPN IPv4
-          egress works; non-VPN IPv4 + all IPv6 egress refused.
+          egress works; non-VPN IPv4 + all IPv6 egress refused; LAN-reply routing
+          present (web UIs reachable cross-subnet).

--- a/roles/download_vpn/templates/download-vpn-lanroute.service.j2
+++ b/roles/download_vpn/templates/download-vpn-lanroute.service.j2
@@ -1,0 +1,38 @@
+[Unit]
+Description=download-vpn LAN-reply policy routing (cross-subnet web UI reachability)
+Documentation=https://github.com/JacobPEvans/ansible-proxmox-apps
+# Order after wg0 so wg-quick's own fwmark policy rules already exist and we
+# layer a higher-priority rule above them; network-online ensures the LAN NIC is
+# configured. Deliberately NOT Requires=download-vpn-wg.service: this reply
+# routing is independent of the tunnel, so the web UIs stay reachable for
+# debugging even during a VPN outage. The killswitch (not this unit) is the
+# egress security boundary, so keeping it up never enables a leak.
+After=network-online.target download-vpn-wg.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+
+# 1. (Re)load the connmark mangle table from a clean slate. Delete first (ignore
+#    if absent) so a restart never hits "chain already exists". This must succeed
+#    on load — without the marking the policy route below is inert.
+ExecStartPre=-/usr/sbin/nft delete table inet vpn_lanroute
+ExecStartPre=/usr/sbin/nft -f {{ download_vpn_mangle_ruleset_path }}
+
+# 2. Policy route: reply packets carrying our fwmark resolve out the LAN NIC via
+#    a dedicated table; everything unmarked keeps using wg0 (or is dropped by the
+#    killswitch). Delete-then-add the rule for idempotency; `route replace` is
+#    inherently idempotent. `env ip` avoids hardcoding the iproute2 path.
+ExecStartPre=-/usr/bin/env ip rule del fwmark {{ download_vpn_lanroute_mark }} table {{ download_vpn_lanroute_table }} priority 1000
+ExecStart=/usr/bin/env ip rule add fwmark {{ download_vpn_lanroute_mark }} table {{ download_vpn_lanroute_table }} priority 1000
+ExecStart=/usr/bin/env ip route replace default via {{ download_vpn_lan_gateway }} dev {{ download_vpn_lan_interface }} table {{ download_vpn_lanroute_table }}
+
+# Teardown: remove the rule, flush the table, drop the mangle marking — leaving
+# no standing non-VPN routing state.
+ExecStop=-/usr/bin/env ip rule del fwmark {{ download_vpn_lanroute_mark }} table {{ download_vpn_lanroute_table }} priority 1000
+ExecStop=-/usr/bin/env ip route flush table {{ download_vpn_lanroute_table }}
+ExecStop=-/usr/sbin/nft delete table inet vpn_lanroute
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/download_vpn/templates/mangle.nft.j2
+++ b/roles/download_vpn/templates/mangle.nft.j2
@@ -1,0 +1,49 @@
+#!/usr/sbin/nft -f
+{#
+  LAN-reply policy-routing connmark table for the download-vpn LXC.
+
+  Rendered by the download_vpn role; loaded + torn down by
+  download-vpn-lanroute.service alongside the matching `ip rule` / table.
+
+  PROBLEM this solves: cross-subnet clients (e.g. the Traefik reverse proxy on
+  the management VLAN) can OPEN a TCP connection to the qBittorrent/Prowlarr web
+  UIs — the inbound SYN arrives on the LAN NIC fine — but the reply follows the
+  container's default route, which wg-quick `Table = auto` points at wg0. The
+  reply is encapsulated toward Proton, which has no route back to an RFC1918 LAN
+  subnet, so it is black-holed and the client times out. Same-subnet replies
+  work only because that /24 is a connected route on the LAN NIC.
+
+  FIX: tag the *inbound* connections we want reachable with a connmark, restore
+  that mark onto their *reply* packets, and (via the companion `ip rule fwmark`)
+  route only those replies out the LAN NIC. See download-vpn-lanroute.service.
+
+  SECURITY INVARIANT (unchanged): this never lets the apps INITIATE non-VPN
+  egress. Only packets belonging to an already-marked inbound connection get the
+  mark; app-initiated flows (torrents, indexer fetches, DNS) are never marked, so
+  they still resolve via wg0 — or are dropped by the killswitch if wg0 is down.
+  The `ct mark {{ download_vpn_lanroute_mark }}` guard on the output chain is
+  load-bearing: an unconditional `meta mark set ct mark` would also clobber
+  WireGuard's own fwmark on its encapsulated UDP (ct mark 0), recursively routing
+  the handshake into the tunnel and breaking the VPN.
+-#}
+table inet vpn_lanroute {
+  chain prerouting {
+    type filter hook prerouting priority mangle; policy accept;
+
+    # Mark NEW inbound connections that arrive on the LAN NIC, originate OUTSIDE
+    # the local /24 (same-subnet replies already work via the connected route),
+    # and target a web-UI port. The mark rides the conntrack entry, so replies
+    # inherit it below. Ports come from OpenTofu constants — nothing hard-coded.
+    iifname "{{ download_vpn_lan_interface }}" ip saddr != {{ download_vpn_lan_subnet }} tcp dport { {{ download_vpn_qbittorrent_web_port | int }}, {{ download_vpn_prowlarr_web_port | int }} } ct state new ct mark set {{ download_vpn_lanroute_mark }}
+  }
+
+  chain output {
+    type route hook output priority mangle;
+
+    # Restore ONLY our mark onto reply packets so the `ip rule fwmark` sends
+    # them out the LAN NIC. `type route` makes the kernel re-evaluate routing
+    # when the mark changes. The `ct mark` guard means WireGuard's encapsulated
+    # UDP (ct mark 0) and every app-initiated flow are left untouched.
+    ct mark {{ download_vpn_lanroute_mark }} meta mark set {{ download_vpn_lanroute_mark }}
+  }
+}


### PR DESCRIPTION
Cross-subnet clients (e.g. a reverse proxy on another VLAN) could open a connection to the qBittorrent/Prowlarr web UIs, but replies followed the wg0 default route (wg-quick Table=auto) and were black-holed in the tunnel — so the UIs timed out for any client not on the LAN's own subnet.

This adds a connmark + dedicated routing table: inbound web-UI connections originating outside the local subnet are marked, the mark is restored onto their replies, and only those replies are policy-routed out the LAN NIC. App-initiated egress is never marked, so torrent/indexer traffic still leaves via wg0 (or is dropped by the killswitch). The ct-mark guard keeps the WireGuard fwmark on encapsulated UDP intact so the tunnel is never recursively routed.

New nftables mangle table (templates/mangle.nft.j2) + download-vpn-lanroute.service; deploy-time validate.yml gates on the routing being present. The runtime leak validator is unchanged — a missing route is a functional failure, not a leak; the forced-non-VPN-egress, IPv6, and route-via-wg0 leak checks all still hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)