### PR TITLE
docs(agents): note --limit must include localhost for the inventory loader

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,12 @@ sops exec-env secrets.enc.yaml 'doppler run -- ansible-playbook \
 ansible-lint
 ```
 
+> **`--limit` must include `localhost`.** The inventory loader
+> (`inventory/load_tofu.yml`) runs on `hosts: localhost` and populates the
+> dynamic inventory via `add_host`. Running with `--limit <group>` but **not**
+> `localhost` silently skips the loader, so no hosts are added and every play
+> reports "no hosts matched". Always use `--limit <group>,localhost`.
+
 ## Testing
 
 ### Fast (CI + pre-commit — runs automatically)


### PR DESCRIPTION
The inventory loader (`inventory/load_tofu.yml`) runs on `hosts: localhost` and builds the dynamic inventory via `add_host`. A `--limit <group>` without `localhost` silently skips it → "no hosts matched" everywhere (a silent no-op that cost debugging time this session). Documents the `--limit <group>,localhost` invariant. Companion to dryvist/ansible-proxmox#284 (which auto-appends localhost in run-ansible.sh; this repo has no wrapper, so doc-only). Part of the resiliency program (P4).