### PR TITLE
fix(infra): add restart-on-failure backoff to keystone LB services

### DIFF
--- a/roles/apt_cacher_ng/defaults/main.yml
+++ b/roles/apt_cacher_ng/defaults/main.yml
@@ -6,6 +6,12 @@ apt_cacher_ng_port: 3142
 apt_cacher_ng_cache_dir: /var/cache/apt-cacher-ng
 apt_cacher_ng_log_dir: /var/log/apt-cacher-ng
 
+# Crash-recovery backoff. The Debian apt-cacher-ng.service already ships
+# Restart=on-failure and WantedBy=multi-user.target, but no RestartSec, so a
+# crash-loop hammers restarts with systemd's ~100ms default. A drop-in adds a
+# sensible backoff without forking the vendor unit (survives package upgrades).
+apt_cacher_ng_restart_sec: 5
+
 # Cache settings
 apt_cacher_ng_expiry_threshold: 4
 

--- a/roles/apt_cacher_ng/tasks/main.yml
+++ b/roles/apt_cacher_ng/tasks/main.yml
@@ -72,11 +72,36 @@
     mode: '0644'
   notify: Restart apt-cacher-ng
 
+- name: Create apt-cacher-ng systemd override directory
+  ansible.builtin.file:
+    path: /etc/systemd/system/apt-cacher-ng.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Deploy apt-cacher-ng restart backoff systemd override
+  # The Debian unit already restarts on failure but sets no RestartSec, so a
+  # crash-loop hammers restarts. A drop-in adds a backoff without forking the
+  # vendor unit.
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/apt-cacher-ng.service.d/restart-backoff.conf
+    content: |
+      # Managed by Ansible (apt_cacher_ng role) — crash-recovery backoff.
+      [Service]
+      Restart=on-failure
+      RestartSec={{ apt_cacher_ng_restart_sec }}
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart apt-cacher-ng
+
 - name: Enable apt-cacher-ng service
   ansible.builtin.systemd:
     name: apt-cacher-ng
     state: started
     enabled: true
+    daemon_reload: true
 
 - name: Configure UFW firewall rule for apt-cacher-ng
   community.general.ufw:

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -16,6 +16,12 @@ haproxy_nginx_service_name: nginx
 haproxy_nginx_service_state: started
 haproxy_nginx_service_enabled: true
 
+# Crash-recovery for the Nginx UDP load balancer. The Debian nginx.service
+# unit ships NO Restart= directive, so a crash leaves the syslog/NetFlow LB
+# down until a manual converge. A systemd drop-in adds restart-on-failure
+# without forking the vendor unit (survives package upgrades).
+haproxy_nginx_restart_sec: 5
+
 # Syslog port mappings: frontend (HAProxy/Nginx) -> backend (Cribl Edge),
 # derived from tofu constants syslog_port_map (single source of truth in
 # terraform-proxmox locals — no hardcoded ports here). Standard frontends

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -82,6 +82,30 @@
   when: "'lxc_containers' in group_names"
   notify: Reload haproxy
 
+- name: Create Nginx systemd override directory
+  ansible.builtin.file:
+    path: /etc/systemd/system/nginx.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Deploy Nginx restart-on-failure systemd override
+  # The Debian nginx.service unit ships no Restart= directive, so a crash of
+  # the syslog/NetFlow UDP load balancer leaves it down until a manual
+  # converge. A drop-in adds crash recovery without forking the vendor unit.
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/nginx.service.d/restart-on-failure.conf
+    content: |
+      # Managed by Ansible (haproxy role) — crash recovery for the Nginx LB.
+      [Service]
+      Restart=on-failure
+      RestartSec={{ haproxy_nginx_restart_sec }}
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Reload nginx
+
 - name: Ensure HAProxy socket directory exists
   ansible.builtin.file:
     path: /run/haproxy


### PR DESCRIPTION
## What

Part of the homelab resiliency program — harden single-point-of-failure infra services so they self-recover after a crash. Adds idempotent systemd **drop-ins** (matching the existing `haproxy` `lxc-override.conf` pattern) for the two services whose units lacked adequate crash recovery. Drop-ins are used instead of forking the vendor units, so the policy survives package upgrades.

## Changes

| Service | Vendor unit shipped | Gap | Fix |
| --- | --- | --- | --- |
| **nginx** (UDP syslog/NetFlow LB, managed by the `haproxy` role) | **no `Restart=` at all** | crash left the LB down until a manual converge | drop-in: `Restart=on-failure` + `RestartSec` |
| **apt-cacher-ng** | `Restart=on-failure`, `WantedBy=multi-user.target`, enabled | no `RestartSec` (crash-loop hammered restarts at the ~100ms default) | drop-in: add a backoff |

Each adds a parametrized `*_restart_sec` default (5s) and a `.service.d/*.conf` drop-in, with `daemon_reload` so the policy applies on first converge.

## Investigated and intentionally left unchanged

These were checked against their actual management mechanism and already ship a full restart policy + `WantedBy=multi-user.target` + enabled onboot — no change made:

- **technitium** — the `technitium_dns` role is config-only (DNS zone/records via API); it manages no systemd unit of its own. The DNS server's upstream unit (installed by the install script) ships `Restart=always`, `RestartSec=10`.
- **cribl_edge / cribl_stream** — native installs (not Docker compose); their units are generated by `cribl boot-start enable` with `Restart=always`, `RestartSec=5`.
- **haproxy** — its own unit ships `Restart=always` (adequate); untouched.

## Validation

- `ansible-lint roles/apt_cacher_ng roles/haproxy roles/technitium_dns roles/cribl_edge roles/cribl_stream` → **0 failures, 0 warnings (profile: production)**.
- All pre-commit hooks pass (yamllint, ansible-lint, etc.).
- Idempotent; no port/config/behavior changes beyond restart/onboot policy.

Code + lint only — no live converge in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)