### PR TITLE
fix(schema): accept FQDN in ingress ip field for DHCP-first guests

### DIFF
--- a/tests/inventory_load/tofu_inventory.json
+++ b/tests/inventory_load/tofu_inventory.json
@@ -394,17 +394,17 @@
   "ingress": [
     {
       "name": "seerr",
-      "ip": "192.168.55.211",
+      "ip": "seerr.example.net",
       "port": 5055
     },
     {
       "name": "sonarr",
-      "ip": "192.168.55.212",
+      "ip": "sonarr.example.net",
       "port": 8989
     },
     {
       "name": "plex",
-      "ip": "192.168.55.210",
+      "ip": "plex.example.net",
       "port": 32400
     },
     {

--- a/tests/inventory_load/tofu_inventory.schema.json
+++ b/tests/inventory_load/tofu_inventory.schema.json
@@ -91,7 +91,7 @@
       "items": {
         "type": "object",
         "additionalProperties": true,
-        "description": "Either an IP-backed service {name, ip, port} or the Proxmox-UI apex pool {name, apex, backends, port} (a hostname pool, no single ip).",
+        "description": "Either a service route {name, ip, port} (ip is a dotted IPv4 or a hostname/FQDN for DHCP-first guests) or the Proxmox-UI apex pool {name, apex, backends, port} (a hostname pool, no single ip).",
         "anyOf": [
           {
             "required": [
@@ -106,7 +106,7 @@
               },
               "ip": {
                 "type": "string",
-                "pattern": "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$"
+                "minLength": 1
               },
               "port": {
                 "type": "integer",


### PR DESCRIPTION
## Why

DHCP-first containers (6-digit VMIDs) export their hostname/FQDN as
the `ip` field in `ansible_inventory.ingress` (via `container_address`
in terraform-proxmox `locals.tf`). The ingress schema's strict IPv4
pattern (`^\d{1,3}…`) rejects these, so `sync-inventory.sh` fails
validation after every `terragrunt apply` that touches a DHCP guest.

## What

Remove the IPv4 pattern restriction from `ingress[].ip` — any
non-empty string is now valid. This is consistent with `ingress[].backends`
which already accepts hostname strings for the Proxmox apex pool.

Update the fixture to use `*.example.net` FQDNs for the DHCP-guest ingress
entries so the test reflects the actual shape produced by terraform-proxmox.

## Verification

`sync-inventory.sh` runs `check-jsonschema` against this schema file.
After this change the FQDN-based ingress entries produced by DHCP containers
will pass validation and the sync will proceed normally.