### PR TITLE
fix(media): unprivileged-LXC /data access, DHCP-first addressing, Plex apt, servarr wiring

### DIFF
--- a/roles/apt_cacher_ng/defaults/main.yml
+++ b/roles/apt_cacher_ng/defaults/main.yml
@@ -44,6 +44,13 @@ apt_cacher_ng_ubuntu_security_mirrors:
 # Docker mirror passthrough
 apt_cacher_ng_docker_passthrough: true
 
+# Plex media-server repo passthrough. The Plex apt repo (repo.plex.tv) and key
+# host (downloads.plex.tv) are HTTPS-only and cannot be cached, so apt tunnels
+# them via CONNECT — which apt-cacher-ng denies unless the target is in
+# PassThroughPattern. Without this the plex role fails at "Add Plex apt
+# repository" with "403 CONNECT denied (ask the admin to allow HTTPS tunnels)".
+apt_cacher_ng_plex_passthrough: true
+
 # Logging
 apt_cacher_ng_verbose_log: 1
 apt_cacher_ng_debug_log: 0

--- a/roles/apt_cacher_ng/templates/acng.conf.j2
+++ b/roles/apt_cacher_ng/templates/acng.conf.j2
@@ -59,6 +59,9 @@ Remap-uburep: file:backends_ubuntu /ubuntu
 {% if apt_cacher_ng_docker_passthrough %}
 {% set _ = passthrough_patterns.append('(^|\\.)download\\.docker\\.com:443$') %}
 {% endif %}
+{% if apt_cacher_ng_plex_passthrough %}
+{% set _ = passthrough_patterns.append('(^|\\.)(repo|downloads)\\.plex\\.tv:443$') %}
+{% endif %}
 {% if passthrough_patterns %}
 PassThroughPattern: {{ passthrough_patterns | join('|') }}
 {% endif %}

--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -59,8 +59,19 @@ download_vpn_wg_persistent_keepalive: 25
 # LAN subnet that may reach the web UIs and that *arr/qBit/Prowlarr use to talk
 # to each other. Derived from the container's own /24 (tofu-owned IP) so
 # nothing is hardcoded. Override only if the LAN is not a /24.
+# DHCP-first inventory contract: container_ip carries the guest's FQDN (DNS-first
+# addressing) and container_reserved_ip the actual DHCP-reservation address.
+# Static guests put the IP in container_ip and leave reserved_ip empty. All LAN
+# IP math below uses this resolved address so it works under both layouts — an
+# FQDN fed to ipaddr() yields `False`, which renders an invalid nftables rule
+# (`ip daddr False accept`) and fails the killswitch deploy.
+download_vpn_lan_ip: >-
+  {{ container_reserved_ip
+     if (container_reserved_ip | default('', true) | length > 0)
+     else (container_ip | default(ansible_default_ipv4.address)) }}
+
 download_vpn_lan_subnet: >-
-  {{ (container_ip | default(ansible_default_ipv4.address) ~ '/24')
+  {{ (download_vpn_lan_ip ~ '/24')
      | ansible.utils.ipaddr('network/prefix') }}
 
 # Primary LAN interface — the NIC that actually holds the container's LAN IP.
@@ -123,7 +134,7 @@ download_vpn_qbittorrent_admin_password: "{{ lookup('env', 'QBITTORRENT_ADMIN_PA
 # (the container's own /24) for a tighter boundary. Applied via the setPreferences
 # API in tasks/main.yml (not the conf template — qBittorrent would clobber it).
 download_vpn_qbittorrent_auth_whitelist: >-
-  {{ ((container_ip | default(ansible_default_ipv4.address)) ~ '/16')
+  {{ (download_vpn_lan_ip ~ '/16')
      | ansible.utils.ipaddr('network/prefix') }}
 # CRITICAL: bind qBittorrent's traffic to wg0 (interface binding). With the
 # killswitch this is belt-and-suspenders; binding alone closed the 30% leak

--- a/roles/download_vpn/tasks/main.yml
+++ b/roles/download_vpn/tasks/main.yml
@@ -38,7 +38,7 @@
            | selectattr('ipv4', 'defined')
            | selectattr('ipv4.address', 'defined')
            | selectattr('ipv4.address', 'equalto',
-                        (container_ip | default(ansible_default_ipv4.address | default(''))))
+                        (download_vpn_lan_ip | default(ansible_default_ipv4.address | default(''))))
            | map(attribute='device') | list | first
            | default('eth0', true)
          ) }}

--- a/roles/download_vpn/tasks/main.yml
+++ b/roles/download_vpn/tasks/main.yml
@@ -75,6 +75,9 @@
       - sqlite3
       - libicu-dev
       - gnupg
+      # Required by community.general.xml (servarr_wiring sets Prowlarr's
+      # <ApiKey> in config.xml on this host); without it the wiring fails on lxml.
+      - python3-lxml
     state: present
     # Only refresh the cache when the proxy is reachable. A locked-down box can't
     # reach it and already has its packages, so it must not block on a fetch.

--- a/roles/download_vpn/tasks/main.yml
+++ b/roles/download_vpn/tasks/main.yml
@@ -110,15 +110,20 @@
     create_home: true
     state: present
 
-# The /data/media library tree is owned by the sonarr/radarr/plex roles (same
-# shared dataset, different LXCs) — managing it here too would flip ownership
-# between service users on every converge.
-- name: Ensure the torrents tree exists with group ownership
+# The whole shared /data tree — the /data/media library AND /data/torrents
+# (incomplete/tv/movies) — is created host-side by the media_lxc_features role
+# (owner root, group media/gid 13000, setgid + group-writable) and exposed via
+# the unprivileged-LXC idmap. qBittorrent runs as the media user and writes via
+# group membership, so only ensure the torrents roots EXIST here — never
+# chown/chmod the shared bind-mount (its host-root owner is unmapped inside the
+# container -> EPERM).
+- name: Ensure the shared /data torrents roots exist
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    owner: "{{ download_vpn_user }}"
-    group: "{{ download_vpn_group }}"
+    # Declares the host-side contract (media_lxc_features sets 2775 + setgid);
+    # a match means no chmod is attempted, so the unmapped-owner mount is never
+    # touched. Owner/group are deliberately NOT enforced here.
     mode: "2775"
   loop:
     - "{{ download_vpn_downloads_dir }}"

--- a/roles/plex/tasks/main.yml
+++ b/roles/plex/tasks/main.yml
@@ -71,26 +71,21 @@
   register: plex_user_group
   failed_when: false
 
-- name: Ensure media directory exists
+# The /data library roots (and their movies/tv subdirs) are created host-side by
+# the media_lxc_features role (owner root, group media/gid 13000, setgid +
+# group-writable) and exposed via the unprivileged-LXC idmap. Plex is added to
+# the media group above and reads them via group/other perms, so only ensure
+# they EXIST here — never chown/chmod the shared bind-mount (its host-root owner
+# is unmapped inside the container -> EPERM).
+- name: Ensure the shared /data library roots exist
   ansible.builtin.file:
-    path: "{{ plex_media_dir }}"
+    path: "{{ item }}"
     state: directory
-    owner: "{{ plex_user }}"
-    group: "{{ plex_group }}"
+    # Declares the host-side contract (media_lxc_features sets 2775 + setgid);
+    # a match means no chmod is attempted, so the unmapped-owner mount is never
+    # touched. Owner/group are deliberately NOT enforced here.
     mode: "2775"
-  failed_when: false
-
-# Scaffold the movies/tv library roots so Plex (and the *arr apps writing here)
-# have the expected directories. The library "add" against the Plex API can be
-# finished later via UI/API; this just guarantees the paths exist.
-- name: Scaffold Plex media library subdirectories
-  ansible.builtin.file:
-    path: "{{ plex_media_dir }}/{{ item }}"
-    state: directory
-    owner: "{{ plex_user }}"
-    group: "{{ plex_group }}"
-    mode: "2775"
-  loop: "{{ plex_library_subdirs }}"
+  loop: "{{ [plex_media_dir] + (plex_library_subdirs | map('regex_replace', '^', plex_media_dir ~ '/') | list) }}"
   failed_when: false
 
 - name: Enable + start Plex Media Server

--- a/roles/radarr/tasks/main.yml
+++ b/roles/radarr/tasks/main.yml
@@ -29,15 +29,30 @@
     create_home: false
     state: present
 
-- name: Ensure radarr data + media directories exist
+# Container-local app dir — owned by the service user (chownable: it lives on
+# the container rootfs, not the shared mount).
+- name: Ensure radarr data directory exists
   ansible.builtin.file:
-    path: "{{ item }}"
+    path: "{{ radarr_data_dir }}"
     state: directory
     owner: "{{ radarr_user }}"
     group: "{{ radarr_group }}"
     mode: "2775"
+
+# Shared /data library roots are created host-side by the media_lxc_features
+# role (owner root, group media/gid 13000, setgid + group-writable) and exposed
+# via the unprivileged-LXC idmap. Radarr reaches them through media-group
+# membership, so only ensure they EXIST here — never chown/chmod the shared
+# bind-mount (its host-root owner is unmapped inside the container -> EPERM).
+- name: Ensure the shared /data library roots exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    # Declares the host-side contract (media_lxc_features sets 2775 + setgid);
+    # a match means no chmod is attempted, so the unmapped-owner mount is never
+    # touched. Owner/group are deliberately NOT enforced here.
+    mode: "2775"
   loop:
-    - "{{ radarr_data_dir }}"
     - "{{ radarr_media_dir }}"
     - "{{ radarr_movies_dir }}"
 

--- a/roles/radarr/tasks/main.yml
+++ b/roles/radarr/tasks/main.yml
@@ -8,6 +8,9 @@
       - ca-certificates
       - sqlite3
       - libicu-dev
+      # Required by community.general.xml (servarr_wiring sets <ApiKey> in
+      # config.xml on this host); without it the wiring fails to import lxml.
+      - python3-lxml
     state: present
     update_cache: true
     cache_valid_time: 3600

--- a/roles/servarr_wiring/defaults/main.yml
+++ b/roles/servarr_wiring/defaults/main.yml
@@ -28,28 +28,34 @@ servarr_wiring_radarr_user: media
 servarr_wiring_prowlarr_user: qbittorrent
 servarr_wiring_group: media
 
-# --- Endpoints (hostname:port). Hosts from inventory, ports from OpenTofu. ---
+# --- Endpoints (host:port). Hosts from inventory, ports from OpenTofu. ---
 # Sonarr / Radarr are LAN-only LXCs; Prowlarr + qBittorrent live in download-vpn.
-# Address resolution: prefer the per-guest `ip` field from the tofu
-# inventory — under the dhcp-first rebuild that field IS the FQDN — and fall
-# back to the static container_ip hostvar. NEVER a hardcoded IP and never a
-# vmid-derived literal.
+# Address resolution: this role runs FROM the download-vpn coordinator, which is
+# behind the Proton VPN with Proton DNS (10.2.0.1) — it CANNOT resolve internal
+# FQDNs. So prefer the per-guest `reserved_ip` (the actual LAN address; the
+# killswitch allows the container's own /24) and only fall back to the `ip`
+# field (an IP for static guests; an FQDN under the dhcp-first rebuild, used
+# only where DNS works). NEVER a hardcoded IP and never a vmid-derived literal.
 servarr_wiring_sonarr_host: >-
-  {{ tofu_data.containers['sonarr'].ip
-     | default(hostvars['sonarr'].container_ip)
-     | default('127.0.0.1') }}
+  {{ tofu_data.containers['sonarr'].reserved_ip
+     if (tofu_data.containers['sonarr'].reserved_ip | default('', true) | length > 0)
+     else (tofu_data.containers['sonarr'].ip
+           | default(hostvars['sonarr'].container_ip, true) | default('127.0.0.1', true)) }}
 servarr_wiring_radarr_host: >-
-  {{ tofu_data.containers['radarr'].ip
-     | default(hostvars['radarr'].container_ip)
-     | default('127.0.0.1') }}
+  {{ tofu_data.containers['radarr'].reserved_ip
+     if (tofu_data.containers['radarr'].reserved_ip | default('', true) | length > 0)
+     else (tofu_data.containers['radarr'].ip
+           | default(hostvars['radarr'].container_ip, true) | default('127.0.0.1', true)) }}
 servarr_wiring_prowlarr_host: >-
-  {{ tofu_data.containers['download-vpn'].ip
-     | default(hostvars['download-vpn'].container_ip)
-     | default('127.0.0.1') }}
+  {{ tofu_data.containers['download-vpn'].reserved_ip
+     if (tofu_data.containers['download-vpn'].reserved_ip | default('', true) | length > 0)
+     else (tofu_data.containers['download-vpn'].ip
+           | default(hostvars['download-vpn'].container_ip, true) | default('127.0.0.1', true)) }}
 servarr_wiring_qbittorrent_host: >-
-  {{ tofu_data.containers['download-vpn'].ip
-     | default(hostvars['download-vpn'].container_ip)
-     | default('127.0.0.1') }}
+  {{ tofu_data.containers['download-vpn'].reserved_ip
+     if (tofu_data.containers['download-vpn'].reserved_ip | default('', true) | length > 0)
+     else (tofu_data.containers['download-vpn'].ip
+           | default(hostvars['download-vpn'].container_ip, true) | default('127.0.0.1', true)) }}
 
 servarr_wiring_sonarr_port: "{{ tofu_data.constants.media_ports.sonarr_web }}"
 servarr_wiring_radarr_port: "{{ tofu_data.constants.media_ports.radarr_web }}"

--- a/roles/servarr_wiring/tasks/prowlarr_apps.yml
+++ b/roles/servarr_wiring/tasks/prowlarr_apps.yml
@@ -66,9 +66,12 @@
     # Rebuild fields with built-in filters only (no custom plugin): keep every
     # schema field whose name is NOT overridden, then append our {name, value}
     # overrides. Unsupplied fields keep the schema defaults Prowlarr provides.
+    # NB: use item['values'], not item.values — dot access resolves `values` to
+    # the dict's built-in .values() method (ansible-core 2.19 templating), which
+    # has no .keys() and fails body resolution. Subscript hits the data key.
     _app_fields: >-
-      {{ (_app_template.fields | rejectattr('name', 'in', item.values.keys()) | list)
-         + (item.values | dict2items(key_name='name', value_name='value')) }}
+      {{ (_app_template.fields | rejectattr('name', 'in', item['values'].keys()) | list)
+         + (item['values'] | dict2items(key_name='name', value_name='value')) }}
     _prowlarr_apps:
       - name: Sonarr
         implementation: Sonarr

--- a/roles/sonarr/tasks/main.yml
+++ b/roles/sonarr/tasks/main.yml
@@ -29,15 +29,30 @@
     create_home: false
     state: present
 
-- name: Ensure sonarr data + media directories exist
+# Container-local app dir — owned by the service user (chownable: it lives on
+# the container rootfs, not the shared mount).
+- name: Ensure sonarr data directory exists
   ansible.builtin.file:
-    path: "{{ item }}"
+    path: "{{ sonarr_data_dir }}"
     state: directory
     owner: "{{ sonarr_user }}"
     group: "{{ sonarr_group }}"
     mode: "2775"
+
+# Shared /data library roots are created host-side by the media_lxc_features
+# role (owner root, group media/gid 13000, setgid + group-writable) and exposed
+# via the unprivileged-LXC idmap. Sonarr reaches them through media-group
+# membership, so only ensure they EXIST here — never chown/chmod the shared
+# bind-mount (its host-root owner is unmapped inside the container -> EPERM).
+- name: Ensure the shared /data library roots exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    # Declares the host-side contract (media_lxc_features sets 2775 + setgid);
+    # a match means no chmod is attempted, so the unmapped-owner mount is never
+    # touched. Owner/group are deliberately NOT enforced here.
+    mode: "2775"
   loop:
-    - "{{ sonarr_data_dir }}"
     - "{{ sonarr_media_dir }}"
     - "{{ sonarr_tv_dir }}"
 

--- a/roles/sonarr/tasks/main.yml
+++ b/roles/sonarr/tasks/main.yml
@@ -8,6 +8,9 @@
       - ca-certificates
       - sqlite3
       - libicu-dev
+      # Required by community.general.xml (servarr_wiring sets <ApiKey> in
+      # config.xml on this host); without it the wiring fails to import lxml.
+      - python3-lxml
     state: present
     update_cache: true
     cache_valid_time: 3600


### PR DESCRIPTION
Brings the migrated media stack (unprivileged LXCs on the new node, one shared
bind-mounted `/data` dataset, DHCP-first/FQDN inventory) to a fully converged,
inter-wired state. Companion to ansible-proxmox#276 (the gid-13000 idmap that
makes `/data` group-writable inside the unprivileged containers).

Each fix below was a distinct converge blocker found and verified live end-to-end
(Sonarr/Radarr/Plex/Seerr running, qBittorrent+Prowlarr behind the VPN, Prowlarr
apps + qBittorrent download client + Seerr service registration all wired).

1. **Shared `/data` via group, not chown** (`sonarr`, `radarr`, `plex`, `download_vpn`):
   the shared mount's host-root owner is unmapped inside the container, so chowning
   it `EPERM`s. Keep owner/group/mode only on the container-local app dir; ensure
   the shared `/data` roots only *exist* (mode 2775 to match the host contract — no
   chmod attempted). Apps access via shared-group membership.
2. **Plex HTTPS apt passthrough** (`apt_cacher_ng`): the Plex repo is HTTPS-only and
   uncacheable; apt-cacher-ng denied the CONNECT tunnel. Add an
   `apt_cacher_ng_plex_passthrough` toggle mirroring the Docker one.
3. **DHCP-first LAN IP** (`download_vpn`): the killswitch subnet / auth-whitelist /
   LAN-NIC math fed `container_ip` (now an FQDN) to `ipaddr()`, yielding `False` and
   an invalid nft rule. Resolve a `download_vpn_lan_ip` from `reserved_ip`.
4. **python3-lxml** (`sonarr`, `radarr`, `download_vpn`): `servarr_wiring` sets the
   deterministic `<ApiKey>` via `community.general.xml`, which needs lxml on each host.
5. **servarr_wiring addresses LAN apps by `reserved_ip`**: the role runs from the
   download-vpn coordinator, which is behind the VPN with Proton DNS and can't resolve
   internal FQDNs. Prefer the LAN IP (killswitch allows the container's own /24).
6. **`item['values']` subscript** (`servarr_wiring` prowlarr apps): under ansible-core
   2.19, `item.values` dot-access resolves to the dict's `.values()` method, breaking
   the Prowlarr applications POST body. Use subscript access.

## Verification (live)

- All roles converge `failed=0`; `ansible-lint` clean (production profile).
- Services active: Plex, Sonarr, Radarr, qBittorrent, Prowlarr; Seerr container running.
- VPN: `wg0` Proton handshake live; killswitch leak-tests pass.
- Wiring confirmed via API: Prowlarr applications `[Radarr, Sonarr]`; Sonarr download
  client `qBittorrent` (enabled); Radarr receiving Prowlarr-synced indexers.