### PR TITLE
fix(inventory): fail loud instead of silently using a stale cache

### DIFF
--- a/inventory/load_tofu.yml
+++ b/inventory/load_tofu.yml
@@ -24,6 +24,19 @@
     tofu_inventory_local: "{{ playbook_dir }}/../inventory/tofu_inventory.json"
     tofu_inventory_s3_uri: "{{ lookup('env', 'TOFU_INVENTORY_S3_URI') | default('', true) }}"
     tofu_inventory_s3_region: "{{ lookup('env', 'TOFU_INVENTORY_S3_REGION') | default('us-east-2', true) }}"
+    # Escape hatch: set to a non-empty value to permit the (possibly STALE) local
+    # cache even when AWS creds are present but the S3 fetch failed. Off by default
+    # so the boto3-missing / S3-unreachable trap fails loud instead of silently
+    # deploying a stale inventory.
+    tofu_inventory_allow_stale: "{{ lookup('env', 'TOFU_INVENTORY_ALLOW_STALE') | default('', true) }}"
+    # Whether AWS credentials appear present. When true, the operator clearly
+    # INTENDED to reach S3, so a failed S3 resolution is an error worth stopping
+    # for — not a cue to silently fall back to the local cache.
+    tofu_inventory_aws_creds_present: >-
+      {{ (lookup('env', 'AWS_ACCESS_KEY_ID') | default('', true) | length > 0)
+         or (lookup('env', 'AWS_PROFILE') | default('', true) | length > 0)
+         or (lookup('env', 'AWS_VAULT') | default('', true) | length > 0)
+         or (lookup('env', 'AWS_ROLE_ARN') | default('', true) | length > 0) }}
 
   tasks:
     - name: Stat the explicit TOFU_INVENTORY_PATH
@@ -104,11 +117,43 @@
                 tofu_inventory_resolved: "{{ tofu_inv_tmp.path }}"
               when: (tofu_inv_s3_stat.stat.size | default(0)) > 0
 
+    # The boto3-missing / S3-unreachable trap: AWS creds are present (operator
+    # intended S3) but the S3 inventory did not resolve. Silently using the local
+    # cache here deploys a STALE inventory (wrong VMIDs/IPs) with confusing
+    # downstream failures. Fail loud instead, unless explicitly overridden.
+    - name: Fail loud when AWS creds are present but the S3 inventory did not resolve
+      ansible.builtin.fail:
+        msg: |
+          AWS credentials are present but the published S3 inventory could not be
+          resolved — refusing to silently fall back to a possibly-STALE local cache.
+
+          Most likely cause: boto3/botocore is not importable in this interpreter
+          (install it in the dev shell), or an S3/creds problem. aws_caller_info said:
+            {{ tofu_inv_aws_acct.msg | default('(skipped or no message)') }}
+
+          To proceed with the local cache anyway, set TOFU_INVENTORY_ALLOW_STALE=1
+          (or pin TOFU_INVENTORY_PATH=/path/to/ansible_inventory.json).
+      when:
+        - tofu_inventory_resolved is not defined
+        - tofu_inventory_path | length == 0
+        - tofu_inventory_aws_creds_present | bool
+        - tofu_inventory_allow_stale | length == 0
+
     - name: Stat the local inventory cache
       ansible.builtin.stat:
         path: "{{ tofu_inventory_local }}"
       register: tofu_inv_localstat
       when: tofu_inventory_resolved is not defined
+
+    - name: Warn that a local (possibly stale) inventory cache is being used
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: using the local inventory cache {{ tofu_inventory_local }} —
+          no explicit path and no S3 resolution. Ensure it is current (run a
+          terraform-proxmox apply to refresh) or pin TOFU_INVENTORY_PATH.
+      when:
+        - tofu_inventory_resolved is not defined
+        - tofu_inv_localstat.stat.exists | default(false)
 
     - name: Resolve inventory from the local cache when present
       ansible.builtin.set_fact:


### PR DESCRIPTION
## Why (Phase 0 of the resiliency program)

The single highest-cost footgun from the media bring-up: when AWS creds are present but the S3 inventory can't be resolved — the **boto3/botocore-missing-from-the-devshell** trap, or any S3/creds problem — the loader silently fell back to the local `tofu_inventory.json` cache. That deploys a **stale** inventory (wrong VMIDs/IPs), and the failures surface far downstream ("container not found", wrong `pct exec` target) with no hint at the real cause.

## What

`inventory/load_tofu.yml` gains a guard between the S3 block and the local-cache fallback:

- If **AWS creds appear present** (`AWS_ACCESS_KEY_ID`/`AWS_PROFILE`/`AWS_VAULT`/`AWS_ROLE_ARN`), **no `TOFU_INVENTORY_PATH`** is pinned, and S3 didn't resolve → **fail** with the actual `aws_caller_info` error and actionable guidance (install boto3 in the dev shell, or fix creds/S3).
- Intentional-offline path preserved: no creds → local cache with a visible WARNING.
- Escape hatch: `TOFU_INVENTORY_ALLOW_STALE=1` to permit the cache anyway; `TOFU_INVENTORY_PATH` to pin.

## Verification (live)

- `ansible-lint` clean (production); `--syntax-check` passes.
- Explicit `TOFU_INVENTORY_PATH` → guard **skipped**, resolves normally (failed=0).
- Fake creds present, no path → guard **fires**, surfacing `aws_caller_info` error `InvalidClientTokenId...`.
- `TOFU_INVENTORY_ALLOW_STALE=1` → guard suppressed (falls through to cache).

Companion change mirrors this into `ansible-proxmox`'s loader. Part of the phased resiliency program (Phase 0: stop silent failures).