### PR TITLE
feat(monitoring): network_quality role (smokeping_prober) on the prometheus LXC

### DIFF
--- a/inventory/group_vars/prometheus_group.yml
+++ b/inventory/group_vars/prometheus_group.yml
@@ -1,0 +1,20 @@
+---
+# group_vars for prometheus_group — the monitoring LXC that runs prometheus_stack
+# AND network_quality (smokeping_prober) co-located.
+#
+# Wire the co-located smokeping_prober scrape job into Prometheus: prometheus_stack
+# appends prometheus_stack_extra_scrape_configs to prometheus.yml and the
+# "Reload prometheus config" handler hot-reloads (no restart, no scrape gap).
+#
+# This lives in group_vars (not the network_quality role defaults) because the
+# prometheus_stack play does not load network_quality's defaults — the scrape job
+# must be visible to whichever play renders prometheus.yml. The port comes from the
+# tofu service_ports constant (default 9374), DRY with the network_quality role.
+smokeping_scrape_port: >-
+  {{ hostvars['localhost']['tofu_data']['constants']['service_ports']['smokeping_prober']
+     | default(9374) }}
+
+prometheus_stack_extra_scrape_configs: |
+  - job_name: smokeping
+    static_configs:
+      - targets: ["127.0.0.1:{{ smokeping_scrape_port }}"]

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -346,6 +346,26 @@
     - role: prometheus_stack
 
 # =============================================================================
+# Phase 3b3: Network-quality probers (co-located on the prometheus LXC)
+# smokeping_prober (ICMP latency-distribution histograms, scraped by Prometheus).
+# Adds the loss/latency-distribution leg that blackbox's binary probe_success
+# lacks. The scrape job is wired into Prometheus via
+# prometheus_stack_extra_scrape_configs (group_vars). Runs after the
+# prometheus_stack play so the local Prometheus is up to scrape it. (irtt jitter/MOS
+# deferred — no official image.)
+# =============================================================================
+
+- name: Configure network-quality probers
+  hosts: prometheus_group
+  become: true
+  gather_facts: false
+  tags:
+    - smokeping
+    - monitoring
+  roles:
+    - role: network_quality
+
+# =============================================================================
 # Phase 3c: UniFi controller telemetry
 # unpoller + Telegraf (Docker-in-LXC) shipping full UniFi device/port/client/WAN
 # metrics Splunk-HEC to Cribl Edge -> Splunk unifi_metrics index. Runs after

--- a/roles/network_quality/README.md
+++ b/roles/network_quality/README.md
@@ -1,0 +1,86 @@
+# network_quality
+
+Deploys active **network-quality probing** as a Docker-in-LXC compose stack —
+co-located on the monitoring (`prometheus`) LXC alongside `prometheus_stack`:
+
+- **[smokeping_prober](https://github.com/SuperQ/smokeping_prober)** (`:9374`,
+  `NET_RAW`): continuous ~1 packet/s ICMP stream to each target, exposing per-host
+  **latency-distribution histograms** + loss. Prometheus scrapes it. This is the
+  loss/latency-**distribution** leg that blackbox's binary `probe_success` lacks.
+
+`irtt` (jitter/MOS) is **deferred** — see below. The role is named `network_quality`
+(not `smokeping`) so the jitter/atlas legs can be added later without a rename.
+
+See `terraform-proxmox/docs/SMOKEPING.md` for the measurement design.
+
+## Networking
+
+Both services run on `network_mode: host`: smokeping_prober needs it so ICMP
+egresses the LXC's uplink (the per-WAN source-IP policy route governs the path) and
+`NET_RAW` lets it open raw sockets. They are **not** on an internal bridge — that
+would break ICMP source-routing (same rationale as `prometheus_stack`).
+
+## daemon.json ownership
+
+This role does **not** write `/etc/docker/daemon.json`. The registry-mirror play in
+`playbooks/site.yml` is the single owner of that file on docker LXCs.
+
+## Wiring smokeping into Prometheus
+
+smokeping_prober is scraped with a single static job, defined in
+`inventory/group_vars/prometheus_group.yml` as
+`prometheus_stack_extra_scrape_configs`. `prometheus.yml.j2` (in `prometheus_stack`)
+appends that block and the `Reload prometheus config` handler hot-reloads — no
+Prometheus restart.
+
+The job lives in `group_vars` (not this role's defaults) because the
+`prometheus_stack` play does not load this role's defaults — the scrape config must
+be visible to whichever play renders `prometheus.yml`. Its port comes from the same
+tofu `smokeping_prober` constant this role uses, so the two stay in sync.
+
+## irtt is deferred
+
+`irtt` (RFC-3393 jitter / MOS) is **not** included. There is no official or
+maintained irtt container image — the upstream repo ships no Dockerfile and only
+low-signal community forks exist on Docker Hub — and real jitter/MOS needs an `irtt
+client` run against a *remote* irtt server anyway, not just a local responder.
+Revisit by building irtt from source (small Go binary) or vetting a community image;
+tracked as a follow-up. The role name leaves room to add it later.
+
+## Targets / privacy
+
+Probe targets default to **generic** values only, defined once as
+`network_quality_modem_ip` (`192.168.100.1`) + `network_quality_anycast_targets`
+(`1.1.1.1` / `8.8.8.8`); `network_quality_smokeping_targets` derives from them. Real
+ISP hop IPs are home-specific — override those vars (or the whole
+`network_quality_smokeping_targets` list) via a **private** inventory; never commit
+them to this public repo.
+
+## Variables
+
+See `defaults/main.yml`: `network_quality_smokeping_image` /
+`network_quality_irtt_image` (pinned, Renovate-tracked), `*_port` (tofu
+`smokeping_prober` / `irtt` constants, defaults `9374` / `2112`),
+`network_quality_smokeping_targets`, `network_quality_smokeping_interval` (`1s`),
+and `network_quality_smokeping_scrape_config` (the Prometheus job snippet).
+
+## Installation
+
+This role ships with the repo; no separate install step. Its only collection
+dependency, `community.docker`, is pinned in the repo-root `requirements.yml`.
+Hosts are selected from the terraform inventory: the metrics LXC (`prometheus`
+hostname / `monitoring` tag) is grouped by `inventory/load_tofu.yml`, and the
+`network_quality` play in `playbooks/site.yml` runs this role against it.
+
+## Usage
+
+Scoped run (never the full `site.yml`):
+
+```bash
+ansible-playbook playbooks/site.yml --tags smokeping
+```
+
+## Handlers
+
+- `Restart network_quality stack` — recreates the compose stack against the
+  rendered config.

--- a/roles/network_quality/defaults/main.yml
+++ b/roles/network_quality/defaults/main.yml
@@ -1,0 +1,55 @@
+---
+# network_quality — smokeping_prober as a Docker-in-LXC compose stack, co-located
+# on the monitoring (prometheus) LXC. Adds the loss/latency-DISTRIBUTION leg
+# (smokeping_prober, ICMP histograms) alongside blackbox's binary probe_success.
+# See terraform-proxmox docs/SMOKEPING.md.
+#
+# Prometheus scrapes smokeping_prober (:9374) via a static job wired through
+# prometheus_stack_extra_scrape_configs — see inventory/group_vars/prometheus_group.yml.
+#
+# irtt (jitter/MOS) is intentionally DEFERRED: there is no official/maintained irtt
+# container image (the repo ships no Dockerfile; only low-signal community forks
+# exist), and real jitter/MOS needs an irtt CLIENT against a remote server anyway.
+# Revisit by building irtt from source or vetting an image — tracked as a follow-up.
+#
+# daemon.json is intentionally NOT written here — the registry-mirror play in
+# site.yml is the single owner of /etc/docker/daemon.json on docker LXCs.
+
+# --- container image (pinned; tracked by the dryvist/.github Renovate manager) ---
+# Canonical image is quay.io/superq/smokeping-prober (hyphen). v0.11.0 is the latest
+# GitHub release but is not on quay yet; v0.10.0 is the newest published tag.
+network_quality_smokeping_image: "quay.io/superq/smokeping-prober:v0.10.0"
+network_quality_smokeping_container_name: smokeping-prober
+
+network_quality_data_dir: /opt/network-quality
+
+# Port from the tofu constant when available, else the upstream default.
+network_quality_smokeping_port: >-
+  {{ hostvars['localhost']['tofu_data']['constants']['service_ports']['smokeping_prober']
+     | default(9374) }}
+
+# Host networking so ICMP egresses the LXC uplink (per-WAN source routing governs
+# the path) and NET_RAW lets smokeping_prober open raw sockets. Molecule/DinD would
+# override network_mode to bridge.
+network_quality_network_mode: "host"
+network_quality_smokeping_cap_add:
+  - "NET_RAW"
+
+# --- probe targets (GENERIC defaults; real ISP hops via PRIVATE inventory) ---
+# Same shape/vars as prometheus_stack so a private override sets both consistently.
+network_quality_modem_ip: "192.168.100.1"     # cable-modem diagnostic IP (ICMP-only)
+network_quality_anycast_targets:              # public resolvers used as probe targets
+  - "1.1.1.1"
+  - "8.8.8.8"
+
+# The full host list smokeping_prober pings — modem + anycast by default; a private
+# inventory can override this whole list to add real ISP hop IPs.
+network_quality_smokeping_targets: "{{ [network_quality_modem_ip] + network_quality_anycast_targets }}"
+
+network_quality_smokeping_interval: "1s"   # ~1 packet/s stream (matches SmokePing cadence)
+network_quality_ip_protocol: "ip4"
+
+# NOTE: the Prometheus scrape job for smokeping_prober is wired into Prometheus via
+# prometheus_stack_extra_scrape_configs in inventory/group_vars/prometheus_group.yml,
+# NOT here — the prometheus_stack play does not load this role's defaults, so the
+# scrape job must live where both plays can see it (group_vars).

--- a/roles/network_quality/handlers/main.yml
+++ b/roles/network_quality/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+# network_quality handlers
+
+# Compose change (or smokeping.yml change, which smokeping_prober only reads at
+# start): recreate the stack against the rendered files.
+- name: Restart network_quality stack
+  community.docker.docker_compose_v2:
+    project_src: "{{ network_quality_data_dir }}"
+    state: present
+    recreate: always
+  vars:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python

--- a/roles/network_quality/meta/main.yml
+++ b/roles/network_quality/meta/main.yml
@@ -1,0 +1,31 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: >-
+    Network-quality probing via smokeping_prober (ICMP latency-distribution
+    histograms, scraped by Prometheus) as a Docker-in-LXC compose stack. Co-located
+    on the monitoring LXC alongside prometheus_stack; adds the loss/latency-
+    distribution leg that blackbox's binary probe_success does not provide. irtt
+    (jitter/MOS) is deferred (no official image). See terraform-proxmox
+    docs/SMOKEPING.md.
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+
+  galaxy_tags:
+    - smokeping
+    - monitoring
+    - network
+    - docker
+
+dependencies: []
+  # community.docker collection is specified in requirements.yml

--- a/roles/network_quality/tasks/main.yml
+++ b/roles/network_quality/tasks/main.yml
@@ -126,6 +126,13 @@
     mode: "0644"
   notify: Restart network_quality stack
 
+# Apply any pending config-change handlers (Restart network_quality stack) BEFORE
+# the verification block, so the health checks validate the freshly-deployed config
+# rather than a container still running the old smokeping.yml (a config-only change
+# is picked up by the recreate handler, which would otherwise flush at play end).
+- name: Flush handlers so config changes apply before verification
+  ansible.builtin.meta: flush_handlers
+
 # The venv interpreter is scoped to this block only — it does NOT leak into later
 # plays the way a play-wide set_fact would.
 - name: Deploy and verify the network_quality stack
@@ -142,13 +149,15 @@
     # producing metrics (not just "container up").
     # =========================================================================
     - name: Verify the smokeping_prober container is running
-      ansible.builtin.command: >-
-        docker ps -q --filter name={{ network_quality_smokeping_container_name }} --filter status=running
-      register: network_quality_running
-      changed_when: false
+      community.docker.docker_container_info:
+        name: "{{ network_quality_smokeping_container_name }}"
+      register: network_quality_container_info
       retries: 6
       delay: 5
-      until: network_quality_running.stdout != ''
+      until: >-
+        network_quality_container_info.exists
+        and (network_quality_container_info.container.State.Running | default(false))
+      changed_when: false
 
     # Real check: the exporter must serve its own metrics with smokeping_* series
     # (proves the config parsed and the prober is running).
@@ -164,11 +173,14 @@
       changed_when: false
 
   rescue:
+    # Use docker compose (not a hardcoded container name) so diagnostics cover every
+    # service in the stack as it grows, and capture stderr too — that is where
+    # container startup failures usually surface.
     - name: Capture stack diagnostics on failure
       ansible.builtin.command: "{{ item }}"
       loop:
-        - "docker ps -a"
-        - "docker logs --tail 50 {{ network_quality_smokeping_container_name }}"
+        - "docker compose -f {{ network_quality_data_dir }}/docker-compose.yml ps -a"
+        - "docker compose -f {{ network_quality_data_dir }}/docker-compose.yml logs --tail 50"
       register: network_quality_diag
       changed_when: false
       failed_when: false
@@ -177,4 +189,9 @@
       ansible.builtin.fail:
         msg: |-
           network_quality stack failed to deploy/verify on {{ inventory_hostname }}.
-          {{ network_quality_diag.results | default([]) | map(attribute='stdout') | join('\n--- next ---\n') }}
+          {% for result in network_quality_diag.results | default([]) %}
+          $ {{ result.item }}
+          {{ result.stdout | default('') }}
+          {{ result.stderr | default('') }}
+          ---
+          {% endfor %}

--- a/roles/network_quality/tasks/main.yml
+++ b/roles/network_quality/tasks/main.yml
@@ -1,0 +1,180 @@
+---
+# network_quality — smokeping_prober + irtt as ONE Docker-in-LXC compose stack,
+# co-located on the monitoring (prometheus) LXC. Mirrors the prometheus_stack
+# Docker bootstrap (a shared docker_base role is tracked separately as #449).
+#
+# daemon.json is intentionally NOT written here — the registry-mirror play in
+# site.yml owns it (same rationale as prometheus_stack).
+
+# =============================================================================
+# Docker installation
+# =============================================================================
+
+- name: Gather OS facts
+  ansible.builtin.setup:
+    filter: ansible_distribution*
+
+- name: Install Docker prerequisites
+  ansible.builtin.apt:
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg
+      - lsb-release
+    state: present
+    update_cache: true
+
+- name: Create keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+
+- name: Set Docker repository distribution
+  ansible.builtin.set_fact:
+    network_quality_distro: "{{ ansible_distribution | lower }}"
+
+- name: Add Docker GPG key
+  ansible.builtin.get_url:
+    url: "https://download.docker.com/linux/{{ network_quality_distro }}/gpg"
+    dest: /etc/apt/keyrings/docker.asc
+    mode: "0644"
+    force: false
+
+- name: Add Docker repository
+  ansible.builtin.apt_repository:
+    repo: >-
+      deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc]
+      https://download.docker.com/linux/{{ network_quality_distro }}
+      {{ ansible_distribution_release }} stable
+    state: present
+    filename: docker
+
+- name: Install Docker packages
+  ansible.builtin.apt:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-buildx-plugin
+      - docker-compose-plugin
+    state: present
+    update_cache: true
+
+- name: Install fuse-overlayfs for Docker on ZFS-backed LXC containers
+  ansible.builtin.apt:
+    name: fuse-overlayfs
+    state: present
+
+- name: Ensure Docker service is running
+  ansible.builtin.systemd:
+    name: docker
+    state: started
+    enabled: true
+
+# =============================================================================
+# Python venv for the Ansible docker_compose_v2 module
+# =============================================================================
+
+- name: Install Python venv and pip for dependencies
+  ansible.builtin.apt:
+    name:
+      - python3-pip
+      - python3-venv
+      - python3-full
+    state: present
+    update_cache: true
+
+- name: Create virtualenv for Ansible Python dependencies
+  ansible.builtin.pip:
+    name:
+      - docker
+      - packaging  # docker_compose_v2 imports packaging for version comparison
+      - requests
+    state: present
+    virtualenv: /opt/ansible-venv
+    virtualenv_command: python3 -m venv
+
+# =============================================================================
+# Config + compose (single project, two services)
+# =============================================================================
+
+- name: Create network_quality data directory
+  ansible.builtin.file:
+    path: "{{ network_quality_data_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Render smokeping_prober configuration
+  ansible.builtin.template:
+    src: smokeping.yml.j2
+    dest: "{{ network_quality_data_dir }}/smokeping.yml"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart network_quality stack
+
+- name: Deploy network_quality docker-compose template
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ network_quality_data_dir }}/docker-compose.yml"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart network_quality stack
+
+# The venv interpreter is scoped to this block only — it does NOT leak into later
+# plays the way a play-wide set_fact would.
+- name: Deploy and verify the network_quality stack
+  vars:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python
+  block:
+    - name: Deploy the network_quality stack via docker compose
+      community.docker.docker_compose_v2:
+        project_src: "{{ network_quality_data_dir }}"
+        state: present
+
+    # =========================================================================
+    # Health checks — the container runs AND smokeping_prober is actually
+    # producing metrics (not just "container up").
+    # =========================================================================
+    - name: Verify the smokeping_prober container is running
+      ansible.builtin.command: >-
+        docker ps -q --filter name={{ network_quality_smokeping_container_name }} --filter status=running
+      register: network_quality_running
+      changed_when: false
+      retries: 6
+      delay: 5
+      until: network_quality_running.stdout != ''
+
+    # Real check: the exporter must serve its own metrics with smokeping_* series
+    # (proves the config parsed and the prober is running).
+    - name: Verify smokeping_prober is serving metrics
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ network_quality_smokeping_port }}/metrics"
+        return_content: true
+        status_code: 200
+      register: network_quality_smokeping_metrics
+      retries: 12
+      delay: 5
+      until: "'smokeping_' in (network_quality_smokeping_metrics.content | default(''))"
+      changed_when: false
+
+  rescue:
+    - name: Capture stack diagnostics on failure
+      ansible.builtin.command: "{{ item }}"
+      loop:
+        - "docker ps -a"
+        - "docker logs --tail 50 {{ network_quality_smokeping_container_name }}"
+      register: network_quality_diag
+      changed_when: false
+      failed_when: false
+
+    - name: Fail with stack diagnostics
+      ansible.builtin.fail:
+        msg: |-
+          network_quality stack failed to deploy/verify on {{ inventory_hostname }}.
+          {{ network_quality_diag.results | default([]) | map(attribute='stdout') | join('\n--- next ---\n') }}

--- a/roles/network_quality/templates/docker-compose.yml.j2
+++ b/roles/network_quality/templates/docker-compose.yml.j2
@@ -1,0 +1,22 @@
+## Managed by Ansible (network_quality role) — do not edit by hand.
+## smokeping-prober on host networking: ICMP latency histograms. NET_RAW + host net
+## so pings egress the LXC's uplink (per-WAN source routing governs the path).
+## Prometheus scrapes it on :{{ network_quality_smokeping_port }}.
+## (irtt is deferred — no official image; see role README.)
+services:
+  smokeping-prober:
+    image: {{ network_quality_smokeping_image }}
+    container_name: {{ network_quality_smokeping_container_name }}
+    restart: unless-stopped
+    network_mode: {{ network_quality_network_mode }}
+{% if network_quality_smokeping_cap_add | length > 0 %}
+    cap_add:
+{% for cap in network_quality_smokeping_cap_add %}
+      - {{ cap }}
+{% endfor %}
+{% endif %}
+    command:
+      - "--config.file=/config/smokeping.yml"
+      - "--web.listen-address=:{{ network_quality_smokeping_port }}"
+    volumes:
+      - {{ network_quality_data_dir }}/smokeping.yml:/config/smokeping.yml:ro

--- a/roles/network_quality/templates/smokeping.yml.j2
+++ b/roles/network_quality/templates/smokeping.yml.j2
@@ -1,0 +1,13 @@
+## Managed by Ansible (network_quality role) — do not edit by hand.
+## smokeping_prober config. The exporter pings these hosts itself (~1 pkt/s) and
+## exposes per-host latency-distribution histograms on /metrics; Prometheus scrapes
+## the exporter. Target hosts come from network_quality_smokeping_targets (modem +
+## anycast by default; real ISP hops via a private inventory override).
+targets:
+  - hosts:
+{% for host in network_quality_smokeping_targets %}
+      - {{ host }}
+{% endfor %}
+    interval: {{ network_quality_smokeping_interval }}
+    network: {{ network_quality_ip_protocol }}
+    protocol: icmp


### PR DESCRIPTION
## What

Adds a `network_quality` role deploying **smokeping_prober** as a Docker-in-LXC compose stack, co-located on the `prometheus` LXC alongside `prometheus_stack`. This is the **loss/latency-distribution** leg that blackbox's binary `probe_success` doesn't provide — smokeping_prober streams ~1 ICMP pkt/s to each target and exposes per-host latency histograms, scraped by the local Prometheus.

First execution stream of the WAN-observability buildout (`terraform-proxmox/docs/SMOKEPING.md`); follows the merged `prometheus_stack` (#446).

## Design

- Built on the `prometheus_stack` pattern: one Docker bootstrap, `network_mode: host` (ICMP source-routing + `NET_RAW`), `docker_compose_v2`, block-scoped venv interpreter, **real** health check (asserts `smokeping_*` series are served, not just "container up"), and **no `daemon.json` write** (the registry-mirror play owns it).
- Targets derive **DRY** from `network_quality_modem_ip` + `network_quality_anycast_targets` (same var shape as `prometheus_stack`; real ISP hops via a **private** inventory override — generic defaults only here).
- Image pinned `quay.io/superq/smokeping-prober:v0.10.0` (the canonical quay path — note hyphen; v0.11.0 isn't on quay yet) → tracked by the dryvist/.github Renovate Docker manager.
- Scrape job wired into Prometheus via `prometheus_stack_extra_scrape_configs` in `inventory/group_vars/prometheus_group.yml` (it lives in group_vars because the `prometheus_stack` play doesn't load this role's defaults). Hot-reloaded, no restart.
- `site.yml`: Phase 3b3 play (`prometheus_group`; tags `smokeping`, `monitoring`).

## irtt deferred

`irtt` (jitter/MOS) is **not** included — there is no official/maintained irtt container image (no upstream Dockerfile; only 0–1 star community forks), and real jitter/MOS needs an `irtt client` against a remote server anyway. The role is named `network_quality` (not `smokeping`) so the jitter/atlas legs can be added later without a rename.

## Validation

- `ansible-lint` production profile: pass. `yamllint`: clean.
- Templates render-verified: smokeping targets (modem + anycast), the quay image pin, and the appended Prometheus `smokeping` scrape job.
- **Not yet deployed** — deploy is the gated Stream 2 (needs the private override with real hop IPs + scoped redeploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)