### PR TITLE
feat(traefik+technitium): front Proxmox cluster UI at the subdomain apex

### DIFF
--- a/roles/technitium_dns/defaults/main.yml
+++ b/roles/technitium_dns/defaults/main.yml
@@ -52,8 +52,19 @@ technitium_dns_cname_records:
 # own name points at Traefik, not the host — safe because all internal
 # service-to-service traffic uses container IPs, not these DNS names).
 technitium_dns_ingress_host: traefik
+# Apex ingress rows (the Proxmox cluster UI fronted at the bare subdomain) are
+# EXCLUDED here — they resolve at the zone root, not as <name>.<subdomain> — and
+# are handled by technitium_dns_ingress_apex below instead.
 technitium_dns_ingress_aliases: >-
-  {{ tofu_data.ingress | default([]) | map(attribute='name') | list }}
+  {{ tofu_data.ingress | default([]) | rejectattr('apex', 'defined')
+     | map(attribute='name') | list }}
+# Apex ingress rows: a fronted service that lives at the subdomain zone root
+# itself, e.g. the Proxmox cluster UI load-balanced across the nodes.
+# Selected from the SAME tofu ingress table; gets an A record AT the zone apex
+# (-> Traefik), never a <name>.<subdomain> alias.
+technitium_dns_ingress_apex: >-
+  {{ tofu_data.ingress | default([]) | selectattr('apex', 'defined')
+     | selectattr('apex') | list }}
 # Ingress lives under PROXMOX_SUBDOMAIN (matches the traefik role's
 # traefik_base_domain): aliases resolve as <name>.<PROXMOX_SUBDOMAIN>. This is the
 # SAME value as the authoritative technitium_dns_zone, so the records land in the

--- a/roles/technitium_dns/tasks/main.yml
+++ b/roles/technitium_dns/tasks/main.yml
@@ -309,6 +309,38 @@
     - technitium_dns_ingress_host in hostvars
     - hostvars[technitium_dns_ingress_host].container_ip is defined
 
+# The Proxmox cluster-UI apex (the subdomain zone root itself) resolves to the
+# Traefik LXC, same target as the per-service aliases above, so the bare apex
+# https://<subdomain> reaches Traefik's load-balanced node pool over TLS.
+# domain == the zone name writes the A record AT the zone apex. Created only when
+# the tofu ingress table carries an apex row (otherwise a no-op).
+- name: Create Traefik apex A record (zone root -> Traefik)
+  ansible.builtin.uri:
+    url: "{{ technitium_dns_api_url }}/api/zones/records/add?token={{ technitium_dns_api_token }}"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      domain: "{{ technitium_dns_zone }}"
+      zone: "{{ technitium_dns_zone }}"
+      type: A
+      ipAddress: "{{ hostvars[technitium_dns_ingress_host].container_ip }}"
+      ttl: "{{ technitium_dns_zone_ttl }}"
+      overwrite: "true"
+    return_content: true
+    timeout: "{{ technitium_dns_api_timeout }}"
+  register: technitium_dns_apex_result
+  changed_when: technitium_dns_apex_result.json.status == "ok"
+  failed_when:
+    - technitium_dns_apex_result.json.status | default('') != "ok"
+    - "'already exists' not in (technitium_dns_apex_result.json.errorMessage | default(''))"
+  no_log: true
+  when:
+    - technitium_dns_ingress_apex | default([]) | length > 0
+    - technitium_dns_role == 'primary'
+    - technitium_dns_apply | bool
+    - technitium_dns_ingress_host in hostvars
+    - hostvars[technitium_dns_ingress_host].container_ip is defined
+
 # Authorize the secondaries to pull the zone via AXFR. UseSpecifiedNetworkACL
 # restricts transfer to exactly the secondary IPs (default-deny otherwise).
 # No-op for a single-node group (no secondaries).

--- a/roles/traefik/README.md
+++ b/roles/traefik/README.md
@@ -95,6 +95,14 @@ fronted service is added/removed in exactly one place. Add it in terraform-proxm
   `media_svc` → target VLAN), enforced in `terraform-unifi`. Some apps also need
   their own reverse-proxy trust setting (e.g. **Home Assistant**
   `http.trusted_proxies` / `use_x_forwarded_for`) — in the app's config, not here.
+- **Apex — Proxmox cluster UI** (the base domain itself, e.g.
+  `pve.<domain>`, with no `<name>.` prefix): an `apex` + multi-backend ingress
+  row that **load-balances across every commissioned node's web UI**
+  (`https://<role>.<domain>:8006`) with a sticky session cookie + per-node health
+  checks. Backends are node **FQDNs** (hostnames, not IPs) that already resolve
+  internally; Traefik re-encrypts over HTTPS and skips verification via the
+  shared `insecure-backend` transport (self-signed node certs). The apex is
+  already a SAN on the wildcard cert, so no extra certificate work.
 
 ## Installation
 

--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -83,25 +83,38 @@
   notify: Restart traefik
 
 # Build the routers from the single tofu-owned ingress table
-# (tofu_data.ingress via traefik_ingress_routes): a list of {name, ip, port}
-# with the backend IP already resolved by tofu (cidrhost). Items may carry an
-# optional scheme (default http) and insecure_tls (default false) for backends
-# that serve HTTPS with a self-signed cert (e.g. Splunk Web). The template just
-# needs name/fqdn/backend/insecure_tls, so it stays dumb (and fixture-testable).
+# (tofu_data.ingress via traefik_ingress_routes). Single-backend rows are
+# {name, ip, port}; the Proxmox cluster-UI apex row is {name, apex, backends[],
+# port} — a load-balanced pool over the node FQDNs. Optional per row: scheme
+# (default http), insecure_tls (self-signed backend, e.g. Splunk / Proxmox),
+# sticky + health_check (pool session affinity + per-node health checks). Every
+# row is normalised here to {name, fqdn, servers[], scheme, insecure_tls,
+# sticky, health_check} so the template stays dumb (and fixture-testable):
+#   - fqdn    = base domain itself when apex, else <name>.<base domain>
+#   - servers = one <scheme>://<host-or-ip>:<port> url per backend (or the
+#               single ip), so single and multi-backend rows render uniformly.
 - name: Build Traefik routers from the inventory ingress table
   ansible.builtin.set_fact:
     traefik_routes: >-
       {{
         traefik_routes | default([]) + [{
           'name': item.name,
-          'fqdn': item.name ~ '.' ~ traefik_base_domain,
-          'backend': (item.scheme | default('http')) ~ '://' ~ item.ip ~ ':' ~ item.port,
-          'insecure_tls': item.insecure_tls | default(false)
+          'fqdn': (item.apex | default(false)) | ternary(
+                    traefik_base_domain,
+                    item.name ~ '.' ~ traefik_base_domain),
+          'servers': (item.backends | default([item.ip | default('')]))
+                     | map('regex_replace', '^', (item.scheme | default('http')) ~ '://')
+                     | map('regex_replace', '$', ':' ~ (item.port | string))
+                     | list,
+          'scheme': item.scheme | default('http'),
+          'insecure_tls': item.insecure_tls | default(false),
+          'sticky': item.sticky | default(false),
+          'health_check': item.health_check | default(false)
         }]
       }}
   loop: "{{ traefik_ingress_routes }}"
   loop_control:
-    label: "{{ item.name }} -> {{ item.ip }}:{{ item.port }}"
+    label: "{{ item.name }} -> {{ (item.backends | default([item.ip | default('?')])) | join(', ') }}:{{ item.port }}"
 
 - name: Render the dynamic Traefik config (routers + services)
   ansible.builtin.template:

--- a/roles/traefik/templates/dynamic.yml.j2
+++ b/roles/traefik/templates/dynamic.yml.j2
@@ -38,8 +38,24 @@ http:
     {{ route.name }}:
       loadBalancer:
         passHostHeader: true
+{% if route.sticky | default(false) %}
+        sticky:
+          cookie:
+            name: "{{ route.name }}_lb"
+            secure: true
+            httpOnly: true
+{% endif %}
         servers:
-          - url: "{{ route.backend }}"
+{% for url in route.servers %}
+          - url: "{{ url }}"
+{% endfor %}
+{% if route.health_check | default(false) %}
+        healthCheck:
+          scheme: "{{ route.scheme | default('http') }}"
+          path: "/"
+          interval: "10s"
+          timeout: "5s"
+{% endif %}
 {% if route.insecure_tls | default(false) %}
         serversTransport: insecure-backend
 {% endif %}

--- a/tests/inventory_load/tofu_inventory.json
+++ b/tests/inventory_load/tofu_inventory.json
@@ -353,6 +353,16 @@
       "name": "plex",
       "ip": "192.168.55.210",
       "port": 32400
+    },
+    {
+      "name": "proxmox",
+      "apex": true,
+      "backends": ["proxmox1.example.com"],
+      "port": 8006,
+      "scheme": "https",
+      "insecure_tls": true,
+      "sticky": true,
+      "health_check": true
     }
   ],
   "nodes": {

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1044,16 +1044,71 @@
     traefik_acme_aws_secret_access_key: "testsecretplaceholderplaceholderplaceholde"
     traefik_acme_aws_region: "us-east-1"
     traefik_acme_route53_zone_id: "Z0123456789ABCDEFGHIJ"
-    # Routes as tasks/main.yml builds them from tofu_data.ingress
-    # ({name, ip, port}) -> {name, fqdn, backend}.
-    traefik_routes:
-      - { name: plex, fqdn: "plex.pve.example.com", backend: "http://192.0.2.10:32400" }
-      - { name: seerr, fqdn: "seerr.pve.example.com", backend: "http://192.0.2.11:5055" }
+    # The tofu-owned ingress table (tofu_data.ingress) the builder consumes:
+    # single-backend {name, ip, port} rows plus the Proxmox apex {name, apex,
+    # backends[], port} pool. Scrubbed/documentation values only. The real
+    # builder (mirrored in the first task below) turns these into traefik_routes.
+    traefik_ingress_routes:
+      - { name: plex, ip: "192.0.2.10", port: 32400 }
       # HTTPS backend with a self-signed cert (e.g. Splunk Web) -> insecure_tls.
-      - { name: splunk, fqdn: "splunk.pve.example.com", backend: "https://192.0.2.12:8000", insecure_tls: true }
+      - { name: splunk, ip: "192.0.2.12", port: 8000, scheme: https, insecure_tls: true }
+      # Proxmox cluster-UI apex: load-balanced pool over the node FQDNs, sticky
+      # + health-checked, https to self-signed node backends.
+      - name: proxmox
+        apex: true
+        backends: ["proxmox1.example.com", "proxmox2.example.com", "proxmox3.example.com"]
+        port: 8006
+        scheme: https
+        insecure_tls: true
+        sticky: true
+        health_check: true
     _template_dir: "../../roles/traefik/templates"
 
   tasks:
+    # Build traefik_routes from the ingress table exactly as
+    # roles/traefik/tasks/main.yml does, so this exercises the real route-builder
+    # transform (apex fqdn, multi-backend servers list, scheme/sticky/health
+    # flags) end-to-end into the template — not a hand-maintained output mirror.
+    - name: Build traefik_routes from the fixture ingress table
+      ansible.builtin.set_fact:
+        traefik_routes: >-
+          {{
+            traefik_routes | default([]) + [{
+              'name': item.name,
+              'fqdn': (item.apex | default(false)) | ternary(
+                        traefik_base_domain,
+                        item.name ~ '.' ~ traefik_base_domain),
+              'servers': (item.backends | default([item.ip | default('')]))
+                         | map('regex_replace', '^', (item.scheme | default('http')) ~ '://')
+                         | map('regex_replace', '$', ':' ~ (item.port | string))
+                         | list,
+              'scheme': item.scheme | default('http'),
+              'insecure_tls': item.insecure_tls | default(false),
+              'sticky': item.sticky | default(false),
+              'health_check': item.health_check | default(false)
+            }]
+          }}
+      loop: "{{ traefik_ingress_routes }}"
+      loop_control:
+        label: "{{ item.name }}"
+
+    - name: Assert the builder normalised apex + multi-backend rows correctly
+      ansible.builtin.assert:
+        that:
+          # Single http backend -> one url; fqdn keeps the <name>. prefix.
+          - (traefik_routes | selectattr('name', 'equalto', 'plex') | first).servers == ["http://192.0.2.10:32400"]
+          - (traefik_routes | selectattr('name', 'equalto', 'plex') | first).fqdn == "plex.pve.example.com"
+          # Apex row -> fqdn is the base domain itself + a 3-server pool.
+          - (traefik_routes | selectattr('name', 'equalto', 'proxmox') | first).fqdn == "pve.example.com"
+          - >-
+            (traefik_routes | selectattr('name', 'equalto', 'proxmox') | first).servers
+            == ["https://proxmox1.example.com:8006", "https://proxmox2.example.com:8006", "https://proxmox3.example.com:8006"]
+          - (traefik_routes | selectattr('name', 'equalto', 'proxmox') | first).sticky | bool
+          - (traefik_routes | selectattr('name', 'equalto', 'proxmox') | first).health_check | bool
+        fail_msg: >-
+          The route-builder did not normalise the ingress table correctly: apex
+          fqdn, the multi-backend servers list, or the sticky/health flags wrong.
+
     - name: Render traefik static config to /tmp
       ansible.builtin.template:
         src: "{{ _template_dir }}/traefik.yml.j2"
@@ -1101,14 +1156,14 @@
         _traefik_dynamic: "{{ _traefik_dynamic_raw.content | b64decode }}"
         _traefik_dynamic_yaml: "{{ _traefik_dynamic_raw.content | b64decode | from_yaml }}"
 
-    - name: Assert routers front each service with the wildcard cert + backend
+    - name: Assert routers front each service with the wildcard cert + apex
       ansible.builtin.assert:
         that:
           - "'Host(`plex.pve.example.com`)' in _traefik_dynamic"
-          - "'Host(`seerr.pve.example.com`)' in _traefik_dynamic"
           - "'http://192.0.2.10:32400' in _traefik_dynamic"
-          - "'http://192.0.2.11:5055' in _traefik_dynamic"
           - "'*.pve.example.com' in _traefik_dynamic"
+          # The apex router's Host rule is the base domain ITSELF (no <name>. prefix).
+          - _traefik_dynamic_yaml.http.routers.proxmox.rule == "Host(`pve.example.com`)"
           # Wildcard requested via the resolver; dashboard secured by a usersFile
           # (no credential inline — the role generates the file on the host).
           - _traefik_dynamic_yaml.http.routers.plex.tls.certResolver == "letsencrypt"
@@ -1118,15 +1173,38 @@
             == "/etc/traefik/dashboard.htpasswd"
           - _traefik_dynamic_yaml.http.services.plex.loadBalancer.servers[0].url == "http://192.0.2.10:32400"
         fail_msg: >-
-          dynamic.yml.j2 missing a router/service, the wildcard SAN, or the
-          usersFile-secured dashboard.
+          dynamic.yml.j2 missing a router/service, the apex Host rule, the
+          wildcard SAN, or the usersFile-secured dashboard.
+
+    - name: Assert the apex service is a sticky, health-checked, 3-node pool
+      ansible.builtin.assert:
+        that:
+          # Load-balanced across all three node UIs, in order.
+          - _traefik_dynamic_yaml.http.services.proxmox.loadBalancer.servers | length == 3
+          - >-
+            (_traefik_dynamic_yaml.http.services.proxmox.loadBalancer.servers | map(attribute='url') | list)
+            == ["https://proxmox1.example.com:8006", "https://proxmox2.example.com:8006", "https://proxmox3.example.com:8006"]
+          # Sticky session cookie pins a browser to one node.
+          - _traefik_dynamic_yaml.http.services.proxmox.loadBalancer.sticky.cookie.name == "proxmox_lb"
+          - _traefik_dynamic_yaml.http.services.proxmox.loadBalancer.sticky.cookie.secure | bool
+          # Health check (https, path /) drops a down node; insecure-backend
+          # transport re-encrypts to the self-signed node certs.
+          - _traefik_dynamic_yaml.http.services.proxmox.loadBalancer.healthCheck.path == "/"
+          - _traefik_dynamic_yaml.http.services.proxmox.loadBalancer.healthCheck.scheme == "https"
+          - _traefik_dynamic_yaml.http.services.proxmox.loadBalancer.serversTransport == "insecure-backend"
+          # A single-backend http service gets neither sticky nor healthCheck.
+          - "'sticky' not in _traefik_dynamic_yaml.http.services.plex.loadBalancer"
+          - "'healthCheck' not in _traefik_dynamic_yaml.http.services.plex.loadBalancer"
+        fail_msg: >-
+          dynamic.yml.j2 apex service wrong: pool size/urls, sticky cookie,
+          healthCheck, or serversTransport not rendered as expected.
 
     - name: Assert HTTPS backend gets an https URL + insecure-backend serversTransport
       ansible.builtin.assert:
         that:
           # The https backend keeps its scheme through to the service URL.
           - _traefik_dynamic_yaml.http.services.splunk.loadBalancer.servers[0].url == "https://192.0.2.12:8000"
-          # Only the insecure_tls route references the shared transport...
+          # Only the insecure_tls routes reference the shared transport...
           - _traefik_dynamic_yaml.http.services.splunk.loadBalancer.serversTransport == "insecure-backend"
           - "'serversTransport' not in _traefik_dynamic_yaml.http.services.plex.loadBalancer"
           # ...and that transport skips verification of the self-signed cert.


### PR DESCRIPTION
## What

Front the Proxmox cluster web UI at the ingress subdomain apex
(`https://<subdomain>`) over the existing Let's Encrypt wildcard cert,
load-balanced across every node's `:8006` UI with a sticky session cookie +
per-node health checks.

## Why

Companion consumer for the apex `ingress` row added in
dryvist/terraform-proxmox#400. Proxmox serves its UI only on
`https://<node>:8006` with a self-signed cert, so Traefik terminates the public
wildcard cert and re-encrypts to each node over HTTPS with verification skipped
(the existing `insecure-backend` transport). Backends are node **role FQDNs**
that already resolve internally — no node IPs are used here.

## Changes

**traefik role**
- Route-builder (`tasks/main.yml`) normalises every ingress row to
  `{name, fqdn, servers[], scheme, insecure_tls, sticky, health_check}`: an
  `apex` row's Host rule is the base domain itself (no `<name>.` prefix);
  `backends[]` rows render a multi-server pool, so single- and multi-backend
  rows render uniformly.
- `dynamic.yml.j2` emits the load-balanced pool with a sticky session cookie and
  a health check, reusing the existing `insecure-backend` `serversTransport`.

**technitium_dns role**
- Create an A record at the subdomain zone root (→ the Traefik LXC) for an apex
  row, and exclude apex rows from the `<name>.<subdomain>` alias loop.

**tests**
- `template_render` now drives the **real** route-builder from an ingress-table
  fixture (incl. an apex multi-backend row) and asserts the apex Host rule,
  3-server pool, sticky cookie, healthCheck, and `insecure-backend` transport.
- `inventory_load` fixture carries a sample apex row.
- Sample node names use `proxmox1/2/3`.

## Tests

`ansible-lint` → passed (0 failures, production profile). The route-builder
transform is validated locally (builder assertions pass); the full render +
render-assertions run in CI (the template plays require root locally).

## Verification (manual, after both PRs merge + inventory synced)

CI cannot see live TLS / the browser. After deploy:
- `dig +short <subdomain> @<technitium>` → the Traefik LXC IP.
- `curl -I https://<subdomain>` → 200, valid Let's Encrypt cert (not a node
  self-signed cert).
- Browser → Proxmox login over trusted TLS; confirm the session is sticky and
  the pool survives one node going down.

Refs: dryvist/terraform-proxmox#400

🤖 Generated with [Claude Code](https://claude.com/claude-code)
