### PR TITLE
feat(service_deadman): deadman watchdog for keystone SPOFs

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -378,6 +378,26 @@
     - role: healthchecks_docker
 
 # =============================================================================
+# Phase 4b: Keystone SPOF deadman watchdog
+# A timer-driven liveness validator on each keystone host (DNS, Traefik, the
+# syslog/netflow LB) that pings healthchecks + ntfy so a silent keystone failure
+# pages instead of going unnoticed. Runs after ntfy + healthchecks so both alert
+# receivers exist. No-op on hosts with no matching checks.
+# =============================================================================
+
+- name: Deploy keystone SPOF deadman watchdog
+  hosts: technitium_dns_group:traefik_group:haproxy_group
+  become: true
+  gather_facts: false
+  tags:
+    - service_deadman
+    - monitoring
+    - deadman
+    - resiliency
+  roles:
+    - role: service_deadman
+
+# =============================================================================
 # Phase 5: Microsoft SQL Server
 # Deploy SQL Server 2022 on Docker in LXC container
 # =============================================================================

--- a/roles/service_deadman/README.md
+++ b/roles/service_deadman/README.md
@@ -1,0 +1,98 @@
+# service_deadman
+
+A timer-driven liveness watchdog for the cluster's keystone single-points-of-
+failure (DNS, the Traefik ingress, the syslog/netflow load balancer). It turns a
+**silent** keystone failure into a page.
+
+## Why
+
+The shared-infra keystones are concentrated on one node. Restart-on-failure
+drop-ins make them self-heal, but a service that exhausts its restart budget — or
+hangs while systemd still reports it `active` — fails silently. This role adds
+the missing **visibility** layer, mirroring the proven `download_vpn`
+killswitch-validator pattern.
+
+```text
+systemd timer (every 60s)
+  -> validator script
+       per keystone on this host: run a functional probe
+         healthy  -> ping healthchecks OK   (deadman stays green)
+         breached -> journal + ntfy alert + ping healthchecks /fail
+```
+
+Because healthchecks expects a ping every cycle, a missed run (validator crash,
+host down) **also** pages — true deadman semantics.
+
+## How it works
+
+Checks are declared per inventory group in `service_deadman_group_checks`. The
+role selects every check whose group this host belongs to (`group_names`), so a
+single `site.yml` play can target the union of keystone groups and each host
+watches only its own services. A host with no matching checks is a no-op.
+
+Each check is a functional probe (not merely `systemctl is-active`), with unit
+names verified against the live services:
+
+| Group | Service | Probe |
+| --- | --- | --- |
+| `technitium_dns_group` | `dns.service` | unit active **and** `dig @127.0.0.1 . NS` answers |
+| `traefik_group` | `traefik.service` | unit active **and** TCP 443 accepts a connection |
+| `haproxy_group` | `haproxy.service` | unit active (TCP VIP) |
+| `haproxy_group` | `nginx.service` | unit active (UDP syslog/netflow LB) |
+
+## Healthchecks URLs
+
+Each check pings its own healthchecks deadman check. The ping URL is read from a
+per-check environment variable and is **optional** — an empty URL skips only the
+deadman ping; the journal entry and ntfy alert still fire. Provision a check per
+keystone in the healthchecks LXC and export its ping URL:
+
+| Check | Env var |
+| --- | --- |
+| technitium-dns | `DEADMAN_HC_URL_DNS` |
+| traefik | `DEADMAN_HC_URL_TRAEFIK` |
+| haproxy-vip | `DEADMAN_HC_URL_HAPROXY` |
+| nginx-syslog-lb | `DEADMAN_HC_URL_NGINX` |
+
+ntfy alerts always fire (no provisioning needed) via the repo's ntfy LXC.
+
+## Installation
+
+No manual install. The role is wired into `playbooks/site.yml` and runs against
+the keystone groups on every converge. It deploys a validator script plus a
+systemd service + timer; no extra packages are required (`curl`, `dig`, and
+`logger` are already present on the infra LXCs). Ansible collection dependencies
+come from the repo `requirements.yml`.
+
+## Usage
+
+Wired into `playbooks/site.yml` against the keystone groups. Target just this
+role by tag:
+
+```bash
+doppler run -- ansible-playbook -i inventory/hosts.yml playbooks/site.yml \
+  --tags service_deadman --limit technitium_dns_group:traefik_group:haproxy_group,localhost
+```
+
+## Verification
+
+```bash
+# On a keystone host:
+systemctl status service-deadman-validate.timer
+/usr/local/bin/service-deadman-validate.sh; echo "rc=$?"   # 0 = all healthy
+
+# Simulate a failure (e.g. stop a watched unit) and confirm a page:
+#   - journal: journalctl -t service-deadman
+#   - ntfy:    the "keystone" topic receives an urgent message
+#   - healthchecks: the corresponding check flips to down
+```
+
+## Contributing
+
+Edit in a worktree, pass `ansible-lint` (production profile) and the
+`template_render` fixture, open a PR. Keep ports and hostnames sourced from the
+inventory — never hardcode them here.
+
+## License
+
+Apache-2.0, matching the repository.

--- a/roles/service_deadman/defaults/main.yml
+++ b/roles/service_deadman/defaults/main.yml
@@ -1,0 +1,66 @@
+---
+# service_deadman — timer-driven liveness watchdog for keystone SPOF services.
+#
+# The cluster concentrates shared-infra keystones (DNS, the Traefik ingress, the
+# syslog/netflow load balancer) on a single node. #421 added Restart= drop-ins so
+# those services self-heal, but a service that exhausts its restart budget — or
+# hangs while still "active" — fails silently. This role adds the missing
+# VISIBILITY layer: a systemd timer runs a validator that probes each keystone
+# every cycle and pings a healthchecks deadman (OK when healthy, /fail on breach)
+# plus an ntfy alert, mirroring the proven download_vpn killswitch-validator
+# pattern. A crash, a restart-loop that gives up, or a stalled validator all page
+# instead of going unnoticed.
+
+# systemd timer cadence (OnUnitActiveSec). Deadman semantics rely on regular runs.
+service_deadman_interval: "60s"
+
+# ntfy alert target. Reuses the repo's ntfy LXC + notification-port convention.
+service_deadman_ntfy_url: >-
+  http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
+  tofu_data.constants.notification_ports.ntfy_http }}/{{ service_deadman_ntfy_topic }}
+service_deadman_ntfy_topic: "keystone"
+
+# Per-group keystone checks. The role selects every check whose group this host
+# belongs to (group_names), so one site.yml play covers all keystones and each
+# host watches only its own services. Each check:
+#   name            - label used in alerts and the healthchecks slug
+#   probe_command   - shell returning 0 when healthy (functional, not just
+#                     "systemd thinks it's up"); unit names verified live
+#   healthcheck_url  - per-check deadman ping URL; EMPTY => ping skipped
+#                     (ntfy + journal alert still fire), set from the
+#                     healthchecks LXC per check via the env var shown.
+service_deadman_group_checks:
+  technitium_dns_group:
+    - name: technitium-dns
+      # dns.service is Technitium; rc 0 from dig proves the resolver answered
+      # (NOERROR or NXDOMAIN both count) independent of any upstream forwarder.
+      probe_command: >-
+        systemctl is-active --quiet dns.service &&
+        dig +tries=1 +time=3 @127.0.0.1 . NS >/dev/null 2>&1
+      healthcheck_url: "{{ lookup('env', 'DEADMAN_HC_URL_DNS') | default('', true) }}"
+  traefik_group:
+    - name: traefik
+      probe_command: >-
+        systemctl is-active --quiet traefik.service &&
+        timeout 5 bash -c '</dev/tcp/127.0.0.1/443'
+      healthcheck_url: "{{ lookup('env', 'DEADMAN_HC_URL_TRAEFIK') | default('', true) }}"
+  haproxy_group:
+    # The LB host runs BOTH the HAProxy TCP VIP and the nginx UDP syslog/netflow
+    # balancer; nginx is the one #421 found shipping no Restart=. nginx listens
+    # UDP-only, so a port probe is unreliable — assert the unit instead.
+    - name: haproxy-vip
+      probe_command: "systemctl is-active --quiet haproxy.service"
+      healthcheck_url: "{{ lookup('env', 'DEADMAN_HC_URL_HAPROXY') | default('', true) }}"
+    - name: nginx-syslog-lb
+      probe_command: "systemctl is-active --quiet nginx.service"
+      healthcheck_url: "{{ lookup('env', 'DEADMAN_HC_URL_NGINX') | default('', true) }}"
+
+# Resolved set of checks for THIS host — every group's checks the host is in.
+service_deadman_checks: >-
+  {{ service_deadman_group_checks | dict2items
+     | selectattr('key', 'in', group_names)
+     | map(attribute='value') | flatten | list }}
+
+# Deployed paths (rarely overridden).
+service_deadman_script_path: /usr/local/bin/service-deadman-validate.sh
+service_deadman_service_name: service-deadman-validate

--- a/roles/service_deadman/handlers/main.yml
+++ b/roles/service_deadman/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+# service_deadman role handlers
+
+- name: Reload systemd and restart deadman timer
+  ansible.builtin.systemd:
+    name: "{{ service_deadman_service_name }}.timer"
+    state: restarted
+    daemon_reload: true
+  listen: Reload systemd and restart deadman timer

--- a/roles/service_deadman/meta/main.yml
+++ b/roles/service_deadman/meta/main.yml
@@ -1,0 +1,25 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: Timer-driven deadman watchdog alerting (ntfy + healthchecks) on keystone SPOF service failure
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+
+  galaxy_tags:
+    - monitoring
+    - healthchecks
+    - deadman
+    - observability
+    - resiliency
+
+dependencies: []

--- a/roles/service_deadman/tasks/main.yml
+++ b/roles/service_deadman/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+# Deploy the keystone liveness watchdog (validator script + systemd timer).
+# No-op on hosts with no matching checks, so the site.yml play can target the
+# union of keystone groups without per-host gymnastics.
+
+- name: Skip hosts with no keystone checks
+  ansible.builtin.meta: end_host
+  when: service_deadman_checks | length == 0
+
+- name: Deploy the keystone liveness validator script
+  ansible.builtin.template:
+    src: service-deadman-validate.sh.j2
+    dest: "{{ service_deadman_script_path }}"
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Deploy the validator systemd service unit
+  ansible.builtin.template:
+    src: service-deadman-validate.service.j2
+    dest: "/etc/systemd/system/{{ service_deadman_service_name }}.service"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd and restart deadman timer
+
+- name: Deploy the validator systemd timer unit
+  ansible.builtin.template:
+    src: service-deadman-validate.timer.j2
+    dest: "/etc/systemd/system/{{ service_deadman_service_name }}.timer"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd and restart deadman timer
+
+- name: Enable and start the validator timer
+  ansible.builtin.systemd:
+    name: "{{ service_deadman_service_name }}.timer"
+    state: started
+    enabled: true
+    daemon_reload: true

--- a/roles/service_deadman/templates/service-deadman-validate.service.j2
+++ b/roles/service_deadman/templates/service-deadman-validate.service.j2
@@ -1,0 +1,7 @@
+[Unit]
+Description=Keystone SPOF liveness watchdog (one-shot, timer-driven)
+Documentation=https://github.com/JacobPEvans/ansible-proxmox-apps
+
+[Service]
+Type=oneshot
+ExecStart={{ service_deadman_script_path }}

--- a/roles/service_deadman/templates/service-deadman-validate.sh.j2
+++ b/roles/service_deadman/templates/service-deadman-validate.sh.j2
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# {{ ansible_managed }}
+#
+# Keystone SPOF liveness watchdog. Rendered by the service_deadman role and run
+# on a systemd timer (every {{ service_deadman_interval }}). For each keystone
+# service on this host it runs a functional probe and:
+#   - healthy  -> pings the per-check healthchecks deadman OK endpoint
+#   - breached -> logs, pushes an ntfy alert, and pings the deadman /fail endpoint
+#
+# A missed run (validator crash / host down) also pages, because healthchecks
+# expects a ping every cycle. Empty healthcheck URLs skip only the deadman ping;
+# the journal + ntfy alert still fire.
+set -uo pipefail
+
+NTFY_URL="{{ service_deadman_ntfy_url }}"
+HOST="$(hostname)"
+rc=0
+
+# Ping a healthchecks endpoint if a URL is configured; no-op otherwise.
+hc_ping() {
+  local url="$1"
+  [[ -n "${url}" ]] || return 0
+  curl -fsS --max-time 8 "${url}" >/dev/null 2>&1 || true
+}
+
+# Healthy: signal the deadman OK so a stalled validator is also caught.
+mark_ok() {
+  local name="$1" url="$2"
+  logger -t service-deadman "OK: ${name} healthy on ${HOST}"
+  hc_ping "${url}"
+}
+
+# Breached: log, alert ntfy, signal the deadman failure endpoint.
+mark_fail() {
+  local name="$1" url="$2"
+  local msg="KEYSTONE DOWN: ${name} failed its liveness probe on ${HOST}"
+  rc=1
+  logger -t service-deadman "${msg}"
+  if [[ -n "${NTFY_URL}" ]]; then
+    curl -fsS --max-time 8 -H "Title: keystone deadman: ${name}" \
+      -H "Priority: urgent" -H "Tags: rotating_light" \
+      -d "${msg}" "${NTFY_URL}" >/dev/null 2>&1 || true
+  fi
+  [[ -n "${url}" ]] && curl -fsS --max-time 8 -d "${msg}" "${url}/fail" >/dev/null 2>&1 || true
+}
+
+{% for check in service_deadman_checks %}
+# --- {{ check.name }} ---
+if {{ check.probe_command }}; then
+  mark_ok "{{ check.name }}" "{{ check.healthcheck_url }}"
+else
+  mark_fail "{{ check.name }}" "{{ check.healthcheck_url }}"
+fi
+{% endfor %}
+
+exit "${rc}"

--- a/roles/service_deadman/templates/service-deadman-validate.timer.j2
+++ b/roles/service_deadman/templates/service-deadman-validate.timer.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Run the keystone liveness watchdog every {{ service_deadman_interval }}
+Documentation=https://github.com/JacobPEvans/ansible-proxmox-apps
+
+[Timer]
+# Start shortly after boot, then on a fixed cadence. Persistent=true catches
+# missed runs — deadman semantics rely on a ping every cycle.
+OnBootSec=90s
+OnUnitActiveSec={{ service_deadman_interval }}
+AccuracySec=15s
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Why

The shared-infra keystones — Technitium DNS, the Traefik ingress, and the syslog/netflow load balancer — are concentrated on a single node. #421 added `Restart=` drop-ins so they self-heal, but a service that **exhausts its restart budget**, or **hangs while systemd still reports it `active`**, fails silently. This is the exact silent-failure class the resiliency program exists to kill. This PR adds the missing **visibility** layer.

## What

A new `service_deadman` role deploys a systemd timer + validator on each keystone host, mirroring the proven `download_vpn` killswitch-validator pattern:

```
systemd timer (60s) -> validator
  per keystone: functional probe
    healthy  -> ping healthchecks OK   (deadman stays green)
    breached -> journal + ntfy alert + ping healthchecks /fail
```

Because healthchecks expects a ping every cycle, a **missed run** (validator crash, host down) also pages — true deadman semantics.

### Probes (unit names verified against the live services)

| Group | Service | Probe |
| --- | --- | --- |
| `technitium_dns_group` | `dns.service` | unit active **and** `dig @127.0.0.1 . NS` answers |
| `traefik_group` | `traefik.service` | unit active **and** TCP 443 accepts |
| `haproxy_group` | `haproxy.service` | unit active (TCP VIP) |
| `haproxy_group` | `nginx.service` | unit active (UDP syslog/netflow LB — the one #421 found with no `Restart=`) |

Checks are declared per inventory group and selected via `group_names`, so one `site.yml` play covers every keystone and a host with no matching checks is a no-op.

### Provisioning-optional

Per-check healthchecks ping URLs are **optional** env overrides (`DEADMAN_HC_URL_*`). Empty => the deadman ping is skipped but the journal entry and ntfy alert still fire, so the role is deployable now and the healthchecks checks can be added later.

## Verification

- `ansible-lint` (production profile): **0 failures** across 151 files.
- `ansible-playbook --syntax-check`: rc=0.
- Validator template rendered offline and checked with `bash -n`: valid.
- **Not yet deployed** — converging keystone hosts is held until live converges are confirmed safe; this PR is the code only.

Assisted-by: Claude:claude-opus-4-8