### PR TITLE
fix(download_vpn): re-assert lanroute table before deploy-time gate

### DIFF
--- a/roles/download_vpn/README.md
+++ b/roles/download_vpn/README.md
@@ -34,7 +34,9 @@ outside the VPN:
    flows are never marked, so they still egress via `wg0` (or are dropped). This
    opens **no new egress path** — the killswitch guarantees above are unchanged,
    and the `ct mark` guard keeps WireGuard's own fwmark on encapsulated UDP
-   intact so the tunnel is never recursively routed.
+   intact so the tunnel is never recursively routed. The role re-asserts this
+   table immediately before the deploy-time gate, atomically rebuilding it only
+   when it has drifted to a clearnet `default via`, so every converge is clean.
 
 ## Bandwidth / QoS (self-throttle)
 

--- a/roles/download_vpn/tasks/main.yml
+++ b/roles/download_vpn/tasks/main.yml
@@ -449,6 +449,32 @@
     daemon_reload: true
   when: download_vpn_manage_services
 
+# --- Phase 9b: re-assert LAN-reply policy routing before the fail-closed gate -
+# The lanroute unit is Type=oneshot + RemainAfterExit=yes, so the Phase 5b
+# `state: started` is a no-op once active and never reconciles a drifted table
+# 100; the "Restart download-vpn lanroute" handler fires only on a mangle change
+# AND only at end-of-play (after validate.yml). So a table 100 drifted to a
+# clearnet `default via` (the leak-surface state) is never healed before the gate
+# inspects it. Read the table and force the atomic ExecStop(flush)->ExecStart
+# (rebuild) only when it has drifted — deterministic, idempotent, ordered before
+# validation. Refs #367.
+- name: Read the LAN-reply policy-routing table before validation
+  ansible.builtin.command:
+    cmd: ip route show table {{ download_vpn_lanroute_table }}
+  register: download_vpn_lanroute_pre
+  changed_when: false
+  when: download_vpn_manage_services
+
+- name: Re-assert LAN-reply policy routing if table 100 has drifted
+  ansible.builtin.systemd:
+    name: download-vpn-lanroute.service
+    state: restarted
+  when:
+    - download_vpn_manage_services
+    - >-
+      'default via' in (download_vpn_lanroute_pre.stdout | default(''))
+      or 'unreachable default' not in (download_vpn_lanroute_pre.stdout | default(''))
+
 # --- Phase 10: MANDATORY deploy-time validation -----------------------------
 # Runs at the END of every play. FAILS the run on any killswitch/leak violation.
 - name: Run fail-closed deploy-time validation


### PR DESCRIPTION
## What

Closes #367. Makes the `download_vpn` converge deterministically heal policy-routing **table 100** before the fail-closed validator inspects it.

## Why

The lanroute systemd unit's `ExecStop`(flush)→`ExecStart`(rebuild) cycle is already atomic and correct — a **manual** `systemctl restart download-vpn-lanroute.service` always produces the right table (RFC1918 reply routes + `unreachable default`). The **converge** failed to trigger that rebuild before the gate, for three structural reasons:

1. **`state: started` is a no-op.** The unit is `Type=oneshot` + `RemainAfterExit=yes`; once active, Ansible's Phase 5b `state: started` never re-runs `ExecStart`, so a drifted table is never rebuilt on re-converge.
2. **The corrective handler runs after the gate.** `Restart download-vpn lanroute` fires only on a mangle change and only at end-of-play — i.e. *after* `validate.yml`. So when the table is drifted, the deploy-time validator (and the runtime timer) flag the leak surface and stop qBittorrent before the fix can run.
3. **Nothing else re-asserts the table at the gate.** wg-quick uses a separate table; no role code writes a clearnet default into table 100 (the injector is environmental/transient — hence "non-deterministic").

## Change

A new **Phase 9b** in `roles/download_vpn/tasks/main.yml`, immediately before Phase 10's `validate.yml`: read `ip route show table <lanroute_table>` and force the atomic service restart **only when** the table shows a clearnet `default via` or is missing `unreachable default`. Deterministic, idempotent (no change in steady state), ordered ahead of the gate. README updated.

## Verification

- `ansible-lint roles/download_vpn` — passed (profile `production`, 0 failures).
- `ansible-playbook --syntax-check playbooks/site.yml` — parses cleanly (incl. the new conditional).
- Molecule renders with `manage_services=false`; the new tasks skip cleanly (guarded by `| default('')`).
- **Live proof requires the box** (CI cannot run the live validator): induce drift (`pct exec 214 -- ip route replace default via <lan_gw> table <lanroute_table>`), converge, and confirm Phase 9b rebuilds the table, `validate.yml` passes, and qBittorrent stays up.