### PR TITLE
fix(ci): accept apex ingress entries in schema + wrap long test lines

### DIFF
--- a/tests/inventory_load/tofu_inventory.schema.json
+++ b/tests/inventory_load/tofu_inventory.schema.json
@@ -64,13 +64,27 @@
       "description": "Traefik ingress route table from OpenTofu — one {name, ip, port} per fronted service UI",
       "items": {
         "type": "object",
-        "required": ["name", "ip", "port"],
         "additionalProperties": true,
-        "properties": {
-          "name": { "type": "string", "minLength": 1 },
-          "ip": { "type": "string", "pattern": "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$" },
-          "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
-        }
+        "description": "Either an IP-backed service {name, ip, port} or the Proxmox-UI apex pool {name, apex, backends, port} (a hostname pool, no single ip).",
+        "anyOf": [
+          {
+            "required": ["name", "ip", "port"],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "ip": { "type": "string", "pattern": "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$" },
+              "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+            }
+          },
+          {
+            "required": ["name", "apex", "backends", "port"],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "apex": { "const": true },
+              "backends": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+              "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+            }
+          }
+        ]
       }
     },
     "nodes": {

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1102,7 +1102,8 @@
           - (traefik_routes | selectattr('name', 'equalto', 'proxmox') | first).fqdn == "pve.example.com"
           - >-
             (traefik_routes | selectattr('name', 'equalto', 'proxmox') | first).servers
-            == ["https://proxmox1.example.com:8006", "https://proxmox2.example.com:8006", "https://proxmox3.example.com:8006"]
+            == ["https://proxmox1.example.com:8006",
+            "https://proxmox2.example.com:8006", "https://proxmox3.example.com:8006"]
           - (traefik_routes | selectattr('name', 'equalto', 'proxmox') | first).sticky | bool
           - (traefik_routes | selectattr('name', 'equalto', 'proxmox') | first).health_check | bool
         fail_msg: >-
@@ -1183,7 +1184,8 @@
           - _traefik_dynamic_yaml.http.services.proxmox.loadBalancer.servers | length == 3
           - >-
             (_traefik_dynamic_yaml.http.services.proxmox.loadBalancer.servers | map(attribute='url') | list)
-            == ["https://proxmox1.example.com:8006", "https://proxmox2.example.com:8006", "https://proxmox3.example.com:8006"]
+            == ["https://proxmox1.example.com:8006",
+            "https://proxmox2.example.com:8006", "https://proxmox3.example.com:8006"]
           # Sticky session cookie pins a browser to one node.
           - _traefik_dynamic_yaml.http.services.proxmox.loadBalancer.sticky.cookie.name == "proxmox_lb"
           - _traefik_dynamic_yaml.http.services.proxmox.loadBalancer.sticky.cookie.secure | bool


### PR DESCRIPTION
Fixes two **pre-existing** CI failures on main, unrelated to netmon. Both trace to the Proxmox-UI **apex ingress** feature (#400): the apex pool entry has `backends` and no single `ip`.

These have been failing every code-touching PR (they were red on PR #383's run too), so any new PR's Merge Gate stays red until this lands. Merge this first to unblock.

## Changes

- **Inventory schema** (`tests/inventory_load/tofu_inventory.schema.json`): ingress items required `name/ip/port`, but the apex entry is `{name, apex, backends, port}` with no `ip`. The validator's fixture (`tests/inventory_load/tofu_inventory.json`) carries that apex entry, so `validate_schema.py` was failing (`[ingress -> 3] 'ip' is a required property`). Items are now `anyOf`: an IP-backed `{name, ip, port}` **or** an apex pool `{name, apex, backends, port}`.
- **Template test** (`tests/template_render/verify_templates.yml:1105,1186`): two 126-char assertion lines (the apex 3-node server list) wrapped under 120 so ansible-lint (`yaml[line-length]`, production profile) passes. Inside `>-` folded scalars, so the assertion expression is unchanged.

## Verification

- `python3 tests/inventory_load/validate_schema.py` → `OK: tofu_inventory.json is valid`.
- `ansible-lint` (production) → **0 failures on 424 files** (was 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)