### PR TITLE
feat(configarr): enforce TRaSH quality profiles/custom formats via Configarr

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -668,6 +668,22 @@
   roles:
     - role: servarr_wiring
 
+# Enforce TRaSH-Guides quality profiles + custom formats on Sonarr/Radarr via
+# the official Configarr container. Runs on docker-host (reaches the *arr LAN
+# and the internet directly, no VPN) AFTER the apps + deterministic keys exist.
+# docker_vms[0]: one docker host is enough, and Configarr is idempotent so it is
+# safe every converge. Owns quality config only — root folders / download
+# clients live in the devopsarr servarr-config tofu module.
+- name: Enforce *arr quality config (Configarr / TRaSH)
+  hosts: docker_vms[0]
+  become: true
+  gather_facts: true
+  tags:
+    - configarr
+    - media
+  roles:
+    - role: configarr
+
 # Immich photo/video backup (Docker-in-LXC). Standalone — no cross-app API
 # wiring; phone/Mac clients point straight at it. Inert until an LXC is tagged
 # `immich` (empty group => no hosts).

--- a/roles/configarr/README.md
+++ b/roles/configarr/README.md
@@ -14,10 +14,11 @@ current; this role just points Configarr at the live apps.
 
 ## How it runs
 
-A one-shot container on **docker-host** (`hosts: docker_vms`, `run_once: true`),
-where it can reach the *arr LAN and the internet (for templates) directly —
-no VPN dependency. Configarr is idempotent: it writes only what differs, so a
-re-run on an in-sync stack is a no-op, making it safe on every converge.
+A one-shot container on **docker-host** (`hosts: docker_vms[0]` — the first
+docker host is enough), where it can reach the *arr LAN and the internet (for
+templates) directly — no VPN dependency. Configarr is idempotent: it writes only
+what differs, so a re-run on an in-sync stack is a no-op, making it safe on every
+converge.
 
 Endpoints resolve from the OpenTofu inventory (`reserved_ip` → `ip` →
 discovered `container_ip`), never a hardcoded IP. API keys come from SOPS
@@ -55,8 +56,8 @@ one). `SONARR_API_KEY` / `RADARR_API_KEY` must be present in the SOPS env.
 
 ## Usage
 
-Runs automatically in its `site.yml` play (`hosts: docker_vms`,
-`run_once: true`). To apply just this role against the live stack:
+Runs automatically in its `site.yml` play (`hosts: docker_vms[0]`). To apply
+just this role against the live stack:
 
 ```bash
 sops exec-env secrets.enc.yaml \

--- a/roles/configarr/README.md
+++ b/roles/configarr/README.md
@@ -1,0 +1,68 @@
+# configarr
+
+Declarative [TRaSH-Guides](https://trash-guides.info/) quality profiles and
+custom formats for Sonarr/Radarr, applied by the official
+[Configarr](https://configarr.de) container. This is the "adopt, don't build"
+replacement for hand-maintained quality config: the community keeps the formats
+current; this role just points Configarr at the live apps.
+
+## Boundary
+
+- **Configarr (this role)** owns quality profiles + custom formats.
+- **devopsarr `servarr-config` (tofu)** owns root folders + download clients.
+- No overlap — and Prowlarr stays with `servarr_wiring` (behind the VPN).
+
+## How it runs
+
+A one-shot container on **docker-host** (`hosts: docker_vms`, `run_once: true`),
+where it can reach the *arr LAN and the internet (for templates) directly —
+no VPN dependency. Configarr is idempotent: it writes only what differs, so a
+re-run on an in-sync stack is a no-op, making it safe on every converge.
+
+Endpoints resolve from the OpenTofu inventory (`reserved_ip` → `ip` →
+discovered `container_ip`), never a hardcoded IP. API keys come from SOPS
+(`SONARR_API_KEY` / `RADARR_API_KEY`) under `sops exec-env` — the same
+deterministic keys `servarr_wiring` uses. The rendered `config.yml` is
+secret-free (URLs + keys live in `secrets.yml`, mode 0600, via Configarr's
+`!secret` tag).
+
+## Quality target
+
+720p minimum, 1080p maximum (Bluray + WEB); per-item higher quality is left to
+Sonarr/Radarr's native per-series / per-movie profile selection. The template
+includes are variables (`configarr_sonarr_templates` /
+`configarr_radarr_templates`) — tune them in inventory without editing the
+role. Radarr's "HD Bluray + WEB" profile matches the 720p/1080p intent
+directly; Sonarr's official TRaSH profiles are WEB-tier-oriented (WEB-1080p is
+the 1080p cap), so adjust the allowed qualities there if you want 720p Bluray
+on the TV side.
+
+## Key variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `configarr_manage` | `true` | master on/off |
+| `configarr_image_tag` | `latest` | pin for a frozen version |
+| `configarr_sonarr_templates` | WEB-1080p set | Recyclarr/TRaSH includes |
+| `configarr_radarr_templates` | HD Bluray+WEB set | Recyclarr/TRaSH includes |
+
+## Installation
+
+No standalone install — the role is part of `playbooks/site.yml` and ships with
+the repo. It needs the `community.docker` collection (already pinned in
+`requirements.yml`) and a Docker engine on the target (docker-host already has
+one). `SONARR_API_KEY` / `RADARR_API_KEY` must be present in the SOPS env.
+
+## Usage
+
+Runs automatically in its `site.yml` play (`hosts: docker_vms`,
+`run_once: true`). To apply just this role against the live stack:
+
+```bash
+sops exec-env secrets.enc.yaml \
+  'ansible-playbook playbooks/site.yml --tags configarr --limit docker_vms'
+```
+
+Disable it without removing the play by setting `configarr_manage: false`. Tune
+the enforced profiles via `configarr_sonarr_templates` /
+`configarr_radarr_templates` in inventory.

--- a/roles/configarr/defaults/main.yml
+++ b/roles/configarr/defaults/main.yml
@@ -1,0 +1,65 @@
+---
+# configarr role defaults — declarative TRaSH-Guides quality profiles + custom
+# formats for Sonarr/Radarr, applied by the official Configarr container
+# (https://configarr.de). Configarr OWNS quality profiles + custom formats;
+# the devopsarr `servarr-config` tofu module owns root folders + download
+# clients — no overlap. Configarr is idempotent (re-running = no changes once
+# applied), so it runs safely as a one-shot on every converge.
+#
+# Configarr ships as a Docker-only image, so per the workspace container
+# decision tree it runs on docker-host (reaches the *arr LAN and the internet
+# for TRaSH/Recyclarr templates directly — no VPN dependency, unlike the
+# servarr_wiring coordinator).
+
+configarr_manage: true
+
+# --- Container ---------------------------------------------------------------
+# Tag left at the moving `latest` per the repo's "don't hardcode versions"
+# rule; pin in inventory if a frozen version is wanted.
+configarr_image: "ghcr.io/raydak-labs/configarr"
+configarr_image_tag: "latest"
+configarr_container_name: "configarr"
+# Host dir holding the rendered config.yml + secrets.yml + the template cache.
+configarr_config_dir: "/opt/configarr"
+
+# --- Deterministic API keys (from SOPS env; never committed) -----------------
+# Same keys servarr_wiring uses — set in secrets.enc.yaml, run under sops
+# exec-env. Templating them means the keys are known before converge.
+configarr_sonarr_api_key: "{{ lookup('env', 'SONARR_API_KEY') | default('', true) }}"
+configarr_radarr_api_key: "{{ lookup('env', 'RADARR_API_KEY') | default('', true) }}"
+
+# --- Endpoints (host:port). Hosts from inventory, ports from OpenTofu. --------
+# Mirrors servarr_wiring's resolution: prefer the per-guest reserved_ip (the
+# actual LAN address), fall back to the `ip` field / discovered container_ip.
+# NEVER a hardcoded IP and never a vmid-derived literal.
+configarr_sonarr_host: >-
+  {{ tofu_data.containers['sonarr'].reserved_ip
+     if (tofu_data.containers['sonarr'].reserved_ip | default('', true) | length > 0)
+     else (tofu_data.containers['sonarr'].ip
+           | default(hostvars['sonarr'].container_ip, true) | default('127.0.0.1', true)) }}
+configarr_radarr_host: >-
+  {{ tofu_data.containers['radarr'].reserved_ip
+     if (tofu_data.containers['radarr'].reserved_ip | default('', true) | length > 0)
+     else (tofu_data.containers['radarr'].ip
+           | default(hostvars['radarr'].container_ip, true) | default('127.0.0.1', true)) }}
+configarr_sonarr_port: "{{ tofu_data.constants.media_ports.sonarr_web }}"
+configarr_radarr_port: "{{ tofu_data.constants.media_ports.radarr_web }}"
+
+configarr_sonarr_base_url: "http://{{ configarr_sonarr_host }}:{{ configarr_sonarr_port }}"
+configarr_radarr_base_url: "http://{{ configarr_radarr_host }}:{{ configarr_radarr_port }}"
+
+# --- Quality target ----------------------------------------------------------
+# Intent: 720p minimum, 1080p maximum (Bluray + WEB), with per-item overrides
+# left to Sonarr/Radarr's native per-series / per-movie profile selection.
+# These are Recyclarr/TRaSH template include names (tunable here, no role edit).
+# Radarr's "HD Bluray + WEB" profile is exactly 720p/1080p Bluray+WEB. Sonarr's
+# official TRaSH profiles are WEB-tier-oriented (WEB-1080p is the 1080p cap);
+# tune the allowed qualities in review if you want 720p Bluray on the TV side.
+configarr_sonarr_templates:
+  - sonarr-quality-definition-series
+  - sonarr-v4-quality-profile-web-1080p
+  - sonarr-v4-custom-formats-web-1080p
+configarr_radarr_templates:
+  - radarr-quality-definition-movie
+  - radarr-quality-profile-hd-bluray-web
+  - radarr-custom-formats-hd-bluray-web

--- a/roles/configarr/meta/main.yml
+++ b/roles/configarr/meta/main.yml
@@ -1,0 +1,24 @@
+---
+galaxy_info:
+  author: Jacob Evans
+  description: >-
+    Declarative TRaSH-Guides quality profiles and custom formats for
+    Sonarr/Radarr via the official Configarr container. Runs one-shot on
+    docker-host; idempotent. Complements the devopsarr servarr-config tofu
+    module (which owns root folders + download clients).
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+  galaxy_tags:
+    - media
+    - sonarr
+    - radarr
+    - trash
+
+dependencies: []
+
+collections:
+  - community.docker

--- a/roles/configarr/tasks/main.yml
+++ b/roles/configarr/tasks/main.yml
@@ -1,0 +1,67 @@
+---
+# Apply TRaSH-Guides quality profiles + custom formats to Sonarr/Radarr via the
+# official Configarr container. Idempotent: Configarr only writes what differs,
+# so a re-run on an in-sync stack is a no-op.
+
+- name: Manage Configarr
+  when: configarr_manage | bool
+  block:
+    - name: Assert Sonarr/Radarr API keys are set
+      ansible.builtin.assert:
+        that:
+          - configarr_sonarr_api_key | length > 0
+          - configarr_radarr_api_key | length > 0
+        fail_msg: >-
+          SONARR_API_KEY / RADARR_API_KEY must be set. Add them to SOPS
+          (secrets.enc.yaml) and run under `sops exec-env` — the same
+          deterministic keys servarr_wiring templates into config.xml.
+        quiet: true
+
+    - name: Ensure Configarr config directory exists
+      ansible.builtin.file:
+        path: "{{ configarr_config_dir }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0750"
+
+    - name: Render Configarr config.yml
+      ansible.builtin.template:
+        src: config.yml.j2
+        dest: "{{ configarr_config_dir }}/config.yml"
+        owner: root
+        group: root
+        mode: "0640"
+
+    - name: Render Configarr secrets.yml
+      ansible.builtin.template:
+        src: secrets.yml.j2
+        dest: "{{ configarr_config_dir }}/secrets.yml"
+        owner: root
+        group: root
+        mode: "0600"
+      no_log: true
+
+    - name: Run Configarr (one-shot — enforces TRaSH quality config)
+      community.docker.docker_container:
+        name: "{{ configarr_container_name }}"
+        image: "{{ configarr_image }}:{{ configarr_image_tag }}"
+        pull: true
+        detach: false
+        cleanup: true
+        container_default_behavior: no_defaults
+        volumes:
+          - "{{ configarr_config_dir }}:/app/config"
+      register: configarr_run
+      # The container running is the enforcement action, not a config change in
+      # itself; Configarr writes only diffs. The devopsarr `servarr-config`
+      # drift plan is the authoritative change signal for the *arr structural
+      # config, so this is not flagged "changed" every converge.
+      changed_when: false
+      tags: [molecule-notest]
+
+    - name: Show Configarr output
+      ansible.builtin.debug:
+        var: configarr_run.container.Output | default(configarr_run.ansible_facts | default(''))
+      when: configarr_run is defined
+      tags: [molecule-notest]

--- a/roles/configarr/tasks/main.yml
+++ b/roles/configarr/tasks/main.yml
@@ -62,6 +62,6 @@
 
     - name: Show Configarr output
       ansible.builtin.debug:
-        var: configarr_run.container.Output | default(configarr_run.ansible_facts | default(''))
+        msg: "{{ configarr_run.container.Output | default('Configarr run complete (no captured output).') }}"
       when: configarr_run is defined
       tags: [molecule-notest]

--- a/roles/configarr/templates/config.yml.j2
+++ b/roles/configarr/templates/config.yml.j2
@@ -1,0 +1,30 @@
+---
+# Managed by the configarr Ansible role — do not edit on the host.
+# Secrets (URLs + API keys) come from secrets.yml via the !secret tag, so this
+# file is free of real endpoints and keys.
+#
+# Quality intent: 720p minimum, 1080p maximum (Bluray + WEB). Per-item higher
+# quality is handled by Sonarr/Radarr's native per-series / per-movie profile
+# selection, not here. Template includes are role variables
+# (configarr_{sonarr,radarr}_templates) — tune them in inventory, not here.
+sonarr:
+  main:
+    base_url: !secret sonarr_url
+    api_key: !secret sonarr_apikey
+    quality_definition:
+      type: series
+    include:
+{% for tpl in configarr_sonarr_templates %}
+      - template: {{ tpl }}
+{% endfor %}
+
+radarr:
+  main:
+    base_url: !secret radarr_url
+    api_key: !secret radarr_apikey
+    quality_definition:
+      type: movie
+    include:
+{% for tpl in configarr_radarr_templates %}
+      - template: {{ tpl }}
+{% endfor %}

--- a/roles/configarr/templates/secrets.yml.j2
+++ b/roles/configarr/templates/secrets.yml.j2
@@ -1,0 +1,7 @@
+---
+# Managed by the configarr Ansible role — rendered with no_log, mode 0600.
+# Referenced from config.yml via the !secret tag.
+sonarr_url: "{{ configarr_sonarr_base_url }}"
+sonarr_apikey: "{{ configarr_sonarr_api_key }}"
+radarr_url: "{{ configarr_radarr_base_url }}"
+radarr_apikey: "{{ configarr_radarr_api_key }}"


### PR DESCRIPTION
## What

Adds a `configarr` role + `site.yml` play that runs the official
[Configarr](https://configarr.de) container one-shot on docker-host to apply
[TRaSH-Guides](https://trash-guides.info/) quality profiles and custom formats
to Sonarr/Radarr. Adopts the community tool rather than hand-maintaining quality
config.

## Boundary (no overlap)

- **Configarr** owns quality profiles + custom formats.
- The **devopsarr `servarr-config`** tofu module owns root folders + download
  clients.
- **Prowlarr** stays with `servarr_wiring` (behind the VPN).

## Design

- Runs on `docker_vms[0]` (docker-host) — reaches the *arr LAN and the internet
  for templates directly, no VPN dependency — after the apps + deterministic
  keys exist. Idempotent (writes only diffs), so safe on every converge.
- Endpoints resolve from the OpenTofu inventory (`reserved_ip` → `ip` →
  discovered `container_ip`), never a hardcoded IP. API keys from SOPS; rendered
  `config.yml` is secret-free (URLs/keys in `secrets.yml` via the `!secret`
  tag, mode 0600).
- Quality target: 720p min / 1080p max, via tunable template-include variables
  (`configarr_{sonarr,radarr}_templates`); per-item higher quality is left to
  the apps' native per-series/movie profile selection.

## Validation

`yamllint`, `ansible-lint`, `markdownlint`, and `ansible-playbook --syntax-check`
all pass. Applying against the live stack needs a converge window (SOPS env +
LAN); not applied here.