### PR TITLE
fix(prometheus): remote_write URL path + Splunk host from instance

### DIFF
--- a/inventory/group_vars/prometheus_group.yml
+++ b/inventory/group_vars/prometheus_group.yml
@@ -23,4 +23,4 @@ prometheus_stack_extra_scrape_configs: |
 # Points at cribl-stream-01 directly (no HAProxy — WAL provides delivery durability).
 prometheus_stack_remote_write_url: >-
   http://{{ hostvars['localhost']['tofu_data']['containers']['cribl-stream-01']['ip']
-  }}:9201/
+  }}:9201/api/v1/write

--- a/roles/cribl_stream/templates/pipelines/prometheus_to_netmon/conf.yml.j2
+++ b/roles/cribl_stream/templates/pipelines/prometheus_to_netmon/conf.yml.j2
@@ -21,4 +21,4 @@ functions:
         - name: sourcetype
           value: "'prometheus:metrics'"
         - name: host
-          value: "instance || job || 'prometheus'"
+          value: "target || instance || job || 'prometheus'"

--- a/roles/cribl_stream/templates/pipelines/prometheus_to_netmon/conf.yml.j2
+++ b/roles/cribl_stream/templates/pipelines/prometheus_to_netmon/conf.yml.j2
@@ -21,4 +21,4 @@ functions:
         - name: sourcetype
           value: "'prometheus:metrics'"
         - name: host
-          value: "job || 'prometheus'"
+          value: "instance || job || 'prometheus'"


### PR DESCRIPTION
## Summary

Follow-up to #469 (merged before this commit landed):

- Append `/api/v1/write` to the Cribl `prometheus_rw` endpoint URL — the root `/` path returns 404 (caught in code review)
- Use `instance || job || 'prometheus'` for Splunk `host` field so target IPs surface directly in search rather than the job name

## Test plan

- [ ] CI passes
- [ ] Deploy: `ansible-playbook playbooks/site.yml --tags cribl_stream,prometheus,monitoring`
- [ ] Verify `index=netmon sourcetype="prometheus:metrics"` events appear in Splunk with `host` = target IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)