### PR TITLE
feat(cribl): per-index HEC outputs (one index = one token)

### DIFF
--- a/roles/cribl_edge/defaults/main.yml
+++ b/roles/cribl_edge/defaults/main.yml
@@ -55,6 +55,21 @@ cribl_edge_splunk_host: >-
 cribl_edge_hec_url: "https://{{ cribl_edge_splunk_host }}:8088"
 cribl_edge_hec_token: "{{ lookup('env', 'SPLUNK_HEC_TOKEN') }}"
 
+# Per-index HEC tokens (one index = one HEC). When HEC_NAMESPACE (Doppler) is
+# set, each index gets a dedicated output whose token is derived the SAME way
+# ansible-splunk derives it — uuid5('splunk-hec-<index>', HEC_NAMESPACE) — so no
+# token value is ever shared or stored, only the namespace UUID. Empty namespace
+# = every input keeps using the shared cribl_edge_hec_token (legacy) output.
+cribl_edge_hec_namespace: "{{ lookup('env', 'HEC_NAMESPACE') | default('', true) }}"
+# Indexes this Edge writes (syslog families + the netmon-HEC streams). Each gets
+# a splunk_hec_<index> output; senders route to their index's output.
+cribl_edge_per_index_indexes:
+  - unifi
+  - firewall
+  - os
+  - netmon
+  - unifi_metrics
+
 # netmon Telegraf HEC ingestion. The per-WAN probers (roles/netmon) push
 # Splunk-HEC to this Edge on cribl_hec_input_port (group_vars/all.yml); the
 # netmon pipeline stamps index=netmon and reuses the splunk_hec output above.

--- a/roles/cribl_edge/tasks/main.yml
+++ b/roles/cribl_edge/tasks/main.yml
@@ -139,6 +139,19 @@
     mode: "0644"
   notify: Restart cribl edge
 
+# Remove stale routes-table / passthru artifacts. Per-index routing uses direct
+# input→output connections (Cribl 4.8.0-alpha cannot split one input across
+# outputs — both the Output Router and a Routes table dead-end events), so no
+# routes.yml or passthru pipeline is used. Clean up any left by an earlier deploy.
+- name: Remove stale Cribl Edge routes table and passthru pipeline
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ cribl_edge_install_dir }}/local/edge/routes.yml"
+    - "{{ cribl_edge_install_dir }}/local/edge/pipelines/passthru"
+  notify: Restart cribl edge
+
 - name: Deploy Cribl Edge instance settings (API bind)
   ansible.builtin.template:
     src: cribl.yml.j2

--- a/roles/cribl_edge/templates/inputs.yml.j2
+++ b/roles/cribl_edge/templates/inputs.yml.j2
@@ -10,7 +10,7 @@ inputs:
     disabled: false
     sendToRoutes: false
     connections:
-{% if cribl_edge_hec_namespace | length > 0 %}
+{% if (cribl_edge_hec_namespace | default('')) | length > 0 %}
       # One index per HEC: this syslog family maps to a single Splunk index, so
       # send directly to that index's dedicated HEC output (no router needed).
       - output: splunk_hec_{{ cribl_edge_syslog_routing[name].index }}
@@ -39,7 +39,7 @@ inputs:
     splunkHecAPI: /services/collector
     sendToRoutes: false
     connections:
-{% if cribl_edge_hec_namespace | length > 0 %}
+{% if (cribl_edge_hec_namespace | default('')) | length > 0 %}
       # Per-index HEC: this input currently carries ONLY unifi_metrics (the
       # netmon per-WAN probers are not deployed), so it pins directly to the
       # dedicated unifi_metrics HEC output. The netmon pipeline still stamps the

--- a/roles/cribl_edge/templates/inputs.yml.j2
+++ b/roles/cribl_edge/templates/inputs.yml.j2
@@ -10,8 +10,15 @@ inputs:
     disabled: false
     sendToRoutes: false
     connections:
+{% if cribl_edge_hec_namespace | length > 0 %}
+      # One index per HEC: this syslog family maps to a single Splunk index, so
+      # send directly to that index's dedicated HEC output (no router needed).
+      - output: splunk_hec_{{ cribl_edge_syslog_routing[name].index }}
+        pipeline: syslog
+{% else %}
       - output: splunk_hec
         pipeline: syslog
+{% endif %}
     host: "0.0.0.0"
     tcpPort: {{ port }}
     udpPort: {{ port }}
@@ -32,8 +39,21 @@ inputs:
     splunkHecAPI: /services/collector
     sendToRoutes: false
     connections:
+{% if cribl_edge_hec_namespace | length > 0 %}
+      # Per-index HEC: this input currently carries ONLY unifi_metrics (the
+      # netmon per-WAN probers are not deployed), so it pins directly to the
+      # dedicated unifi_metrics HEC output. The netmon pipeline still stamps the
+      # index. NOTE: if/when the netmon probers are deployed, they push to this
+      # same HEC port and would land on the unifi_metrics token — at that point
+      # give the probers a DEDICATED Cribl HEC input (separate port) → its own
+      # splunk_hec_netmon output. Cribl 4.8.0-alpha cannot split one input across
+      # outputs (both the Output Router and a Routes table dead-end events here).
+      - output: splunk_hec_unifi_metrics
+        pipeline: netmon
+{% else %}
       - output: splunk_hec
         pipeline: netmon
+{% endif %}
     pqEnabled: true
     tls:
       disabled: true

--- a/roles/cribl_edge/templates/outputs.yml.j2
+++ b/roles/cribl_edge/templates/outputs.yml.j2
@@ -25,3 +25,31 @@ outputs:
     useRoundRobinDns: false
     failedRequestLoggingMode: payload
     safeHeaders: []
+{% if cribl_edge_hec_namespace | length > 0 %}
+{% for idx in cribl_edge_per_index_indexes %}
+  # Dedicated HEC output for index '{{ idx }}'. Token derived from HEC_NAMESPACE
+  # (uuid5('splunk-hec-{{ idx }}', namespace)) — identical to the Splunk-side token.
+  splunk_hec_{{ idx }}:
+    id: splunk_hec_{{ idx }}
+    type: splunk_hec
+    disabled: false
+    url: "{{ cribl_edge_hec_url }}/services/collector/event"
+    token: "{{ ('splunk-hec-' ~ idx) | to_uuid(cribl_edge_hec_namespace) }}"
+    compress: true
+    rejectUnauthorized: false
+    onBackpressure: block
+    pqEnabled: true
+    pqPath: "$CRIBL_HOME/state/queues"
+    pqMaxFileSize: "1 GB"
+    pqMaxSize: "10 GB"
+    pqCompress: none
+    concurrency: 5
+    maxPayloadSizeKB: 4096
+    maxPayloadEvents: 0
+    timeoutSec: 30
+    flushPeriodSec: 1
+    useRoundRobinDns: false
+    failedRequestLoggingMode: payload
+    safeHeaders: []
+{% endfor %}
+{% endif %}

--- a/roles/cribl_edge/templates/outputs.yml.j2
+++ b/roles/cribl_edge/templates/outputs.yml.j2
@@ -25,7 +25,7 @@ outputs:
     useRoundRobinDns: false
     failedRequestLoggingMode: payload
     safeHeaders: []
-{% if cribl_edge_hec_namespace | length > 0 %}
+{% if (cribl_edge_hec_namespace | default('')) | length > 0 %}
 {% for idx in cribl_edge_per_index_indexes %}
   # Dedicated HEC output for index '{{ idx }}'. Token derived from HEC_NAMESPACE
   # (uuid5('splunk-hec-{{ idx }}', namespace)) — identical to the Splunk-side token.

--- a/roles/cribl_stream/defaults/main.yml
+++ b/roles/cribl_stream/defaults/main.yml
@@ -42,6 +42,15 @@ cribl_stream_splunk_host: >-
 cribl_stream_splunk_hec_port: >-
   {{ hostvars['localhost']['tofu_data']['constants']['service_ports']['splunk_hec'] }}
 cribl_stream_splunk_hec_token: "{{ lookup('env', 'SPLUNK_HEC_TOKEN') }}"
+# Per-index HEC (one index = one token). When HEC_NAMESPACE (Doppler) is set,
+# single-index inputs send to a dedicated splunk_hec_<index> output whose token
+# is derived as uuid5('splunk-hec-<index>', HEC_NAMESPACE) — identical to the
+# Splunk side. Only netflow (in_ipfix) is single-index; the S2S input
+# (in_cribl_s2s) fans one TCP stream into many indexes by datatype and stays on
+# the shared legacy output (Cribl 4.8.0-alpha can't split one input by index).
+cribl_stream_hec_namespace: "{{ lookup('env', 'HEC_NAMESPACE') | default('', true) }}"
+cribl_stream_per_index_indexes:
+  - netflow
 cribl_stream_splunk_hec_tls: true
 cribl_stream_splunk_hec_tls_verify: false  # Self-signed cert in lab
 # Single definition shared by the template and the drift check in tasks.

--- a/roles/cribl_stream/templates/inputs.yml.j2
+++ b/roles/cribl_stream/templates/inputs.yml.j2
@@ -11,7 +11,7 @@ inputs:
     port: {{ cribl_stream_netflow_port }}
     sendToRoutes: false
     connections:
-{% if cribl_stream_hec_namespace | length > 0 %}
+{% if (cribl_stream_hec_namespace | default('')) | length > 0 %}
       # One index per HEC: IPFIX is single-index (netflow) -> dedicated output.
       - output: splunk_hec_netflow
         pipeline: ipfix

--- a/roles/cribl_stream/templates/inputs.yml.j2
+++ b/roles/cribl_stream/templates/inputs.yml.j2
@@ -11,8 +11,14 @@ inputs:
     port: {{ cribl_stream_netflow_port }}
     sendToRoutes: false
     connections:
+{% if cribl_stream_hec_namespace | length > 0 %}
+      # One index per HEC: IPFIX is single-index (netflow) -> dedicated output.
+      - output: splunk_hec_netflow
+        pipeline: ipfix
+{% else %}
       - output: splunk_hec
         pipeline: ipfix
+{% endif %}
     pqEnabled: {{ cribl_stream_pq_enabled | lower }}
   tcpjson:in_cribl_s2s:
     id: in_cribl_s2s

--- a/roles/cribl_stream/templates/outputs.yml.j2
+++ b/roles/cribl_stream/templates/outputs.yml.j2
@@ -25,3 +25,31 @@ outputs:
     pqMaxFileSize: "1 GB"
     pqMaxSize: "10 GB"
     pqCompress: none
+{% if cribl_stream_hec_namespace | length > 0 %}
+{% for idx in cribl_stream_per_index_indexes %}
+  # Dedicated HEC output for index '{{ idx }}'. Token = uuid5('splunk-hec-{{ idx }}',
+  # HEC_NAMESPACE) — identical to the Splunk-side per-index token.
+  splunk_hec_{{ idx }}:
+    id: splunk_hec_{{ idx }}
+    type: splunk_hec
+    disabled: false
+    url: "{{ cribl_stream_splunk_hec_url }}"
+    token: "{{ ('splunk-hec-' ~ idx) | to_uuid(cribl_stream_hec_namespace) }}"
+    concurrency: 5
+    maxPayloadSizeKB: 4096
+    maxPayloadEvents: 0
+    compress: true
+    rejectUnauthorized: {{ cribl_stream_splunk_hec_tls_verify | lower }}
+    timeoutSec: 30
+    flushPeriodSec: 1
+    useRoundRobinDns: false
+    failedRequestLoggingMode: payload
+    safeHeaders: []
+    onBackpressure: block
+    pqEnabled: {{ cribl_stream_pq_enabled | lower }}
+    pqPath: "$CRIBL_HOME/state/queues"
+    pqMaxFileSize: "1 GB"
+    pqMaxSize: "10 GB"
+    pqCompress: none
+{% endfor %}
+{% endif %}

--- a/roles/cribl_stream/templates/outputs.yml.j2
+++ b/roles/cribl_stream/templates/outputs.yml.j2
@@ -25,7 +25,7 @@ outputs:
     pqMaxFileSize: "1 GB"
     pqMaxSize: "10 GB"
     pqCompress: none
-{% if cribl_stream_hec_namespace | length > 0 %}
+{% if (cribl_stream_hec_namespace | default('')) | length > 0 %}
 {% for idx in cribl_stream_per_index_indexes %}
   # Dedicated HEC output for index '{{ idx }}'. Token = uuid5('splunk-hec-{{ idx }}',
   # HEC_NAMESPACE) — identical to the Splunk-side per-index token.


### PR DESCRIPTION
## Summary

Makes Cribl send each Splunk index via its **own** dedicated HEC token ("one index = one HEC"). When `HEC_NAMESPACE` (Doppler) is set, each index gets a `splunk_hec_<index>` output whose token is derived `uuid5('splunk-hec-<index>', HEC_NAMESPACE)` — identical to what ansible-splunk derives, so no token value is ever shared or stored, only the namespace UUID.

**Single-index inputs pin directly to their index's output** (the proven `connections` mechanism):
- `cribl_edge`: `in_syslog_<port>` → `splunk_hec_{unifi,firewall,os}`; `in_netmon_hec` → `splunk_hec_unifi_metrics` (it currently carries only unifi_metrics — the netmon probers are undeployed).
- `cribl_stream`: `in_ipfix` → `splunk_hec_netflow`.

Empty namespace keeps everything on the shared legacy `splunk_hec` output (no behavior change).

## Cribl 4.8.0-alpha limitation (important)

This build **cannot split one input across multiple outputs**. Both approaches were tried **live** and fail:
- **Output Router** (`type: output_router`) — accepted, but jams the input (events back up, sender times out).
- **Routes table** (`sendToRoutes: true`) — accepted, but dead-ends events (they enter but never reach an output).

So multi-index inputs stay on the legacy token:
- `cribl_stream` `in_cribl_s2s` fans one S2S stream into many indexes (claude/gemini/copilot/os by datatype) → remains on legacy. **Legacy token cannot be retired** until this is resolved (newer Cribl, or per-datatype dedicated inputs).
- If the netmon per-WAN probers are deployed, they need a **dedicated Cribl HEC input** (separate port) → `splunk_hec_netmon` (documented inline in `inputs.yml.j2`).

## Verified live

unifi syslog and unifi_metrics flow via their **dedicated** tokens (direct connection = no catch-all, definitive); S2S dev telemetry (claude/gemini) unaffected on legacy; ansible-lint clean (production profile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)