### PR TITLE
fix(cribl_stream): S2S input must be tcpjson — cribl_tcp is distributed-only

### DIFF
--- a/roles/cribl_stream/templates/inputs.yml.j2
+++ b/roles/cribl_stream/templates/inputs.yml.j2
@@ -14,9 +14,14 @@ inputs:
       - output: splunk_hec
         pipeline: ipfix
     pqEnabled: {{ cribl_stream_pq_enabled | lower }}
-  cribl_tcp:in_cribl_s2s:
+  tcpjson:in_cribl_s2s:
     id: in_cribl_s2s
-    type: cribl_tcp
+    # TCP JSON, not cribl_tcp: the Cribl TCP source is only available in
+    # DISTRIBUTED Stream deployments and fails on this single-instance Stream
+    # with "Source is not allowed in this deployment". TCP JSON is Cribl's
+    # documented single-instance equivalent; the remote Edge ships with the
+    # matching tcpjson destination on the same port.
+    type: tcpjson
     disabled: false
     host: "0.0.0.0"
     port: {{ cribl_stream_s2s_port }}

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -606,6 +606,12 @@
         container_ip: 192.168.0.180
       - inventory_hostname: cribl-edge-02
         container_ip: 192.168.0.181
+    haproxy_cribl_s2s_port: 10300
+    haproxy_ipfix_backend_servers:
+      - inventory_hostname: cribl-stream-01
+        container_ip: 192.168.0.182
+      - inventory_hostname: cribl-stream-02
+        container_ip: 192.168.0.183
     _template_dir: "../../roles/haproxy/templates"
 
   tasks:
@@ -644,6 +650,9 @@
           - "'default_backend syslog_backend_1514' in _haproxy_disabled"
           - "'backend syslog_backend_1514' in _haproxy_disabled"
           - "'server cribl-edge-01 192.168.0.180:1514' in _haproxy_disabled"
+          - "'frontend cribl_s2s_10300' in _haproxy_disabled"
+          - "'bind *:10300' in _haproxy_disabled"
+          - "'server cribl-stream-01 192.168.0.182:10300' in _haproxy_disabled"
         fail_msg: >-
           DRY audit caused a behavior change with HTTP disabled — TCP/syslog
           rendering differs from prior literal-baked config.


### PR DESCRIPTION
## Why

Deploying the merged S2S listener (#393) surfaced a hard product limit: the **Cribl TCP source is only available in distributed Stream deployments** ([Cribl docs](https://docs.cribl.io/stream/sources-cribl-tcp/)). On our single-instance Stream the worker fails the input with `Source is not allowed in this deployment`, so :10300 never binds — HAProxy's frontend is up but the backends can never accept.

## What changed

`roles/cribl_stream/templates/inputs.yml.j2`: `cribl_tcp:in_cribl_s2s` → `tcpjson:in_cribl_s2s` (type `tcpjson`), with a comment explaining the deployment-mode restriction. Same id, same port (tofu constants), same passthrough-to-splunk_hec contract, same PQ settings. The sender side (the remote Edge's output) switches to the matching `tcpjson` destination in its own repo.

TCP JSON is Cribl's documented single-instance equivalent; the only caveat is it doesn't carry *internal* fields, which we don't rely on — index/sourcetype are stamped as regular event fields at the source.

## Verification

- `ansible-lint` production profile passes.
- Post-merge converge + cribl restart must show :10300 LISTEN on both stream workers and `started TCP input` for `in_cribl_s2s` in the worker log (the failing init error gone).

Refs: dryvist/orbstack-kubernetes#272