### PR TITLE
feat(inventory): accept DHCP-first container fields (mac, reserved_ip, FQDN ip)

### DIFF
--- a/tests/inventory_load/tofu_inventory.json
+++ b/tests/inventory_load/tofu_inventory.json
@@ -3,6 +3,8 @@
     "haproxy": {
       "vmid": 175,
       "ip": "192.168.0.175",
+      "mac": null,
+      "reserved_ip": null,
       "hostname": "haproxy",
       "ansible_connection": "community.proxmox.proxmox_pct_remote",
       "ansible_pct_vmid": 175,
@@ -240,7 +242,9 @@
     },
     "plex": {
       "vmid": 213,
-      "ip": "192.168.0.213",
+      "ip": "plex.example.internal",
+      "mac": "02:00:c0:a8:00:d5",
+      "reserved_ip": "192.168.0.213",
       "hostname": "plex",
       "ansible_connection": "community.proxmox.proxmox_pct_remote",
       "ansible_pct_vmid": 213,

--- a/tests/inventory_load/tofu_inventory.schema.json
+++ b/tests/inventory_load/tofu_inventory.schema.json
@@ -178,7 +178,33 @@
         },
         "ip": {
           "type": "string",
-          "pattern": "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$"
+          "description": "Static guests: IPv4 address. DHCP-first guests: hostname/FQDN (DNS A record resolves to the DHCP reservation).",
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$"
+            },
+            {
+              "type": "string",
+              "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$"
+            }
+          ]
+        },
+        "mac": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^([0-9a-f]{2}:){5}[0-9a-f]{2}$",
+          "description": "Deterministic locally-administered MAC for DHCP-first guests (02: prefix); null for static guests."
+        },
+        "reserved_ip": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$",
+          "description": "DHCP-reservation address for DHCP-first guests (UniFi pins mac to this IP; DNS A record resolves here); null for static guests."
         },
         "hostname": {
           "type": "string",


### PR DESCRIPTION
## Why

dryvist/terraform-proxmox PR #430 (merged) added `mac` and `reserved_ip` (both null for static guests) to every entry of `ansible_inventory.containers`, and DHCP-first guests now advertise an FQDN in the `ip` field instead of a dotted-quad. `tests/inventory_load/tofu_inventory.schema.json` is the default validator the inventory sync pipeline runs before distribution, so it must accept the new shape **before the next apply**.

## What

Surgical change to `definitions.container_entry` (which already had `additionalProperties: true`):

- **`ip`** relaxed from ipv4-only to `anyOf` ipv4 OR hostname/FQDN. Static guests = ipv4, DHCP-first guests = FQDN (DNS A record resolves to the DHCP reservation).
- **`mac`** / **`reserved_ip`** documented as explicit nullable properties for self-documentation (lowercase colon-hex `02:`-prefixed MAC; DHCP-reservation address that UniFi pins the mac to). `additionalProperties` stays true.
- Fixture `tofu_inventory.json`: static `haproxy` entry gains explicit nulls; `plex` becomes DHCP-shaped (FQDN ip + mac + reserved_ip) so the validate-inventory-schema CI job exercises both shapes. `inventory/load_tofu.yml` only passes `ip` through as `container_ip` and `verify_inventory.yml` asserts group membership only, so verify-inventory-load is unaffected.

## Validation

- `check-jsonschema --schemafile tests/inventory_load/tofu_inventory.schema.json tests/inventory_load/tofu_inventory.json` → `ok -- validation done` (same jsonschema library CI's `validate_schema.py` uses; Draft-07 honored via the `$schema` key)
- Negative tests: dash-separated MAC and a malformed double-dot FQDN both correctly rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)