### PR TITLE
feat(object-storage): add RustFS object_storage role replacing MinIO

### DIFF
--- a/inventory/load_tofu.yml
+++ b/inventory/load_tofu.yml
@@ -308,6 +308,11 @@
               else []
             ) +
             (
+              ['object_storage_group']
+              if 'object-storage' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
               ['openbao_group']
               if 'openbao' in (item.value.tags | default([]))
               else []

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -185,6 +185,18 @@
   roles:
     - role: minio
 
+# RustFS object storage — MinIO replacement. Runs alongside the minio play
+# during the migration soak; both are removed together after cutover.
+- name: Deploy RustFS object storage
+  hosts: object_storage_group
+  become: true
+  gather_facts: false
+  tags:
+    - object-storage
+    - storage
+  roles:
+    - role: object_storage
+
 # =============================================================================
 # Phase 1a: DNS Installation
 # Install Technitium DNS server and bootstrap credentials from Doppler.

--- a/roles/object_storage/defaults/main.yml
+++ b/roles/object_storage/defaults/main.yml
@@ -1,13 +1,16 @@
 ---
 # Object storage (RustFS) role defaults — S3-compatible store replacing MinIO.
-# RustFS is beta: the version + checksum below are pinned deliberately. Never
-# switch to the rolling "-latest" release asset.
+# RustFS is beta: the version below is pinned deliberately (never the rolling
+# "-latest" asset) and is tracked + bumped by Renovate via the annotation.
 
+# renovate: datasource=github-releases depName=rustfs/rustfs
 object_storage_rustfs_version: "1.0.0-beta.8"
 object_storage_binary_base: "https://github.com/rustfs/rustfs/releases/download"
 object_storage_binary_asset: "rustfs-linux-x86_64-gnu-v{{ object_storage_rustfs_version }}.zip"
-# SHA256 of the pinned linux-x86_64-gnu asset (from the release SHA256SUMS).
-object_storage_binary_sha256: "f6dbe05430743820db5c38efda403bfa7c1b30967013f792735ab37cee1dc137"
+# Integrity: verify against the release SHA256SUMS, fetched at install time and
+# built from the pinned version so it stays correct across Renovate bumps — no
+# hardcoded hash to go stale (mirrors the zot_registry/openbao roles).
+object_storage_checksums_url: "{{ object_storage_binary_base }}/{{ object_storage_rustfs_version }}/SHA256SUMS"
 
 # Installation paths
 object_storage_install_dir: /usr/local/bin

--- a/roles/object_storage/defaults/main.yml
+++ b/roles/object_storage/defaults/main.yml
@@ -1,0 +1,61 @@
+---
+# Object storage (RustFS) role defaults — S3-compatible store replacing MinIO.
+# RustFS is beta: the version + checksum below are pinned deliberately. Never
+# switch to the rolling "-latest" release asset.
+
+object_storage_rustfs_version: "1.0.0-beta.8"
+object_storage_binary_base: "https://github.com/rustfs/rustfs/releases/download"
+object_storage_binary_asset: "rustfs-linux-x86_64-gnu-v{{ object_storage_rustfs_version }}.zip"
+# SHA256 of the pinned linux-x86_64-gnu asset (from the release SHA256SUMS).
+object_storage_binary_sha256: "f6dbe05430743820db5c38efda403bfa7c1b30967013f792735ab37cee1dc137"
+
+# Installation paths
+object_storage_install_dir: /usr/local/bin
+object_storage_data_dir: /srv/object-storage/data
+object_storage_env_file: /etc/default/object-storage
+object_storage_config_dir: /etc/object-storage
+
+# Service configuration
+object_storage_s3_port: 9000
+object_storage_console_port: 9001
+object_storage_region: us-east-1
+
+# System user
+object_storage_user: rustfs
+object_storage_group: rustfs
+
+# Credentials (from Doppler — new keys mirroring MINIO_ROOT_* semantics).
+object_storage_root_user: "{{ lookup('env', 'OBJECT_STORAGE_ROOT_USER') }}"
+object_storage_root_password: "{{ lookup('env', 'OBJECT_STORAGE_ROOT_PASSWORD') }}"
+
+# Loopback S3 endpoint for local bucket administration via the aws CLI.
+object_storage_endpoint: "http://127.0.0.1:{{ object_storage_s3_port }}"
+
+# Environment applied to every `aws` admin command (loopback, root creds).
+object_storage_aws_env:
+  AWS_ACCESS_KEY_ID: "{{ object_storage_root_user }}"
+  AWS_SECRET_ACCESS_KEY: "{{ object_storage_root_password }}"
+  AWS_DEFAULT_REGION: "{{ object_storage_region }}"
+
+# Default buckets (same contract as the MinIO role: anonymous read on the
+# internal network, versioned, lifecycle-bounded).
+object_storage_default_buckets:
+  - name: splunk-addons
+    policy: download
+    versioning: true
+
+# Lifecycle: expire noncurrent object versions after this many days, bounding
+# data-volume growth when artifacts are repeatedly re-uploaded. 10 years =
+# effectively "keep forever" with a safety ceiling. Lower per-host as needed.
+object_storage_noncurrent_expiration_days: 3650
+
+# Infrastructure artifact mirrors. Roles on egress-restricted LXCs cannot reach
+# public CDNs, so the controller (unrestricted egress) stages each artifact and
+# uploads it into the anonymous-read bucket for local pulls. Existing objects
+# are left alone so manual retention decisions are not clobbered on re-runs.
+object_storage_infra_mirrors:
+  - name: cribl
+    description: Cribl Edge/Stream tarball (rolling latest)
+    url: https://cdn.cribl.io/dl/latest/cribl-linux-x64.tgz
+    bucket: splunk-addons
+    key: infra/cribl-linux-x64.tgz

--- a/roles/object_storage/handlers/main.yml
+++ b/roles/object_storage/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart object-storage
+  ansible.builtin.systemd:
+    name: object-storage
+    state: restarted
+    daemon_reload: true

--- a/roles/object_storage/meta/main.yml
+++ b/roles/object_storage/meta/main.yml
@@ -1,0 +1,17 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: Deploy RustFS S3-compatible object storage (MinIO replacement)
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+  galaxy_tags:
+    - rustfs
+    - s3
+    - storage
+    - objectstorage
+dependencies: []

--- a/roles/object_storage/tasks/main.yml
+++ b/roles/object_storage/tasks/main.yml
@@ -1,0 +1,372 @@
+---
+# RustFS object storage installation and configuration.
+# S3-compatible store replacing MinIO. Bucket administration uses the `aws`
+# CLI (s3api) against the loopback endpoint — RustFS speaks standard S3, so no
+# vendor client is needed.
+
+# Phase 1: Install prerequisites
+- name: Install required packages
+  ansible.builtin.apt:
+    name:
+      - curl
+      - ca-certificates
+      - unzip
+      - awscli
+    state: present
+    update_cache: true
+
+# Phase 2: Create system user
+- name: Create object-storage system group
+  ansible.builtin.group:
+    name: "{{ object_storage_group }}"
+    system: true
+    state: present
+
+- name: Create object-storage system user
+  ansible.builtin.user:
+    name: "{{ object_storage_user }}"
+    group: "{{ object_storage_group }}"
+    system: true
+    shell: /usr/sbin/nologin
+    home: /srv/object-storage
+    create_home: true
+    state: present
+
+# Phase 3: Create directories
+- name: Create object-storage data directory
+  ansible.builtin.file:
+    path: "{{ object_storage_data_dir }}"
+    state: directory
+    owner: "{{ object_storage_user }}"
+    group: "{{ object_storage_group }}"
+    mode: "0750"
+
+- name: Create object-storage config directory
+  ansible.builtin.file:
+    path: "{{ object_storage_config_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0750"
+
+# Phase 4: Download + verify + install the RustFS binary.
+# Staged on the controller (unrestricted egress) then copied to the target,
+# which may sit in the outbound-internal firewall group and cannot reach
+# github.com. The pinned URL + SHA256 guarantee a fixed beta build.
+- name: Stage RustFS release archive on controller
+  ansible.builtin.get_url:
+    url: "{{ object_storage_binary_base }}/{{ object_storage_rustfs_version }}/{{ object_storage_binary_asset }}"
+    dest: "/tmp/rustfs-{{ object_storage_rustfs_version }}.zip"
+    checksum: "sha256:{{ object_storage_binary_sha256 }}"
+    mode: "0644"
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  run_once: true
+
+- name: Ensure controller extraction directory exists
+  ansible.builtin.file:
+    path: "/tmp/rustfs-{{ object_storage_rustfs_version }}"
+    state: directory
+    mode: "0755"
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  run_once: true
+
+- name: Extract RustFS binary on controller
+  ansible.builtin.unarchive:
+    src: "/tmp/rustfs-{{ object_storage_rustfs_version }}.zip"
+    dest: "/tmp/rustfs-{{ object_storage_rustfs_version }}"
+    remote_src: true
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  run_once: true
+
+- name: Locate extracted rustfs binary on controller
+  ansible.builtin.find:
+    paths: "/tmp/rustfs-{{ object_storage_rustfs_version }}"
+    patterns: rustfs
+    file_type: file
+    recurse: true
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  run_once: true
+  register: object_storage_binary_find
+
+- name: Assert the rustfs binary was found in the archive
+  ansible.builtin.assert:
+    that: object_storage_binary_find.matched | int > 0
+    fail_msg: "No 'rustfs' binary found in {{ object_storage_binary_url }} — the release asset layout may have changed."
+  run_once: true
+
+- name: Copy rustfs binary to target
+  ansible.builtin.copy:
+    src: "{{ object_storage_binary_find.files[0].path }}"
+    dest: "{{ object_storage_install_dir }}/rustfs"
+    owner: root
+    group: root
+    mode: "0755"
+
+# Phase 5: Deploy configuration
+- name: Deploy object-storage environment file
+  ansible.builtin.template:
+    src: object-storage.env.j2
+    dest: "{{ object_storage_env_file }}"
+    owner: root
+    group: "{{ object_storage_group }}"
+    mode: "0640"
+  no_log: true
+  notify: Restart object-storage
+
+- name: Deploy object-storage systemd unit file
+  ansible.builtin.template:
+    src: object-storage.service.j2
+    dest: /etc/systemd/system/object-storage.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart object-storage
+
+# Phase 6: Enable and start service
+- name: Enable and start object-storage service
+  ansible.builtin.systemd:
+    name: object-storage
+    state: started
+    enabled: true
+    daemon_reload: true
+
+- name: Flush handlers so the service restarts before bucket setup
+  ansible.builtin.meta: flush_handlers
+
+# Phase 7: Health check — RustFS S3 API answers on its port once ready
+# (an unauthenticated request returns 403, which still proves it is listening).
+- name: Wait for object-storage S3 API to accept connections
+  ansible.builtin.wait_for:
+    host: 127.0.0.1
+    port: "{{ object_storage_s3_port }}"
+    timeout: 60
+
+# Phase 8: Create + configure buckets via the aws CLI (loopback, root creds).
+- name: Check which default buckets already exist
+  ansible.builtin.command:
+    cmd: "aws --endpoint-url {{ object_storage_endpoint }} s3api head-bucket --bucket {{ item.name }}"
+  loop: "{{ object_storage_default_buckets }}"
+  loop_control:
+    label: "{{ item.name }}"
+  environment: "{{ object_storage_aws_env }}"
+  register: object_storage_bucket_check
+  changed_when: false
+  failed_when: false
+  no_log: true
+
+- name: Create missing default buckets
+  ansible.builtin.command:
+    cmd: "aws --endpoint-url {{ object_storage_endpoint }} s3api create-bucket --bucket {{ item.item.name }}"
+  loop: "{{ object_storage_bucket_check.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  environment: "{{ object_storage_aws_env }}"
+  when: item.rc != 0
+  changed_when: true
+  no_log: true
+
+- name: Enable versioning on versioned buckets
+  ansible.builtin.command:
+    cmd: >-
+      aws --endpoint-url {{ object_storage_endpoint }} s3api put-bucket-versioning
+      --bucket {{ item.name }} --versioning-configuration Status=Enabled
+  loop: "{{ object_storage_default_buckets | selectattr('versioning', 'defined') | selectattr('versioning') | list }}"
+  loop_control:
+    label: "{{ item.name }}"
+  environment: "{{ object_storage_aws_env }}"
+  changed_when: false
+  no_log: true
+
+# Anonymous (public-read) download policy — Splunk and other internal consumers
+# pull artifacts with no credentials on the internal network. Read the current
+# policy first so re-runs only report changed when the document actually differs.
+- name: Read current bucket policy
+  ansible.builtin.command:
+    cmd: "aws --endpoint-url {{ object_storage_endpoint }} s3api get-bucket-policy --bucket {{ item.name }}"
+  loop: >-
+    {{ object_storage_default_buckets
+       | selectattr('policy', 'defined')
+       | selectattr('policy', 'equalto', 'download')
+       | list }}
+  loop_control:
+    label: "{{ item.name }}"
+  environment: "{{ object_storage_aws_env }}"
+  register: object_storage_policy_current
+  changed_when: false
+  failed_when: false
+  no_log: true
+
+- name: Render anonymous download policy documents
+  ansible.builtin.template:
+    src: bucket-policy.json.j2
+    dest: "{{ object_storage_config_dir }}/policy-{{ item.name }}.json"
+    owner: root
+    group: root
+    mode: "0640"
+  loop: >-
+    {{ object_storage_default_buckets
+       | selectattr('policy', 'defined')
+       | selectattr('policy', 'equalto', 'download')
+       | list }}
+  loop_control:
+    label: "{{ item.name }}"
+  vars:
+    bucket: "{{ item.name }}"
+
+- name: Set anonymous download policy where missing
+  ansible.builtin.command:
+    cmd: >-
+      aws --endpoint-url {{ object_storage_endpoint }} s3api put-bucket-policy
+      --bucket {{ item.item.name }}
+      --policy file://{{ object_storage_config_dir }}/policy-{{ item.item.name }}.json
+  loop: "{{ object_storage_policy_current.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  environment: "{{ object_storage_aws_env }}"
+  when: >-
+    item.rc != 0 or
+    's3:GetObject' not in (item.stdout | default(''))
+  changed_when: true
+  no_log: true
+
+# Phase 9: Lifecycle — expire noncurrent versions to bound the data volume.
+# Add-if-missing only, mirroring the MinIO role: if a noncurrent-expiration
+# rule already exists the role leaves it alone so operators can tighten
+# retention by hand without Ansible reverting it.
+- name: Read current lifecycle configuration on versioned buckets
+  ansible.builtin.command:
+    cmd: >-
+      aws --endpoint-url {{ object_storage_endpoint }} s3api
+      get-bucket-lifecycle-configuration --bucket {{ item.name }}
+  loop: "{{ object_storage_default_buckets | selectattr('versioning', 'defined') | selectattr('versioning') | list }}"
+  loop_control:
+    label: "{{ item.name }}"
+  environment: "{{ object_storage_aws_env }}"
+  register: object_storage_lifecycle_current
+  changed_when: false
+  failed_when: false
+  no_log: true
+
+- name: Render lifecycle configuration documents
+  ansible.builtin.template:
+    src: lifecycle.json.j2
+    dest: "{{ object_storage_config_dir }}/lifecycle-{{ item.name }}.json"
+    owner: root
+    group: root
+    mode: "0640"
+  loop: "{{ object_storage_default_buckets | selectattr('versioning', 'defined') | selectattr('versioning') | list }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Add noncurrent-version expiration rule when none exists
+  ansible.builtin.command:
+    cmd: >-
+      aws --endpoint-url {{ object_storage_endpoint }} s3api put-bucket-lifecycle-configuration
+      --bucket {{ item.item.name }}
+      --lifecycle-configuration file://{{ object_storage_config_dir }}/lifecycle-{{ item.item.name }}.json
+  loop: "{{ object_storage_lifecycle_current.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  environment: "{{ object_storage_aws_env }}"
+  when: >-
+    item.rc != 0 or
+    (item.stdout | default('')) is not search('NoncurrentVersionExpiration')
+  changed_when: true
+  no_log: true
+
+# Phase 10: Mirror external infrastructure artifacts into the local bucket so
+# egress-restricted roles can pull them over the internal network. The
+# controller stages the download; the target uploads via the aws CLI. Existing
+# objects are left alone (manual retention is not clobbered on re-runs).
+- name: Check which infra artifacts are already mirrored
+  ansible.builtin.command:
+    cmd: >-
+      aws --endpoint-url {{ object_storage_endpoint }} s3api head-object
+      --bucket {{ item.bucket }} --key {{ item.key }}
+  loop: "{{ object_storage_infra_mirrors }}"
+  loop_control:
+    label: "{{ item.name }}"
+  environment: "{{ object_storage_aws_env }}"
+  register: object_storage_infra_stat
+  changed_when: false
+  failed_when: false
+  no_log: true
+
+- name: Stage missing infra artifacts on controller
+  ansible.builtin.get_url:
+    url: "{{ item.item.url }}"
+    dest: "/tmp/object-storage-mirror-{{ inventory_hostname }}-{{ item.item.name }}"
+    mode: "0644"
+    force: true
+  loop: "{{ object_storage_infra_stat.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  when: item.rc != 0
+
+- name: Push missing infra artifacts to target
+  ansible.builtin.copy:
+    src: "/tmp/object-storage-mirror-{{ inventory_hostname }}-{{ item.item.name }}"
+    dest: "/tmp/object-storage-mirror-{{ item.item.name }}"
+    mode: "0644"
+  loop: "{{ object_storage_infra_stat.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  when: item.rc != 0
+
+- name: Upload missing infra artifacts to object storage
+  ansible.builtin.command:
+    cmd: >-
+      aws --endpoint-url {{ object_storage_endpoint }} s3 cp
+      /tmp/object-storage-mirror-{{ item.item.name }}
+      s3://{{ item.item.bucket }}/{{ item.item.key }}
+  loop: "{{ object_storage_infra_stat.results }}"
+  loop_control:
+    label: "{{ item.item.name }} -> {{ item.item.bucket }}/{{ item.item.key }}"
+  environment: "{{ object_storage_aws_env }}"
+  when: item.rc != 0
+  changed_when: true
+  no_log: true
+
+- name: Remove staging files from target
+  ansible.builtin.file:
+    path: "/tmp/object-storage-mirror-{{ item.item.name }}"
+    state: absent
+  loop: "{{ object_storage_infra_stat.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  when: item.rc != 0
+
+- name: Remove staging files from controller
+  ansible.builtin.file:
+    path: "/tmp/object-storage-mirror-{{ inventory_hostname }}-{{ item.item.name }}"
+    state: absent
+  loop: "{{ object_storage_infra_stat.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  when: item.rc != 0

--- a/roles/object_storage/tasks/main.yml
+++ b/roles/object_storage/tasks/main.yml
@@ -107,12 +107,12 @@
 - name: Assert the rustfs binary was found in the archive
   ansible.builtin.assert:
     that: object_storage_binary_find.matched | int > 0
-    fail_msg: "No 'rustfs' binary found in {{ object_storage_binary_url }} — the release asset layout may have changed."
+    fail_msg: "No 'rustfs' binary found in the downloaded release archive — the asset layout may have changed."
   run_once: true
 
 - name: Copy rustfs binary to target
   ansible.builtin.copy:
-    src: "{{ object_storage_binary_find.files[0].path }}"
+    src: "{{ hostvars[ansible_play_hosts[0]].object_storage_binary_find.files[0].path }}"
     dest: "{{ object_storage_install_dir }}/rustfs"
     owner: root
     group: root
@@ -181,16 +181,29 @@
   changed_when: true
   no_log: true
 
-- name: Enable versioning on versioned buckets
+- name: Read current versioning status
   ansible.builtin.command:
-    cmd: >-
-      aws --endpoint-url {{ object_storage_endpoint }} s3api put-bucket-versioning
-      --bucket {{ item.name }} --versioning-configuration Status=Enabled
+    cmd: "aws --endpoint-url {{ object_storage_endpoint }} s3api get-bucket-versioning --bucket {{ item.name }}"
   loop: "{{ object_storage_default_buckets | selectattr('versioning', 'defined') | selectattr('versioning') | list }}"
   loop_control:
     label: "{{ item.name }}"
   environment: "{{ object_storage_aws_env }}"
+  register: object_storage_versioning_current
   changed_when: false
+  failed_when: false
+  no_log: true
+
+- name: Enable versioning where not already enabled
+  ansible.builtin.command:
+    cmd: >-
+      aws --endpoint-url {{ object_storage_endpoint }} s3api put-bucket-versioning
+      --bucket {{ item.item.name }} --versioning-configuration Status=Enabled
+  loop: "{{ object_storage_versioning_current.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  environment: "{{ object_storage_aws_env }}"
+  when: "'Enabled' not in (item.stdout | default(''))"
+  changed_when: true
   no_log: true
 
 # Anonymous (public-read) download policy — Splunk and other internal consumers
@@ -305,7 +318,11 @@
   environment: "{{ object_storage_aws_env }}"
   register: object_storage_infra_stat
   changed_when: false
-  failed_when: false
+  failed_when: >-
+    object_storage_infra_stat.rc is defined and
+    object_storage_infra_stat.rc != 0 and
+    '404' not in (object_storage_infra_stat.stderr | default('')) and
+    'Not Found' not in (object_storage_infra_stat.stderr | default(''))
   no_log: true
 
 - name: Stage missing infra artifacts on controller

--- a/roles/object_storage/tasks/main.yml
+++ b/roles/object_storage/tasks/main.yml
@@ -56,8 +56,8 @@
 - name: Stage RustFS release archive on controller
   ansible.builtin.get_url:
     url: "{{ object_storage_binary_base }}/{{ object_storage_rustfs_version }}/{{ object_storage_binary_asset }}"
-    dest: "/tmp/rustfs-{{ object_storage_rustfs_version }}.zip"
-    checksum: "sha256:{{ object_storage_binary_sha256 }}"
+    dest: "/tmp/{{ object_storage_binary_asset }}"
+    checksum: "sha256:{{ object_storage_checksums_url }}"
     mode: "0644"
   delegate_to: localhost
   connection: local
@@ -80,7 +80,7 @@
 
 - name: Extract RustFS binary on controller
   ansible.builtin.unarchive:
-    src: "/tmp/rustfs-{{ object_storage_rustfs_version }}.zip"
+    src: "/tmp/{{ object_storage_binary_asset }}"
     dest: "/tmp/rustfs-{{ object_storage_rustfs_version }}"
     remote_src: true
   delegate_to: localhost

--- a/roles/object_storage/templates/bucket-policy.json.j2
+++ b/roles/object_storage/templates/bucket-policy.json.j2
@@ -1,0 +1,11 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": ["s3:GetObject"],
+      "Resource": ["arn:aws:s3:::{{ bucket }}/*"]
+    }
+  ]
+}

--- a/roles/object_storage/templates/lifecycle.json.j2
+++ b/roles/object_storage/templates/lifecycle.json.j2
@@ -1,0 +1,10 @@
+{
+  "Rules": [
+    {
+      "ID": "expire-noncurrent",
+      "Status": "Enabled",
+      "Filter": {"Prefix": ""},
+      "NoncurrentVersionExpiration": {"NoncurrentDays": {{ object_storage_noncurrent_expiration_days }}}
+    }
+  ]
+}

--- a/roles/object_storage/templates/object-storage.env.j2
+++ b/roles/object_storage/templates/object-storage.env.j2
@@ -1,0 +1,8 @@
+# RustFS object storage environment — managed by Ansible, do not edit manually.
+RUSTFS_VOLUMES="{{ object_storage_data_dir }}"
+RUSTFS_ADDRESS=":{{ object_storage_s3_port }}"
+RUSTFS_CONSOLE_ENABLE="true"
+RUSTFS_CONSOLE_ADDRESS=":{{ object_storage_console_port }}"
+RUSTFS_ACCESS_KEY="{{ object_storage_root_user }}"
+RUSTFS_SECRET_KEY="{{ object_storage_root_password }}"
+RUSTFS_REGION="{{ object_storage_region }}"

--- a/roles/object_storage/templates/object-storage.service.j2
+++ b/roles/object_storage/templates/object-storage.service.j2
@@ -1,0 +1,20 @@
+[Unit]
+Description=RustFS Object Storage
+Documentation=https://rustfs.com
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ object_storage_user }}
+Group={{ object_storage_group }}
+EnvironmentFile={{ object_storage_env_file }}
+ExecStart={{ object_storage_install_dir }}/rustfs server {{ object_storage_data_dir }}
+Restart=on-failure
+RestartSec=10
+LimitNOFILE=65536
+TasksMax=infinity
+TimeoutStopSec=120
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Why

The MinIO community edition is end-of-life (upstream archived the repo in Feb 2026). This adds the **RustFS** install/config role under a neutral `object_storage` name, the configuration-management half of migrating the homelab's S3-compatible store off MinIO. Pairs with the infra-layer PR (terraform-proxmox #456) that provisions the `object-storage` LXC.

## What

`roles/object_storage` mirrors the `minio` role's contract on RustFS, **rewritten** rather than renamed — every `mc` call is replaced with the `aws` CLI (`s3api`), since `mc` is itself a MinIO client:

- Pinned RustFS server binary install (controller-staged + SHA256-verified — egress-restricted targets can't reach GitHub), systemd unit, S3 readiness wait
- Bucket setup via `aws s3api`: create, versioning, **anonymous public-read download policy**, and a noncurrent-version lifecycle rule (add-if-missing, same 10-year default as the minio role)
- Infra-artifact mirror (Cribl tarball) into the `splunk-addons` bucket for egress-restricted consumers
- `load_tofu`: new `object_storage_group` derived from the `object-storage` tag
- `site.yml`: deploy play running **alongside** the minio play during the soak
- Credentials from new `OBJECT_STORAGE_ROOT_USER` / `OBJECT_STORAGE_ROOT_PASSWORD` env (Doppler)

## Verification

A local RustFS capability spike (beta `1.0.0-beta.8`) confirmed via `aws s3api` that bucket **versioning + history**, **`NoncurrentVersionExpiration` lifecycle**, **anonymous policy + unauthenticated GET**, and **object tagging** all work — everything the `splunk-addons` workflow needs. `ansible-lint` (production profile) runs in CI; YAML + line-length validated locally (no local ansible toolchain). RustFS is beta — version + checksum pinned; the dual-run soak with MinIO retained is the safety net.

## Follow-ups (later phases)

- Add `OBJECT_STORAGE_ROOT_*` to Doppler before converge.
- Data migration (bucket copy preserving object tags), consumer repoint (ansible-splunk, homelab-schemas, nix-home), 30-day soak, then full MinIO decommission.