### PR TITLE
fix(download_vpn): skip apt cache refresh when the proxy is unreachable

### DIFF
--- a/roles/download_vpn/README.md
+++ b/roles/download_vpn/README.md
@@ -127,6 +127,8 @@ derived LAN subnet) — nothing is hardcoded. See `defaults/main.yml`.
   narrow to `download_vpn_lan_subnet` for a tighter boundary. Applied via the
   `setPreferences` API (not the conf template — qBittorrent rewrites that file).
 - `download_vpn_prowlarr_web_port` — Prowlarr WebUI port (tofu).
+- `download_vpn_apt_cacher_host` / `download_vpn_apt_cacher_port` — apt proxy,
+  probed before refreshing the cache so a locked-down (offline) box doesn't block.
 - `download_vpn_validator_interval` — runtime validator cadence (default 2min).
 - `download_vpn_ntfy_url` / `download_vpn_healthcheck_url` — breach alerting.
 - `download_vpn_qbittorrent_{up,dl,alt_up,alt_dl}_limit` — KiB/s, `-1` =

--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -91,6 +91,13 @@ download_vpn_lanroute_reply_networks:
   - "172.16.0.0/12"
   - "192.168.0.0/16"
 
+# --- apt proxy ---------------------------------------------------------------
+# apt-cacher proxy coordinates, used only to probe reachability before refreshing
+# the cache. Same source as the proxy config in playbooks/site.yml. Empty when the
+# proxy host isn't in inventory (e.g. CI).
+download_vpn_apt_cacher_host: "{{ hostvars['apt-cacher-ng']['container_ip'] | default('') }}"
+download_vpn_apt_cacher_port: "{{ tofu_data.constants.service_ports.apt_cacher_ng | default(3142) }}"
+
 # --- qBittorrent -------------------------------------------------------------
 download_vpn_qbittorrent_package: qbittorrent-nox
 download_vpn_qbittorrent_user: "{{ download_vpn_user }}"

--- a/roles/download_vpn/tasks/main.yml
+++ b/roles/download_vpn/tasks/main.yml
@@ -51,6 +51,16 @@
       eth0).
 
 # --- Phase 1: packages -------------------------------------------------------
+- name: Check whether the apt proxy is reachable
+  ansible.builtin.wait_for:
+    host: "{{ download_vpn_apt_cacher_host }}"
+    port: "{{ download_vpn_apt_cacher_port }}"
+    timeout: 5
+  register: download_vpn_apt_proxy
+  ignore_errors: true
+  changed_when: false
+  when: download_vpn_apt_cacher_host | length > 0
+
 - name: Install media + VPN + firewall packages
   ansible.builtin.apt:
     name:
@@ -66,7 +76,11 @@
       - libicu-dev
       - gnupg
     state: present
-    update_cache: true
+    # Only refresh the cache when the proxy is reachable. A locked-down box can't
+    # reach it and already has its packages, so it must not block on a fetch.
+    update_cache: >-
+      {{ (download_vpn_apt_cacher_host | length == 0)
+         or (not (download_vpn_apt_proxy.failed | default(false))) }}
     cache_valid_time: 3600
 
 # --- Phase 1b: timezone -----------------------------------------------------


### PR DESCRIPTION
Probe the apt proxy before installing packages and only refresh the cache when it
answers. A locked-down container can't reach the proxy and already has its packages,
so a converge must not fail offline.

Closes #363