### PR TITLE
fix(ntp): skip chrony service start in LXC; exclude download_vpn from apt proxy

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -24,7 +24,7 @@
     - role: apt_cacher_ng
 
 - name: Configure apt proxy on LXC containers
-  hosts: lxc_containers:!apt_cacher_group
+  hosts: lxc_containers:!apt_cacher_group:!download_vpn_group
   become: true
   gather_facts: false
   tags:
@@ -51,6 +51,20 @@
 
     - name: Remove stale apt proxy configuration
       when: "'apt-cacher-ng' not in hostvars"
+      ansible.builtin.file:
+        path: /etc/apt/apt.conf.d/00proxy
+        state: absent
+
+- name: Remove apt proxy from download_vpn (killswitch blocks cross-subnet proxy)
+  hosts: download_vpn_group
+  become: true
+  gather_facts: false
+  tags:
+    - apt_proxy
+    - download_vpn
+    - lxc
+  tasks:
+    - name: Ensure no apt proxy is configured (apt-cacher-ng is in a different /24 than wg0 allows)
       ansible.builtin.file:
         path: /etc/apt/apt.conf.d/00proxy
         state: absent

--- a/roles/ntp/tasks/main.yml
+++ b/roles/ntp/tasks/main.yml
@@ -29,6 +29,6 @@
     name: chrony
     state: "{{ ntp_service_state }}"
     enabled: "{{ ntp_service_enabled }}"
-  when: ansible_virtualization_type | default('') != 'docker'
+  when: ansible_virtualization_type | default('') not in ['docker', 'lxc']
   tags:
     - ntp


### PR DESCRIPTION
## Summary

- **chrony in LXC**: `chrony.service` fails to start in unprivileged Proxmox LXC containers because they lack `CAP_SYS_TIME`. The NTP role already guarded against Docker — extended the same guard to `lxc`. Clock sync in LXC is handled by the Proxmox host.
- **download_vpn apt proxy**: The download_vpn container's nftables killswitch restricts egress to its own `/24`. apt-cacher-ng lives in a different `/24`, so setting the proxy causes every `apt` call to time out. Excluded `download_vpn_group` from the apt proxy play and added an explicit cleanup step to remove any previously-deployed proxy config.

## Test plan

- [ ] Redeploy confirms chrony tasks skip on all LXC hosts (no `failed` for chrony)
- [ ] download-vpn apt cache updates succeed without proxy
- [ ] Verify qBittorrent QoS API settings applied correctly post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)