### PR TITLE
feat(plex): warn loudly when the config dir is not on a persistent mount

### DIFF
--- a/roles/plex/tasks/main.yml
+++ b/roles/plex/tasks/main.yml
@@ -96,6 +96,34 @@
     daemon_reload: true
   when: plex_manage_services
 
+# ---------------------------------------------------------------------------
+# Persistence guard — surface a config dir on the disposable rootfs LOUDLY
+# ---------------------------------------------------------------------------
+# Plex identity (Preferences.xml machineIdentifier + claim + publish flag) and
+# the watch-history DB live under /var/lib/plexmediaserver. The media_lxc_features
+# role bind-mounts the persistent bulk/appdata/plex dataset there so they survive
+# a container REBUILD. If that mount is missing, a rebuild silently resets Plex to
+# a brand-new server (lost history, re-claim prompt) — so make the missing mount a
+# VISIBLE warning on every converge instead of a silent time bomb. Non-fatal.
+- name: Check whether the Plex config dir is on a persistent mount
+  ansible.builtin.command:
+    cmd: mountpoint -q /var/lib/plexmediaserver
+  register: plex_config_mountpoint
+  changed_when: false
+  failed_when: false
+  when: plex_manage_services
+
+- name: Warn loudly when the Plex config dir is NOT persistent
+  ansible.builtin.debug:
+    msg: >-
+      WARNING: /var/lib/plexmediaserver is NOT a persistent mount. Plex identity
+      and watch history are on the disposable LXC rootfs and will be LOST on the
+      next container rebuild (server resets to a fresh install). Apply the
+      media_lxc_features role to bind-mount bulk/appdata/plex.
+  when:
+    - plex_manage_services
+    - plex_config_mountpoint.rc | default(0) != 0
+
 # Idempotent + non-fatal server claim (see tasks/claim.yml). Only attempted on a
 # live host (plex_manage_services), since it talks to the running Plex API.
 - name: Claim the Plex server (idempotent, non-fatal)


### PR DESCRIPTION
## What

Adds a non-fatal converge-time guard to the `plex` role: it checks whether `/var/lib/plexmediaserver` is a persistent mount and **warns loudly** when it is not.

## Why

Plex's identity (`Preferences.xml` — machineIdentifier, claim token, publish flag) and its watch-history DB live under `/var/lib/plexmediaserver`. The `media_lxc_features` role now bind-mounts a persistent `bulk/appdata/plex` dataset there so they survive a container rebuild. If that mount is ever missing, a rebuild **silently** resets Plex to a brand-new server — lost history, re-claim prompt. This guard turns that silent time bomb into a visible warning on every converge.

Pairs with dryvist/ansible-proxmox#286 (the dataset + mount).

## Verification

- `ansible-lint roles/plex/` → **passed** (production profile, 0 failures / 0 warnings).
- Non-fatal + gated on `plex_manage_services`, so it never breaks a converge and stays quiet in molecule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)