### PR TITLE
fix(download_vpn): set qBittorrent auth whitelist via API, not template

### DIFF
--- a/roles/download_vpn/README.md
+++ b/roles/download_vpn/README.md
@@ -124,7 +124,8 @@ derived LAN subnet) — nothing is hardcoded. See `defaults/main.yml`.
 - `download_vpn_qbittorrent_auth_whitelist` — CIDRs that skip WebUI auth
   (qBittorrent's `DisabledForLocalAddresses` analogue). Defaults to the `/16`
   supernet of `container_ip` (every homelab VLAN, derived — no hardcoded CIDR);
-  narrow to `download_vpn_lan_subnet` for a tighter boundary.
+  narrow to `download_vpn_lan_subnet` for a tighter boundary. Applied via the
+  `setPreferences` API (not the conf template — qBittorrent rewrites that file).
 - `download_vpn_prowlarr_web_port` — Prowlarr WebUI port (tofu).
 - `download_vpn_validator_interval` — runtime validator cadence (default 2min).
 - `download_vpn_ntfy_url` / `download_vpn_healthcheck_url` — breach alerting.

--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -108,7 +108,8 @@ download_vpn_qbittorrent_admin_password: "{{ lookup('env', 'QBITTORRENT_ADMIN_PA
 # the container's own IP — i.e. every VLAN in the homelab (3rd octet = VLAN id),
 # so cross-VLAN clients and Traefik-proxied requests are trusted too. Derived
 # from container_ip, so no CIDR is hardcoded. Narrow to download_vpn_lan_subnet
-# (the container's own /24) for a tighter boundary.
+# (the container's own /24) for a tighter boundary. Applied via the setPreferences
+# API in tasks/main.yml (not the conf template — qBittorrent would clobber it).
 download_vpn_qbittorrent_auth_whitelist: >-
   {{ ((container_ip | default(ansible_default_ipv4.address)) ~ '/16')
      | ansible.utils.ipaddr('network/prefix') }}

--- a/roles/download_vpn/tasks/main.yml
+++ b/roles/download_vpn/tasks/main.yml
@@ -267,13 +267,33 @@
   changed_when: false
   when: download_vpn_manage_services
 
-- name: Set the qBittorrent WebUI admin password via API
+- name: Assert the qBittorrent admin password is available
+  # A missing SOPS env makes the lookup return "", which would silently set an
+  # empty WebUI password. Fail loudly instead — this is the most likely cause of
+  # the live password drifting from SOPS. Run the play via `sops exec-env`.
+  ansible.builtin.assert:
+    that:
+      - download_vpn_qbittorrent_admin_password | length > 0
+    fail_msg: >-
+      QBITTORRENT_ADMIN_PASSWORD is empty — SOPS env not injected. Run the play
+      via `sops exec-env secrets.enc.yaml '...'` so the WebUI password is set.
+    quiet: true
+  when: download_vpn_manage_services
+
+- name: Set the qBittorrent WebUI admin password + auth whitelist via API
+  # The auth subnet whitelist is set HERE (not in qBittorrent.conf.j2): qBittorrent
+  # rewrites its conf from in-memory prefs on every setPreferences call, so a
+  # template-written whitelist is clobbered by the QoS write below. Setting it via
+  # the API lands it in memory, where it survives subsequent writes and the flush.
   ansible.builtin.uri:
     url: "http://127.0.0.1:{{ download_vpn_qbittorrent_web_port }}/api/v2/app/setPreferences"
     method: POST
     body_format: form-urlencoded
     body:
-      json: '{"web_ui_password":"{{ download_vpn_qbittorrent_admin_password }}"}'
+      json: >-
+        {"web_ui_password":"{{ download_vpn_qbittorrent_admin_password }}",
+         "bypass_auth_subnet_whitelist_enabled":true,
+         "bypass_auth_subnet_whitelist":"{{ download_vpn_qbittorrent_auth_whitelist }}"}
     status_code: 200
   no_log: true
   changed_when: false

--- a/roles/download_vpn/templates/qBittorrent.conf.j2
+++ b/roles/download_vpn/templates/qBittorrent.conf.j2
@@ -49,11 +49,10 @@ General\Locale=en
 WebUI\Address=*
 WebUI\Port={{ download_vpn_qbittorrent_web_port }}
 WebUI\LocalHostAuth=false
-# Skip the login form for clients inside the trusted network — qBittorrent's
-# analogue of the *arr apps' AuthenticationRequired=DisabledForLocalAddresses.
-# Whitelisted source IPs bypass auth entirely, so they also never trip the
-# failed-auth IP ban. Scope is set by download_vpn_qbittorrent_auth_whitelist.
-WebUI\AuthSubnetWhitelistEnabled=true
-WebUI\AuthSubnetWhitelist={{ download_vpn_qbittorrent_auth_whitelist }}
+# NOTE: the auth subnet whitelist is NOT set here. qBittorrent rewrites this file
+# from its in-memory prefs whenever a setPreferences call runs, so a whitelist
+# written here (but never loaded, because the daemon is already running) gets
+# clobbered by the next API write. It is applied via setPreferences in
+# tasks/main.yml instead — same reason the bandwidth QoS keys live there, not here.
 Downloads\SavePath={{ download_vpn_downloads_dir }}/
 Downloads\TempPath={{ download_vpn_downloads_dir }}/incomplete/


### PR DESCRIPTION
## Problem

The qBittorrent auth subnet whitelist added in #352 was written into
`qBittorrent.conf.j2`. qBittorrent rewrites that file from its in-memory
preferences on every `setPreferences` call, so a whitelist written to the
template — but never loaded, because the daemon is already running — is
**clobbered by the next API write**. The bandwidth-QoS `setPreferences` call
added in #356 does exactly that.

**Confirmed live**: after a later converge, LXC 214's
`bypass_auth_subnet_whitelist_enabled` had reverted to `false` / empty, re-locking
WebUI access. The role even documents this footgun for the QoS keys
(tasks/main.yml: "the daemon overwrites them") — the whitelist just wasn't moved
with them.

## Fix

- Move the whitelist into the password `setPreferences` call (lands in memory →
  survives the QoS write and the flush). Same pattern the QoS keys already use.
- Remove the whitelist lines from `qBittorrent.conf.j2` (leave a NOTE explaining why).
- Assert `download_vpn_qbittorrent_admin_password` is non-empty before setting it —
  an empty SOPS env lookup would silently blank the WebUI password, the likely
  original cause of the password drift tracked in #355.

No behaviour change to the trust model: the whitelist value is unchanged (derived
`/16` supernet of `container_ip`, no hardcoded CIDR).

## Verification

- CI: yamllint / ansible-lint / molecule (Template Rendering + download_vpn).
- Post-merge converge applies whitelist + password via API; durability re-checked
  by restarting qBittorrent and confirming the whitelist persists through the QoS
  write (the exact case that previously failed).

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)