### PR TITLE
test(e2e): validate syslog pipeline components

### DIFF
--- a/.github/workflows/_e2e-tests.yml
+++ b/.github/workflows/_e2e-tests.yml
@@ -8,11 +8,9 @@ on:
 permissions:
   contents: read
 
-# One job per test file so each suite's pass/fail is independently visible
-# in the GitHub UI, logs are separate, and any data-flow suite that touches
-# the live cluster can run in parallel with the others. Smoke gates the
-# data-flow suites — no point chasing data through Splunk if Cribl/HAProxy
-# are down.
+# One job per component so each layer's pass/fail is independently visible.
+# Smoke gates the data-flow suites -- no point chasing data through Splunk
+# if the live endpoints are down.
 
 jobs:
   smoke:
@@ -28,7 +26,7 @@ jobs:
         run: python3 -m pytest tests/e2e/test_smoke.py -v
 
   pipeline:
-    name: Pipeline data flow
+    name: Syslog pipeline data flow
     needs: smoke
     runs-on: [self-hosted, Linux]
     steps:
@@ -45,8 +43,55 @@ jobs:
           sops exec-env secrets.enc.yaml
           'python3 -m pytest tests/e2e/test_pipeline.py -v'
 
+  splunk:
+    name: Splunk component
+    needs: smoke
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Mask secrets
+        uses: JacobPEvans/.github/actions/mask-secrets@main
+        with:
+          sops-file: secrets.enc.yaml
+
+      - name: pytest tests/e2e/test_splunk.py
+        run: >-
+          sops exec-env secrets.enc.yaml
+          'python3 -m pytest tests/e2e/test_splunk.py -v'
+
+  cribl-edge:
+    name: Cribl Edge component
+    needs: smoke
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Mask secrets
+        uses: JacobPEvans/.github/actions/mask-secrets@main
+        with:
+          sops-file: secrets.enc.yaml
+
+      - name: pytest tests/e2e/test_cribl_edge.py
+        run: >-
+          sops exec-env secrets.enc.yaml
+          'python3 -m pytest tests/e2e/test_cribl_edge.py -v'
+
+  haproxy:
+    name: HAProxy component
+    needs: smoke
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: pytest tests/e2e/test_haproxy.py
+        run: python3 -m pytest tests/e2e/test_haproxy.py -v
+
   forwarding:
-    name: Index routing and protocol forwarding
+    name: NetFlow forwarding
     needs: smoke
     runs-on: [self-hosted, Linux]
     steps:

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -83,6 +83,7 @@ jobs:
               - 'tests/**'
               - 'scripts/**'
               - '.github/workflows/_e2e-tests.yml'
+              - '.github/workflows/e2e-pipeline-schedule.yml'
 
   # ==========================================================================
   # CONDITIONAL CHECKS (call reusable workflows)

--- a/.github/workflows/e2e-pipeline-schedule.yml
+++ b/.github/workflows/e2e-pipeline-schedule.yml
@@ -1,9 +1,9 @@
 ---
-# Daily E2E pipeline validation (UniFi -> HAProxy -> Cribl -> Splunk).
+# Frequent E2E pipeline validation (syslog sources -> HAProxy -> Cribl -> Splunk).
 #
 # Runs the existing reusable `_e2e-tests.yml` against the live cluster.
 # Triggered by:
-#   - daily cron at 08:30 UTC (early-morning local time)
+#   - every 15 minutes
 #   - manual workflow_dispatch
 #
 # Gated by repo variable `E2E_RUNNERS_ENABLED == 'true'` (same gate the
@@ -16,12 +16,15 @@ name: E2E Pipeline Schedule
 
 on:
   schedule:
-    # Daily at 08:30 UTC -- well clear of cluster maintenance windows.
-    - cron: '30 8 * * *'
+    - cron: '*/15 * * * *'
   workflow_dispatch:
 
 permissions:
   contents: read
+
+concurrency:
+  group: e2e-pipeline-schedule
+  cancel-in-progress: false
 
 jobs:
   gate-check:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -68,6 +68,41 @@ directly. To regenerate the OpenTofu inventory:
 
 ## Automated Testing
 
+### Pytest E2E Suites -- Component Isolation
+
+The pytest E2E suites validate the live pipeline one component at a time,
+then validate full data flow for every configured syslog source family.
+They are also run by `.github/workflows/_e2e-tests.yml` on self-hosted
+Linux runners.
+
+| Suite | Command | Validates |
+| --- | --- | --- |
+| Smoke | `python3 -m pytest tests/e2e/test_smoke.py -v` | Ports and basic service reachability |
+| Splunk | `sops exec-env secrets.enc.yaml 'python3 -m pytest tests/e2e/test_splunk.py -v'` | Splunk export search, HEC health, direct HEC ingest |
+| HAProxy | `python3 -m pytest tests/e2e/test_haproxy.py -v` | TCP/UDP standard and high syslog frontends |
+| Cribl Edge | `sops exec-env secrets.enc.yaml 'python3 -m pytest tests/e2e/test_cribl_edge.py -v'` | Edge API/listeners and direct Edge-to-Splunk syslog |
+| Syslog Pipeline | `sops exec-env secrets.enc.yaml 'python3 -m pytest tests/e2e/test_pipeline.py -v'` | Each syslog source through HAProxy to Splunk |
+| NetFlow | `sops exec-env secrets.enc.yaml 'python3 -m pytest tests/e2e/test_forwarding.py -v'` | NetFlow through HAProxy/Cribl Stream to Splunk |
+| macOS | `sops exec-env secrets.enc.yaml 'python3 -m pytest tests/e2e/test_macos.py -v'` | macbook-m4 Cribl Edge freshness |
+
+The syslog source matrix is:
+
+| Source family | App-facing port | Backend port | Splunk index | Sourcetype |
+| --- | ---: | ---: | --- | --- |
+| UniFi | 514 | 1514 | `unifi` | `ubiquiti:unifi` |
+| Palo Alto | 515 | 1515 | `firewall` | `pan:firewall` |
+| Cisco ASA | 516 | 1516 | `firewall` | `cisco:asa` |
+| Linux | 517 | 1517 | `os` | `syslog` |
+| Windows | 518 | 1518 | `os` | `syslog` |
+
+The full syslog pipeline suite sends unique sentinels over TCP and UDP to
+the app-facing HAProxy ports, then polls Splunk through
+`/services/search/jobs/export` until the event lands with the expected
+index and sourcetype.
+
+The scheduled workflow runs every 15 minutes when the repository variable
+`E2E_RUNNERS_ENABLED` is set to `true`.
+
 ### validate-pipeline.yml -- E2E Data Flow
 
 Validates the full pipeline by sending a test syslog message and confirming
@@ -117,6 +152,15 @@ environment or your local shell).
 | --- | --- |
 | `SPLUNK_PASSWORD` | Splunk admin password for search API queries |
 | `SPLUNK_HEC_TOKEN` | HEC token for event submission and validation |
+
+Optional pytest overrides:
+
+| Variable | Purpose |
+| --- | --- |
+| `SPLUNK_MGMT_URL` | Override the Splunk management URL used for export searches |
+| `SPLUNK_HEC_URL` | Override the Splunk HEC base URL |
+| `PIPELINE_POLL_TIMEOUT_SECONDS` | Override sentinel search timeout, default `120` |
+| `PIPELINE_POLL_INTERVAL_SECONDS` | Override sentinel search interval, default `10` |
 
 #### Non-secret configuration
 
@@ -218,19 +262,21 @@ General configuration pattern for any syslog source:
 
 1. Look up the assigned port in `inventory/pipeline_constants.json`
 2. Configure the source to send syslog (UDP or TCP) to `$HAPROXY_IP:$ASSIGNED_PORT`
-3. Verify events arrive using the `validate-pipeline.yml` playbook
+3. Verify events arrive using `tests/e2e/test_pipeline.py`
 
 ## Troubleshooting
 
 ### No Events in Splunk
 
-Run `validate-pipeline.yml` with specific tags to isolate the failing
-component. Start from HAProxy and work forward:
+Run the component pytest suites to isolate the failing component. Start
+from Splunk and HAProxy reachability, then work through Cribl Edge and
+full data flow:
 
 ```bash
-doppler run -- ansible-playbook \
-  -i inventory/hosts.yml playbooks/validate-pipeline.yml \
-  --tags haproxy,cribl_edge,splunk
+python3 -m pytest tests/e2e/test_haproxy.py -v
+sops exec-env secrets.enc.yaml 'python3 -m pytest tests/e2e/test_splunk.py -v'
+sops exec-env secrets.enc.yaml 'python3 -m pytest tests/e2e/test_cribl_edge.py -v'
+sops exec-env secrets.enc.yaml 'python3 -m pytest tests/e2e/test_pipeline.py -v'
 ```
 
 ### HAProxy Backend Down
@@ -257,11 +303,13 @@ doppler run -- ansible-playbook \
 
 ## Verification Checklist
 
-- [ ] HAProxy listening on all syslog ports
+- [ ] HAProxy listening on all standard syslog ports 514-518
+- [ ] HAProxy listening on all high syslog ports 1514-1518
 - [ ] HAProxy stats page accessible
 - [ ] Cribl Edge LXC containers running
 - [ ] Cribl Stream LXC containers running
 - [ ] Splunk VM running and healthy
 - [ ] Splunk HEC endpoint responding
 - [ ] HEC token valid
-- [ ] E2E test event visible in Splunk index
+- [ ] Each syslog source family lands in the expected Splunk index
+- [ ] Each syslog source family lands with the expected sourcetype

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,11 +1,47 @@
 """Pytest fixtures for E2E pipeline tests."""
 
+from dataclasses import dataclass
 import json
 import os
-import socket
 from pathlib import Path
 
 import pytest
+
+
+class SecretValue:
+    """String-like secret value with a redacted repr for pytest tracebacks."""
+
+    def __init__(self, value):
+        self._value = value
+
+    def __str__(self):
+        return self._value
+
+    def __repr__(self):
+        return "<redacted>"
+
+    def __format__(self, spec):
+        return format(self._value, spec)
+
+
+@dataclass(frozen=True)
+class SplunkCredentials:
+    """Splunk credentials with redacted secret representation."""
+
+    mgmt_url: str
+    user: str
+    password: SecretValue
+
+    def __iter__(self):
+        yield self.mgmt_url
+        yield self.user
+        yield self.password
+
+    def __repr__(self):
+        return (
+            "SplunkCredentials("
+            f"mgmt_url={self.mgmt_url!r}, user={self.user!r}, password=<redacted>)"
+        )
 
 
 @pytest.fixture(scope="session")
@@ -104,41 +140,36 @@ def splunk_creds(tofu_inventory, constants):
     """
     splunk_ip = tofu_inventory["splunk_vm"]["splunk"]["ip"]
     mgmt_port = constants["service_ports"]["splunk_mgmt"]
-    password = os.environ.get("SPLUNK_PASSWORD")
-    if not password:
+    raw_password = os.environ.get("SPLUNK_PASSWORD")
+    if not raw_password:
         pytest.skip("SPLUNK_PASSWORD environment variable not set")
-    mgmt_url = f"https://{splunk_ip}:{mgmt_port}"
-    return (mgmt_url, "admin", password)
+    mgmt_url = os.environ.get("SPLUNK_MGMT_URL", f"https://{splunk_ip}:{mgmt_port}")
+    return SplunkCredentials(mgmt_url, "admin", SecretValue(raw_password))
 
 
-@pytest.fixture(scope="session", autouse=True)
-def infrastructure_reachable(
-    cribl_edge_ips, cribl_stream_ips, haproxy_host, constants
-):
-    """Skip all tests if pipeline infrastructure is unreachable.
+@pytest.fixture(scope="session")
+def splunk_hec_url(splunk_host, constants):
+    """Return the Splunk HEC base URL."""
+    port = constants["service_ports"]["splunk_hec"]
+    return os.environ.get("SPLUNK_HEC_URL", f"https://{splunk_host}:{port}")
 
-    Attempts a TCP connection to the Cribl Edge API port on the first
-    Edge LXC, the Cribl Stream API port on the first Stream LXC, and
-    port 22 (SSH) on HAProxy with a 5-second timeout each. Ports are
-    read from tofu constants. If any host is unreachable, all E2E
-    tests are skipped.
-    """
-    edge_api_port = constants["service_ports"]["cribl_edge_api"]
-    stream_api_port = constants["service_ports"]["cribl_stream_api"]
-    hosts = [
-        (cribl_edge_ips[0], edge_api_port, "cribl-edge"),
-        (cribl_stream_ips[0], stream_api_port, "cribl-stream"),
-        (haproxy_host, 22, "haproxy"),
-    ]
-    for host_ip, port, label in hosts:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.settimeout(5)
-        try:
-            sock.connect((host_ip, port))
-        except (socket.timeout, ConnectionRefusedError, OSError):
-            pytest.skip(
-                f"Infrastructure unreachable: cannot connect to "
-                f"{host_ip}:{port} ({label})"
-            )
-        finally:
-            sock.close()
+
+@pytest.fixture(scope="session")
+def splunk_hec_token():
+    """Return the Splunk HEC token from the environment."""
+    raw_token = os.environ.get("SPLUNK_HEC_TOKEN")
+    if not raw_token:
+        pytest.skip("SPLUNK_HEC_TOKEN environment variable not set")
+    return SecretValue(raw_token)
+
+
+@pytest.fixture(scope="session")
+def pipeline_poll_timeout():
+    """Return the live-pipeline poll timeout in seconds."""
+    return int(os.environ.get("PIPELINE_POLL_TIMEOUT_SECONDS", "120"))
+
+
+@pytest.fixture(scope="session")
+def pipeline_poll_interval():
+    """Return the live-pipeline poll interval in seconds."""
+    return int(os.environ.get("PIPELINE_POLL_INTERVAL_SECONDS", "10"))

--- a/tests/e2e/fixtures.py
+++ b/tests/e2e/fixtures.py
@@ -1,0 +1,26 @@
+"""Shared E2E test fixtures and source matrix."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SyslogSource:
+    """Expected routing contract for one app-facing syslog source family."""
+
+    key: str
+    label: str
+    standard_port: int
+    expected_index: str
+    expected_sourcetype: str
+
+
+SYSLOG_SOURCES = [
+    SyslogSource("unifi", "UniFi", 514, "unifi", "ubiquiti:unifi"),
+    SyslogSource("palo_alto", "Palo Alto", 515, "firewall", "pan:firewall"),
+    SyslogSource("cisco_asa", "Cisco ASA", 516, "firewall", "cisco:asa"),
+    SyslogSource("linux", "Linux", 517, "os", "syslog"),
+    SyslogSource("windows", "Windows", 518, "os", "syslog"),
+]
+
+
+SYSLOG_SOURCE_IDS = [source.key for source in SYSLOG_SOURCES]

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -1,16 +1,20 @@
-"""Pure utility functions for E2E pipeline tests.
+"""Pure utility functions for E2E pipeline tests."""
 
-Uses Python stdlib only: socket, urllib, struct, json, time.
-No third-party dependencies.
-"""
-
+import base64
 import json
 import socket
 import ssl
 import struct
 import time
+import urllib.error
 import urllib.parse
 import urllib.request
+
+
+def make_syslog_message(sentinel, app_name="ansible-e2e-test"):
+    """Build a syslog message with a unique sentinel."""
+    timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    return f"<14>1 {timestamp} ansible-e2e-host {app_name} - - - {sentinel}"
 
 
 def send_udp_syslog(host, port, message):
@@ -28,45 +32,98 @@ def send_udp_syslog(host, port, message):
         sock.close()
 
 
-def query_splunk(mgmt_url, user, password, search_str, timeout=120):
-    """Execute a oneshot search against Splunk REST API.
+def send_tcp_syslog(host, port, message, timeout=5):
+    """Send a syslog message over TCP."""
+    with socket.create_connection((host, port), timeout=timeout) as sock:
+        sock.sendall((message + "\n").encode("utf-8"))
+
+
+def _splunk_search_text(search_str):
+    """Return a search string accepted by Splunk's search/export endpoint."""
+    stripped = search_str.strip()
+    if stripped.startswith("|") or stripped.startswith("search "):
+        return stripped
+    return f"search {stripped}"
+
+
+def query_splunk(
+    mgmt_url,
+    user,
+    password,
+    search_str,
+    earliest="-15m",
+    timeout=30,
+    verify_tls=False,
+    raise_errors=False,
+):
+    """Execute a Splunk search/export query and return result rows.
 
     Args:
         mgmt_url: Splunk management URL (e.g., https://192.168.0.200:8089).
         user: Splunk username.
         password: Splunk password.
-        search_str: SPL search string (must start with 'search').
+        search_str: SPL search string with or without leading 'search'.
+        earliest: Optional earliest_time value for Splunk.
         timeout: HTTP request timeout in seconds.
+        verify_tls: Whether to validate the Splunk management certificate.
+        raise_errors: Raise urllib errors instead of returning [].
 
     Returns:
-        Parsed JSON response dict from Splunk.
+        List of result dicts parsed from JSON-lines export output.
     """
-    url = f"{mgmt_url}/services/search/jobs"
-    data = (
-        f"search={urllib.parse.quote(search_str)}"
-        f"&output_mode=json"
-        f"&exec_mode=oneshot"
-    ).encode("utf-8")
+    params = {
+        "search": _splunk_search_text(search_str),
+        "output_mode": "json",
+    }
+    if earliest is not None and "earliest=" not in search_str:
+        params["earliest_time"] = earliest
+    data = urllib.parse.urlencode(params).encode("utf-8")
 
-    # Set up basic auth
-    password_mgr = urllib.request.HTTPPasswordMgrWithDefaultRealm()
-    password_mgr.add_password(None, url, user, password)
-    auth_handler = urllib.request.HTTPBasicAuthHandler(password_mgr)
+    credentials = f"{user}:{password}"
+    encoded = base64.b64encode(credentials.encode("utf-8")).decode("ascii")
 
-    # Disable SSL cert verification for self-signed certs
     ssl_ctx = ssl.create_default_context()
-    ssl_ctx.check_hostname = False
-    ssl_ctx.verify_mode = ssl.CERT_NONE
-    https_handler = urllib.request.HTTPSHandler(context=ssl_ctx)
+    if not verify_tls:
+        ssl_ctx.check_hostname = False
+        ssl_ctx.verify_mode = ssl.CERT_NONE
 
-    opener = urllib.request.build_opener(auth_handler, https_handler)
+    req = urllib.request.Request(
+        f"{mgmt_url}/services/search/jobs/export",
+        data=data,
+        method="POST",
+        headers={"Authorization": f"Basic {encoded}"},
+    )
 
-    req = urllib.request.Request(url, data=data, method="POST")
-    with opener.open(req, timeout=timeout) as response:
-        return json.loads(response.read().decode("utf-8"))
+    results = []
+    try:
+        with urllib.request.urlopen(req, context=ssl_ctx, timeout=timeout) as response:
+            for raw_line in response:
+                line = raw_line.decode("utf-8").strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except ValueError:
+                    continue
+                if "result" in payload:
+                    results.append(payload["result"])
+    except (urllib.error.URLError, OSError):
+        if raise_errors:
+            raise
+        return []
+    return results
 
 
-def wait_for_event(mgmt_url, user, password, sentinel, index, timeout=120):
+def wait_for_event(
+    mgmt_url,
+    user,
+    password,
+    sentinel,
+    index,
+    sourcetype=None,
+    timeout=120,
+    poll_interval=10,
+):
     """Poll Splunk until an event containing the sentinel string appears.
 
     Args:
@@ -75,7 +132,9 @@ def wait_for_event(mgmt_url, user, password, sentinel, index, timeout=120):
         password: Splunk password.
         sentinel: Unique string to search for in events.
         index: Splunk index to search in.
+        sourcetype: Optional expected sourcetype.
         timeout: Maximum time in seconds to wait for the event.
+        poll_interval: Seconds between search attempts.
 
     Returns:
         List of matching result dicts from Splunk.
@@ -83,15 +142,22 @@ def wait_for_event(mgmt_url, user, password, sentinel, index, timeout=120):
     Raises:
         TimeoutError: If the event is not found within the timeout period.
     """
-    search_str = f'search index={index} "{sentinel}" | head 5'
+    sourcetype_clause = f' sourcetype="{sourcetype}"' if sourcetype else ""
+    search_str = f'index={index}{sourcetype_clause} "{sentinel}" | head 5'
     deadline = time.time() + timeout
 
     while time.time() < deadline:
-        result = query_splunk(mgmt_url, user, password, search_str, timeout=30)
-        results = result.get("results", [])
+        results = query_splunk(
+            mgmt_url,
+            user,
+            password,
+            search_str,
+            earliest="-5m",
+            timeout=30,
+        )
         if results:
             return results
-        time.sleep(10)
+        time.sleep(poll_interval)
 
     raise TimeoutError(
         f"Event with sentinel '{sentinel}' not found in index={index} "
@@ -166,6 +232,47 @@ def send_netflow_v5(host, port, src_port=12345, dst_port=80):
         sock.sendto(packet, (host, port))
     finally:
         sock.close()
+
+
+def post_splunk_hec(hec_url, token, event, index="main", sourcetype="e2e:hec:test"):
+    """Post a single event to Splunk HEC and return (status, body)."""
+    payload = json.dumps(
+        {
+            "event": event,
+            "index": index,
+            "sourcetype": sourcetype,
+        }
+    ).encode("utf-8")
+
+    ssl_ctx = ssl.create_default_context()
+    ssl_ctx.check_hostname = False
+    ssl_ctx.verify_mode = ssl.CERT_NONE
+
+    req = urllib.request.Request(
+        f"{hec_url}/services/collector/event",
+        data=payload,
+        method="POST",
+        headers={
+            "Authorization": f"Splunk {token}",
+            "Content-Type": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req, context=ssl_ctx, timeout=10) as response:
+        return response.status, response.read().decode("utf-8")
+
+
+def splunk_hec_health(hec_url):
+    """Return (status, body) from the Splunk HEC health endpoint."""
+    ssl_ctx = ssl.create_default_context()
+    ssl_ctx.check_hostname = False
+    ssl_ctx.verify_mode = ssl.CERT_NONE
+
+    req = urllib.request.Request(
+        f"{hec_url}/services/collector/health/1.0",
+        method="GET",
+    )
+    with urllib.request.urlopen(req, context=ssl_ctx, timeout=10) as response:
+        return response.status, response.read().decode("utf-8")
 
 
 def check_port_tcp(host, port, timeout=2):

--- a/tests/e2e/test_cribl_edge.py
+++ b/tests/e2e/test_cribl_edge.py
@@ -1,0 +1,97 @@
+"""Cribl Edge component tests for the syslog pipeline."""
+
+import time
+import uuid
+
+import pytest
+
+from .fixtures import SYSLOG_SOURCES, SYSLOG_SOURCE_IDS
+from .helpers import (
+    check_port_tcp,
+    check_port_udp,
+    make_syslog_message,
+    send_udp_syslog,
+    wait_for_event,
+)
+
+
+class TestCriblEdgeComponent:
+    """Validate Cribl Edge listeners and direct routing."""
+
+    def test_api_port_is_open(self, cribl_edge_ips, constants):
+        """Verify every Cribl Edge API port is open."""
+        port = constants["service_ports"]["cribl_edge_api"]
+        for edge_ip in cribl_edge_ips:
+            assert check_port_tcp(edge_ip, port), (
+                f"Cribl Edge API port {port} is not open on {edge_ip}"
+            )
+
+    @pytest.mark.parametrize("source", SYSLOG_SOURCES, ids=SYSLOG_SOURCE_IDS)
+    def test_syslog_listener_is_reachable(self, cribl_edge_ips, constants, source):
+        """Verify every Cribl Edge listens on each syslog source-family port."""
+        port = constants["syslog_ports"][source.key]
+        for edge_ip in cribl_edge_ips:
+            assert check_port_udp(edge_ip, port), (
+                f"Cribl Edge UDP syslog port {port} for {source.label} "
+                f"is not reachable on {edge_ip}"
+            )
+
+    def test_each_edge_can_forward_direct_syslog(
+        self,
+        cribl_edge_ips,
+        constants,
+        splunk_creds,
+        pipeline_poll_timeout,
+        pipeline_poll_interval,
+    ):
+        """Send directly to each Edge LXC and verify Splunk receives it."""
+        mgmt_url, user, password = splunk_creds
+        source = SYSLOG_SOURCES[0]
+        port = constants["syslog_ports"][source.key]
+
+        for edge_ip in cribl_edge_ips:
+            sentinel = f"e2e-edge-{edge_ip.replace('.', '-')}-{uuid.uuid4().hex[:10]}-{int(time.time())}"
+            send_udp_syslog(edge_ip, port, make_syslog_message(sentinel, "e2e-edge-direct"))
+            results = wait_for_event(
+                mgmt_url,
+                user,
+                password,
+                sentinel,
+                index=source.expected_index,
+                sourcetype=source.expected_sourcetype,
+                timeout=pipeline_poll_timeout,
+                poll_interval=pipeline_poll_interval,
+            )
+            assert results, f"Direct Cribl Edge sentinel {sentinel} from {edge_ip} was not searchable"
+
+    @pytest.mark.parametrize("source", SYSLOG_SOURCES, ids=SYSLOG_SOURCE_IDS)
+    def test_first_edge_routes_each_source_family(
+        self,
+        cribl_edge_ips,
+        constants,
+        splunk_creds,
+        source,
+        pipeline_poll_timeout,
+        pipeline_poll_interval,
+    ):
+        """Verify Cribl Edge sets expected index and sourcetype by syslog port."""
+        mgmt_url, user, password = splunk_creds
+        edge_ip = cribl_edge_ips[0]
+        port = constants["syslog_ports"][source.key]
+        sentinel = f"e2e-edge-route-{source.key}-{uuid.uuid4().hex[:10]}-{int(time.time())}"
+
+        send_udp_syslog(edge_ip, port, make_syslog_message(sentinel, f"e2e-{source.key}"))
+        results = wait_for_event(
+            mgmt_url,
+            user,
+            password,
+            sentinel,
+            index=source.expected_index,
+            sourcetype=source.expected_sourcetype,
+            timeout=pipeline_poll_timeout,
+            poll_interval=pipeline_poll_interval,
+        )
+        assert results, (
+            f"Cribl Edge did not route {source.label} sentinel {sentinel} "
+            f"to index={source.expected_index} sourcetype={source.expected_sourcetype}"
+        )

--- a/tests/e2e/test_forwarding.py
+++ b/tests/e2e/test_forwarding.py
@@ -1,85 +1,11 @@
-"""Tier 3: Index routing and protocol-specific forwarding tests.
+"""NetFlow forwarding test retained outside the syslog issue scope."""
 
-Validates that syslog, NetFlow, and HEC data are routed to the correct
-Splunk indexes with proper sourcetype assignment.
-"""
-
-import json
-import os
-import ssl
 import time
-import urllib.error
-import urllib.request
-import uuid
-
-import pytest
 
 from .helpers import (
     query_splunk,
     send_netflow_v5,
-    send_udp_syslog,
-    wait_for_event,
 )
-
-
-class TestIndexRouting:
-    """Verify syslog ports route to the correct Splunk indexes."""
-
-    def test_unifi_index_routing(
-        self, haproxy_host, constants, splunk_creds
-    ):
-        """Verify port 1514 (UniFi) routes to index=unifi.
-
-        Sends a syslog message to the UniFi port and confirms it appears
-        in the unifi index within the timeout period.
-        """
-        mgmt_url, user, password = splunk_creds
-        port = constants["syslog_ports"]["unifi"]
-        sentinel = (
-            f"e2e-unifi-idx-{uuid.uuid4().hex[:8]}-{int(time.time())}"
-        )
-        message = (
-            f"<14>1 {time.strftime('%Y-%m-%dT%H:%M:%SZ')} testhost "
-            f"e2e-test - - - {sentinel}"
-        )
-
-        send_udp_syslog(haproxy_host, port, message)
-
-        results = wait_for_event(
-            mgmt_url, user, password, sentinel, index="unifi", timeout=120
-        )
-        assert len(results) > 0, (
-            f"UniFi index routing: sentinel '{sentinel}' not found in "
-            f"index=unifi after 120s"
-        )
-
-    def test_firewall_index_routing(
-        self, haproxy_host, constants, splunk_creds
-    ):
-        """Verify port 1515 (Palo Alto) routes to index=firewall.
-
-        Sends a syslog message to the Palo Alto port and confirms it
-        appears in the firewall index within the timeout period.
-        """
-        mgmt_url, user, password = splunk_creds
-        port = constants["syslog_ports"]["palo_alto"]
-        sentinel = (
-            f"e2e-fw-idx-{uuid.uuid4().hex[:8]}-{int(time.time())}"
-        )
-        message = (
-            f"<14>1 {time.strftime('%Y-%m-%dT%H:%M:%SZ')} testhost "
-            f"e2e-test - - - {sentinel}"
-        )
-
-        send_udp_syslog(haproxy_host, port, message)
-
-        results = wait_for_event(
-            mgmt_url, user, password, sentinel, index="firewall", timeout=120
-        )
-        assert len(results) > 0, (
-            f"Firewall index routing: sentinel '{sentinel}' not found in "
-            f"index=firewall after 120s"
-        )
 
 
 class TestNetFlow:
@@ -101,18 +27,14 @@ class TestNetFlow:
         send_netflow_v5(haproxy_host, port, src_port=sentinel_port)
 
         # Filter by the sentinel src_port to avoid matching pre-existing traffic
-        search_str = (
-            f'search index=network earliest=-5m src_port={sentinel_port} '
-            f'| head 5'
-        )
+        search_str = f'index=network src_port={sentinel_port} | head 5'
         deadline = time.time() + 120
 
         results = []
         while time.time() < deadline:
-            result = query_splunk(
+            results = query_splunk(
                 mgmt_url, user, password, search_str, timeout=30
             )
-            results = result.get("results", [])
             if results:
                 break
             time.sleep(10)
@@ -121,51 +43,3 @@ class TestNetFlow:
             f"NetFlow routing: no events with src_port={sentinel_port} "
             f"found in index=network after 120s"
         )
-
-
-class TestHECDirect:
-    """Verify direct HEC POST to Splunk works."""
-
-    def test_hec_direct_post(self, splunk_host, constants):
-        """POST an event directly to Splunk HEC and verify HTTP 200.
-
-        Uses the SPLUNK_HEC_TOKEN environment variable to authenticate.
-        This tests the HEC endpoint independently of the syslog pipeline.
-        """
-        hec_token = os.environ.get("SPLUNK_HEC_TOKEN")
-        if not hec_token:
-            pytest.skip("SPLUNK_HEC_TOKEN environment variable not set")
-
-        port = constants["service_ports"]["splunk_hec"]
-        url = f"https://{splunk_host}:{port}/services/collector/event"
-        sentinel = f"e2e-hec-{uuid.uuid4().hex[:8]}-{int(time.time())}"
-
-        payload = json.dumps({
-            "event": f"E2E HEC test: {sentinel}",
-            "sourcetype": "e2e:hec:test",
-            "index": "main",
-        }).encode("utf-8")
-
-        ssl_ctx = ssl.create_default_context()
-        ssl_ctx.check_hostname = False
-        ssl_ctx.verify_mode = ssl.CERT_NONE
-
-        req = urllib.request.Request(
-            url,
-            data=payload,
-            method="POST",
-            headers={
-                "Authorization": f"Splunk {hec_token}",
-                "Content-Type": "application/json",
-            },
-        )
-        handler = urllib.request.HTTPSHandler(context=ssl_ctx)
-        opener = urllib.request.build_opener(handler)
-
-        try:
-            response = opener.open(req, timeout=10)
-            assert response.status == 200, (
-                f"HEC POST returned {response.status}, expected 200"
-            )
-        except urllib.error.URLError as exc:
-            pytest.fail(f"HEC POST failed at {url}: {exc}")

--- a/tests/e2e/test_haproxy.py
+++ b/tests/e2e/test_haproxy.py
@@ -1,0 +1,49 @@
+"""HAProxy component tests for the syslog pipeline."""
+
+import pytest
+
+from .fixtures import SYSLOG_SOURCES, SYSLOG_SOURCE_IDS
+from .helpers import check_port_tcp, check_port_udp
+
+
+class TestHAProxyComponent:
+    """Validate HAProxy/Nginx frontends independently of Splunk searches."""
+
+    def test_stats_port_is_open(self, haproxy_host, constants):
+        """Verify HAProxy stats is reachable."""
+        port = constants["service_ports"]["haproxy_stats"]
+        assert check_port_tcp(haproxy_host, port), (
+            f"HAProxy stats port {port} is not accepting connections on {haproxy_host}"
+        )
+
+    @pytest.mark.parametrize("source", SYSLOG_SOURCES, ids=SYSLOG_SOURCE_IDS)
+    def test_tcp_standard_frontend_is_open(self, haproxy_host, source):
+        """Verify the app-facing TCP syslog frontend exists."""
+        assert check_port_tcp(haproxy_host, source.standard_port), (
+            f"HAProxy TCP standard frontend {source.standard_port} "
+            f"for {source.label} is not open"
+        )
+
+    @pytest.mark.parametrize("source", SYSLOG_SOURCES, ids=SYSLOG_SOURCE_IDS)
+    def test_tcp_high_frontend_is_open(self, haproxy_host, constants, source):
+        """Verify the backward-compatible TCP syslog frontend exists."""
+        port = constants["syslog_ports"][source.key]
+        assert check_port_tcp(haproxy_host, port), (
+            f"HAProxy TCP high frontend {port} for {source.label} is not open"
+        )
+
+    @pytest.mark.parametrize("source", SYSLOG_SOURCES, ids=SYSLOG_SOURCE_IDS)
+    def test_udp_standard_frontend_is_reachable(self, haproxy_host, source):
+        """Verify the app-facing UDP syslog frontend is reachable."""
+        assert check_port_udp(haproxy_host, source.standard_port), (
+            f"HAProxy UDP standard frontend {source.standard_port} "
+            f"for {source.label} is not reachable"
+        )
+
+    @pytest.mark.parametrize("source", SYSLOG_SOURCES, ids=SYSLOG_SOURCE_IDS)
+    def test_udp_high_frontend_is_reachable(self, haproxy_host, constants, source):
+        """Verify the backward-compatible UDP syslog frontend is reachable."""
+        port = constants["syslog_ports"][source.key]
+        assert check_port_udp(haproxy_host, port), (
+            f"HAProxy UDP high frontend {port} for {source.label} is not reachable"
+        )

--- a/tests/e2e/test_macos.py
+++ b/tests/e2e/test_macos.py
@@ -34,13 +34,12 @@ class TestMacOSPipelineFreshness:
         """
         mgmt_url, user, password = splunk_creds
         search_str = (
-            "search (index=os OR index=mac_perf) sourcetype=macos:* "
-            "earliest=-5m | head 5"
+            "(index=os OR index=mac_perf) sourcetype=macos:* "
+            "| head 5"
         )
-        result = query_splunk(
-            mgmt_url, user, password, search_str, timeout=30
+        results = query_splunk(
+            mgmt_url, user, password, search_str, earliest="-5m", timeout=30
         )
-        results = result.get("results", [])
         assert results, (
             "macbook-m4 Cribl Edge -> Cloud -> Splunk chain appears broken: "
             "no events with sourcetype=macos:* in (os OR mac_perf) within "
@@ -69,10 +68,9 @@ class TestMacOSPipelineFreshness:
             "(sourcetype=macos:unified_log OR sourcetype=macos:system:*) "
             "BY sourcetype"
         )
-        result = query_splunk(
+        results = query_splunk(
             mgmt_url, user, password, search_str, timeout=30
         )
-        results = result.get("results", [])
         sourcetypes_seen = {row.get("sourcetype") for row in results}
 
         assert any(
@@ -111,10 +109,9 @@ class TestMacOSPipelineFreshness:
             "| where isnotnull(last_seen) "
             "| eval seconds_ago = now() - last_seen | head 1"
         )
-        result = query_splunk(
+        results = query_splunk(
             mgmt_url, user, password, search_str, timeout=30
         )
-        results = result.get("results", [])
         assert results, (
             "no macOS pack events ever indexed in (index=os OR index=mac_perf): "
             "the pack may have never emitted data, or the indexes do not "

--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -1,128 +1,120 @@
-"""Tier 2: Full-path data flow pipeline tests.
-
-Sends syslog data through the pipeline and verifies it arrives in
-the correct Splunk index. Tests both the HAProxy-fronted path and
-the direct-to-LXC path.
-"""
+"""Full syslog source-family pipeline tests."""
 
 import time
 import uuid
 
 import pytest
 
-from .helpers import send_udp_syslog, wait_for_event
-
-
-# Map syslog port names to their expected Splunk index
-SYSLOG_PORT_INDEX_MAP = {
-    "unifi": "unifi",
-    "palo_alto": "firewall",
-    "cisco_asa": "firewall",
-    "linux": "os",
-    "windows": "os",
-}
+from .fixtures import SYSLOG_SOURCES, SYSLOG_SOURCE_IDS
+from .helpers import (
+    make_syslog_message,
+    send_tcp_syslog,
+    send_udp_syslog,
+    wait_for_event,
+)
 
 
 class TestSyslogViaHAProxy:
-    """Tests that send syslog through HAProxy to Splunk."""
+    """Validate every app-facing syslog source path through HAProxy."""
 
-    def test_syslog_via_haproxy(self, haproxy_host, constants, splunk_creds):
-        """Send a UDP syslog message via HAProxy and verify it reaches Splunk.
-
-        Sends a uniquely identifiable syslog message to HAProxy on the
-        UniFi syslog port (1514) and waits up to 120 seconds for it to
-        appear in the unifi index in Splunk.
-        """
-        mgmt_url, user, password = splunk_creds
-        port = constants["syslog_ports"]["unifi"]
-        sentinel = f"e2e-haproxy-{uuid.uuid4().hex[:8]}-{int(time.time())}"
-        message = (
-            f"<14>1 {time.strftime('%Y-%m-%dT%H:%M:%SZ')} testhost "
-            f"e2e-test - - - {sentinel}"
-        )
-
-        send_udp_syslog(haproxy_host, port, message)
-
-        results = wait_for_event(
-            mgmt_url, user, password, sentinel, index="unifi", timeout=120
-        )
-        assert len(results) > 0, (
-            f"Syslog via HAProxy: sentinel '{sentinel}' not found in "
-            f"index=unifi after 120s"
-        )
-
-
-class TestSyslogDirectToLXC:
-    """Tests that send syslog directly to Cribl Edge LXC containers."""
-
-    def test_syslog_direct_to_lxc(
-        self, cribl_edge_ips, constants, splunk_creds
-    ):
-        """Send a UDP syslog message directly to a Cribl Edge LXC and verify.
-
-        Bypasses HAProxy and sends directly to the first Cribl Edge LXC
-        on the UniFi syslog port, then verifies the event arrives in Splunk.
-        """
-        mgmt_url, user, password = splunk_creds
-        port = constants["syslog_ports"]["unifi"]
-        edge_ip = cribl_edge_ips[0]
-        sentinel = f"e2e-direct-{uuid.uuid4().hex[:8]}-{int(time.time())}"
-        message = (
-            f"<14>1 {time.strftime('%Y-%m-%dT%H:%M:%SZ')} testhost "
-            f"e2e-test - - - {sentinel}"
-        )
-
-        send_udp_syslog(edge_ip, port, message)
-
-        results = wait_for_event(
-            mgmt_url, user, password, sentinel, index="unifi", timeout=120
-        )
-        assert len(results) > 0, (
-            f"Syslog direct to LXC: sentinel '{sentinel}' not found in "
-            f"index=unifi after 120s"
-        )
-
-    @pytest.mark.parametrize(
-        "port_name,expected_index",
-        list(SYSLOG_PORT_INDEX_MAP.items()),
-        ids=list(SYSLOG_PORT_INDEX_MAP.keys()),
-    )
-    def test_syslog_port_routing(
+    @pytest.mark.parametrize("source", SYSLOG_SOURCES, ids=SYSLOG_SOURCE_IDS)
+    def test_udp_syslog_via_haproxy_standard_port(
         self,
-        cribl_edge_ips,
+        haproxy_host,
+        splunk_creds,
+        source,
+        pipeline_poll_timeout,
+        pipeline_poll_interval,
+    ):
+        """Send UDP syslog via HAProxy and verify Splunk routing."""
+        mgmt_url, user, password = splunk_creds
+        sentinel = f"e2e-haproxy-udp-{source.key}-{uuid.uuid4().hex[:10]}-{int(time.time())}"
+
+        send_udp_syslog(
+            haproxy_host,
+            source.standard_port,
+            make_syslog_message(sentinel, f"e2e-{source.key}-udp"),
+        )
+        results = wait_for_event(
+            mgmt_url,
+            user,
+            password,
+            sentinel,
+            index=source.expected_index,
+            sourcetype=source.expected_sourcetype,
+            timeout=pipeline_poll_timeout,
+            poll_interval=pipeline_poll_interval,
+        )
+        assert results, (
+            f"UDP {source.label} sentinel {sentinel} did not reach Splunk "
+            f"with index={source.expected_index} sourcetype={source.expected_sourcetype}"
+        )
+
+    @pytest.mark.parametrize("source", SYSLOG_SOURCES, ids=SYSLOG_SOURCE_IDS)
+    def test_tcp_syslog_via_haproxy_standard_port(
+        self,
+        haproxy_host,
+        splunk_creds,
+        source,
+        pipeline_poll_timeout,
+        pipeline_poll_interval,
+    ):
+        """Send TCP syslog via HAProxy and verify Splunk routing."""
+        mgmt_url, user, password = splunk_creds
+        sentinel = f"e2e-haproxy-tcp-{source.key}-{uuid.uuid4().hex[:10]}-{int(time.time())}"
+
+        send_tcp_syslog(
+            haproxy_host,
+            source.standard_port,
+            make_syslog_message(sentinel, f"e2e-{source.key}-tcp"),
+        )
+        results = wait_for_event(
+            mgmt_url,
+            user,
+            password,
+            sentinel,
+            index=source.expected_index,
+            sourcetype=source.expected_sourcetype,
+            timeout=pipeline_poll_timeout,
+            poll_interval=pipeline_poll_interval,
+        )
+        assert results, (
+            f"TCP {source.label} sentinel {sentinel} did not reach Splunk "
+            f"with index={source.expected_index} sourcetype={source.expected_sourcetype}"
+        )
+
+    @pytest.mark.parametrize("source", SYSLOG_SOURCES, ids=SYSLOG_SOURCE_IDS)
+    def test_udp_syslog_via_haproxy_high_port(
+        self,
+        haproxy_host,
         constants,
         splunk_creds,
-        port_name,
-        expected_index,
+        source,
+        pipeline_poll_timeout,
+        pipeline_poll_interval,
     ):
-        """Verify each syslog port routes to the correct Splunk index.
-
-        Sends a uniquely identifiable syslog message to each port on
-        the first Cribl Edge LXC and confirms it lands in the expected
-        Splunk index based on the port-to-index routing configuration.
-        """
+        """Verify backward-compatible high UDP ports still route correctly."""
         mgmt_url, user, password = splunk_creds
-        port = constants["syslog_ports"][port_name]
-        edge_ip = cribl_edge_ips[0]
-        sentinel = (
-            f"e2e-route-{port_name}-{uuid.uuid4().hex[:8]}-{int(time.time())}"
-        )
-        message = (
-            f"<14>1 {time.strftime('%Y-%m-%dT%H:%M:%SZ')} testhost "
-            f"e2e-test - - - {sentinel}"
-        )
+        port = constants["syslog_ports"][source.key]
+        sentinel = f"e2e-haproxy-high-{source.key}-{uuid.uuid4().hex[:10]}-{int(time.time())}"
 
-        send_udp_syslog(edge_ip, port, message)
+        send_udp_syslog(
+            haproxy_host,
+            port,
+            make_syslog_message(sentinel, f"e2e-{source.key}-high"),
+        )
 
         results = wait_for_event(
             mgmt_url,
             user,
             password,
             sentinel,
-            index=expected_index,
-            timeout=120,
+            index=source.expected_index,
+            sourcetype=source.expected_sourcetype,
+            timeout=pipeline_poll_timeout,
+            poll_interval=pipeline_poll_interval,
         )
-        assert len(results) > 0, (
-            f"Port routing: sentinel '{sentinel}' sent to port {port} "
-            f"({port_name}) not found in index={expected_index} after 120s"
+        assert results, (
+            f"High-port UDP {source.label} sentinel {sentinel} did not reach Splunk "
+            f"with index={source.expected_index} sourcetype={source.expected_sourcetype}"
         )

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -1,32 +1,62 @@
-"""Tier 1: Service health smoke tests.
-
-Validates that all pipeline services are running and listening on their
-expected ports. No data is sent through the pipeline -- these tests only
-verify TCP/UDP connectivity to each service endpoint.
-"""
-
-import ssl
-import urllib.error
-import urllib.request
+"""Tier 1: service health smoke tests."""
 
 import pytest
 
-from .helpers import check_port_tcp, check_port_udp
+from .fixtures import SYSLOG_SOURCES, SYSLOG_SOURCE_IDS
+from .helpers import check_port_tcp, check_port_udp, splunk_hec_health
 
 
 class TestHAProxy:
     """HAProxy load balancer port checks."""
 
     @pytest.mark.parametrize(
-        "port_name",
-        ["unifi", "palo_alto", "cisco_asa", "linux", "windows"],
+        "source",
+        SYSLOG_SOURCES,
+        ids=SYSLOG_SOURCE_IDS,
     )
-    def test_haproxy_syslog_ports(self, haproxy_host, constants, port_name):
-        """Verify HAProxy is accepting UDP syslog on each port."""
-        port = constants["syslog_ports"][port_name]
+    def test_haproxy_udp_syslog_high_ports(self, haproxy_host, constants, source):
+        """Verify HAProxy/Nginx is accepting UDP syslog on each high port."""
+        port = constants["syslog_ports"][source.key]
         assert check_port_udp(haproxy_host, port), (
-            f"HAProxy syslog port {port} ({port_name}) is not reachable "
-            f"via UDP on {haproxy_host}"
+            f"HAProxy UDP syslog port {port} ({source.key}) is not reachable "
+            f"on {haproxy_host}"
+        )
+
+    @pytest.mark.parametrize(
+        "source",
+        SYSLOG_SOURCES,
+        ids=SYSLOG_SOURCE_IDS,
+    )
+    def test_haproxy_udp_syslog_standard_ports(self, haproxy_host, source):
+        """Verify HAProxy/Nginx is accepting UDP syslog on each app-facing port."""
+        assert check_port_udp(haproxy_host, source.standard_port), (
+            f"HAProxy UDP syslog port {source.standard_port} "
+            f"({source.key}) is not reachable on {haproxy_host}"
+        )
+
+    @pytest.mark.parametrize(
+        "source",
+        SYSLOG_SOURCES,
+        ids=SYSLOG_SOURCE_IDS,
+    )
+    def test_haproxy_tcp_syslog_standard_ports(self, haproxy_host, source):
+        """Verify HAProxy is accepting TCP syslog on each app-facing port."""
+        assert check_port_tcp(haproxy_host, source.standard_port), (
+            f"HAProxy TCP syslog port {source.standard_port} "
+            f"({source.key}) is not accepting connections on {haproxy_host}"
+        )
+
+    @pytest.mark.parametrize(
+        "source",
+        SYSLOG_SOURCES,
+        ids=SYSLOG_SOURCE_IDS,
+    )
+    def test_haproxy_tcp_syslog_high_ports(self, haproxy_host, constants, source):
+        """Verify HAProxy is accepting TCP syslog on each high port."""
+        port = constants["syslog_ports"][source.key]
+        assert check_port_tcp(haproxy_host, port), (
+            f"HAProxy TCP syslog port {port} ({source.key}) is not accepting connections "
+            f"on {haproxy_host}"
         )
 
     def test_haproxy_stats(self, haproxy_host, constants):
@@ -42,17 +72,18 @@ class TestCriblEdgeLXC:
     """Cribl Edge LXC container port checks (syslog processing)."""
 
     @pytest.mark.parametrize(
-        "port_name",
-        ["unifi", "palo_alto", "cisco_asa", "linux", "windows"],
+        "source",
+        SYSLOG_SOURCES,
+        ids=SYSLOG_SOURCE_IDS,
     )
     def test_cribl_edge_syslog_ports(
-        self, cribl_edge_ips, constants, port_name
+        self, cribl_edge_ips, constants, source
     ):
         """Verify each Cribl Edge LXC is accepting syslog on each UDP port."""
-        port = constants["syslog_ports"][port_name]
+        port = constants["syslog_ports"][source.key]
         for edge_ip in cribl_edge_ips:
             assert check_port_udp(edge_ip, port), (
-                f"Cribl Edge syslog port {port} ({port_name}) is not "
+                f"Cribl Edge syslog port {port} ({source.key}) is not "
                 f"reachable on {edge_ip}"
             )
 
@@ -107,30 +138,13 @@ class TestSplunk:
             f"connections on {splunk_host}"
         )
 
-    def test_splunk_hec_health(self, splunk_host, constants):
+    def test_splunk_hec_health(self, splunk_hec_url):
         """Verify Splunk HEC health endpoint returns HTTP 200.
 
         The HEC health endpoint at /services/collector/health/1.0 responds
         with 200 when HEC is enabled and accepting events.
         """
-        port = constants["service_ports"]["splunk_hec"]
-        url = f"https://{splunk_host}:{port}/services/collector/health/1.0"
-
-        ssl_ctx = ssl.create_default_context()
-        ssl_ctx.check_hostname = False
-        ssl_ctx.verify_mode = ssl.CERT_NONE
-
-        req = urllib.request.Request(url, method="GET")
-        handler = urllib.request.HTTPSHandler(context=ssl_ctx)
-        opener = urllib.request.build_opener(handler)
-
-        try:
-            with opener.open(req, timeout=10) as response:
-                assert response.status == 200, (
-                    f"Splunk HEC health endpoint returned {response.status}, "
-                    f"expected 200"
-                )
-        except urllib.error.URLError as exc:
-            pytest.fail(
-                f"Splunk HEC health endpoint unreachable at {url}: {exc}"
-            )
+        status, body = splunk_hec_health(splunk_hec_url)
+        assert status == 200, (
+            f"Splunk HEC health endpoint returned {status}, expected 200: {body}"
+        )

--- a/tests/e2e/test_splunk.py
+++ b/tests/e2e/test_splunk.py
@@ -1,0 +1,73 @@
+"""Splunk component tests for the logging pipeline."""
+
+import time
+import urllib.error
+import uuid
+
+import pytest
+
+from .helpers import post_splunk_hec, query_splunk, splunk_hec_health, wait_for_event
+
+
+class TestSplunkComponent:
+    """Validate Splunk independently of HAProxy and Cribl."""
+
+    def test_management_export_query_works(self, splunk_creds):
+        """Verify the search/jobs/export endpoint accepts an authenticated query."""
+        mgmt_url, user, password = splunk_creds
+        try:
+            results = query_splunk(
+                mgmt_url,
+                user,
+                password,
+                "| makeresults | eval e2e_component=\"splunk-export\"",
+                earliest=None,
+                timeout=30,
+                raise_errors=True,
+            )
+        except (urllib.error.URLError, OSError) as exc:
+            pytest.fail(f"Splunk management export query failed at {mgmt_url}: {exc}")
+
+        assert results, "Splunk export query returned no results"
+        assert results[0].get("e2e_component") == "splunk-export"
+
+    def test_hec_health_endpoint(self, splunk_hec_url):
+        """Verify Splunk HEC reports healthy."""
+        status, body = splunk_hec_health(splunk_hec_url)
+        assert status == 200, f"Splunk HEC health returned {status}: {body}"
+
+    def test_direct_hec_event_is_searchable(
+        self,
+        splunk_creds,
+        splunk_hec_url,
+        splunk_hec_token,
+        pipeline_poll_timeout,
+        pipeline_poll_interval,
+    ):
+        """POST directly to HEC and verify the sentinel is searchable."""
+        mgmt_url, user, password = splunk_creds
+        sentinel = f"e2e-hec-{uuid.uuid4().hex[:12]}-{int(time.time())}"
+        status, body = post_splunk_hec(
+            splunk_hec_url,
+            splunk_hec_token,
+            f"E2E direct HEC sentinel: {sentinel}",
+            index="main",
+            sourcetype="e2e:hec:test",
+        )
+
+        assert status == 200, f"Splunk HEC POST returned {status}: {body}"
+        assert "Success" in body or '"code":0' in body, (
+            f"Splunk HEC POST did not return a success body: {body}"
+        )
+
+        results = wait_for_event(
+            mgmt_url,
+            user,
+            password,
+            sentinel,
+            index="main",
+            sourcetype="e2e:hec:test",
+            timeout=pipeline_poll_timeout,
+            poll_interval=pipeline_poll_interval,
+        )
+        assert results, f"Direct HEC sentinel {sentinel} was not searchable"


### PR DESCRIPTION
## Summary
- adds a syslog source matrix for UniFi, Palo Alto, Cisco ASA, Linux, and Windows
- switches Splunk E2E searches to `/services/search/jobs/export` with JSON-lines parsing
- splits live E2E coverage into Splunk, HAProxy, Cribl Edge, syslog pipeline, NetFlow, and macOS suites
- updates the scheduled E2E workflow to run every 15 minutes and updates CI path filtering/docs
- redacts Splunk secret reprs in pytest fixture output so failures do not leak credentials

Refs: #379

## Validation
- `python3 -m compileall tests/e2e`
- `uv run --with pytest python -m pytest tests/e2e -q --collect-only` (87 tests collected)
- `uv run --with ruff ruff check tests/e2e`
- `git diff --check`
- `doppler run -- direnv exec . ansible-playbook --syntax-check playbooks/validate-pipeline.yml -i inventory/hosts.yml`
- `doppler run -- uv run --with pytest python -m pytest tests/e2e/test_splunk.py -v` (3 passed)

## Live pipeline findings
The new checks found existing live pipeline failures:
- `tests/e2e/test_smoke.py`: 27 passed, 5 failed
- HAProxy TCP standard ports 515-518 are closed while UDP standard ports and high TCP ports 1514-1518 pass
- Cribl Edge API port 9420 is closed on the first Edge host
- a UniFi UDP sentinel through HAProxy did not reach Splunk within 120s
- a direct-to-Cribl-Edge UniFi sentinel also did not reach Splunk within 120s, pointing downstream of HAProxy

Inventory note: fresh Terragrunt inventory export was blocked by missing AWS remote-state credentials locally, so live pytest runs used the existing ignored live `inventory/tofu_inventory.json` copied from the `main` worktree.
