### PR TITLE
fix(inventory): assign unifi_metrics_group from unifi_metrics tag

### DIFF
--- a/inventory/load_tofu.yml
+++ b/inventory/load_tofu.yml
@@ -322,6 +322,11 @@
               else []
             ) +
             (
+              ['unifi_metrics_group']
+              if 'unifi_metrics' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
               ['prometheus_group']
               if 'prometheus' in (item.value.tags | default([]))
               else []


### PR DESCRIPTION
## Summary

`apps#425` added the `Configure UniFi metrics collector` play (`hosts: unifi_metrics_group`) plus the `unifi_metrics` role, but `inventory/load_tofu.yml` never populated that group. The play therefore matched **zero hosts** and the collector never deployed.

This adds the missing group assignment, mirroring the existing `netmon`/`prometheus` tag→group clauses: any container tagged `unifi_metrics` joins `unifi_metrics_group`.

## Verification

Live converge against the `unifi-metrics` LXC after this fix: play matched the host, `ok=21 changed=14 failed=0`; unpoller + Telegraf containers up, scraping :9130, shipping to the Cribl Edge HEC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)