### PR TITLE
feat(download_vpn): skip qBittorrent WebUI auth for trusted subnets

### DIFF
--- a/roles/download_vpn/README.md
+++ b/roles/download_vpn/README.md
@@ -86,6 +86,10 @@ derived LAN subnet) — nothing is hardcoded. See `defaults/main.yml`.
 - `download_vpn_wg_endpoint` — Proton `host:port` (SOPS env).
 - `download_vpn_lan_subnet` — LAN allowed through the killswitch (derived).
 - `download_vpn_qbittorrent_web_port` — qBittorrent WebUI port (tofu).
+- `download_vpn_qbittorrent_auth_whitelist` — CIDRs that skip WebUI auth
+  (qBittorrent's `DisabledForLocalAddresses` analogue). Defaults to the `/16`
+  supernet of `container_ip` (every homelab VLAN, derived — no hardcoded CIDR);
+  narrow to `download_vpn_lan_subnet` for a tighter boundary.
 - `download_vpn_prowlarr_web_port` — Prowlarr WebUI port (tofu).
 - `download_vpn_validator_interval` — runtime validator cadence (default 2min).
 - `download_vpn_ntfy_url` / `download_vpn_healthcheck_url` — breach alerting.

--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -89,8 +89,20 @@ download_vpn_qbittorrent_config_dir: "/home/{{ download_vpn_user }}/.config/qBit
 # Web UI port from tofu constants (no hardcoded port).
 download_vpn_qbittorrent_web_port: >-
   {{ tofu_data.constants.media_ports.qbittorrent_web }}
-# Admin password for the WebUI — from SOPS env.
+# Admin password for the WebUI — from SOPS env. Still required for any client
+# OUTSIDE the auth whitelist below (defence in depth); whitelisted clients skip it.
 download_vpn_qbittorrent_admin_password: "{{ lookup('env', 'QBITTORRENT_ADMIN_PASSWORD') }}"
+# WebUI auth bypass for trusted in-network clients — the qBittorrent analogue of
+# the *arr apps' AuthenticationRequired=DisabledForLocalAddresses. Clients whose
+# source IP is in this comma-separated CIDR list skip the login form (and so can
+# never trip qBittorrent's failed-auth IP ban). Defaults to the /16 supernet of
+# the container's own IP — i.e. every VLAN in the homelab (3rd octet = VLAN id),
+# so cross-VLAN clients and Traefik-proxied requests are trusted too. Derived
+# from container_ip, so no CIDR is hardcoded. Narrow to download_vpn_lan_subnet
+# (the container's own /24) for a tighter boundary.
+download_vpn_qbittorrent_auth_whitelist: >-
+  {{ ((container_ip | default(ansible_default_ipv4.address)) ~ '/16')
+     | ansible.utils.ipaddr('network/prefix') }}
 # CRITICAL: bind qBittorrent's traffic to wg0 (interface binding). With the
 # killswitch this is belt-and-suspenders; binding alone closed the 30% leak
 # seen in killswitch-only testing.

--- a/roles/download_vpn/templates/qBittorrent.conf.j2
+++ b/roles/download_vpn/templates/qBittorrent.conf.j2
@@ -56,5 +56,11 @@ General\Locale=en
 WebUI\Address=*
 WebUI\Port={{ download_vpn_qbittorrent_web_port }}
 WebUI\LocalHostAuth=false
+# Skip the login form for clients inside the trusted network — qBittorrent's
+# analogue of the *arr apps' AuthenticationRequired=DisabledForLocalAddresses.
+# Whitelisted source IPs bypass auth entirely, so they also never trip the
+# failed-auth IP ban. Scope is set by download_vpn_qbittorrent_auth_whitelist.
+WebUI\AuthSubnetWhitelistEnabled=true
+WebUI\AuthSubnetWhitelist={{ download_vpn_qbittorrent_auth_whitelist }}
 Downloads\SavePath={{ download_vpn_downloads_dir }}/
 Downloads\TempPath={{ download_vpn_downloads_dir }}/incomplete/


### PR DESCRIPTION
## Problem

The qBittorrent WebUI (LXC 214, fronted at the `qbittorrent.*` ingress) demanded
a username/password, unlike the *arr apps which are auth-free for in-network
clients. The live admin password had also drifted out of sync with the SOPS
source, and repeated failed logins tripped qBittorrent's failed-auth **IP ban**,
locking the operator out entirely.

## Change

qBittorrent has no `AuthenticationRequired=DisabledForLocalAddresses` toggle like
Sonarr/Radarr/Prowlarr. Its equivalent is the WebUI subnet whitelist, so this PR:

- Sets `WebUI\AuthSubnetWhitelistEnabled=true` + `WebUI\AuthSubnetWhitelist` in
  `qBittorrent.conf.j2`.
- Adds `download_vpn_qbittorrent_auth_whitelist`, defaulting to the **`/16`
  supernet of `container_ip`** — every homelab VLAN (3rd octet = VLAN id), so
  cross-VLAN clients and Traefik-proxied requests are trusted too. Derived from
  `container_ip`; **no CIDR is hardcoded** (keeps real topology out of this
  public repo). Narrow to `download_vpn_lan_subnet` for a tighter boundary.
- Retains the SOPS admin password for any client outside the whitelist (defence
  in depth).

Whitelisted clients bypass the login form, so they can never accrue failed
attempts → the IP-ban trap disappears.

## Trust model

Matches the LAN-trusted posture already accepted for the *arr WebUIs. It is a
deliberate reduction of this one service's auth surface for in-network clients.

## Verification

- CI: yamllint / ansible-lint / molecule.
- Runtime state already set live on LXC 214 via the localhost API
  (`bypass_auth_subnet_whitelist=10.0.0.0/16`); this PR makes it Ansible-durable
  on the next converge. Browser login behaviour is not covered by CI — verify by
  loading the qBittorrent UI and confirming no login prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)