### PR TITLE
ci: adopt the shared _ansible-ci.yml gate (lint centralized)

### DIFF
--- a/.github/workflows/_data-contract.yml
+++ b/.github/workflows/_data-contract.yml
@@ -1,5 +1,13 @@
 ---
-name: Ansible Lint
+# Repo-specific data-contract checks for ansible-proxmox-apps.
+#
+# ansible-lint is centralized in dryvist/.github/_ansible-ci.yml. The jobs here
+# assert THIS repo's data contract — playbook syntax, the tofu inventory schema,
+# and that the inventory loads with correct group assignments. They are not
+# generic ansible CI, so they stay local and are aggregated by the wrapper's
+# "Merge Gate".
+
+name: Data Contract
 
 on:
   workflow_call:
@@ -8,32 +16,6 @@ permissions:
   contents: read
 
 jobs:
-  lint:
-    name: Ansible Lint
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.14'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install ansible-lint ansible
-
-      - name: Install Ansible collections
-        run: |
-          ansible-galaxy collection install -r requirements.yml
-
-      - name: Run ansible-lint
-        run: |
-          ansible-lint
-
   syntax-check:
     name: Syntax Check
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -1,32 +1,24 @@
 ---
-# CI Gate - Conditional Required Checks
+# CI Gate — wrapper around the shared ansible CI gate.
 #
-# FRAMEWORK: Merge Gatekeeper Pattern
-# ====================================
-# Solves: "Required checks that only run when relevant files change"
+# ansible-lint and the standardized change filter live in
+# dryvist/.github/.github/workflows/_ansible-ci.yml so lint runs identically
+# across ansible-proxmox, ansible-splunk and this repo.
 #
-# Problem: GitHub branch protection only supports "always required" or "not required"
-#          Path-filtered workflows that don't run = pending forever = blocks merge
-#
-# Solution: Single workflow that:
-# 1. Always triggers on ALL PRs (no path filters at workflow level)
-# 2. Detects which file categories changed
-# 3. Calls reusable workflows conditionally (skipped = success)
-# 4. Final "Merge Gate" job aggregates all results
-#
-# Branch Protection: Set ONLY "Merge Gate" as required check
-#
-# Adding New Checks:
-# 1. Create reusable workflow: _your-check.yml with `on: workflow_call`
-# 2. Add filter pattern under `changes.steps.filter.with.filters`
-# 3. Add job that calls the reusable workflow with appropriate `if:` condition
-# 4. Add job name to `gate.needs` array and `allowed-skips`
+# Molecule stays LOCAL here: this repo's molecule job has a deliberate
+# least-privilege Doppler handling (it maps only the three secrets the scenarios
+# consume into the test step, never inject-env-vars) plus a wide scenario matrix
+# and a template-render job. Routing it through the shared molecule (which uses
+# inject-env-vars) would regress that. So the shared workflow runs lint only
+# (molecule:false) and this wrapper keeps _molecule.yml, _data-contract.yml, and
+# the self-hosted _e2e-tests.yml local, aggregating everything in its own
+# required "Merge Gate". All local jobs gate on the shared workflow's exported
+# filter outputs — one change-detection definition.
 #
 # E2E Runner Guard:
-# E2E tests require self-hosted runners. To prevent jobs from hanging
-# indefinitely when no runner is available, the e2e job checks the
-# repository variable `E2E_RUNNERS_ENABLED`. Set to 'true' after
-# deploying runners: `gh variable set E2E_RUNNERS_ENABLED --body true`
+# E2E tests require self-hosted runners. The e2e job checks the repository
+# variable `E2E_RUNNERS_ENABLED`; set to 'true' after deploying runners:
+# `gh variable set E2E_RUNNERS_ENABLED --body true`.
 
 name: CI Gate
 
@@ -43,84 +35,47 @@ permissions:
   pull-requests: read
 
 jobs:
-  # ==========================================================================
-  # CHANGE DETECTION
-  # ==========================================================================
-  changes:
-    name: Detect Changes
-    runs-on: ubuntu-latest
+  ci:
     permissions:
       contents: read
       pull-requests: read
-    outputs:
-      ansible: ${{ steps.filter.outputs.ansible }}
-      molecule: ${{ steps.filter.outputs.molecule }}
-      e2e: ${{ steps.filter.outputs.e2e }}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
-        id: filter
-        with:
-          filters: |
-            ansible:
-              - 'playbooks/**/*.yml'
-              - 'playbooks/**/*.yaml'
-              - 'roles/**/*.yml'
-              - 'roles/**/*.yaml'
-              - 'roles/**/*.j2'
-              - 'inventory/**'
-              - 'tests/**'
-              - '.ansible-lint'
-              - 'requirements.yml'
-            molecule:
-              - 'molecule/**'
-              - 'roles/**/*.yml'
-              - 'roles/**/*.yaml'
-              - 'roles/**/*.j2'
-            e2e:
-              - 'playbooks/**'
-              - 'roles/**'
-              - 'inventory/**'
-              - 'tests/**'
-              - 'scripts/**'
-              - '.github/workflows/_e2e-tests.yml'
-              - '.github/workflows/e2e-pipeline-schedule.yml'
+    uses: dryvist/.github/.github/workflows/_ansible-ci.yml@main
+    with:
+      # Molecule is owned locally (see header); the shared workflow runs lint only.
+      molecule: false
+      emit_gate: false
 
-  # ==========================================================================
-  # CONDITIONAL CHECKS (call reusable workflows)
-  # ==========================================================================
-  ansible-lint:
-    name: Ansible Lint
-    needs: changes
-    if: needs.changes.outputs.ansible == 'true'
-    uses: ./.github/workflows/_ansible-lint.yml
+  data-contract:
+    name: Data Contract
+    needs: ci
+    if: ${{ needs.ci.outputs.ansible == 'true' }}
+    uses: ./.github/workflows/_data-contract.yml
 
   molecule:
     name: Molecule
-    needs: changes
-    if: needs.changes.outputs.molecule == 'true'
+    needs: ci
+    if: ${{ needs.ci.outputs.molecule == 'true' }}
     uses: ./.github/workflows/_molecule.yml
     secrets: inherit
 
   e2e:
     name: E2E Tests
-    needs: changes
+    needs: ci
+    # Self-hosted; the shared `ansible` filter covers the meaningful inputs.
+    # (PR e2e also runs on its own schedule / workflow_dispatch.)
     if: >-
-      needs.changes.outputs.e2e == 'true' &&
+      needs.ci.outputs.ansible == 'true' &&
       vars.E2E_RUNNERS_ENABLED == 'true'
     uses: ./.github/workflows/_e2e-tests.yml
 
-  # ==========================================================================
-  # MERGE GATE - The ONLY required check in branch protection
-  # ==========================================================================
   gate:
     name: Merge Gate
-    needs: [changes, ansible-lint, molecule, e2e]
-    if: ${{ !cancelled() }}
+    needs: [ci, data-contract, molecule, e2e]
+    if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Check all results
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
-          allowed-skips: ansible-lint, molecule, e2e
+          allowed-skips: data-contract, molecule, e2e
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Route ansible-lint + the standardized change filter through the centralized
dryvist/.github/_ansible-ci.yml so lint runs identically across all three
ansible repos.

- ci-gate.yml calls the shared workflow (molecule:false, emit_gate:false) and
  keeps a thin local Merge Gate aggregating the shared result plus the local
  data-contract, molecule, and self-hosted e2e jobs.
- _ansible-lint.yml -> _data-contract.yml: drop the now-centralized lint job;
  keep the repo-specific syntax-check, inventory-schema, inventory-load checks.
- molecule stays local: it has deliberate least-privilege Doppler handling
  (maps only the 3 consumed secrets, never inject-env-vars) + a wide scenario
  matrix; the shared molecule uses inject-env-vars, which would regress that.

Local jobs gate on the shared workflow's exported `ansible`/`molecule` filter
outputs, so there is one change-detection definition. Supersedes the prior
.j2-filter point-fix (the .j2 path now lives in the shared filter).
