### PR TITLE
fix(tests): add cribl_s2s to the template-render fixture service_ports

### DIFF
--- a/tests/inventory_load/tofu_inventory.json
+++ b/tests/inventory_load/tofu_inventory.json
@@ -310,6 +310,7 @@
       "splunk_mgmt": 8089,
       "cribl_edge_api": 9000,
       "cribl_stream_api": 9100,
+      "cribl_s2s": 10300,
       "apt_cacher_ng": 3142
     },
     "syslog_ports": {


### PR DESCRIPTION
## What
Adds `cribl_s2s: 10300` to `tests/inventory_load/tofu_inventory.json` `constants.service_ports`.

## Why
#393 made `roles/haproxy/defaults/main.yml` consume `tofu_data.constants.service_ports.cribl_s2s`, but the template-rendering harness fixture never gained the key — since that merge, **every PR that triggers the Molecule workflow fails** with `'haproxy_cribl_s2s_port' is undefined` (e.g. #400, #401). Value mirrors the producer constant (terraform-proxmox `constants.tf`, already public).

Schema-validated: `check-jsonschema` ok (service_ports allows additional integer ports).

Follow-up worth noting: #393 added the haproxy S2S frontend but no harness assertion for it; this PR only unbreaks the fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)