### PR TITLE
fix(inventory): scrub manual terragrunt-output instructions from fail messages

### DIFF
--- a/inventory/load_tofu.yml
+++ b/inventory/load_tofu.yml
@@ -150,10 +150,10 @@
             - tofu_data.constants.service_ports
             - tofu_data.constants.syslog_ports
 
-          Please ensure OpenTofu outputs (including pipeline_constants) are correctly
-          generated and merged into ansible_inventory, e.g. by re-running:
-            terragrunt output -json ansible_inventory > \
-              ~/git/ansible-proxmox-apps/main/inventory/tofu_inventory.json
+          Please ensure OpenTofu outputs (including pipeline_constants) are
+          correctly generated and merged into ansible_inventory — run
+          terraform-proxmox `terragrunt apply` so the inventory is republished
+          to S3 and the local cache is refreshed by the after-hook.
 
     - name: Validate Docker VM SSH key path is set when Docker VMs are present
       ansible.builtin.assert:

--- a/scripts/check-pipeline-health.sh
+++ b/scripts/check-pipeline-health.sh
@@ -14,7 +14,7 @@ INVENTORY_FILE="${INVENTORY_FILE:-inventory/tofu_inventory.json}"
 
 if [ ! -f "$INVENTORY_FILE" ]; then
     echo -e "${RED}ERROR: $INVENTORY_FILE not found${NC}"
-    echo "Generate it with: terragrunt output -json ansible_inventory > $INVENTORY_FILE"
+    echo "Refresh it by running terraform-proxmox 'terragrunt apply' (after-hook writes it), or set INVENTORY_FILE to a copy."
     exit 1
 fi
 


### PR DESCRIPTION
Follow-up stragglers from #397 found by a doc sweep: the constants-validation `fail_msg` in `inventory/load_tofu.yml` and the `check-pipeline-health.sh` error message still instructed hand-running `terragrunt output -json ansible_inventory >` — the hand-injection anti-pattern the S3 pipeline exists to eliminate. Both now point at the apply/after-hook publish boundary.

ansible-lint production clean; syntax-check clean; `bash -n` clean.

Refs: #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)