### PR TITLE
fix(plex): publish claimed server to plex.tv so clients can discover it

### DIFF
--- a/roles/plex/defaults/main.yml
+++ b/roles/plex/defaults/main.yml
@@ -77,3 +77,16 @@ plex_apt_keyring_path: /etc/apt/keyrings/plexmediaserver.v2.asc
 plex_apt_repo: "deb [signed-by={{ plex_apt_keyring_path }}] https://repo.plex.tv/deb/ public main"
 plex_package: plexmediaserver
 plex_manage_services: true
+
+# Publish the server to plex.tv so account-based clients (the Plex app on Roku,
+# app.plex.tv) can DISCOVER it. A CLAIMED server with libraries is still hidden
+# from the account while this is off (PublishServerOnPlexOnlineKey=0) — which is
+# exactly what leaves Plex "unreachable" on Roku after a fresh install/migration.
+# Default on; set false only for a deliberately unlisted / local-only server.
+plex_publish_to_plextv: true
+# Opt-in strict onboarding gate. The claim/library/publish steps are non-fatal by
+# design (a stale ~4-min claim token must not break routine converges), so by
+# default an incomplete onboarding only WARNs (see tasks/status.yml). Set true
+# (e.g. in a verification run) to hard-fail when the server is not both claimed
+# AND published.
+plex_require_onboarded: false

--- a/roles/plex/tasks/main.yml
+++ b/roles/plex/tasks/main.yml
@@ -115,3 +115,18 @@
 - name: Advertise the Traefik hostname as Plex custom access URL (idempotent, non-fatal)
   ansible.builtin.import_tasks: customconnections.yml
   when: plex_manage_services
+
+# Publish the claimed server to plex.tv so the Plex app on Roku / app.plex.tv can
+# DISCOVER it. A claimed server with libraries stays invisible to account clients
+# while PublishServerOnPlexOnlineKey is 0 — this reconciles it. Reuses
+# plex_effective_token; skips cleanly without one.
+- name: Ensure the Plex server is published to plex.tv (idempotent, non-fatal)
+  ansible.builtin.import_tasks: publish.yml
+  when: plex_manage_services
+
+# Loud end-of-role status: claim/publish are non-fatal, so without this a server
+# left UNCLAIMED or UNPUBLISHED (invisible on Roku) would slip by silently. Warns
+# unmissably and can hard-fail when plex_require_onboarded is set.
+- name: Report Plex onboarding status (loud; opt-in strict)
+  ansible.builtin.import_tasks: status.yml
+  when: plex_manage_services

--- a/roles/plex/tasks/publish.yml
+++ b/roles/plex/tasks/publish.yml
@@ -1,0 +1,20 @@
+---
+# Publish the server to plex.tv so account-based clients (the Plex app on Roku,
+# app.plex.tv, etc.) can DISCOVER it. Plex hides any server whose
+# PublishServerOnPlexOnlineKey pref is 0 from the account's server list, so a
+# CLAIMED server with libraries is still invisible on Roku until this is 1.
+# Idempotent (PUT sets the pref) + NON-FATAL. Reuses plex_effective_token from
+# libraries.yml; a server that is not yet signed in has no token and skips here.
+
+- name: Ensure the server is published to plex.tv (idempotent, non-fatal)
+  ansible.builtin.uri:
+    url: >-
+      http://127.0.0.1:{{ plex_local_api_port }}/:/prefs?PublishServerOnPlexOnlineKey={{
+      1 if plex_publish_to_plextv else 0 }}&X-Plex-Token={{ plex_effective_token }}
+    method: PUT
+    status_code: [200, 201, 204]
+  register: plex_publish
+  changed_when: plex_publish.status in [200, 201, 204]
+  failed_when: false
+  no_log: true
+  when: plex_effective_token | default('') | length > 0

--- a/roles/plex/tasks/status.yml
+++ b/roles/plex/tasks/status.yml
@@ -1,0 +1,49 @@
+---
+# Loud, end-of-role onboarding status. Claim, library, customConnections, and
+# publish are all NON-FATAL by design (a stale ~4-min claim token must not break
+# routine converges), which previously let a freshly-migrated server run
+# UNCLAIMED and UNPUBLISHED — invisible to the Plex app on Roku — while the
+# failure scrolled past as ordinary debug output. This surfaces the final state
+# unmissably so the gap cannot hide again, and offers an opt-in strict failure.
+
+- name: Re-read Preferences.xml for the final onboarding state
+  ansible.builtin.slurp:
+    src: "{{ plex_preferences_path }}"
+  register: plex_prefs_final
+  failed_when: false
+  no_log: true
+
+- name: Compute onboarding state (claimed / published)
+  ansible.builtin.set_fact:
+    plex_is_claimed: >-
+      {{ (plex_prefs_final.content | default('') | b64decode)
+         is search('PlexOnlineToken="[^"]+"') }}
+    plex_is_published: >-
+      {{ (plex_prefs_final.content | default('') | b64decode)
+         is search('PublishServerOnPlexOnlineKey="1"') }}
+  no_log: true
+
+- name: Confirm the server is fully onboarded
+  ansible.builtin.debug:
+    msg: "Plex onboarding OK — server is claimed and published to plex.tv (discoverable on Roku)."
+  when: plex_is_claimed and plex_is_published
+
+- name: WARN when the server is not discoverable on Roku
+  ansible.builtin.debug:
+    msg: >-
+      PLEX ONBOARDING INCOMPLETE — server is
+      {{ 'NOT CLAIMED' if not plex_is_claimed else 'claimed' }} and
+      {{ 'NOT PUBLISHED to plex.tv' if not plex_is_published else 'published' }}.
+      Until BOTH are true the Plex app on Roku cannot discover it. Re-run with a
+      FRESH claim token (-e plex_claim_token=claim-XXXX from
+      https://www.plex.tv/claim) or claim via the web UI, then converge again.
+  when: not (plex_is_claimed and plex_is_published)
+
+- name: Fail when onboarding is incomplete (opt-in strict mode)
+  ansible.builtin.assert:
+    that: plex_is_claimed and plex_is_published
+    fail_msg: >-
+      Plex is not discoverable on Roku (claimed={{ plex_is_claimed }},
+      published={{ plex_is_published }}) and plex_require_onboarded is true.
+    quiet: true
+  when: plex_require_onboarded | default(false)


### PR DESCRIPTION
## What

The plex role claims the server and sets libraries + a custom access URL, but never
reconciled `PublishServerOnPlexOnlineKey`. Plex hides any server with that pref off from the
account's server list, so a claimed server with media could remain undiscoverable to
account-based clients (e.g. the Plex app on Roku). This adds the missing reconciliation and a
loud end-of-role status so an incomplete onboarding can't pass silently.

## Changes
- **`roles/plex/tasks/publish.yml`** (new) — idempotent, non-fatal PUT of
  `PublishServerOnPlexOnlineKey` (default on via `plex_publish_to_plextv`), reusing the
  effective token from `libraries.yml`. Skips cleanly on an unsigned server.
- **`roles/plex/tasks/status.yml`** (new) — re-reads `Preferences.xml`, prints an unmissable
  WARNING when the server is not both **claimed** and **published**, and hard-fails when
  `plex_require_onboarded` is set (opt-in strict gate).
- **`roles/plex/tasks/main.yml`** — wire both after `customconnections.yml`.
- **`roles/plex/defaults/main.yml`** — add `plex_publish_to_plextv: true` and
  `plex_require_onboarded: false`.

Claim / library / publish / customConnections all stay **non-fatal** so a stale ~4-minute
claim token never breaks a routine converge; the status task makes incomplete onboarding
visible.

## Validation
- `yamllint`: clean · `ansible-lint roles/plex/` (production profile): 0 failures, 0 warnings.

## Verify
On a converge with a signed-in server: `PublishServerOnPlexOnlineKey="1"` in `Preferences.xml`,
the server shows `presence=True` under `plex.tv/api/v2/resources`, and the Plex app lists it.