### PR TITLE
feat: prometheus role + blackbox scrape config (2/n)

### DIFF
--- a/roles/prometheus/README.md
+++ b/roles/prometheus/README.md
@@ -1,0 +1,68 @@
+# prometheus
+
+Deploys [Prometheus](https://prometheus.io/) as a Docker-in-LXC stack — the
+**system of record** for the Prometheus-native network-quality monitoring stack
+(see `terraform-proxmox/docs/SMOKEPING.md`). It scrapes the `blackbox_exporter`
+via the multi-target `/probe` pattern, producing the WAN/ISP loss, latency, and
+reachability metrics, and grows `smokeping_prober` / `irtt` / `snmp_exporter`
+jobs as those roles land.
+
+## What it scrapes
+
+| Job | Source | Signal |
+| --- | --- | --- |
+| `prometheus` | self | scrape health |
+| `blackbox_icmp` | blackbox `/probe?module=icmp` | loss + RTT to the modem (`192.168.100.1`) + internet |
+| `blackbox_http_2xx_tls` | blackbox | HTTPS response + TLS health |
+| `blackbox_dns_udp` | blackbox | DNS RTT + resolution |
+
+`probe_success` + `probe_duration_seconds` per target carry the ISP-degradation
+signal — this is the evidence path now that the modem exposes no DOCSIS data.
+
+## Targets / privacy
+
+Probe targets default to **generic** values only (the cable-modem diagnostic IP
+`192.168.100.1` and public anycast `1.1.1.1` / `8.8.8.8`). Real ISP hop IPs and
+ISP-specific targets are home-specific — supply them via a **private** inventory
+override of `prometheus_blackbox_jobs`; never commit them to this public repo.
+
+## Variables
+
+See `defaults/main.yml`: `prometheus_image` (pinned), `prometheus_port` (tofu
+`prometheus_web`, default `9090`), `prometheus_retention` (`30d`),
+`prometheus_blackbox_address` (host:port of the exporter; co-located by default),
+`prometheus_blackbox_jobs` (probe modules + targets), and
+`prometheus_extra_scrape_configs` (raw YAML appended for later exporters).
+
+## Installation
+
+This role ships with the repo; no separate install step. Its only collection
+dependency, `community.docker`, is pinned in the repo-root `requirements.yml`.
+Hosts are selected from the terraform inventory: the metrics LXC (`prometheus`
+hostname / `monitoring` tag) is grouped by `inventory/load_tofu.yml`, and the
+monitoring play in `playbooks/site.yml` runs this role against it.
+
+## Usage
+
+Run via the standard site playbook (scoped — never the full `site.yml`):
+
+```bash
+ansible-playbook playbooks/site.yml --tags prometheus
+```
+
+Or include the role directly against the metrics host:
+
+```yaml
+- name: Configure prometheus
+  hosts: prometheus_group
+  become: true
+  roles:
+    - role: prometheus
+```
+
+## Handlers
+
+- `Reload prometheus config` — POST `/-/reload` (config-only change; no restart,
+  no scrape gap).
+- `Restart prometheus stack` — recreates the compose stack (TSDB persists in the
+  named volume).

--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -1,0 +1,47 @@
+---
+# prometheus — metrics collection + storage (Docker-in-LXC). System of record for
+# the Prometheus-native network-quality stack (see terraform-proxmox
+# docs/SMOKEPING.md). Scrapes blackbox_exporter via the multi-target /probe
+# pattern; smokeping_prober / irtt / snmp_exporter jobs append as those land.
+
+# --- container image (pinned; bump via Renovate or manual review) ---
+prometheus_image: "prom/prometheus:v3.1.0"
+prometheus_container_name: prometheus
+prometheus_data_dir: /opt/prometheus
+prometheus_port: >-
+  {{ hostvars['localhost']['tofu_data']['constants']['service_ports']['prometheus_web']
+     | default(9090) }}
+
+prometheus_docker_storage_driver: "fuse-overlayfs"
+prometheus_scrape_interval: "15s"
+prometheus_retention: "30d"
+
+# Where the blackbox_exporter listens (host:port). Co-located on the prometheus
+# LXC by default; override per inventory if blackbox runs on a separate vantage.
+prometheus_blackbox_port: >-
+  {{ hostvars['localhost']['tofu_data']['constants']['service_ports']['blackbox_exporter']
+     | default(9115) }}
+prometheus_blackbox_address: "127.0.0.1:{{ prometheus_blackbox_port }}"
+
+# Probe targets — GENERIC defaults only: the cable-modem diagnostic IP and public
+# anycast. Real ISP hop IPs / ISP-specific targets are home-specific; supply them
+# via a PRIVATE inventory override of prometheus_blackbox_jobs — never commit them
+# to this public repo.
+prometheus_blackbox_jobs:
+  - module: icmp
+    targets:
+      - "192.168.100.1"   # cable-modem diagnostic IP (generic; ICMP-only)
+      - "1.1.1.1"
+      - "8.8.8.8"
+  - module: http_2xx_tls
+    targets:
+      - "https://1.1.1.1"
+      - "https://8.8.8.8"
+  - module: dns_udp
+    targets:
+      - "1.1.1.1"
+      - "8.8.8.8"
+
+# Raw YAML appended to scrape_configs for exporters that land later
+# (smokeping_prober, irtt, snmp_exporter). Empty until those roles ship.
+prometheus_extra_scrape_configs: ""

--- a/roles/prometheus/handlers/main.yml
+++ b/roles/prometheus/handlers/main.yml
@@ -1,0 +1,22 @@
+---
+# prometheus handlers
+
+# Config-only change: hot-reload via the lifecycle API (no restart, no scrape
+# gap, TSDB untouched). Requires --web.enable-lifecycle (set in the compose).
+- name: Reload prometheus config
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ prometheus_port }}/-/reload"
+    method: POST
+    status_code: [200, 204]
+  vars:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python
+
+# Compose change: recreate the stack against the rendered compose. TSDB persists
+# in the named volume across the recreate.
+- name: Restart prometheus stack
+  community.docker.docker_compose_v2:
+    project_src: "{{ prometheus_data_dir }}"
+    state: present
+    recreate: always
+  vars:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python

--- a/roles/prometheus/meta/main.yml
+++ b/roles/prometheus/meta/main.yml
@@ -1,0 +1,31 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: >-
+    Prometheus (Docker-in-LXC) — metrics collection + storage and the system of
+    record for the Prometheus-native network-quality stack. Scrapes
+    blackbox_exporter via the multi-target /probe pattern; smokeping_prober /
+    irtt / snmp_exporter jobs append as those roles land. See terraform-proxmox
+    docs/SMOKEPING.md.
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+
+  galaxy_tags:
+    - prometheus
+    - monitoring
+    - metrics
+    - network
+    - docker
+
+dependencies: []
+  # community.docker collection is specified in requirements.yml

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -1,0 +1,192 @@
+---
+# prometheus — deploy Prometheus as a Docker-in-LXC stack. Mirrors the netmon /
+# blackbox_exporter Docker bootstrap.
+
+# =============================================================================
+# Docker installation
+# =============================================================================
+
+- name: Gather OS facts
+  ansible.builtin.setup:
+    filter: ansible_distribution*
+
+- name: Install Docker prerequisites
+  ansible.builtin.apt:
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg
+      - lsb-release
+    state: present
+    update_cache: true
+
+- name: Create keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+
+- name: Set Docker repository distribution
+  ansible.builtin.set_fact:
+    prometheus_distro: "{{ ansible_distribution | lower }}"
+
+- name: Add Docker GPG key
+  ansible.builtin.get_url:
+    url: "https://download.docker.com/linux/{{ prometheus_distro }}/gpg"
+    dest: /etc/apt/keyrings/docker.asc
+    mode: "0644"
+    force: false
+
+- name: Add Docker repository
+  ansible.builtin.apt_repository:
+    repo: >-
+      deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc]
+      https://download.docker.com/linux/{{ prometheus_distro }}
+      {{ ansible_distribution_release }} stable
+    state: present
+    filename: docker
+
+- name: Install Docker packages
+  ansible.builtin.apt:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-buildx-plugin
+      - docker-compose-plugin
+    state: present
+    update_cache: true
+
+- name: Install fuse-overlayfs for Docker on ZFS-backed LXC containers
+  ansible.builtin.apt:
+    name: fuse-overlayfs
+    state: present
+
+- name: Configure Docker storage driver (fuse-overlayfs on ZFS-backed LXC; vfs under molecule)
+  ansible.builtin.copy:
+    dest: /etc/docker/daemon.json
+    content: |
+      {
+        "storage-driver": "{{ prometheus_docker_storage_driver }}"
+      }
+    owner: root
+    group: root
+    mode: "0644"
+  register: prometheus_daemon_config
+
+- name: Restart Docker to apply fuse-overlayfs configuration
+  ansible.builtin.systemd:  # noqa: no-handler
+    name: docker
+    state: restarted
+  when: prometheus_daemon_config.changed
+
+- name: Ensure Docker service is running
+  ansible.builtin.systemd:
+    name: docker
+    state: started
+    enabled: true
+
+# =============================================================================
+# Python venv for the Ansible docker_compose_v2 module
+# =============================================================================
+
+- name: Install Python venv and pip for dependencies
+  ansible.builtin.apt:
+    name:
+      - python3-pip
+      - python3-venv
+      - python3-full
+    state: present
+    update_cache: true
+
+- name: Create virtualenv for Ansible Python dependencies
+  ansible.builtin.pip:
+    name:
+      - docker
+    state: present
+    virtualenv: /opt/ansible-venv
+    virtualenv_command: python3 -m venv
+
+- name: Set Python interpreter to use venv for subsequent tasks
+  ansible.builtin.set_fact:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python
+
+# =============================================================================
+# Config + compose
+# =============================================================================
+
+- name: Create prometheus data directory
+  ansible.builtin.file:
+    path: "{{ prometheus_data_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Render prometheus.yml scrape configuration
+  ansible.builtin.template:
+    src: prometheus.yml.j2
+    dest: "{{ prometheus_data_dir }}/prometheus.yml"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload prometheus config
+
+- name: Deploy prometheus docker-compose template
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ prometheus_data_dir }}/docker-compose.yml"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart prometheus stack
+
+- name: Deploy prometheus stack via docker compose
+  community.docker.docker_compose_v2:
+    project_src: "{{ prometheus_data_dir }}"
+    state: present
+
+# =============================================================================
+# Health check
+# =============================================================================
+
+- name: Verify the prometheus container is running
+  ansible.builtin.command: >-
+    docker ps -q --filter name={{ prometheus_container_name }} --filter status=running
+  register: prometheus_running
+  changed_when: false
+  failed_when: false
+  retries: 6
+  delay: 5
+  until: prometheus_running.stdout != ''
+
+# Real smoke test: the server must report healthy AND ready (config parsed, TSDB
+# open). A bare "container up" check is how a config error silently passes.
+- name: Verify prometheus is healthy and ready
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ prometheus_port }}/-/ready"
+    status_code: 200
+  register: prometheus_ready
+  retries: 12
+  delay: 5
+  until: prometheus_ready.status | default(0) == 200
+  changed_when: false
+  when: prometheus_running.stdout != ''
+
+- name: Capture diagnostics when prometheus is not running
+  ansible.builtin.shell: "{{ item }} 2>&1"
+  loop:
+    - "docker ps -a --filter name={{ prometheus_container_name }}"
+    - "docker logs {{ prometheus_container_name }}"
+  register: prometheus_diag
+  changed_when: false
+  failed_when: false
+  when: prometheus_running.stdout == ''
+
+- name: Fail with diagnostics when the container is not running
+  ansible.builtin.fail:
+    msg: |-
+      prometheus container '{{ prometheus_container_name }}' is not running after deploy.
+      {{ prometheus_diag.results | default([]) | map(attribute='stdout') | join('\n--- next ---\n') }}
+  when: prometheus_running.stdout == ''

--- a/roles/prometheus/templates/docker-compose.yml.j2
+++ b/roles/prometheus/templates/docker-compose.yml.j2
@@ -1,0 +1,22 @@
+## Managed by Ansible (prometheus role) — do not edit by hand.
+## host networking so Prometheus can reach scrape targets across VLANs (the
+## exporters, and a co-located blackbox on 127.0.0.1). TSDB persists in a named
+## volume across container recreates.
+services:
+  prometheus:
+    image: {{ prometheus_image }}
+    container_name: {{ prometheus_container_name }}
+    restart: unless-stopped
+    network_mode: host
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time={{ prometheus_retention }}"
+      - "--web.listen-address=:{{ prometheus_port }}"
+      - "--web.enable-lifecycle"
+    volumes:
+      - {{ prometheus_data_dir }}/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+
+volumes:
+  prometheus-data:

--- a/roles/prometheus/templates/prometheus.yml.j2
+++ b/roles/prometheus/templates/prometheus.yml.j2
@@ -1,0 +1,35 @@
+## Managed by Ansible (prometheus role) — do not edit by hand.
+global:
+  scrape_interval: {{ prometheus_scrape_interval }}
+  evaluation_interval: {{ prometheus_scrape_interval }}
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["127.0.0.1:{{ prometheus_port }}"]
+
+  ## blackbox active probes — multi-target: Prometheus passes the target via
+  ## __param_target; the exporter runs the module. One job per module.
+{% for job in prometheus_blackbox_jobs %}
+  - job_name: "blackbox_{{ job.module }}"
+    metrics_path: /probe
+    params:
+      module: ["{{ job.module }}"]
+    scrape_interval: {{ job.interval | default(prometheus_scrape_interval) }}
+    static_configs:
+      - targets:
+{% for t in job.targets %}
+          - "{{ t }}"
+{% endfor %}
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: "{{ prometheus_blackbox_address }}"
+{% endfor %}
+{% if prometheus_extra_scrape_configs | trim | length > 0 %}
+  ## appended jobs (smokeping_prober / irtt / snmp_exporter)
+{{ prometheus_extra_scrape_configs | indent(2, true) }}
+{% endif %}


### PR DESCRIPTION
## Context

Builds on #430 (`blackbox_exporter`). This adds the **keystone** that turns the
exporter into actual data: a `prometheus` role whose scrape config drives
blackbox's multi-target `/probe` jobs against the cable modem (ICMP) and the
internet — the WAN/ISP loss/latency/reachability evidence path, now that the
Comcast modem is confirmed to expose **no DOCSIS data** (ICMP-only).

## This PR

`roles/prometheus` — Docker-in-LXC Prometheus with:
- `blackbox_icmp` / `blackbox_http_2xx_tls` / `blackbox_dns_udp` scrape jobs
  (multi-target relabel pattern) → `probe_success`, `probe_duration_seconds`.
- Hot-reload handler (`POST /-/reload`, no scrape gap) + real `/-/ready` health check.
- `prometheus_extra_scrape_configs` hook for `smokeping_prober` / `irtt` /
  `snmp_exporter` jobs as those roles land.

**Targets are generic only** (modem `192.168.100.1`, `1.1.1.1`, `8.8.8.8`); real
ISP hop IPs come from a **private** inventory override — none in this public repo.

## Streaming safety

No changes to Plex/media/storage or the streaming network path. `speedtest`
(the only WAN-saturating component) is intentionally **not** included.

## Still to come
`smokeping_prober`, `irtt`, `snmp_exporter` roles; terraform-proxmox LXC
provisioning + site.yml/inventory wiring; gated `terragrunt`/`ansible` apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)