### PR TITLE
feat(inventory): derive each LXC ansible_host from its node, drop global PROXMOX_VE_HOSTNAME

### DIFF
--- a/.github/workflows/_ansible-lint.yml
+++ b/.github/workflows/_ansible-lint.yml
@@ -119,7 +119,6 @@ jobs:
           # hermetic even on a runner with ambient AWS creds — the S3 artifact
           # (priority 2) must never feed a test.
           TOFU_INVENTORY_PATH: ${{ github.workspace }}/tests/inventory_load/tofu_inventory.json
-          PROXMOX_VE_HOSTNAME: test-pve
           PROXMOX_SSH_KEY_PATH: /dev/null
           PROXMOX_DKR_SSH_KEY_PATH: /dev/null
           ANSIBLE_HOST_KEY_CHECKING: 'false'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,6 @@ Port constants come from `tofu_data.constants`
 | `TOFU_INVENTORY_PATH` | Explicit inventory file pin (tests/overrides) | env (optional) |
 | `TOFU_INVENTORY_S3_URI` | Override the published-inventory S3 location | env (optional) |
 | `TOFU_INVENTORY_S3_REGION` | Region of the inventory bucket (default `us-east-2`) | env (optional) |
-| `PROXMOX_VE_HOSTNAME` | Proxmox VE hostname | Doppler / SOPS |
 | `PROXMOX_VE_NODE` | Proxmox node name | SOPS |
 | `PROXMOX_VE_GATEWAY` | Network gateway (for IP derivation) | Doppler / SOPS |
 | `PROXMOX_DOMAIN` | Internal DNS domain | Doppler / SOPS |

--- a/README.md
+++ b/README.md
@@ -45,12 +45,14 @@ doppler configure set project ansible-proxmox-apps
 doppler configure set config prd
 ```
 
-Set the required environment variables for Proxmox LXC connection:
+Set the required environment variable for the Proxmox LXC SSH connection:
 
 ```bash
-export PROXMOX_VE_HOSTNAME="<proxmox-host>"
 export PROXMOX_SSH_KEY_PATH="<path-to-ssh-key>"
 ```
+
+Each container's Proxmox node host is derived automatically from the inventory
+(`{node-role}.{domain}`) — there is no global Proxmox host to set.
 
 ## Usage
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -170,8 +170,10 @@ playbook that uses `inventory/hosts.yml` together with
 
 | Variable | Purpose |
 | --- | --- |
-| `PROXMOX_VE_HOSTNAME` | Hostname or IP of the Proxmox VE endpoint |
 | `PROXMOX_SSH_KEY_PATH` | Path to SSH private key for Proxmox VMs |
+
+Each LXC container's Proxmox node host is derived from the inventory as
+`{node-role}.{domain}`; there is no global Proxmox endpoint variable to set.
 
 In addition, these playbooks expect an OpenTofu-generated inventory file:
 

--- a/inventory/load_tofu.yml
+++ b/inventory/load_tofu.yml
@@ -201,6 +201,22 @@
           terraform-proxmox `terragrunt apply` so the inventory is republished
           to S3 and the local cache is refreshed by the after-hook.
 
+    - name: Validate tofu_data carries the node-FQDN derivation inputs
+      ansible.builtin.assert:
+        that:
+          - tofu_data.nodes is defined
+          - tofu_data.domain is defined
+          - tofu_data.domain | length > 0
+        fail_msg: |
+          tofu_data.nodes and/or tofu_data.domain are missing from
+          tofu_inventory.json. Every LXC container's ansible_host is DERIVED as
+          {node-role}.{domain} (the per-node management FQDN) — a missing or
+          empty domain would silently produce a broken host (a bare
+          "{node-role}." with no domain suffix).
+
+          Re-run terraform-proxmox `terragrunt apply` so the inventory is
+          republished with `nodes` and `domain` populated.
+
     - name: Validate Docker VM SSH key path is set when Docker VMs are present
       ansible.builtin.assert:
         that:
@@ -373,7 +389,17 @@
             )
           }}
         proxmox_vmid: "{{ item.value.vmid }}"
-        ansible_host: "{{ lookup('env', 'PROXMOX_VE_HOSTNAME') }}"
+        # Per-node management FQDN, DERIVED — never a hand-pinned global host.
+        # A guest reaches its own node at {node-role}.{domain}, the same pattern
+        # terraform-proxmox ingress.tf uses for the Proxmox-UI apex pool; those
+        # names resolve internally while the bare cluster member name does not.
+        # The container's `node` field already carries the role form; the
+        # nodes-map lookup additionally corrects a legacy bare node key to its
+        # role, and falls back to the node value itself when the map omits the
+        # key (e.g. the generic test-fixture node key).
+        ansible_host: >-
+          {{ (tofu_data.nodes[item.value.node] | default({})).role
+             | default(item.value.node, true) }}.{{ tofu_data.domain }}
         ansible_connection: "{{ item.value.ansible_connection }}"
         ansible_user: root
         ansible_ssh_private_key_file: "{{ lookup('env', 'PROXMOX_SSH_KEY_PATH') }}"

--- a/secrets.enc.yaml.example
+++ b/secrets.enc.yaml.example
@@ -11,7 +11,8 @@
 # them as environment variables before running ansible-playbook.
 
 # Proxmox connection
-PROXMOX_VE_HOSTNAME: pve.example.local
+# (no global Proxmox host: each LXC's node host is derived from the inventory
+# as {node-role}.{domain})
 PROXMOX_VE_NODE: pve
 PROXMOX_VE_GATEWAY: "192.168.0.1"
 PROXMOX_DOMAIN: example.local


### PR DESCRIPTION
## Why

Every container's `proxmox_pct_remote` connection set `ansible_host` from a
single global `PROXMOX_VE_HOSTNAME`, **ignoring each container's `node` field**.
A converge could therefore only correctly reach guests on whichever one node
that env var named — so a guest on another node needed a hand-pinned node-host
override. That hand-pinned value is the same stale-pin failure class as a
hardcoded IP (it goes wrong the moment a guest moves nodes), and it blocks
unattended multi-node converges.

## What

Derive `ansible_host` per guest as `{node-role}.{domain}` — the exact pattern
`terraform-proxmox/ingress.tf` already uses for the Proxmox-UI apex pool, where
`{role}.{domain}` resolves internally while the bare cluster-member name
deliberately does not.

- The container's `node` field already carries the role form.
- The nodes-map lookup additionally corrects a legacy bare node key to its role,
  and falls back to the node value itself when the map omits the key (e.g. the
  generic test fixture).
- A fail-loud assert guards a missing/empty `domain` (which would otherwise
  silently yield a broken host with no domain suffix).
- Removes the now-dead `PROXMOX_VE_HOSTNAME` from the README, AGENTS env table,
  TESTING doc, secrets example, and the ansible-lint fixture.

This is the foundational prerequisite for multi-node auto-converge: no converge
ever hand-pins a node host again.

## Verification

- Inventory-load CI test passes (37 asserts).
- Derivation yields the correct per-node FQDN for both the generic fixture and a
  multi-node fixture guest.
- `ansible-lint` clean (production profile).

## Note (pre-existing, not changed here)

`tests/inventory_load/tofu_inventory.json` commits a real domain in its
`domain` field. Flagging per workspace policy; left untouched to avoid scope
creep, but worth scrubbing to a fake (`example.net`) in a follow-up.