### PR TITLE
feat(cribl): route UniFi IPFIX/NetFlow to the netflow index

### DIFF
--- a/roles/cribl_stream/templates/pipelines/ipfix/conf.yml.j2
+++ b/roles/cribl_stream/templates/pipelines/ipfix/conf.yml.j2
@@ -13,7 +13,7 @@ functions:
     conf:
       add:
         - name: index
-          value: "'network'"
+          value: "'netflow'"
         - name: sourcetype
           value: "'ipfix'"
         - name: source


### PR DESCRIPTION
## What
One-line Cribl Stream change: the IPFIX pipeline now stamps `index = netflow` instead of `network`, so high-volume UniFi NetFlow lands in its dedicated index. `sourcetype = ipfix` and the per-port `source` are unchanged.

File: `roles/cribl_stream/templates/pipelines/ipfix/conf.yml.j2` (templated to `/opt/cribl/local/cribl/pipelines/ipfix/conf.yml`, Cribl Stream restarts on converge).

## Why
UniFi NetFlow volume was inflating the 365-day `network` index. `netflow` is provisioned (dryvist/ansible-splunk#251) as 90-day / 50 GB to contain it.

## Risk / migration
None to history — existing `network`/`ipfix` events stay in `network`; only **new** flows route to `netflow`. No backfill.

Refs: dryvist/terraform-proxmox#438, dryvist/ansible-splunk#251.
Deploy = converge `cribl_stream`; verify via Splunk MCP that `index=netflow` receives `ipfix` and `network` stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)