### PR TITLE
fix(download_vpn): correct qBittorrent uTP/overhead rate-limit API field names

### DIFF
--- a/roles/download_vpn/tasks/main.yml
+++ b/roles/download_vpn/tasks/main.yml
@@ -302,8 +302,8 @@
          "schedule_to_hour":{{ download_vpn_qbittorrent_schedule_to_hour | int }},
          "schedule_to_min":{{ download_vpn_qbittorrent_schedule_to_min | int }},
          "scheduler_days":{{ download_vpn_qbittorrent_scheduler_days | int }},
-         "limit_utp":true,
-         "include_overhead":true,
+         "limit_utp_rate":true,
+         "limit_tcp_overhead":true,
          "limit_lan_peers":true}
     status_code: 200
   changed_when: false


### PR DESCRIPTION
## Why

A bug shipped in **1.26.0** (#356): the qBittorrent `setPreferences` call sends `limit_utp` and `include_overhead`. Those are **not** valid WebUI API fields — the API silently ignores unknown keys — so the "apply rate limit to μTP / transport overhead" toggles were never enabled.

Verified correct field names against the [qBittorrent 5.0 WebUI API wiki](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)):
- `limit_utp` → **`limit_utp_rate`**
- `include_overhead` → **`limit_tcp_overhead`**
- `limit_lan_peers` was already correct.

## Impact

Without these, the global/alt speed caps applied only to **TCP payload**, not to μTP connections or transport overhead. BitTorrent uses μTP heavily, so the upload cap was **partially bypassed** — i.e. the bufferbloat the rate-limiting exists to prevent could still occur. This restores the behavior #354 intended ("apply rate limits to μTP, transport overhead, and LAN peers"), which was carried into the API-driven approach but with the wrong key names during the #354→#356 merge resolution.

## Change

Two field-name corrections in `roles/download_vpn/tasks/main.yml`. No behavior change beyond the limits now actually applying to μTP + overhead.

## Verification

- `ansible-lint roles/download_vpn` → passed (production profile).
- Post-deploy: `GET /api/v2/app/preferences` should now report `limit_utp_rate: true` and `limit_tcp_overhead: true` (previously absent/default), and saturating-seed tests should respect the upload cap on μTP swarms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)