### PR TITLE
fix(object-storage): source root creds from SOPS at the least-shared tier

### DIFF
--- a/roles/object_storage/defaults/main.yml
+++ b/roles/object_storage/defaults/main.yml
@@ -32,11 +32,17 @@ object_storage_group: rustfs
 # pre-seeded into a shared store; promote to Doppler only if a cross-repo
 # consumer ever needs write access (anonymous read needs no credentials).
 # Regenerate with `openssl rand -hex 12` / `-hex 32` then `sops set`.
+# `lookup('env', ...)` returns "" (a *defined* empty string) when the var is
+# unset, which `mandatory` would happily pass through. `default(undef(), true)`
+# coerces that empty string to undefined first, so `mandatory` actually fails
+# fast on a missing credential instead of booting RustFS with empty creds.
 object_storage_root_user: >-
   {{ lookup('env', 'OBJECT_STORAGE_ROOT_USER')
+     | default(undef(), true)
      | mandatory('OBJECT_STORAGE_ROOT_USER must be set (openssl rand -hex 12; store in SOPS secrets.enc.yaml)') }}
 object_storage_root_password: >-
   {{ lookup('env', 'OBJECT_STORAGE_ROOT_PASSWORD')
+     | default(undef(), true)
      | mandatory('OBJECT_STORAGE_ROOT_PASSWORD must be set (openssl rand -hex 32; store in SOPS secrets.enc.yaml)') }}
 
 # Loopback S3 endpoint for local bucket administration via the aws CLI.

--- a/roles/object_storage/defaults/main.yml
+++ b/roles/object_storage/defaults/main.yml
@@ -27,9 +27,17 @@ object_storage_region: us-east-1
 object_storage_user: rustfs
 object_storage_group: rustfs
 
-# Credentials (from Doppler — new keys mirroring MINIO_ROOT_* semantics).
-object_storage_root_user: "{{ lookup('env', 'OBJECT_STORAGE_ROOT_USER') }}"
-object_storage_root_password: "{{ lookup('env', 'OBJECT_STORAGE_ROOT_PASSWORD') }}"
+# Root credentials — generated randomly and stored in SOPS (secrets.enc.yaml)
+# in THIS repo, the least-shared tier where they are first used. They are NOT
+# pre-seeded into a shared store; promote to Doppler only if a cross-repo
+# consumer ever needs write access (anonymous read needs no credentials).
+# Regenerate with `openssl rand -hex 12` / `-hex 32` then `sops set`.
+object_storage_root_user: >-
+  {{ lookup('env', 'OBJECT_STORAGE_ROOT_USER')
+     | mandatory('OBJECT_STORAGE_ROOT_USER must be set (openssl rand -hex 12; store in SOPS secrets.enc.yaml)') }}
+object_storage_root_password: >-
+  {{ lookup('env', 'OBJECT_STORAGE_ROOT_PASSWORD')
+     | mandatory('OBJECT_STORAGE_ROOT_PASSWORD must be set (openssl rand -hex 32; store in SOPS secrets.enc.yaml)') }}
 
 # Loopback S3 endpoint for local bucket administration via the aws CLI.
 object_storage_endpoint: "http://127.0.0.1:{{ object_storage_s3_port }}"

--- a/secrets.enc.yaml
+++ b/secrets.enc.yaml
@@ -14,6 +14,8 @@ PLEX_TOKEN: ENC[AES256_GCM,data:KLX08kSX65wwqvwKbFrmm82c++k=,iv:SCZ0t+v6cvLCzjrB
 SEERR_API_KEY: ENC[AES256_GCM,data:JH7jxyveO3+uIoRkKA+niEkOZ0kkltV1l5Lu/WFkqps=,iv:OdOi3siPjrT7CwLo+UynHT+LeCU6diXtnE88Fa5UuD4=,tag:W2qPUA35R0jlJNO78aWe/g==,type:str]
 SPLUNK_PASSWORD: ENC[AES256_GCM,data:OT65lV1uBUbrqC1rzPdrr00hN8Sd4hTM4O9A4kApwpiJOtdMLN6nzYXQ3g==,iv:vq2SghLJFALb1sPVWwmc/Gqmp2KHeyyWMzLsp9+SH7A=,tag:kKFbS0fMpbaclW4Xf0vRJQ==,type:str]
 SPLUNK_HEC_TOKEN: ENC[AES256_GCM,data:rdCcnHZefsdFxQbra/LKvqWlaTSg6pPmJuEKYPVM4a0trDQI,iv:2DRi1/FmfkBEJUghV6MX53zfwgqSIkqCOkzPv4dkVSc=,tag:YvKwxGRiUXQ+Q72HGIYEDA==,type:str]
+OBJECT_STORAGE_ROOT_USER: ENC[AES256_GCM,data:YI2FQGiiYhPW37vs8Cx4YiKmzqJ5o4iJ,iv:Yj4LmIESwtUl80YirpvESVZN7pTyRDArqEOdXnyoZnI=,tag:uRdDOSSfXAeojhdLxgY84w==,type:str]
+OBJECT_STORAGE_ROOT_PASSWORD: ENC[AES256_GCM,data:RAQQC2wyPyug1N5KzSL4BddgM1NXxThOcdN0p6ekRBsYxdbTojPWrR4lB5NoGJgfsA7DOBn3aZhl5heW2yUfeg==,iv:EHKxoS8EdKUEMVFK4o0P6mbNdppN9e5XHbFUuNnd/cQ=,tag:X1gqvIDXNQa5VhvD2gy/Ug==,type:str]
 sops:
     age:
         - enc: |
@@ -25,7 +27,7 @@ sops:
             yB3E157iHA3Qn3eYx7vfSFrviMIZFhWdAsVZ821y/cDXeUfG0yU33g==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
-    lastmodified: "2026-06-10T23:04:48Z"
-    mac: ENC[AES256_GCM,data:+2vILMIG0Ex8gpSu63J75WK/PK3641vb23c3cCGUhvgJt+aCH0V5zgHZqPtWjgPZGVrjjRbiKGmPcAZswk1kvnkMCXazhjK0odp8uBPFWbLaaXB0oWhgxQch8bE6zdq/bHIhnVJiqsegBfcORIpwbMXa+30VFDl+pe/gLEFf7kI=,iv:8i7Q8AS3EeZ3n/L4a6MaF4XoYNn8Mr51gDGyC/5BUHc=,tag:MCypWtQnaT5HqdW8X/DwAQ==,type:str]
+    lastmodified: "2026-06-15T13:52:13Z"
+    mac: ENC[AES256_GCM,data:uutLIBXEdbbvsTfnfnVHHw16b7knicVNL5nRzMDZr/wVBouClght634BxVFOOYRd+HSVTJEEg1frQH3zRvDyDcRynQabUHEmIANeUlCTS2Y7qyDG0j+RClb4YyXe9amMR+pILIwH/bvjYAZsiiY6wiWVEJcotjO0T2oHuQr3UiM=,iv:4aLlEiUSou3dmjgngrFXBFf0vgPjvDZDV074BPu12Pw=,tag:jE2yK2Pa9hL0zHRU8QuJEQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.0


### PR DESCRIPTION
## Why

The merged `object_storage` role (#455) read its root credentials from a pre-seeded **shared-store** env var (Doppler-style `OBJECT_STORAGE_ROOT_*`). That inverts the credential model: a new self-hosted service credential should be **generated randomly at its source — the least-shared tier** — and promoted up-chain to more-shared stores **only as a consumer requires it**.

## What

- **Generate** random root user/password and store them in **SOPS `secrets.enc.yaml`** in *this* repo — the same source tier already used for `openproject`/`infisical`/`servarr` secrets (SOPS-encrypted, safe to commit).
- **Role** now reads them via `| mandatory(...)`, matching the `openproject_docker` pattern, and no longer implies a pre-seeded shared store.
- **Not promoted to Doppler.** The `splunk-addons` bucket is anonymous-read during the soak, so no consumer needs credentials yet. Promotion happens only when a cross-repo **write** consumer (e.g. the `ansible-splunk` `sync-splunkbase` playbook) actually needs it — at which point it widens scope by one tier, not by default.

## Test plan

- `sops -d secrets.enc.yaml` decrypts cleanly with the two new keys present.
- Role defaults parse; `mandatory()` mirrors the established convention; `ansible-lint` runs in CI.