### PR TITLE
feat: Prometheus-native network monitoring — blackbox_exporter (1/n)

### DIFF
--- a/roles/blackbox_exporter/README.md
+++ b/roles/blackbox_exporter/README.md
@@ -1,0 +1,102 @@
+# blackbox_exporter
+
+Deploys the [Prometheus blackbox exporter](https://github.com/prometheus/blackbox_exporter)
+as a Docker-in-LXC stack for **active WAN/ISP reachability and response-time
+probing**: ICMP latency/loss to the cable modem, the ISP hops, and public anycast
+targets; TCP/HTTP(S)/TLS reachability + latency; and DNS RTT.
+
+This is the **system-of-record for "is the link up and how does it feel"** in the
+Prometheus-native monitoring design — see `terraform-proxmox/docs/SMOKEPING.md`.
+It is the path to proving ISP-side degradation **without** needing the cable
+modem to expose SNMP/HTTP (many Comcast modems answer only ICMP).
+
+## How it works
+
+The exporter exposes **modules** (how to probe), and Prometheus supplies the
+**target** per scrape via the multi-target pattern:
+
+```text
+GET http://<this-host>:9115/probe?target=192.168.100.1&module=icmp
+```
+
+So the **targets are not configured here** — they live in the Prometheus scrape
+config (the `prometheus` role). This role only defines the modules:
+
+| Module | Probes |
+| --- | --- |
+| `icmp` | latency/loss to the modem + ISP hops + public anycast |
+| `tcp_connect` | bare TCP reachability + connect latency |
+| `http_2xx` | HTTP response + latency |
+| `http_2xx_tls` | HTTPS response + TLS handshake / cert expiry |
+| `dns_udp` | DNS RTT + resolution success |
+
+### Example Prometheus scrape (lives in the `prometheus` role, not here)
+
+```yaml
+- job_name: blackbox-icmp
+  metrics_path: /probe
+  params: { module: [icmp] }
+  static_configs:
+    - targets: ["192.168.100.1", "1.1.1.1", "8.8.8.8"]   # modem + internet
+  relabel_configs:
+    - source_labels: [__address__]
+      target_label: __param_target
+    - source_labels: [__param_target]
+      target_label: instance
+    - target_label: __address__
+      replacement: "<blackbox-host>:9115"
+```
+
+`probe_success`, `probe_duration_seconds`, `probe_icmp_duration_seconds`, and
+`probe_http_status_code` then carry the per-target signal for Grafana / alerts.
+
+## Why host networking + NET_RAW
+
+ICMP probes must egress the LXC's uplink so the per-WAN source-IP policy route
+(`tofu-unifi`) governs which WAN they traverse, and the icmp prober needs
+`NET_RAW` to open raw sockets. Molecule/Docker-in-Docker overrides
+`blackbox_exporter_network_mode` to `bridge`.
+
+## Variables
+
+See `defaults/main.yml`. Key ones: `blackbox_exporter_image` (pinned),
+`blackbox_exporter_port` (from the tofu `blackbox_exporter` constant, default
+`9115`), `blackbox_exporter_modules` (the module set above).
+
+## Installation
+
+This role ships with the repo; no separate install step. Its only collection
+dependency, `community.docker`, is pinned in the repo-root `requirements.yml`
+(installed by the bootstrap playbook). Hosts are selected from the terraform
+inventory: the monitoring vantage LXC (the `smokeping`/`netq-probe-*` guests,
+`monitoring` tag) is grouped by `inventory/load_tofu.yml`, and the monitoring
+play in `playbooks/site.yml` runs this role against it.
+
+## Usage
+
+Run via the standard site playbook (tags `blackbox`, `monitoring`):
+
+```bash
+ansible-playbook playbooks/site.yml --tags blackbox
+```
+
+Or include the role directly against the monitoring vantage group:
+
+```yaml
+- name: Configure blackbox exporter
+  hosts: monitoring_group
+  become: true
+  roles:
+    - role: blackbox_exporter
+```
+
+## Handlers
+
+- `Restart blackbox_exporter stack` — recreates the compose stack against the
+  rendered config (`recreate: always`).
+
+## Privacy
+
+No homelab IPs, ISP names, or topology live in this role — probe targets are
+supplied by Prometheus from inventory/constants. Keep ISP-specific values and
+incident data out of this public repo.

--- a/roles/blackbox_exporter/defaults/main.yml
+++ b/roles/blackbox_exporter/defaults/main.yml
@@ -1,0 +1,70 @@
+---
+# blackbox_exporter — Prometheus blackbox exporter (Docker-in-LXC).
+#
+# Active black-box probing of WAN/ISP reachability and response time: ICMP to the
+# cable modem + public anycast targets, TCP/HTTP(S)/TLS reachability + latency,
+# and DNS RTT. Prometheus scrapes this exporter with the multi-target pattern
+# (/probe?target=<addr>&module=<module>); the TARGETS live in the Prometheus
+# scrape config (prometheus role), never here. See terraform-proxmox
+# docs/SMOKEPING.md for the measurement design.
+
+# --- container image (pinned; bump via Renovate or manual review) ---
+blackbox_exporter_image: "quay.io/prometheus/blackbox-exporter:v0.25.0"
+blackbox_exporter_container_name: blackbox-exporter
+blackbox_exporter_data_dir: /opt/blackbox-exporter
+
+# Listen port — from the tofu constant when available, else the upstream default.
+# Prometheus scrapes http://<this-host>:<port>/probe.
+blackbox_exporter_port: >-
+  {{ hostvars['localhost']['tofu_data']['constants']['service_ports']['blackbox_exporter']
+     | default(9115) }}
+
+# Docker storage driver. fuse-overlayfs is required for Docker on a ZFS-backed
+# LXC; molecule's Docker-in-Docker overrides this to vfs.
+blackbox_exporter_docker_storage_driver: "fuse-overlayfs"
+
+# Host networking so ICMP probes egress the LXC's uplink (and the per-WAN
+# source-IP policy route governs which WAN they traverse); NET_RAW lets the icmp
+# prober open raw sockets. Molecule/DinD overrides network_mode to bridge.
+blackbox_exporter_network_mode: "host"
+blackbox_exporter_cap_add:
+  - "NET_RAW"
+
+# --- probe modules (HOW to probe; the targets come from Prometheus, not here) ---
+# icmp        — latency/loss to the modem + Comcast hops + public anycast
+# tcp_connect — bare TCP reachability + connect latency
+# http_2xx    — HTTP response + latency (any 2xx)
+# http_2xx_tls— HTTPS response + TLS handshake/cert-expiry
+# dns_udp     — DNS RTT + resolution success
+blackbox_exporter_modules:
+  icmp:
+    prober: icmp
+    timeout: 5s
+    icmp:
+      preferred_ip_protocol: ip4
+  tcp_connect:
+    prober: tcp
+    timeout: 5s
+    tcp:
+      preferred_ip_protocol: ip4
+  http_2xx:
+    prober: http
+    timeout: 5s
+    http:
+      preferred_ip_protocol: ip4
+      valid_status_codes: []
+      fail_if_not_ssl: false
+  http_2xx_tls:
+    prober: http
+    timeout: 5s
+    http:
+      preferred_ip_protocol: ip4
+      fail_if_not_ssl: true
+  dns_udp:
+    prober: dns
+    timeout: 5s
+    dns:
+      transport_protocol: udp
+      preferred_ip_protocol: ip4
+      query_name: "example.com"
+      query_type: "A"

--- a/roles/blackbox_exporter/handlers/main.yml
+++ b/roles/blackbox_exporter/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+# blackbox_exporter handlers
+
+# state: present with recreate: always so a config-only change (new blackbox.yml
+# or compose that doesn't restart the running container) triggers a full recreate
+# against the rendered config. state: restarted would keep the old config.
+- name: Restart blackbox_exporter stack
+  community.docker.docker_compose_v2:
+    project_src: "{{ blackbox_exporter_data_dir }}"
+    state: present
+    recreate: always
+  vars:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python

--- a/roles/blackbox_exporter/meta/main.yml
+++ b/roles/blackbox_exporter/meta/main.yml
@@ -1,0 +1,30 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: >-
+    Prometheus blackbox exporter (Docker-in-LXC) for active WAN/ISP reachability
+    and response-time probing — ICMP, TCP, HTTP(S)/TLS, and DNS — scraped by
+    Prometheus via the multi-target /probe pattern. See terraform-proxmox
+    docs/SMOKEPING.md for the measurement design.
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+
+  galaxy_tags:
+    - blackbox
+    - prometheus
+    - monitoring
+    - network
+    - docker
+
+dependencies: []
+  # community.docker collection is specified in requirements.yml

--- a/roles/blackbox_exporter/tasks/main.yml
+++ b/roles/blackbox_exporter/tasks/main.yml
@@ -1,0 +1,193 @@
+---
+# blackbox_exporter — deploy the Prometheus blackbox exporter as a Docker-in-LXC
+# stack. Mirrors the netmon role's Docker bootstrap.
+
+# =============================================================================
+# Docker installation
+# =============================================================================
+
+- name: Gather OS facts
+  ansible.builtin.setup:
+    filter: ansible_distribution*
+
+- name: Install Docker prerequisites
+  ansible.builtin.apt:
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg
+      - lsb-release
+    state: present
+    update_cache: true
+
+- name: Create keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+
+- name: Set Docker repository distribution
+  ansible.builtin.set_fact:
+    blackbox_exporter_distro: "{{ ansible_distribution | lower }}"
+
+- name: Add Docker GPG key
+  ansible.builtin.get_url:
+    url: "https://download.docker.com/linux/{{ blackbox_exporter_distro }}/gpg"
+    dest: /etc/apt/keyrings/docker.asc
+    mode: "0644"
+    force: false
+
+- name: Add Docker repository
+  ansible.builtin.apt_repository:
+    repo: >-
+      deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc]
+      https://download.docker.com/linux/{{ blackbox_exporter_distro }}
+      {{ ansible_distribution_release }} stable
+    state: present
+    filename: docker
+
+- name: Install Docker packages
+  ansible.builtin.apt:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-buildx-plugin
+      - docker-compose-plugin
+    state: present
+    update_cache: true
+
+- name: Install fuse-overlayfs for Docker on ZFS-backed LXC containers
+  ansible.builtin.apt:
+    name: fuse-overlayfs
+    state: present
+
+- name: Configure Docker storage driver (fuse-overlayfs on ZFS-backed LXC; vfs under molecule)
+  ansible.builtin.copy:
+    dest: /etc/docker/daemon.json
+    content: |
+      {
+        "storage-driver": "{{ blackbox_exporter_docker_storage_driver }}"
+      }
+    owner: root
+    group: root
+    mode: "0644"
+  register: blackbox_exporter_daemon_config
+
+- name: Restart Docker to apply fuse-overlayfs configuration
+  ansible.builtin.systemd:  # noqa: no-handler
+    name: docker
+    state: restarted
+  when: blackbox_exporter_daemon_config.changed
+
+- name: Ensure Docker service is running
+  ansible.builtin.systemd:
+    name: docker
+    state: started
+    enabled: true
+
+# =============================================================================
+# Python venv for the Ansible docker_compose_v2 module
+# =============================================================================
+
+- name: Install Python venv and pip for dependencies
+  ansible.builtin.apt:
+    name:
+      - python3-pip
+      - python3-venv
+      - python3-full
+    state: present
+    update_cache: true
+
+- name: Create virtualenv for Ansible Python dependencies
+  ansible.builtin.pip:
+    name:
+      - docker
+    state: present
+    virtualenv: /opt/ansible-venv
+    virtualenv_command: python3 -m venv
+
+- name: Set Python interpreter to use venv for subsequent tasks
+  ansible.builtin.set_fact:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python
+
+# =============================================================================
+# Config + compose
+# =============================================================================
+
+- name: Create blackbox_exporter data directory
+  ansible.builtin.file:
+    path: "{{ blackbox_exporter_data_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Render blackbox exporter configuration
+  ansible.builtin.template:
+    src: blackbox.yml.j2
+    dest: "{{ blackbox_exporter_data_dir }}/blackbox.yml"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart blackbox_exporter stack
+
+- name: Deploy blackbox_exporter docker-compose template
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ blackbox_exporter_data_dir }}/docker-compose.yml"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart blackbox_exporter stack
+
+- name: Deploy blackbox_exporter stack via docker compose
+  community.docker.docker_compose_v2:
+    project_src: "{{ blackbox_exporter_data_dir }}"
+    state: present
+
+# =============================================================================
+# Health check
+# =============================================================================
+
+- name: Verify the blackbox-exporter container is running
+  ansible.builtin.command: >-
+    docker ps -q --filter name={{ blackbox_exporter_container_name }} --filter status=running
+  register: blackbox_exporter_running
+  changed_when: false
+  failed_when: false
+  retries: 6
+  delay: 5
+  until: blackbox_exporter_running.stdout != ''
+
+# Real smoke test: the exporter must answer its own health endpoint AND complete
+# a probe. A bare "container up" check (like a missing health check) is how a
+# silently-broken exporter passes — verify it actually serves /-/healthy.
+- name: Verify the exporter answers /-/healthy
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ blackbox_exporter_port }}/-/healthy"
+    status_code: 200
+  register: blackbox_exporter_healthy
+  retries: 6
+  delay: 5
+  until: blackbox_exporter_healthy.status | default(0) == 200
+  changed_when: false
+  when: blackbox_exporter_running.stdout != ''
+
+- name: Capture diagnostics when the exporter is not running
+  ansible.builtin.shell: "{{ item }} 2>&1"
+  loop:
+    - "docker ps -a --filter name={{ blackbox_exporter_container_name }}"
+    - "docker logs {{ blackbox_exporter_container_name }}"
+  register: blackbox_exporter_diag
+  changed_when: false
+  failed_when: false
+  when: blackbox_exporter_running.stdout == ''
+
+- name: Fail with diagnostics when the container is not running
+  ansible.builtin.fail:
+    msg: |-
+      blackbox-exporter container '{{ blackbox_exporter_container_name }}' is not running after deploy.
+      {{ blackbox_exporter_diag.results | default([]) | map(attribute='stdout') | join('\n--- next ---\n') }}
+  when: blackbox_exporter_running.stdout == ''

--- a/roles/blackbox_exporter/templates/blackbox.yml.j2
+++ b/roles/blackbox_exporter/templates/blackbox.yml.j2
@@ -1,0 +1,6 @@
+## Managed by Ansible (blackbox_exporter role) — do not edit by hand.
+## Probe MODULES only. Prometheus supplies the target per scrape via the
+## multi-target pattern: /probe?target=<addr>&module=<module-name>. The list of
+## targets lives in the prometheus role's scrape config, not here.
+modules:
+{{ blackbox_exporter_modules | to_nice_yaml(indent=2) | indent(2, true) }}

--- a/roles/blackbox_exporter/templates/docker-compose.yml.j2
+++ b/roles/blackbox_exporter/templates/docker-compose.yml.j2
@@ -1,0 +1,21 @@
+## Managed by Ansible (blackbox_exporter role) — do not edit by hand.
+## host networking: ICMP probes must egress the LXC's uplink so the per-WAN
+## source-IP policy route (tofu-unifi) governs the path; NET_RAW lets the icmp
+## prober open raw sockets. Molecule/DinD overrides network_mode to bridge.
+services:
+  blackbox-exporter:
+    image: {{ blackbox_exporter_image }}
+    container_name: {{ blackbox_exporter_container_name }}
+    restart: unless-stopped
+    network_mode: {{ blackbox_exporter_network_mode }}
+{% if blackbox_exporter_cap_add | length > 0 %}
+    cap_add:
+{% for cap in blackbox_exporter_cap_add %}
+      - {{ cap }}
+{% endfor %}
+{% endif %}
+    command:
+      - "--config.file=/etc/blackbox_exporter/config.yml"
+      - "--web.listen-address=:{{ blackbox_exporter_port }}"
+    volumes:
+      - {{ blackbox_exporter_data_dir }}/blackbox.yml:/etc/blackbox_exporter/config.yml:ro


### PR DESCRIPTION
## Context

The DOCSIS `netmon` prober was found to have **never been deployed** (no LXC in
the cluster), and the Comcast modem was confirmed to expose **no SNMP/HTTP on the
LAN — ICMP only**. So DOCSIS counters are ungettable, and the path to ISP-fault
evidence is the **active-probe** approach already designed in
`terraform-proxmox/docs/SMOKEPING.md` (Prometheus-native).

Per repo convention, all container/service config lives here in
`ansible-proxmox-apps` (Splunk excepted).

## This PR (first of several)

`roles/blackbox_exporter` — Prometheus blackbox exporter (Docker-in-LXC, mirrors
the `netmon` role): ICMP / TCP / HTTP(S)+TLS / DNS probe modules. Targets are
supplied by Prometheus via the multi-target `/probe` pattern (in the forthcoming
`prometheus` role), not hardcoded here. Health check does a real `/-/healthy`
smoke test, not just "container up".

## Still to come (this branch or follow-ups)

- `smokeping_prober`, `irtt`, `speedtest-exporter` roles
- `snmp_exporter` role (UniFi SNMPv3 + iDRAC + PDUs) → `snmp.pve.jacobpevans.com`
- `prometheus` role + scrape config (targets: modem ICMP, ISP hops, internet)
- terraform-proxmox: LXC provisioning (`deployment.json`/ports/ingress) — separate
- Gated (user): enable UniFi SNMPv3, Infisical creds, `terragrunt`/`ansible` apply

No homelab IPs / ISP names / topology in this role (privacy-only rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)