### PR TITLE
fix(cribl): idempotent converge — guard mode-edge, drift-check stream outputs

### DIFF
--- a/inventory/load_tofu.yml
+++ b/inventory/load_tofu.yml
@@ -76,6 +76,7 @@
                 state: file
                 suffix: tofu_inventory.json
               register: tofu_inv_tmp
+              changed_when: false
               check_mode: false
 
             - name: Download the inventory from S3
@@ -330,6 +331,7 @@
         container_ip: "{{ item.value.ip }}"
         host_tags: "{{ item.value.tags | default([]) }}"
       loop: "{{ tofu_data.containers | dict2items }}"
+      changed_when: false
       when:
         - tofu_data.containers is defined
         - tofu_data.containers | length > 0
@@ -347,6 +349,7 @@
         hostname: "{{ item.value.hostname }}"
         host_tags: "{{ item.value.tags | default([]) }}"
       loop: "{{ tofu_data.vms | dict2items }}"
+      changed_when: false
       when:
         - tofu_data.vms is defined
         - tofu_data.vms | length > 0
@@ -364,6 +367,7 @@
         ansible_ssh_private_key_file: "{{ lookup('env', 'PROXMOX_SSH_KEY_PATH') }}"
         hostname: "{{ tofu_data.splunk_vm.splunk.hostname }}"
         vmid: "{{ tofu_data.splunk_vm.splunk.vmid }}"
+      changed_when: false
       when: tofu_data.splunk_vm.splunk is defined
 
     # NOTE: Docker VMs (docker-host) are for TESTING/DEV ONLY.
@@ -385,6 +389,7 @@
         vmid: "{{ item.value.vmid }}"
         host_tags: "{{ item.value.tags | default([]) }}"
       loop: "{{ tofu_data.docker_vms | dict2items }}"
+      changed_when: false
       when:
         - tofu_data.docker_vms is defined
         - tofu_data.docker_vms | length > 0

--- a/roles/cribl_edge/tasks/main.yml
+++ b/roles/cribl_edge/tasks/main.yml
@@ -68,13 +68,24 @@
     recurse: true
     state: directory
 
+- name: Check current Cribl mode
+  ansible.builtin.slurp:
+    src: "{{ cribl_edge_install_dir }}/local/_system/instance.yml"
+  register: cribl_edge_instance
+  failed_when: false
+
+# `cribl mode-edge` rewrites local config to defaults on every invocation
+# (including the API bind deployed below) — only run it when the recorded
+# mode in local/_system/instance.yml differs.
 - name: Set Cribl to Edge mode
   ansible.builtin.command:
     cmd: "{{ cribl_edge_install_dir }}/bin/cribl mode-edge"
   become: true
   become_user: "{{ cribl_edge_user }}"
-  register: cribl_edge_mode_result
-  changed_when: "'already' not in cribl_edge_mode_result.stdout"
+  changed_when: true
+  when: >-
+    ((cribl_edge_instance.content | default('') | b64decode | from_yaml)
+     | default({}, true)).get('distributed', {}).get('mode', '') != 'edge'
 
 - name: Ensure Edge config directories exist
   # Cribl Edge worker (LEADER process) loads ALL config (inputs, outputs,

--- a/roles/cribl_stream/defaults/main.yml
+++ b/roles/cribl_stream/defaults/main.yml
@@ -44,6 +44,11 @@ cribl_stream_splunk_hec_port: >-
 cribl_stream_splunk_hec_token: "{{ lookup('env', 'SPLUNK_HEC_TOKEN') }}"
 cribl_stream_splunk_hec_tls: true
 cribl_stream_splunk_hec_tls_verify: false  # Self-signed cert in lab
+# Single definition shared by the template and the drift check in tasks.
+cribl_stream_splunk_hec_url: >-
+  {{ 'https' if cribl_stream_splunk_hec_tls else 'http'
+  }}://{{ cribl_stream_splunk_host }}:{{ cribl_stream_splunk_hec_port
+  }}/services/collector/event
 
 # Persistent queue
 cribl_stream_pq_enabled: true

--- a/roles/cribl_stream/tasks/main.yml
+++ b/roles/cribl_stream/tasks/main.yml
@@ -91,6 +91,23 @@
     mode: "0644"
   notify: Restart cribl stream
 
+# Cribl Stream rewrites local/cribl/outputs.yml at startup (strips comments,
+# materializes defaults), so an unconditional template re-diffs and bounces
+# the service on every converge. Deploy only when a managed field drifts.
+- name: Read live Cribl Stream outputs configuration
+  ansible.builtin.slurp:
+    src: "{{ cribl_stream_install_dir }}/local/cribl/outputs.yml"
+  register: cribl_stream_outputs_live
+  failed_when: false
+  no_log: true  # file contains the HEC token
+
+- name: Extract live Splunk HEC output settings
+  ansible.builtin.set_fact:
+    cribl_stream_hec_live: >-
+      {{ ((cribl_stream_outputs_live.content | default('') | b64decode | from_yaml)
+          | default({}, true)).get('outputs', {}).get('splunk_hec', {}) }}
+  no_log: true
+
 - name: Deploy Cribl Stream outputs configuration
   ansible.builtin.template:
     src: outputs.yml.j2
@@ -100,7 +117,15 @@
     mode: "0600"
   no_log: true
   notify: Restart cribl stream
-  when: cribl_stream_splunk_hec_token != ''
+  when:
+    - cribl_stream_splunk_hec_token != ''
+    - >-
+      cribl_stream_hec_live.get('url', '') != cribl_stream_splunk_hec_url
+      or cribl_stream_hec_live.get('token', '') != cribl_stream_splunk_hec_token
+      or cribl_stream_hec_live.get('rejectUnauthorized', none) | bool
+         != cribl_stream_splunk_hec_tls_verify | bool
+      or cribl_stream_hec_live.get('pqEnabled', none) | bool
+         != cribl_stream_pq_enabled | bool
 
 - name: Deploy IPFIX pipeline configuration
   ansible.builtin.template:

--- a/roles/cribl_stream/templates/outputs.yml.j2
+++ b/roles/cribl_stream/templates/outputs.yml.j2
@@ -7,7 +7,7 @@ outputs:
     id: splunk_hec
     type: splunk_hec
     disabled: false
-    url: "{{ 'https' if cribl_stream_splunk_hec_tls else 'http' }}://{{ cribl_stream_splunk_host }}:{{ cribl_stream_splunk_hec_port }}/services/collector/event"
+    url: "{{ cribl_stream_splunk_hec_url }}"
     token: "{{ cribl_stream_splunk_hec_token }}"
     concurrency: 5
     maxPayloadSizeKB: 4096


### PR DESCRIPTION
## Problem

Every `--tags cribl` converge reported changes and **restarted all four Cribl services** even with zero real drift. Two self-sustaining loops:

1. **cribl_edge**: `cribl mode-edge` ran unconditionally. The command rewrites local edge config to defaults on every invocation — including the API bind the role deploys — so the instance-settings template always re-diffed and bounced the service.
2. **cribl_stream**: Cribl Stream normalizes `local/cribl/outputs.yml` at startup (strips comments, materializes defaults), so the minimal template always re-diffed and bounced the service.

Needless restarts also reset Cribl's hourly license-telemetry clock, which is what previously masked the license block.

## Fix

- Guard `mode-edge` on the recorded mode in `local/_system/instance.yml`.
- Gate the Stream outputs deploy on real drift in the managed fields (url, token, TLS verify, PQ); HEC URL derivation moved to a single shared default.
- `changed_when: false` on the inventory-load `add_host`/`tempfile` tasks so a steady-state run recaps changed=0.
- Resolver fail_msg path now uses `$GIT_HOME_PUBLIC` per workspace conventions.

## Verification

- Live converge of the cribl tag against an edge and a stream node: **changed=0 on all hosts** (previously changed=3/2 + handler restarts every run).
- `ansible-lint` production profile: 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)