### PR TITLE
fix(media): self-own *arr keys, non-fatal seerr reg, secret preflights

### DIFF
--- a/roles/download_vpn/tasks/main.yml
+++ b/roles/download_vpn/tasks/main.yml
@@ -2,6 +2,31 @@
 # download_vpn — qBittorrent + Prowlarr behind Proton WireGuard with a
 # fail-closed nftables killswitch. See defaults/main.yml for the security model.
 
+# --- Phase -1: secret pre-flight (fail loud before a blank wg0.conf) ----------
+# The four PROTON_WG_* values come from Doppler at runtime. If the converge runs
+# under the WRONG Doppler project they resolve to empty strings and the role
+# silently renders a blank/broken wg0.conf (the tunnel never comes up). Assert
+# they are non-empty FIRST — before the endpoint split below uses them — and name
+# the most likely cause. Gated on download_vpn_manage_services so render-only
+# runs (Molecule) are unaffected; Molecule injects test PROTON_WG_* values
+# regardless.
+- name: Assert the Proton WireGuard secrets are present (fail loud, live only)
+  ansible.builtin.assert:
+    that:
+      - download_vpn_wg_private_key | length > 0
+      - download_vpn_wg_address | length > 0
+      - download_vpn_wg_peer_public_key | length > 0
+      - download_vpn_wg_endpoint | length > 0
+    fail_msg: >-
+      One or more PROTON_WG_* secrets are empty
+      (PROTON_WG_IFACE_PRIVATE_KEY / PROTON_WG_IFACE_ADDRESS /
+      PROTON_WG_PEER_PUBLIC_KEY / PROTON_WG_PEER_ENDPOINT). Rendering wg0.conf now
+      would produce a blank, non-functional tunnel. This almost always means the
+      converge ran under the wrong Doppler project — run under
+      `doppler run -p iac-conf-mgmt -c prd`.
+    quiet: true
+  when: download_vpn_manage_services | bool
+
 # --- Phase 0: resolve endpoint family (v4 vs v6) ----------------------------
 - name: Resolve Proton endpoint host/port
   ansible.builtin.set_fact:

--- a/roles/radarr/defaults/main.yml
+++ b/roles/radarr/defaults/main.yml
@@ -18,3 +18,17 @@ radarr_web_port: "{{ tofu_data.constants.media_ports.radarr_web }}"
 radarr_tarball_url: >-
   https://radarr.servarr.com/v1/update/master/updatefile?os=linux&runtime=netcore&arch=x64
 radarr_manage_services: true
+
+# --- Self-owned deterministic API key + auth (decoupled from servarr_wiring) --
+# Radarr sets its OWN <ApiKey> + auth method in config.xml right after install,
+# so it answers on the deterministic key as soon as this role runs — without
+# waiting on download_vpn / servarr_wiring (which run from behind the Proton
+# VPN). Consumers like Seerr can then authenticate against Radarr regardless of
+# VPN/ordering. servarr_wiring still owns ALL cross-app wiring; it no longer
+# touches Radarr's own key. From SOPS env; never committed.
+radarr_api_key: "{{ lookup('env', 'RADARR_API_KEY') | default('', true) }}"
+# v4 refuses to serve the UI with AuthenticationMethod=None. "External" delegates
+# auth to the reverse proxy and "DisabledForLocalAddresses" lets LAN requests
+# through without a login prompt — matching the servarr_wiring defaults.
+radarr_auth_method: External
+radarr_auth_required: DisabledForLocalAddresses

--- a/roles/radarr/tasks/api_key.yml
+++ b/roles/radarr/tasks/api_key.yml
@@ -1,0 +1,90 @@
+---
+# Self-own Radarr's deterministic <ApiKey> + a valid <Authentication*> method in
+# its own config.xml, right after the app is installed and started. This makes
+# Radarr answer on the deterministic RADARR_API_KEY independently of
+# download_vpn / servarr_wiring (which run from behind the Proton VPN), so
+# consumers like Seerr can authenticate against Radarr regardless of ordering.
+#
+# community.general.xml is idempotent: it only rewrites when a value differs and
+# reports changed accordingly. On any change we restart Radarr (so the new key
+# loads) and wait for its API to answer with that key. Mirrors the house pattern
+# in roles/servarr_wiring/tasks/api_keys.yml (which no longer touches this key).
+#
+# Gated on radarr_manage_services: render-only runs (Molecule / CI) have no
+# running Radarr and no config.xml to edit.
+
+# Fail loud BEFORE writing a blank key into config.xml — a blank RADARR_API_KEY
+# almost always means the converge ran under the wrong Doppler project.
+- name: Assert RADARR_API_KEY is set (decoupled self-own)
+  ansible.builtin.assert:
+    that:
+      - radarr_api_key | length > 0
+    fail_msg: >-
+      RADARR_API_KEY is empty. Radarr cannot self-own its deterministic API key
+      and consumers (Seerr) will 401 against it. This almost always means the
+      converge ran under the wrong Doppler project — run under
+      `doppler run -p iac-conf-mgmt -c prd` (and ensure RADARR_API_KEY exists in
+      SOPS secrets.enc.yaml).
+    quiet: true
+  when: radarr_manage_services | bool
+
+- name: Self-own Radarr's deterministic API key + auth (live only)
+  when: radarr_manage_services | bool
+  block:
+    # Radarr writes config.xml on first start; wait for it before editing.
+    - name: Wait for Radarr config.xml to exist
+      ansible.builtin.wait_for:
+        path: "{{ radarr_data_dir }}/config.xml"
+        timeout: 120
+
+    - name: Ensure <ApiKey> is set in Radarr's config.xml
+      community.general.xml:
+        path: "{{ radarr_data_dir }}/config.xml"
+        xpath: /Config/ApiKey
+        value: "{{ radarr_api_key }}"
+      register: radarr_apikey_set
+      no_log: true
+
+    # Pin a valid authentication method (v4 walls the UI off when it is None) and
+    # let LAN requests through without a login prompt. Both elements already exist
+    # in the config.xml, so this only updates their values.
+    - name: Ensure <AuthenticationMethod> is set in Radarr's config.xml
+      community.general.xml:
+        path: "{{ radarr_data_dir }}/config.xml"
+        xpath: /Config/AuthenticationMethod
+        value: "{{ radarr_auth_method }}"
+      register: radarr_authmethod_set
+
+    - name: Ensure <AuthenticationRequired> is set in Radarr's config.xml
+      community.general.xml:
+        path: "{{ radarr_data_dir }}/config.xml"
+        xpath: /Config/AuthenticationRequired
+        value: "{{ radarr_auth_required }}"
+      register: radarr_authreq_set
+
+    # noqa no-handler: restart only when config.xml actually changed, then wait
+    # inline for the API to answer with the new key. A handler would defer the
+    # restart to the end of the play, but later same-run consumers must reach
+    # Radarr on the deterministic key immediately, so the restart is inline.
+    - name: Restart Radarr when its config.xml changed  # noqa: no-handler
+      ansible.builtin.systemd:
+        name: radarr.service
+        state: restarted
+      when: >-
+        radarr_apikey_set.changed
+        or radarr_authmethod_set.changed
+        or radarr_authreq_set.changed
+
+    - name: Wait for the Radarr API to answer with the deterministic key
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ radarr_web_port }}/api/v3/system/status"
+        method: GET
+        headers:
+          X-Api-Key: "{{ radarr_api_key }}"
+        status_code: 200
+      register: radarr_apikey_ready
+      retries: 30
+      delay: 5
+      until: radarr_apikey_ready.status == 200
+      changed_when: false
+      no_log: true

--- a/roles/radarr/tasks/main.yml
+++ b/roles/radarr/tasks/main.yml
@@ -89,3 +89,8 @@
     enabled: true
     daemon_reload: true
   when: radarr_manage_services
+
+# Self-own the deterministic API key + auth so Radarr answers on RADARR_API_KEY
+# immediately — independent of download_vpn / servarr_wiring ordering.
+- name: Self-own Radarr's deterministic API key + auth
+  ansible.builtin.include_tasks: api_key.yml

--- a/roles/seerr/tasks/register.yml
+++ b/roles/seerr/tasks/register.yml
@@ -230,6 +230,19 @@
           or (seerr_radarr_entry.useSsl | default(false) | bool) != (seerr_radarr_use_ssl | bool)
           or seerr_radarr_entry.activeDirectory | default('') != seerr_radarr_root_folder
 
+  # Non-fatal: a Radarr that is down/unreachable (e.g. its role has not converged
+  # yet, or it is mid-restart) must NOT abort the play. The seerr container still
+  # converges; registration self-heals on a later run — matching the non-fatal
+  # owner/Plex handling above.
+  rescue:
+    - name: Note that Seerr Radarr registration was skipped (non-fatal)
+      ansible.builtin.debug:
+        msg: >-
+          Seerr Radarr registration SKIPPED — Radarr did not respond as expected
+          (likely not converged yet or mid-restart). The seerr container still
+          converged; re-run after Radarr is up to complete registration.
+          Non-fatal.
+
 - name: Register Sonarr in Seerr
   when:
     - seerr_registration_ready | bool
@@ -348,6 +361,19 @@
           or (seerr_sonarr_entry.port | default(0) | int) != (seerr_sonarr_port | int)
           or (seerr_sonarr_entry.useSsl | default(false) | bool) != (seerr_sonarr_use_ssl | bool)
           or seerr_sonarr_entry.activeDirectory | default('') != seerr_sonarr_root_folder
+
+  # Non-fatal: a Sonarr that is down/unreachable (e.g. its role has not converged
+  # yet, or it is mid-restart) must NOT abort the play. The seerr container still
+  # converges; registration self-heals on a later run — matching the non-fatal
+  # owner/Plex handling above.
+  rescue:
+    - name: Note that Seerr Sonarr registration was skipped (non-fatal)
+      ansible.builtin.debug:
+        msg: >-
+          Seerr Sonarr registration SKIPPED — Sonarr did not respond as expected
+          (likely not converged yet or mid-restart). The seerr container still
+          converged; re-run after Sonarr is up to complete registration.
+          Non-fatal.
 
 # --- Plex server settings + library sync (owner already signed in above) -----
 

--- a/roles/servarr_wiring/tasks/api_keys.yml
+++ b/roles/servarr_wiring/tasks/api_keys.yml
@@ -1,33 +1,26 @@
 ---
-# Set a deterministic <ApiKey> and a valid <Authentication*> method in each app's
-# config.xml, delegated to the host that holds the file. Sonarr/Radarr/Prowlarr
-# v4 refuse to serve the UI with AuthenticationMethod=None, so we also pin a valid
+# Set a deterministic <ApiKey> and a valid <Authentication*> method in
+# Prowlarr's config.xml, delegated to the host that holds the file. Prowlarr v1
+# refuses to serve the UI with AuthenticationMethod=None, so we also pin a valid
 # method here. community.general.xml is idempotent: it only rewrites when a value
 # differs and reports changed accordingly. When any element changed, restart the
 # app (delegated) and wait for its API to answer, so later wiring authenticates.
 #
-# One compact per-app spec drives all three apps through a single code path.
+# Sonarr and Radarr now SELF-OWN their own deterministic keys in their own roles
+# (roles/{sonarr,radarr}/tasks/api_key.yml), so they answer on the deterministic
+# key right after their role runs — independent of download_vpn / servarr_wiring,
+# which run from behind the Proton VPN. That decoupling is why consumers like
+# Seerr no longer transitively depend on the VPN for *arr authentication. Only
+# Prowlarr's key is set here (Prowlarr lives in the download-vpn LXC alongside
+# qBittorrent, so this role is its natural owner). All cross-app wiring below
+# still consumes the Sonarr/Radarr keys via servarr_wiring_*_api_key.
+#
+# The one-element spec keeps the changed-then-restart-then-wait code path intact.
 
 - name: Build the per-app servarr spec
   ansible.builtin.set_fact:
     servarr_wiring_apps:
-      - name: sonarr
-        host_inventory: sonarr
-        data_dir: "{{ servarr_wiring_sonarr_data_dir }}"
-        api_key: "{{ servarr_wiring_sonarr_api_key }}"
-        service: sonarr
-        port: "{{ servarr_wiring_sonarr_port }}"
-        endpoint_host: "{{ servarr_wiring_sonarr_host }}"
-        api_version: v3
-      - name: radarr
-        host_inventory: radarr
-        data_dir: "{{ servarr_wiring_radarr_data_dir }}"
-        api_key: "{{ servarr_wiring_radarr_api_key }}"
-        service: radarr
-        port: "{{ servarr_wiring_radarr_port }}"
-        endpoint_host: "{{ servarr_wiring_radarr_host }}"
-        api_version: v3
-      # Prowlarr is a v1 API (Sonarr/Radarr are v3).
+      # Prowlarr is a v1 API (Sonarr/Radarr are v3, and self-own their keys).
       - name: prowlarr
         host_inventory: download-vpn
         data_dir: "{{ servarr_wiring_prowlarr_data_dir }}"

--- a/roles/sonarr/defaults/main.yml
+++ b/roles/sonarr/defaults/main.yml
@@ -18,3 +18,17 @@ sonarr_web_port: "{{ tofu_data.constants.media_ports.sonarr_web }}"
 sonarr_tarball_url: >-
   https://services.sonarr.tv/v1/download/main/latest?version=4&os=linux&arch=x64
 sonarr_manage_services: true
+
+# --- Self-owned deterministic API key + auth (decoupled from servarr_wiring) --
+# Sonarr sets its OWN <ApiKey> + auth method in config.xml right after install,
+# so it answers on the deterministic key as soon as this role runs — without
+# waiting on download_vpn / servarr_wiring (which run from behind the Proton
+# VPN). Consumers like Seerr can then authenticate against Sonarr regardless of
+# VPN/ordering. servarr_wiring still owns ALL cross-app wiring; it no longer
+# touches Sonarr's own key. From SOPS env; never committed.
+sonarr_api_key: "{{ lookup('env', 'SONARR_API_KEY') | default('', true) }}"
+# v4 refuses to serve the UI with AuthenticationMethod=None. "External" delegates
+# auth to the reverse proxy and "DisabledForLocalAddresses" lets LAN requests
+# through without a login prompt — matching the servarr_wiring defaults.
+sonarr_auth_method: External
+sonarr_auth_required: DisabledForLocalAddresses

--- a/roles/sonarr/tasks/api_key.yml
+++ b/roles/sonarr/tasks/api_key.yml
@@ -1,0 +1,90 @@
+---
+# Self-own Sonarr's deterministic <ApiKey> + a valid <Authentication*> method in
+# its own config.xml, right after the app is installed and started. This makes
+# Sonarr answer on the deterministic SONARR_API_KEY independently of
+# download_vpn / servarr_wiring (which run from behind the Proton VPN), so
+# consumers like Seerr can authenticate against Sonarr regardless of ordering.
+#
+# community.general.xml is idempotent: it only rewrites when a value differs and
+# reports changed accordingly. On any change we restart Sonarr (so the new key
+# loads) and wait for its API to answer with that key. Mirrors the house pattern
+# in roles/servarr_wiring/tasks/api_keys.yml (which no longer touches this key).
+#
+# Gated on sonarr_manage_services: render-only runs (Molecule / CI) have no
+# running Sonarr and no config.xml to edit.
+
+# Fail loud BEFORE writing a blank key into config.xml — a blank SONARR_API_KEY
+# almost always means the converge ran under the wrong Doppler project.
+- name: Assert SONARR_API_KEY is set (decoupled self-own)
+  ansible.builtin.assert:
+    that:
+      - sonarr_api_key | length > 0
+    fail_msg: >-
+      SONARR_API_KEY is empty. Sonarr cannot self-own its deterministic API key
+      and consumers (Seerr) will 401 against it. This almost always means the
+      converge ran under the wrong Doppler project — run under
+      `doppler run -p iac-conf-mgmt -c prd` (and ensure SONARR_API_KEY exists in
+      SOPS secrets.enc.yaml).
+    quiet: true
+  when: sonarr_manage_services | bool
+
+- name: Self-own Sonarr's deterministic API key + auth (live only)
+  when: sonarr_manage_services | bool
+  block:
+    # Sonarr writes config.xml on first start; wait for it before editing.
+    - name: Wait for Sonarr config.xml to exist
+      ansible.builtin.wait_for:
+        path: "{{ sonarr_data_dir }}/config.xml"
+        timeout: 120
+
+    - name: Ensure <ApiKey> is set in Sonarr's config.xml
+      community.general.xml:
+        path: "{{ sonarr_data_dir }}/config.xml"
+        xpath: /Config/ApiKey
+        value: "{{ sonarr_api_key }}"
+      register: sonarr_apikey_set
+      no_log: true
+
+    # Pin a valid authentication method (v4 walls the UI off when it is None) and
+    # let LAN requests through without a login prompt. Both elements already exist
+    # in the config.xml, so this only updates their values.
+    - name: Ensure <AuthenticationMethod> is set in Sonarr's config.xml
+      community.general.xml:
+        path: "{{ sonarr_data_dir }}/config.xml"
+        xpath: /Config/AuthenticationMethod
+        value: "{{ sonarr_auth_method }}"
+      register: sonarr_authmethod_set
+
+    - name: Ensure <AuthenticationRequired> is set in Sonarr's config.xml
+      community.general.xml:
+        path: "{{ sonarr_data_dir }}/config.xml"
+        xpath: /Config/AuthenticationRequired
+        value: "{{ sonarr_auth_required }}"
+      register: sonarr_authreq_set
+
+    # noqa no-handler: restart only when config.xml actually changed, then wait
+    # inline for the API to answer with the new key. A handler would defer the
+    # restart to the end of the play, but later same-run consumers must reach
+    # Sonarr on the deterministic key immediately, so the restart is inline.
+    - name: Restart Sonarr when its config.xml changed  # noqa: no-handler
+      ansible.builtin.systemd:
+        name: sonarr.service
+        state: restarted
+      when: >-
+        sonarr_apikey_set.changed
+        or sonarr_authmethod_set.changed
+        or sonarr_authreq_set.changed
+
+    - name: Wait for the Sonarr API to answer with the deterministic key
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ sonarr_web_port }}/api/v3/system/status"
+        method: GET
+        headers:
+          X-Api-Key: "{{ sonarr_api_key }}"
+        status_code: 200
+      register: sonarr_apikey_ready
+      retries: 30
+      delay: 5
+      until: sonarr_apikey_ready.status == 200
+      changed_when: false
+      no_log: true

--- a/roles/sonarr/tasks/main.yml
+++ b/roles/sonarr/tasks/main.yml
@@ -89,3 +89,8 @@
     enabled: true
     daemon_reload: true
   when: sonarr_manage_services
+
+# Self-own the deterministic API key + auth so Sonarr answers on SONARR_API_KEY
+# immediately — independent of download_vpn / servarr_wiring ordering.
+- name: Self-own Sonarr's deterministic API key + auth
+  ansible.builtin.include_tasks: api_key.yml


### PR DESCRIPTION
## Why

Make the media converge robust to role ordering and the Proton VPN dependency, and fail loud instead of silently rendering blank configs when secrets are missing. During the recent bring-up, Seerr 401'd against Radarr because the deterministic key wasn't set yet (it was set only by the VPN-gated wiring), and a blank `wg0.conf` was rendered silently when the converge ran under the wrong Doppler project.

## What changed (per task)

### Task 1 — self-own the deterministic *arr API keys (decouple from VPN-gated wiring)
- New `roles/sonarr/tasks/api_key.yml` and `roles/radarr/tasks/api_key.yml`: each app sets its **own** `<ApiKey>` + `<AuthenticationMethod>`/`<AuthenticationRequired>` in its own `config.xml` from `SONARR_API_KEY` / `RADARR_API_KEY`, idempotently (only restart + wait on change), included from each role's `main.yml` right after install/start.
- Removed Sonarr/Radarr handling from `roles/servarr_wiring/tasks/api_keys.yml` — now only sets Prowlarr's key. All cross-wiring (Prowlarr applications, qBittorrent download client, root folders, quality profiles, media-management) is untouched and still consumes the *arr keys.
- Result: each *arr answers on its deterministic key as soon as its role runs, independent of `download_vpn` / `servarr_wiring` (which run from behind the Proton VPN). Consumers like Seerr no longer transitively depend on the VPN.
- `python3-lxml` (required by `community.general.xml`) was already in both roles' apt prereqs — confirmed, no change needed.

### Task 2 — make Seerr registration non-fatal / self-healing
- Wrapped the Sonarr and Radarr registration `block`s in `roles/seerr/tasks/register.yml` with a `rescue` that emits a clear skip notice, matching the existing non-fatal owner/Plex pattern. The Plex block was already non-fatal (`failed_when: false`). The seerr container always converges; registration completes on a later run. Nothing security-related weakened.

### Task 3 — secret pre-flight asserts (fail loud on wrong Doppler project / missing secrets)
- `roles/download_vpn/tasks/main.yml`: early `assert` that the four `PROTON_WG_*` values are non-empty, placed **before** the endpoint split / `wg0.conf` render.
- The *arr `api_key.yml` tasks assert `SONARR_API_KEY` / `RADARR_API_KEY` non-empty before writing config.xml.
- Each fail message names the likely cause (run under `doppler run -p iac-conf-mgmt -c prd`). All gated on the role's `*_manage_services` flag so render-only CI/Molecule runs are unaffected (Molecule injects test `PROTON_WG_*` values regardless).

## Validation
- `ansible-lint roles/sonarr roles/radarr roles/seerr roles/servarr_wiring roles/download_vpn` → 0 failures, production profile.
- `ansible-playbook -i inventory/hosts.yml playbooks/site.yml --syntax-check` → passes.
- No `ansible.cfg` edits, no ignores/suppressions.

## Out of scope (per constraints)
- Did not touch `inventory/load_tofu.yml`, `playbooks/site.yml`, or the apt_cacher / technitium / haproxy / cribl roles.