### PR TITLE
feat(syslog_forwarder): forward infra LXC logs to the Cribl pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,10 @@ this repo handles app config only.
 - **Cribl Edge** (`cribl_edge` role — native install on LXC containers)
 - **Cribl Stream** (`cribl_stream` role — native install on LXC containers)
 - **HAProxy** (LXC container, syslog/netflow VIP forwarding to Cribl LXCs)
+- **Syslog forwarding** (`syslog_forwarder` role — rsyslog on every infra LXC
+  ships host + native-service logs to the HAProxy syslog VIP on the Linux port
+  -> Cribl Edge -> Splunk `os` index; the pipeline (Cribl) and LB (HAProxy) LXCs
+  are excluded to avoid feedback loops)
 - **Technitium DNS** (LXC container)
 - **apt-cacher-ng** (LXC container)
 - **Mailpit** (LXC container, SMTP relay with web UI)
@@ -33,7 +37,9 @@ this repo handles app config only.
 ## Pipeline Data Flow
 
 ```text
-Source -> HAProxy LXC (175, TCP+UDP 514-518, 1514-1518, 2055)
+Sources: external (network gear, OS hosts) + infra LXCs self-logging
+         (syslog_forwarder role, Linux port 1517)
+         -> HAProxy LXC (175, TCP+UDP 514-518, 1514-1518, 2055)
            |
        Cribl Edge LXCs (180, 181) [syslog ports 1514-1518]
          - Pipeline: sets index + sourcetype by port

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -151,6 +151,26 @@
     - role: ntp
 
 # =============================================================================
+# Phase 0a2: Syslog forwarding to the central pipeline
+# Every infra LXC ships its logs (systemd journal + native services) to the
+# HAProxy syslog VIP -> Cribl Edge -> Splunk (os index). Runs after NTP so log
+# timestamps are accurate. The pipeline (cribl_edge / cribl_stream) and the load
+# balancer (haproxy) are excluded: they RECEIVE this traffic, so forwarding into
+# themselves would loop; their own logs are collected locally by Cribl Edge.
+# =============================================================================
+
+- name: Forward infra LXC logs to the syslog pipeline
+  hosts: lxc_containers:!cribl_edge:!cribl_stream_group:!haproxy_group
+  become: true
+  gather_facts: false
+  tags:
+    - syslog_forwarder
+    - logging
+    - baseline
+  roles:
+    - role: syslog_forwarder
+
+# =============================================================================
 # Phase 0b: MinIO Object Storage
 # S3-compatible artifact store for Splunk add-ons and other deployment assets
 # =============================================================================

--- a/roles/syslog_forwarder/README.md
+++ b/roles/syslog_forwarder/README.md
@@ -1,0 +1,92 @@
+# syslog_forwarder
+
+Forward an infra LXC's logs to the central syslog pipeline so everything lands
+in Splunk. Installs `rsyslog`, which ingests the systemd journal by default on
+Debian, and adds one drop-in rule that ships **all** logs to the HAProxy syslog
+VIP.
+
+```text
+this LXC (journald + rsyslog)
+  -> syslog.<PROXMOX_SUBDOMAIN>:<linux port>  (TCP, disk-assisted queue)
+     -> HAProxy syslog VIP
+        -> Cribl Edge  (syslog pipeline)
+           -> Splunk HEC  (os index)
+```
+
+## How it works
+
+`rsyslog` reads the systemd journal (`imjournal`) by default on Debian, so a
+single forward rule captures host logs plus every native systemd service. The
+rule uses `omfwd` with a disk-assisted action queue, so a HAProxy/Cribl outage
+buffers (up to `syslog_forwarder_queue_max_disk_space`) instead of dropping
+logs.
+
+## What it captures
+
+- All host/system logs and **every native systemd service** (Traefik,
+  Technitium, apt-cacher-ng, etc.) — these go through journald, which rsyslog
+  reads.
+- **Docker-in-LXC container logs** only when that service's Compose `logging`
+  driver is `journald` (set per service in the relevant `*_docker` role). The
+  default Docker `json-file` driver is **not** in journald and is not forwarded.
+
+## Where it runs
+
+Applied by the `site.yml` play to `lxc_containers` **minus** the pipeline and
+load balancer:
+
+```text
+lxc_containers:!cribl_edge:!cribl_stream_group:!haproxy_group
+```
+
+Those hosts are excluded to avoid forwarding into the receiver they feed. Their
+own logs are better collected locally by Cribl Edge (a separate follow-up).
+
+## Installation
+
+No manual install. The role is wired into `playbooks/site.yml` and runs against
+the host pattern above on every converge. `rsyslog` is installed by the role via
+`apt`. Ansible collection dependencies come from the repo `requirements.yml`.
+
+## Usage
+
+Deploy with the rest of the apps, or target just this role by tag:
+
+```bash
+doppler run -- ansible-playbook -i inventory/hosts.yml playbooks/site.yml \
+  --tags syslog_forwarder
+```
+
+### Variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `syslog_forwarder_target_host` | `syslog.{{ PROXMOX_SUBDOMAIN }}` | The `syslog` CNAME (→ HAProxy VIP). Never a literal. |
+| `syslog_forwarder_target_port` | `tofu_data.constants.syslog_ports.linux` | Linux syslog port (→ Splunk `os` index). |
+| `syslog_forwarder_protocol` | `tcp` | `tcp` (reliable) or `udp`. |
+| `syslog_forwarder_queue_max_disk_space` | `256m` | Disk-queue cap so a receiver outage buffers instead of dropping. |
+
+Port and target are sourced from the inventory / `PROXMOX_SUBDOMAIN`, never
+hardcoded (see `.claude/rules/ip-addressing.md`).
+
+## Verification
+
+```bash
+# On a forwarding LXC: the drop-in exists and rsyslog is happy.
+cat /etc/rsyslog.d/10-forward-cribl.conf
+rsyslogd -N1
+systemctl is-active rsyslog
+
+# End to end: this host's logs appear in Splunk under the os index
+#   index=os host=<this-lxc>
+```
+
+## Contributing
+
+Changes go through the repo's standard flow: edit in a worktree, pass
+`ansible-lint` and the `tests/template_render` fixture, open a PR. Keep ports and
+hostnames sourced from the inventory — never hardcode them here.
+
+## License
+
+Apache-2.0, matching the repository.

--- a/roles/syslog_forwarder/defaults/main.yml
+++ b/roles/syslog_forwarder/defaults/main.yml
@@ -1,0 +1,26 @@
+---
+# Forward this host's logs (the systemd journal + everything rsyslog ingests) to
+# the central syslog pipeline: HAProxy syslog VIP -> Cribl Edge -> Splunk (os
+# index). rsyslog reads the journal by default on Debian, so installing it and
+# adding one forward rule captures host logs plus every systemd service (and
+# Docker containers whose compose log-driver is journald).
+#
+# No literals: the port comes from the tofu constants and the target from the
+# stable `syslog` CNAME (-> haproxy). See .claude/rules/ip-addressing.md.
+
+# Stable syslog entry point: the `syslog` CNAME the technitium_dns role creates
+# (-> the HAProxy VIP). Sized off PROXMOX_SUBDOMAIN, never a committed literal.
+syslog_forwarder_target_host: "syslog.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
+
+# Linux syslog port from tofu pipeline_constants (routes to the Splunk os index).
+syslog_forwarder_target_port: "{{ tofu_data.constants.syslog_ports.linux }}"
+
+# tcp (omfwd protocol=tcp) is reliable; udp drops under load. Cribl accepts both.
+syslog_forwarder_protocol: tcp
+
+# Drop-in rsyslog config file owned by this role.
+syslog_forwarder_config_path: /etc/rsyslog.d/10-forward-cribl.conf
+
+# Disk-assisted action queue: buffer through a HAProxy/Cribl outage instead of
+# dropping logs (capped so a long outage can't fill the root filesystem).
+syslog_forwarder_queue_max_disk_space: 256m

--- a/roles/syslog_forwarder/handlers/main.yml
+++ b/roles/syslog_forwarder/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+# syslog_forwarder role handlers
+
+- name: Restart rsyslog
+  ansible.builtin.systemd:
+    name: rsyslog
+    state: restarted
+  listen: Restart rsyslog

--- a/roles/syslog_forwarder/meta/main.yml
+++ b/roles/syslog_forwarder/meta/main.yml
@@ -1,0 +1,24 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: Forward host + service logs to the central syslog pipeline (HAProxy VIP -> Cribl Edge -> Splunk)
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+
+  galaxy_tags:
+    - syslog
+    - rsyslog
+    - logging
+    - observability
+
+dependencies: []

--- a/roles/syslog_forwarder/tasks/main.yml
+++ b/roles/syslog_forwarder/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+# Install rsyslog and add a single forward rule so this host's logs (systemd
+# journal + everything rsyslog sees) flow to the central syslog VIP -> Cribl
+# Edge -> Splunk. The pipeline + load-balancer LXCs are excluded by the site.yml
+# play's host pattern, so this never forwards into the receiver it feeds.
+
+- name: Assert the syslog VIP target + port resolved from inventory
+  ansible.builtin.assert:
+    that:
+      - syslog_forwarder_target_host | length > 0
+      - syslog_forwarder_target_port | string | length > 0
+    fail_msg: >-
+      syslog_forwarder needs PROXMOX_SUBDOMAIN (for the syslog CNAME target) and
+      tofu_data.constants.syslog_ports.linux. Ensure the inventory is synced and
+      PROXMOX_SUBDOMAIN is set.
+    quiet: true
+
+- name: Install rsyslog
+  ansible.builtin.apt:
+    name: rsyslog
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Deploy the Cribl syslog-forward rule
+  ansible.builtin.template:
+    src: 10-forward-cribl.conf.j2
+    dest: "{{ syslog_forwarder_config_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+    validate: rsyslogd -N1 -f %s
+  notify: Restart rsyslog
+
+- name: Enable and start rsyslog
+  ansible.builtin.systemd:
+    name: rsyslog
+    state: started
+    enabled: true

--- a/roles/syslog_forwarder/templates/10-forward-cribl.conf.j2
+++ b/roles/syslog_forwarder/templates/10-forward-cribl.conf.j2
@@ -1,0 +1,17 @@
+# {{ ansible_managed }}
+# Forward all logs to the central syslog pipeline:
+#   this host -> {{ syslog_forwarder_target_host }}:{{ syslog_forwarder_target_port }} ({{ syslog_forwarder_protocol }})
+#   -> HAProxy syslog VIP -> Cribl Edge -> Splunk (os index).
+# rsyslog ingests the systemd journal by default on Debian, so this captures
+# host logs + every systemd service (and Docker containers whose compose
+# log-driver is journald). The disk-assisted queue survives a receiver outage
+# instead of dropping logs.
+*.* action(type="omfwd"
+           target="{{ syslog_forwarder_target_host }}"
+           port="{{ syslog_forwarder_target_port }}"
+           protocol="{{ syslog_forwarder_protocol }}"
+           queue.type="LinkedList"
+           queue.filename="cribl_fwd"
+           queue.maxDiskSpace="{{ syslog_forwarder_queue_max_disk_space }}"
+           queue.saveOnShutdown="on"
+           action.resumeRetryCount="-1")

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1168,3 +1168,60 @@
           - traefik.yml.j2: route53 DNS-01 resolver, secured API, TLS >= 1.2, no leaked creds
           - dynamic.yml.j2: per-service routers + backends, wildcard SAN, secured dashboard
           - acme.env.j2: AWS creds + AWS_HOSTED_ZONE_ID in the root-only EnvironmentFile
+
+# =============================================================================
+# syslog_forwarder — the rsyslog drop-in that forwards every log to the central
+# syslog VIP (-> HAProxy -> Cribl Edge -> Splunk). Render + assert the omfwd rule.
+# =============================================================================
+- name: Render and verify syslog_forwarder template
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    # Mirror roles/syslog_forwarder/defaults/main.yml with scrubbed values.
+    syslog_forwarder_target_host: "syslog.pve.example.com"
+    syslog_forwarder_target_port: 1517
+    syslog_forwarder_protocol: tcp
+    syslog_forwarder_queue_max_disk_space: 256m
+    _sf_template_dir: "../../roles/syslog_forwarder/templates"
+
+  tasks:
+    - name: Render the syslog forward rule to /tmp
+      ansible.builtin.template:
+        src: "{{ _sf_template_dir }}/10-forward-cribl.conf.j2"
+        dest: /tmp/test_syslog_forward.conf
+        mode: "0644"
+
+    - name: Read rendered syslog forward rule
+      ansible.builtin.slurp:
+        src: /tmp/test_syslog_forward.conf
+      register: _sf_raw
+
+    - name: Decode rendered syslog forward rule
+      ansible.builtin.set_fact:
+        _sf: "{{ _sf_raw.content | b64decode }}"
+
+    - name: Assert all logs forward to the VIP over TCP with a disk-assisted queue
+      ansible.builtin.assert:
+        that:
+          # All facilities/severities, via the omfwd output module.
+          - "'*.*' in _sf"
+          - "'action(type=' in _sf"
+          - "'omfwd' in _sf"
+          # To the stable syslog CNAME on the Linux port, over TCP.
+          - "'syslog.pve.example.com' in _sf"
+          - "'1517' in _sf"
+          - "'protocol' in _sf"
+          - "'tcp' in _sf"
+          # Disk-assisted queue so a receiver outage buffers instead of dropping.
+          - "'queue.filename' in _sf"
+          - "'cribl_fwd' in _sf"
+          - "'256m' in _sf"
+        fail_msg: >-
+          10-forward-cribl.conf.j2 did not render the expected omfwd rule
+          (selector/target/port/protocol/queue).
+
+    - name: Syslog forwarder template rendering PASSED
+      ansible.builtin.debug:
+        msg: "syslog_forwarder: omfwd rule -> syslog.pve.example.com:1517/tcp with disk queue"


### PR DESCRIPTION
## What

A new `syslog_forwarder` role that ships every infra LXC's logs to the central
syslog pipeline (HAProxy VIP → Cribl Edge → Splunk `os` index), so host +
service logs are searchable in Splunk instead of living only in each container's
local journal.

## How

- `roles/syslog_forwarder`: installs `rsyslog` (which ingests the systemd journal
  by default on Debian) and drops `/etc/rsyslog.d/10-forward-cribl.conf` — one
  `omfwd` rule forwarding `*.*` to `syslog.<subdomain>:<linux port>` over **TCP**
  with a **disk-assisted queue** (buffers through a receiver outage instead of
  dropping logs).
- `site.yml`: new play after NTP, `hosts:
  lxc_containers:!cribl_edge:!cribl_stream_group:!haproxy_group` — the pipeline
  (Cribl) and load balancer (HAProxy) are excluded because they *receive* this
  traffic, so forwarding into themselves would loop.
- Port + target sourced from `tofu_data.constants.syslog_ports.linux` and the
  `syslog` CNAME — no literals (per `.claude/rules/ip-addressing.md`).

## Coverage

Captures host logs + **every native systemd service** (Traefik, Technitium,
apt-cacher-ng, etc.). Docker-in-LXC *container* logs use Docker's `json-file`
driver (not in journald), so they're a **fast-follow** — per-compose
`log-driver: journald` across the 8 LXC docker roles — tracked in #378, which
also fixes the pre-existing `/etc/docker/daemon.json` multi-writer bug discovered
here.

## Tests

`ansible-lint` → passed (0 failures, production profile). `tests/template_render`
renders the drop-in and asserts the `omfwd` rule (selector/target/port/protocol/
queue). Full molecule + live verification run in CI / on deploy.

## Verification (after merge + deploy)

```bash
# On a forwarding LXC:
rsyslogd -N1 && systemctl is-active rsyslog
# In Splunk: index=os host=<an-infra-lxc>   (logs arriving)
```

Docs synced: AGENTS.md "This Repo Owns" + the pipeline data flow updated; role
README added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
