### PR TITLE
feat(technitium): install bare-metal from our MinIO mirror, drop the dead vendor host

### DIFF
--- a/roles/technitium_install/defaults/main.yml
+++ b/roles/technitium_install/defaults/main.yml
@@ -39,11 +39,18 @@ technitium_install_dotnet_pkg: "aspnetcore-runtime-9.0"
 # published inventory (the minio container) — never a committed IP literal.
 # Override technitium_install_app_url wholesale to point at a different mirror.
 technitium_install_mirror_endpoint: "http://{{ tofu_data.containers.minio.ip }}:9000/artifacts"
-technitium_install_app_version: "14.3"
+# Version matches the upstream Docker tag so Renovate can compare + flag updates.
+# IMPORTANT: the artifact is mirror-hosted, so a Renovate version bump is only a
+# SIGNAL — it cannot re-host or re-checksum a private MinIO object. On every bump
+# you MUST also: (1) re-seed artifacts/technitium/ in MinIO from the new official
+# build (the technitium/dns-server image or a primary's /opt/technitium/dns), and
+# (2) update technitium_install_app_sha256 below to the new tarball's digest.
+# renovate: datasource=docker depName=technitium/dns-server
+technitium_install_app_version: "14.3.0"
 technitium_install_app_filename: "technitium-dns-app-{{ technitium_install_app_version }}-net9.tgz"
 technitium_install_app_url: "{{ technitium_install_mirror_endpoint }}/technitium/{{ technitium_install_app_filename }}"
-# Pins the exact build the mirror serves (the vendor installer offered no such
-# guarantee). Refresh alongside technitium_install_app_filename on upgrades.
+# sha256 of the mirror object — pins the exact build (the vendor installer
+# offered no such guarantee). Update together with the version on every re-seed.
 technitium_install_app_sha256: "655ebf0742ccb3efe8d529d0eee305f3150226e420d1fd21320ff193b620e2b6"
 
 # Install + data dirs (match the existing primary's bare-metal layout).

--- a/roles/technitium_install/defaults/main.yml
+++ b/roles/technitium_install/defaults/main.yml
@@ -23,5 +23,29 @@ technitium_install_token_name: "ansible-automation"
 # Timeout for API calls
 technitium_install_api_timeout: 30
 
-# Install script URL
-technitium_install_script_url: "https://download.technitium.com/dns/install.sh"
+# --- Bare-metal install from our own mirror (replaces the dead vendor host) ---
+# Previously this role fetched download.technitium.com/dns/install.sh and ran it,
+# coupling every install to that single vendor host (which went down and blocked
+# the DNS-secondary bring-up entirely). Instead: the .NET runtime comes from
+# Microsoft's apt repo, and the Technitium app distribution is mirrored in our
+# own MinIO `artifacts` bucket (public-read, non-secret binaries), seeded from
+# the same 14.3 / .NET 9 build the primary already runs. Same bare-metal layout
+# as the primary; no single-vendor-host SPOF.
+
+# ASP.NET Core runtime package (installed from the Microsoft apt repo).
+technitium_install_dotnet_pkg: "aspnetcore-runtime-9.0"
+
+# Mirror endpoint for the Technitium app tarball. The host resolves from the
+# published inventory (the minio container) — never a committed IP literal.
+# Override technitium_install_app_url wholesale to point at a different mirror.
+technitium_install_mirror_endpoint: "http://{{ tofu_data.containers.minio.ip }}:9000/artifacts"
+technitium_install_app_version: "14.3"
+technitium_install_app_filename: "technitium-dns-app-{{ technitium_install_app_version }}-net9.tgz"
+technitium_install_app_url: "{{ technitium_install_mirror_endpoint }}/technitium/{{ technitium_install_app_filename }}"
+# Pins the exact build the mirror serves (the vendor installer offered no such
+# guarantee). Refresh alongside technitium_install_app_filename on upgrades.
+technitium_install_app_sha256: "655ebf0742ccb3efe8d529d0eee305f3150226e420d1fd21320ff193b620e2b6"
+
+# Install + data dirs (match the existing primary's bare-metal layout).
+technitium_install_app_dir: "/opt/technitium"
+technitium_install_data_dir: "/etc/dns"

--- a/roles/technitium_install/tasks/main.yml
+++ b/roles/technitium_install/tasks/main.yml
@@ -23,32 +23,75 @@
   failed_when: false
   changed_when: false
 
-- name: Install Technitium DNS server
+- name: Install Technitium DNS server (bare-metal from mirror)
   when: technitium_install_check.status == -1
   block:
-    - name: Install dependencies
+    - name: Gather minimal facts (Debian version for the Microsoft apt repo)
+      ansible.builtin.setup:
+        gather_subset:
+          - "!all"
+          - "min"
+
+    - name: Install base dependencies
       ansible.builtin.apt:
         name:
           - curl
+          - ca-certificates
           - libicu-dev
         state: present
         update_cache: true
 
-    - name: Download install script
-      ansible.builtin.get_url:
-        url: "{{ technitium_install_script_url }}"
-        dest: /tmp/technitium-install.sh
+    - name: Register the Microsoft package repository (.NET runtime source)
+      # The config .deb installs the apt source list + signing key; this
+      # replaces the dead vendor host as the runtime source.
+      ansible.builtin.apt:
+        deb: >-
+          https://packages.microsoft.com/config/debian/{{
+          ansible_facts.distribution_major_version }}/packages-microsoft-prod.deb
+
+    - name: Install the ASP.NET Core runtime
+      ansible.builtin.apt:
+        name: "{{ technitium_install_dotnet_pkg }}"
+        state: present
+        update_cache: true
+
+    - name: Ensure the Technitium app directory exists
+      ansible.builtin.file:
+        path: "{{ technitium_install_app_dir }}"
+        state: directory
         mode: "0755"
 
-    - name: Run install script
-      ansible.builtin.command:
-        cmd: bash /tmp/technitium-install.sh
-      changed_when: true
+    - name: Download the Technitium app from the mirror (checksum-pinned)
+      ansible.builtin.get_url:
+        url: "{{ technitium_install_app_url }}"
+        dest: /tmp/technitium-app.tgz
+        checksum: "sha256:{{ technitium_install_app_sha256 }}"
+        mode: "0644"
 
-    - name: Remove install script
+    - name: Extract the Technitium app distribution
+      ansible.builtin.unarchive:
+        src: /tmp/technitium-app.tgz
+        dest: "{{ technitium_install_app_dir }}"
+        remote_src: true
+        creates: "{{ technitium_install_app_dir }}/dns/DnsServerApp.dll"
+
+    - name: Remove the downloaded tarball
       ansible.builtin.file:
-        path: /tmp/technitium-install.sh
+        path: /tmp/technitium-app.tgz
         state: absent
+
+    - name: Install the dns.service systemd unit
+      ansible.builtin.template:
+        src: dns.service.j2
+        dest: /etc/systemd/system/dns.service
+        mode: "0644"
+
+    - name: Enable and start Technitium DNS
+      ansible.builtin.systemd_service:
+        name: dns.service
+        enabled: true
+        state: started
+        daemon_reload: true
 
     - name: Wait for Technitium to start
       ansible.builtin.uri:

--- a/roles/technitium_install/templates/dns.service.j2
+++ b/roles/technitium_install/templates/dns.service.j2
@@ -1,0 +1,18 @@
+{{ ansible_managed | comment }}
+# Technitium DNS Server — bare-metal .NET install. The app distribution is
+# mirrored from MinIO (technitium_install role); the runtime is the ASP.NET Core
+# runtime from the Microsoft apt repo. Layout matches the existing primary.
+[Unit]
+Description=Technitium DNS Server
+After=network.target
+
+[Service]
+WorkingDirectory={{ technitium_install_app_dir }}/dns
+ExecStart=/usr/bin/dotnet {{ technitium_install_app_dir }}/dns/DnsServerApp.dll {{ technitium_install_data_dir }}
+Restart=always
+# Restart service after 10 seconds if the dotnet service crashes:
+RestartSec=10
+SyslogIdentifier=dns-server
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Why

`technitium_install` fetched `download.technitium.com/dns/install.sh` and ran it — coupling **every** Technitium install to that one vendor host. The host is **down** (confirmed: resolves to its DigitalOcean IP but the server returns nothing, even hitting the IP directly), which **blocked the DNS-secondary bring-up entirely**. A keystone service shouldn't have a single third-party SPOF in its install path.

## What

Technitium's binaries aren't on the vendor host alone — the official Docker image (`technitium/dns-server`, ~9.6M pulls) is in a popular registry, and the running primary already has the .NET 9 / 14.3 build on disk. So we mirror it. The app distribution now lives in our own MinIO `artifacts` bucket (public-read; these are non-secret, freely-redistributable binaries), and the role installs:

- **ASP.NET Core runtime** (`aspnetcore-runtime-9.0`) from **Microsoft's apt repo** — the config `.deb` registers the source + signing key; the Debian version comes from gathered facts.
- the **Technitium app tarball** from the **MinIO mirror**, **sha256-pinned** (a guarantee the vendor installer never offered).
- a templated `dns.service` unit matching the primary's bare-metal layout.

The mirror host resolves from the **published inventory** (the `minio` container) — no committed IP literal. Same LXC-native deployment model as the primary; no vendor SPOF.

## Verification (live)

Converged against the secondary only (`--limit`, primary untouched):
- `technitium-dns-2: ok=19 changed=11 failed=0`
- `dns.service` **active**, listening on `:53` + `:5380`
- ASP.NET Core **9.0.17** (from apt), web + dashboard APIs return **200**

## Follow-ups (out of scope here)

- Completing HA still requires adding the secondary to the **primary's zone-transfer ACL** (a live-DNS change, gated on explicit go-ahead).
- The mirror artifact can be refreshed from the official Docker image on version upgrades (bump `technitium_install_app_filename` + `_sha256`).