### PR TITLE
feat(plex): declarative library sharing to Plex Home members

### DIFF
--- a/roles/plex/defaults/main.yml
+++ b/roles/plex/defaults/main.yml
@@ -49,6 +49,21 @@ plex_libraries:
     scanner: Plex TV Series
     language: en-US
 
+# --- Declarative sharing (account token required) -----------------------------
+# Re-shares this server's libraries to your Plex Home members so a rebuilt server
+# (fresh machineIdentifier) re-grants access FROM CODE, fixing the "second profile
+# shows unavailable" symptom. Idempotent + non-fatal (see tasks/sharing.yml).
+plex_manage_sharing: true
+# Share all libraries with every non-owner Plex Home member (self-healing — no
+# emails to hardcode; new members are picked up automatically).
+plex_share_with_home: true
+# Optional explicit friend invites by email (sensitive -> SOPS secrets.enc.yaml).
+# Each gets all library sections shared. Empty by default.
+plex_shared_friend_emails: []
+# Permissions applied to each grant.
+plex_share_allow_sync: false
+plex_share_allow_tuners: false
+
 # --- Server claim (account linking) ------------------------------------------
 # Plex claim tokens are account-scoped and EXPIRE ~4 minutes after generation
 # (https://www.plex.tv/claim), so a stored token is usually already stale. The

--- a/roles/plex/tasks/main.yml
+++ b/roles/plex/tasks/main.yml
@@ -124,6 +124,14 @@
   ansible.builtin.import_tasks: publish.yml
   when: plex_manage_services
 
+# Re-share this server's libraries to Plex Home members so a rebuilt server (fresh
+# machineIdentifier) re-grants access FROM CODE — fixes the "second profile on the
+# same Roku shows unavailable" symptom. Reuses plex_effective_token; idempotent +
+# non-fatal; only ADDS shares (never removes access).
+- name: Ensure Plex libraries are shared to Home members (idempotent, non-fatal)
+  ansible.builtin.import_tasks: sharing.yml
+  when: plex_manage_services
+
 # Loud end-of-role status: claim/publish are non-fatal, so without this a server
 # left UNCLAIMED or UNPUBLISHED (invisible on Roku) would slip by silently. Warns
 # unmissably and can hard-fail when plex_require_onboarded is set.

--- a/roles/plex/tasks/sharing.yml
+++ b/roles/plex/tasks/sharing.yml
@@ -1,0 +1,141 @@
+---
+# Idempotent + NON-FATAL declarative Plex sharing.
+#
+# Re-shares this server's library sections to your Plex Home members (and any
+# explicit friend emails) so a rebuilt server with a fresh machineIdentifier
+# re-grants access FROM CODE. Fixes the "second profile on the same Roku shows
+# unavailable" symptom: library shares are bound to the old machineIdentifier and
+# do not carry over on a rebuild.
+#
+# Requires an account token (reuses plex_effective_token resolved in libraries.yml);
+# skips cleanly without one. POST .../shared_servers returns 422 when the share
+# already exists, so a re-run is a no-op. Sharing only ADDS access — it never
+# removes an existing grant — so it cannot reduce who can watch.
+
+- name: Manage Plex sharing
+  when:
+    - plex_manage_sharing | bool
+    - plex_effective_token | default('') | length > 0
+  block:
+    - name: Discover the server machineIdentifier
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ plex_local_api_port }}/identity"
+        method: GET
+        headers:
+          Accept: application/json
+        status_code: [200]
+      register: plex_identity
+      changed_when: false
+      failed_when: false
+      no_log: true
+
+    - name: Resolve the current server machineIdentifier (never the stale duplicate)
+      ansible.builtin.set_fact:
+        _plex_mid: "{{ plex_identity.json.MediaContainer.machineIdentifier | default('') }}"
+      no_log: true
+
+    - name: Read existing library sections (ids to share)
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ plex_local_api_port }}/library/sections"
+        method: GET
+        headers:
+          Accept: application/json
+          X-Plex-Token: "{{ plex_effective_token }}"
+        status_code: [200, 401]
+      register: plex_sharing_sections
+      changed_when: false
+      failed_when: false
+      no_log: true
+
+    - name: Discover Plex Home users
+      ansible.builtin.uri:
+        url: https://plex.tv/api/v2/home/users
+        method: GET
+        headers:
+          Accept: application/json
+          X-Plex-Token: "{{ plex_effective_token }}"
+          X-Plex-Client-Identifier: "{{ _plex_mid | default('ansible-plex', true) }}"
+        status_code: [200, 401, 404]
+      register: plex_home_users
+      changed_when: false
+      failed_when: false
+      no_log: true
+      when: plex_share_with_home | bool
+
+    - name: Resolve section ids and Home share targets
+      ansible.builtin.set_fact:
+        _plex_section_ids: >-
+          {{ (plex_sharing_sections.json.MediaContainer.Directory | default([]))
+             | map(attribute='key') | map('int') | list }}
+        # Every NON-owner Home member (admin == false). Self-healing: no emails to
+        # hardcode, and new Home members are picked up automatically.
+        _plex_home_invited_ids: >-
+          {{ ((plex_home_users.json.users | default([]))
+              | selectattr('admin', 'equalto', false)
+              | map(attribute='id') | list) if (plex_share_with_home | bool) else [] }}
+      no_log: true
+
+    - name: Share all libraries with each Plex Home member (422 = already shared)
+      ansible.builtin.uri:
+        url: https://plex.tv/api/v2/shared_servers
+        method: POST
+        headers:
+          Accept: application/json
+          X-Plex-Token: "{{ plex_effective_token }}"
+          X-Plex-Client-Identifier: "{{ _plex_mid | default('ansible-plex', true) }}"
+        body_format: json
+        body:
+          machineIdentifier: "{{ _plex_mid }}"
+          librarySectionIds: "{{ _plex_section_ids }}"
+          invitedId: "{{ item }}"
+          settings:
+            allowTuners: "{{ plex_share_allow_tuners | bool }}"
+            allowSync: "{{ plex_share_allow_sync | bool }}"
+        status_code: [200, 201, 422]
+      loop: "{{ _plex_home_invited_ids }}"
+      register: plex_share_home
+      # The share is enforcement; 200/201 = newly shared, 422 = already shared.
+      # Don't flag "changed" per run; the summary below is the observable signal.
+      changed_when: false
+      failed_when: false
+      no_log: true
+      when:
+        - _plex_mid | length > 0
+        - _plex_section_ids | length > 0
+
+    - name: Invite explicit friends by email (422 = already shared)
+      ansible.builtin.uri:
+        url: https://plex.tv/api/v2/shared_servers
+        method: POST
+        headers:
+          Accept: application/json
+          X-Plex-Token: "{{ plex_effective_token }}"
+          X-Plex-Client-Identifier: "{{ _plex_mid | default('ansible-plex', true) }}"
+        body_format: json
+        body:
+          machineIdentifier: "{{ _plex_mid }}"
+          librarySectionIds: "{{ _plex_section_ids }}"
+          invitedEmail: "{{ item }}"
+          settings:
+            allowTuners: "{{ plex_share_allow_tuners | bool }}"
+            allowSync: "{{ plex_share_allow_sync | bool }}"
+        status_code: [200, 201, 422]
+      loop: "{{ plex_shared_friend_emails }}"
+      register: plex_share_friends
+      changed_when: false
+      failed_when: false
+      no_log: true
+      when:
+        - _plex_mid | length > 0
+        - _plex_section_ids | length > 0
+        - plex_shared_friend_emails | length > 0
+
+    - name: Summarize sharing (loud — the non-fatal tasks otherwise hide outcomes)
+      ansible.builtin.debug:
+        msg: >-
+          Plex sharing: {{ _plex_section_ids | length }} libraries to
+          {{ _plex_home_invited_ids | length }} Home member(s) +
+          {{ plex_shared_friend_emails | length }} friend(s). Home share HTTP codes
+          {{ plex_share_home.results | default([]) | map(attribute='status') | list }}
+          (200/201 = newly shared, 422 = already shared). If empty and shares were
+          expected, confirm the server is claimed and PLEX_TOKEN is the account token.


### PR DESCRIPTION
## What

Adds `roles/plex/tasks/sharing.yml` (wired into the plex role after publish) that
makes library sharing reproducible from code: it re-shares the server's library
sections to every non-owner Plex Home member.

A server rebuild produces a fresh `machineIdentifier`; library shares are bound to
the old identifier and don't carry over, so a second Home profile loses access
until someone re-shares by hand. This task re-grants that access automatically on
every converge — the last from-code gap in the media stack.

## Design

- **Idempotent + non-fatal**, mirroring `libraries.yml`/`publish.yml`. Reuses
  `plex_effective_token` (SOPS `PLEX_TOKEN`, else on-server `PlexOnlineToken`);
  skips cleanly without a token.
- **Self-healing**: Home members are discovered at runtime
  (`GET /api/v2/home/users`, filtered to `admin == false`) — no emails hardcoded;
  new members are picked up automatically. Optional explicit friend invites via
  `plex_shared_friend_emails` (SOPS).
- `machineIdentifier` comes from the live server's local `/identity` (never a
  stale duplicate). `POST /api/v2/shared_servers` treats `422` as already-shared,
  so re-runs are no-ops. Sharing only **adds** access — it never removes a grant.
- New defaults: `plex_manage_sharing`, `plex_share_with_home`,
  `plex_shared_friend_emails`, `plex_share_allow_sync`, `plex_share_allow_tuners`.

## Validation

`yamllint` + `ansible-lint` pass. The plex.tv API shapes were confirmed against
the live account before writing the filters.