### PR TITLE
fix(syslog_forwarder): start rsyslog in unprivileged LXC

### DIFF
--- a/roles/syslog_forwarder/README.md
+++ b/roles/syslog_forwarder/README.md
@@ -21,6 +21,14 @@ rule uses `omfwd` with a disk-assisted action queue, so a HAProxy/Cribl outage
 buffers (up to `syslog_forwarder_queue_max_disk_space`) instead of dropping
 logs.
 
+Debian's `rsyslog.service` ships systemd sandboxing (`PrivateDevices`,
+`ProtectKernelTunables`, `ProtectControlGroups`, …) that an unprivileged LXC
+cannot satisfy — systemd fails the unit with `status=226/NAMESPACE` before
+`rsyslogd` runs. The role drops in
+`/etc/systemd/system/rsyslog.service.d/zz-lxc-unpriv.conf` to neutralize those
+directives so the forwarder starts in a container. It disables only the
+host-privilege sandboxing, not any rsyslog functionality.
+
 ## What it captures
 
 - All host/system logs and **every native systemd service** (Traefik,

--- a/roles/syslog_forwarder/handlers/main.yml
+++ b/roles/syslog_forwarder/handlers/main.yml
@@ -5,4 +5,5 @@
   ansible.builtin.systemd:
     name: rsyslog
     state: restarted
+    daemon_reload: true
   listen: Restart rsyslog

--- a/roles/syslog_forwarder/tasks/main.yml
+++ b/roles/syslog_forwarder/tasks/main.yml
@@ -22,6 +22,28 @@
     update_cache: true
     cache_valid_time: 3600
 
+# rsyslog's Debian unit enables systemd sandboxing (PrivateDevices,
+# ProtectKernelTunables, ProtectControlGroups, ...) that an unprivileged LXC
+# cannot satisfy, so systemd fails the unit with status=226/NAMESPACE before
+# rsyslogd starts. Drop in an override that neutralizes those directives so the
+# forwarder runs in a container. Harmless on hosts that could honor them.
+- name: Ensure rsyslog systemd drop-in directory exists
+  ansible.builtin.file:
+    path: /etc/systemd/system/rsyslog.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Deploy rsyslog unprivileged-LXC systemd override
+  ansible.builtin.template:
+    src: rsyslog-lxc-override.conf.j2
+    dest: /etc/systemd/system/rsyslog.service.d/zz-lxc-unpriv.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart rsyslog
+
 - name: Deploy the Cribl syslog-forward rule
   ansible.builtin.template:
     src: 10-forward-cribl.conf.j2
@@ -37,3 +59,4 @@
     name: rsyslog
     state: started
     enabled: true
+    daemon_reload: true

--- a/roles/syslog_forwarder/templates/rsyslog-lxc-override.conf.j2
+++ b/roles/syslog_forwarder/templates/rsyslog-lxc-override.conf.j2
@@ -1,0 +1,17 @@
+# {{ ansible_managed }}
+# rsyslog ships with systemd sandboxing that needs host-level privileges
+# (mount/namespace manipulation, CAP_SYS_ADMIN). In an unprivileged LXC those
+# directives make systemd fail the unit with status=226/NAMESPACE before
+# rsyslogd ever runs. Neutralize exactly the directives Debian's unit sets so
+# the forwarder can start in a container. This adapts the hardening to the
+# container's reality; it does not disable any rsyslog functionality.
+[Service]
+PrivateTmp=no
+PrivateDevices=no
+ProtectHome=no
+ProtectSystem=no
+ProtectKernelTunables=no
+ProtectKernelModules=no
+ProtectClock=no
+ProtectControlGroups=no
+ProtectHostname=no


### PR DESCRIPTION
## Problem

A freshly-built Debian 13 LXC converged through `site.yml` aborts at **syslog_forwarder → Enable and start rsyslog** with:

```
status=226/NAMESPACE
```

Debian's `rsyslog.service` enables systemd sandboxing (`PrivateDevices`, `ProtectKernelTunables`, `ProtectControlGroups`, `ProtectClock`, …). An **unprivileged** LXC cannot set up those namespaces, so systemd fails the unit before `rsyslogd` runs. Containers built before this role was added to `site.yml` never exercised the start task, so this is a latent bug that only surfaces on the next fresh container.

## Fix

Deploy a systemd drop-in `/etc/systemd/system/rsyslog.service.d/zz-lxc-unpriv.conf` that neutralizes the host-privilege sandboxing directives (it disables only the sandboxing, **not** any rsyslog functionality), and `daemon_reload` before start/restart.

This adapts the unit hardening to the unprivileged-container reality — the documented approach — rather than suppressing any check.

## Verification

- Reproduced live on a fresh container: rsyslog failed `226/NAMESPACE`; after the drop-in it goes `active`.
- `ansible-lint` (production profile): **0 failures** across the role.
- Static drop-in (no Jinja variables) → no template_render fixture entry needed.

Assisted-by: Claude:claude-opus-4-8