### PR TITLE
feat(cribl): S2S path — HAProxy :10300 frontend + Stream cribl_tcp input

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@ this repo handles app config only.
 
 - **Cribl Edge** (`cribl_edge` role — native install on LXC containers)
 - **Cribl Stream** (`cribl_stream` role — native install on LXC containers)
+  - Fleet policy: Cribl Cloud fleets are reserved for Linux machines
+    (the LXC/VM nodes this repo deploys). macOS hosts run standalone,
+    GitOps-managed Edge nodes (see nix-darwin docs/CRIBL-GITOPS.md).
 - **HAProxy** (LXC container, syslog/netflow VIP forwarding to Cribl LXCs)
 - **Syslog forwarding** (`syslog_forwarder` role — rsyslog on every infra LXC
   ships host + native-service logs to the HAProxy syslog VIP on the Linux port

--- a/roles/cribl_stream/defaults/main.yml
+++ b/roles/cribl_stream/defaults/main.yml
@@ -29,6 +29,11 @@ cribl_stream_service_enabled: true
 cribl_stream_netflow_port: >-
   {{ hostvars['localhost']['tofu_data']['constants']['netflow_ports']['unifi'] }}
 
+# Cribl-to-Cribl (S2S) listener for remote Edge nodes, fronted by HAProxy.
+# Port from tofu constants (single source of truth).
+cribl_stream_s2s_port: >-
+  {{ hostvars['localhost']['tofu_data']['constants']['service_ports']['cribl_s2s'] }}
+
 # Splunk HEC output configuration — FQDN, never an IP (see cribl_edge
 # defaults for rationale).
 cribl_stream_splunk_host: >-

--- a/roles/cribl_stream/templates/inputs.yml.j2
+++ b/roles/cribl_stream/templates/inputs.yml.j2
@@ -14,3 +14,15 @@ inputs:
       - output: splunk_hec
         pipeline: ipfix
     pqEnabled: {{ cribl_stream_pq_enabled | lower }}
+  cribl_tcp:in_cribl_s2s:
+    id: in_cribl_s2s
+    type: cribl_tcp
+    disabled: false
+    host: "0.0.0.0"
+    port: {{ cribl_stream_s2s_port }}
+    # Remote Edge nodes stamp index/sourcetype at the source; pass events
+    # straight to the Splunk HEC output (no pipeline = passthrough).
+    sendToRoutes: false
+    connections:
+      - output: splunk_hec
+    pqEnabled: {{ cribl_stream_pq_enabled | lower }}

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -38,6 +38,11 @@ haproxy_netflow_port:
   frontend: 2055
   backend: 2055
 
+# Cribl-to-Cribl (S2S) TCP: remote Edge nodes -> HAProxy -> Cribl Stream.
+# Same port on both sides; from tofu constants (single source of truth).
+haproxy_cribl_s2s_port: >-
+  {{ hostvars['localhost']['tofu_data']['constants']['service_ports']['cribl_s2s'] }}
+
 # Backend servers - Cribl Edge LXC containers (syslog traffic)
 # IP addresses derived from inventory (NEVER hardcoded)
 haproxy_syslog_backend_servers: "{{ groups['cribl_edge'] | default([]) | map('extract', hostvars) | list }}"

--- a/roles/haproxy/templates/haproxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy.cfg.j2
@@ -49,6 +49,24 @@ frontend syslog_{{ mapping.name }}_{{ mapping.frontend }}
 # NetFlow traffic is handled via Nginx (UDP stream); no TCP NetFlow frontend is defined in HAProxy.
 
 # =============================================================================
+# Cribl S2S (remote Edge -> Stream) TCP Load Balancing
+# =============================================================================
+
+frontend cribl_s2s_{{ haproxy_cribl_s2s_port }}
+  bind *:{{ haproxy_cribl_s2s_port }}
+  mode {{ haproxy_mode_tcp }}
+  default_backend cribl_s2s_backend
+
+backend cribl_s2s_backend
+  mode {{ haproxy_mode_tcp }}
+  balance {{ haproxy_algorithm }}
+  option tcp-check
+  timeout server {{ haproxy_health_check_timeout }}
+{% for server in haproxy_ipfix_backend_servers %}
+  server {{ server.inventory_hostname }} {{ server.container_ip }}:{{ haproxy_cribl_s2s_port }} check inter {{ haproxy_health_check_interval }}
+{% endfor %}
+
+# =============================================================================
 # TCP Backends for Cribl Edge nodes (one per destination port)
 # =============================================================================
 {% set unique_backend_ports = (haproxy_syslog_port_mappings | map(attribute='backend') | list) | unique %}


### PR DESCRIPTION
## What

- **haproxy role**: TCP frontend `cribl_s2s_<port>` on `service_ports.cribl_s2s` (10300, from tofu constants), load-balancing across the `cribl_stream_group` backends with the same health-check pattern as the syslog frontends.
- **cribl_stream role**: `cribl_tcp` (Cribl-to-Cribl) input on the same port. Remote Edge senders stamp `index`/`sourcetype` at the source, so events pass straight to the existing `splunk_hec` output (persistent queue on, no pipeline).

## How

This creates the first generic remote-Edge → Stream ingestion path: any Cribl Edge node (e.g. a workstation Edge) points its `cribl_tcp` output at `haproxy:<cribl_s2s>` and gets load-balanced Stream delivery to Splunk HEC. The companion firewall rules and port constant land in terraform-proxmox#424; the destination index in ansible-splunk#246.

## Apply

After terraform-proxmox#424 applies: ansible run for the haproxy + cribl_stream hosts.

Refs: dryvist/terraform-proxmox#424, dryvist/ansible-splunk#246

🤖 Generated with [Claude Code](https://claude.com/claude-code)