### PR TITLE
chore(secrets): add Infisical bootstrap secrets to SOPS

### DIFF
--- a/secrets.enc.yaml
+++ b/secrets.enc.yaml
@@ -16,8 +16,8 @@ SPLUNK_PASSWORD: ENC[AES256_GCM,data:OT65lV1uBUbrqC1rzPdrr00hN8Sd4hTM4O9A4kApwpi
 SPLUNK_HEC_TOKEN: ENC[AES256_GCM,data:rdCcnHZefsdFxQbra/LKvqWlaTSg6pPmJuEKYPVM4a0trDQI,iv:2DRi1/FmfkBEJUghV6MX53zfwgqSIkqCOkzPv4dkVSc=,tag:YvKwxGRiUXQ+Q72HGIYEDA==,type:str]
 OBJECT_STORAGE_ROOT_USER: ENC[AES256_GCM,data:YI2FQGiiYhPW37vs8Cx4YiKmzqJ5o4iJ,iv:Yj4LmIESwtUl80YirpvESVZN7pTyRDArqEOdXnyoZnI=,tag:uRdDOSSfXAeojhdLxgY84w==,type:str]
 OBJECT_STORAGE_ROOT_PASSWORD: ENC[AES256_GCM,data:RAQQC2wyPyug1N5KzSL4BddgM1NXxThOcdN0p6ekRBsYxdbTojPWrR4lB5NoGJgfsA7DOBn3aZhl5heW2yUfeg==,iv:EHKxoS8EdKUEMVFK4o0P6mbNdppN9e5XHbFUuNnd/cQ=,tag:X1gqvIDXNQa5VhvD2gy/Ug==,type:str]
-INFISICAL_ENCRYPTION_KEY: ENC[AES256_GCM,data:TuiNCwLHmqI2r7TLK43mjkjvwzwpTeYfh9N9aa4jHE93O/0TrRG3gHffjWQ=,iv:resoRYniIrk+lFc6+lPiW7yJvhXa8Lhf3KcU3qavPWA=,tag:igfINqpfeUj9Rmp1Fs0Row==,type:str]
-INFISICAL_AUTH_SECRET: ENC[AES256_GCM,data:hde97WBokpCVOtkZoe5mljkOAut/dsD0YyTaEkS6MOtT9dkqq1TDnyJG1jo=,iv:/rKfGE9Z0sTOLSJTdktXaaKl1moV4fKuRWkWvPtyNhY=,tag:SedxT4qBxjgMb2m6YgorAw==,type:str]
+INFISICAL_ENCRYPTION_KEY: ENC[AES256_GCM,data:OPmI13wioBw1m8jrVEI0rQfqk83HNipAzhF7pte2WnZ4sNyyXrpGvNNHOce5OVCtuomoVRHIaZfs8DjzA6zpWw==,iv:Aa2BKo9UgOYRwuY1gndLZdME50ZnEh8TMvxn/l03rD0=,tag:eipRIyP+Ixx1cWZRmTUgaQ==,type:str]
+INFISICAL_AUTH_SECRET: ENC[AES256_GCM,data:A5N8jnHJ68t2TNPIrx5nnY7k6XTQmgWCgUPlc4T0tKHUH26pouyNW5nOpp74MASMM4xhtIkpue31q5tpRdgjhw==,iv:LrOSrr7DwKInWs3FolXOwVJyfWgfn44ldBScjVKSvTw=,tag:vjNMqPGHGh4fVbeShJH5CQ==,type:str]
 INFISICAL_DB_PASSWORD: ENC[AES256_GCM,data:+r9Fk3XZqfdRk/3dYpITy8i/kHS8QIr0p0bSUDCJWN0=,iv:5YjX6dbuc0FIT5oEn69fHb5xyrF59lTWPy7cXW8A9SY=,tag:ufRvPLMxwmxUB1uHoCdp7Q==,type:str]
 sops:
     age:
@@ -30,7 +30,7 @@ sops:
             yB3E157iHA3Qn3eYx7vfSFrviMIZFhWdAsVZ821y/cDXeUfG0yU33g==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
-    lastmodified: "2026-06-16T01:26:50Z"
-    mac: ENC[AES256_GCM,data:T6Q8s74d1veB6A7qjrLIRgFt9PX1FQpkP++kzvQ+CcfEpBWHz2dSm9zo1jvxspKOxkTcth3yOPYKlOxufPmkf8Xb6SD4KGtJEQRpPBlgZOfTxGecdngwBComZUUsaT33LLhXA++6ktFH/P8WBH+LB/PsSRahpvN8HQlFBXbSsnU=,iv:pSUgfXmu4H9KNJEgH1xhjgMFEM0fFhld9gIswcQp6OQ=,tag:w9EuCt/BnQYnFR8j+eTDJg==,type:str]
+    lastmodified: "2026-06-16T15:31:32Z"
+    mac: ENC[AES256_GCM,data:xHbLfUaj4wGEpr4ZSd1JJ0zowC6SJyjwyWAUFkuty5pWqutUnCYHyVLCSKOV8XQDF2Eg0LcHflISdLuN6WKN7FAxIYDiRNRRH8QVIZJ7GqvdDXd33qXUBR641G2354juNhMTT2b/mYlRtZBHkaymxYRxiZdKV4T9LbC1Nn/sPfM=,iv:zE7tTc6A4B97FHIc9LpS39BBXvnC80xkVSHkH0c0640=,tag:cUPLjMAcefB6244uHKT0Tg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.0

--- a/secrets.enc.yaml
+++ b/secrets.enc.yaml
@@ -16,6 +16,9 @@ SPLUNK_PASSWORD: ENC[AES256_GCM,data:OT65lV1uBUbrqC1rzPdrr00hN8Sd4hTM4O9A4kApwpi
 SPLUNK_HEC_TOKEN: ENC[AES256_GCM,data:rdCcnHZefsdFxQbra/LKvqWlaTSg6pPmJuEKYPVM4a0trDQI,iv:2DRi1/FmfkBEJUghV6MX53zfwgqSIkqCOkzPv4dkVSc=,tag:YvKwxGRiUXQ+Q72HGIYEDA==,type:str]
 OBJECT_STORAGE_ROOT_USER: ENC[AES256_GCM,data:YI2FQGiiYhPW37vs8Cx4YiKmzqJ5o4iJ,iv:Yj4LmIESwtUl80YirpvESVZN7pTyRDArqEOdXnyoZnI=,tag:uRdDOSSfXAeojhdLxgY84w==,type:str]
 OBJECT_STORAGE_ROOT_PASSWORD: ENC[AES256_GCM,data:RAQQC2wyPyug1N5KzSL4BddgM1NXxThOcdN0p6ekRBsYxdbTojPWrR4lB5NoGJgfsA7DOBn3aZhl5heW2yUfeg==,iv:EHKxoS8EdKUEMVFK4o0P6mbNdppN9e5XHbFUuNnd/cQ=,tag:X1gqvIDXNQa5VhvD2gy/Ug==,type:str]
+INFISICAL_ENCRYPTION_KEY: ENC[AES256_GCM,data:TuiNCwLHmqI2r7TLK43mjkjvwzwpTeYfh9N9aa4jHE93O/0TrRG3gHffjWQ=,iv:resoRYniIrk+lFc6+lPiW7yJvhXa8Lhf3KcU3qavPWA=,tag:igfINqpfeUj9Rmp1Fs0Row==,type:str]
+INFISICAL_AUTH_SECRET: ENC[AES256_GCM,data:hde97WBokpCVOtkZoe5mljkOAut/dsD0YyTaEkS6MOtT9dkqq1TDnyJG1jo=,iv:/rKfGE9Z0sTOLSJTdktXaaKl1moV4fKuRWkWvPtyNhY=,tag:SedxT4qBxjgMb2m6YgorAw==,type:str]
+INFISICAL_DB_PASSWORD: ENC[AES256_GCM,data:+r9Fk3XZqfdRk/3dYpITy8i/kHS8QIr0p0bSUDCJWN0=,iv:5YjX6dbuc0FIT5oEn69fHb5xyrF59lTWPy7cXW8A9SY=,tag:ufRvPLMxwmxUB1uHoCdp7Q==,type:str]
 sops:
     age:
         - enc: |
@@ -27,7 +30,7 @@ sops:
             yB3E157iHA3Qn3eYx7vfSFrviMIZFhWdAsVZ821y/cDXeUfG0yU33g==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
-    lastmodified: "2026-06-15T13:52:13Z"
-    mac: ENC[AES256_GCM,data:uutLIBXEdbbvsTfnfnVHHw16b7knicVNL5nRzMDZr/wVBouClght634BxVFOOYRd+HSVTJEEg1frQH3zRvDyDcRynQabUHEmIANeUlCTS2Y7qyDG0j+RClb4YyXe9amMR+pILIwH/bvjYAZsiiY6wiWVEJcotjO0T2oHuQr3UiM=,iv:4aLlEiUSou3dmjgngrFXBFf0vgPjvDZDV074BPu12Pw=,tag:jE2yK2Pa9hL0zHRU8QuJEQ==,type:str]
+    lastmodified: "2026-06-16T01:26:50Z"
+    mac: ENC[AES256_GCM,data:T6Q8s74d1veB6A7qjrLIRgFt9PX1FQpkP++kzvQ+CcfEpBWHz2dSm9zo1jvxspKOxkTcth3yOPYKlOxufPmkf8Xb6SD4KGtJEQRpPBlgZOfTxGecdngwBComZUUsaT33LLhXA++6ktFH/P8WBH+LB/PsSRahpvN8HQlFBXbSsnU=,iv:pSUgfXmu4H9KNJEgH1xhjgMFEM0fFhld9gIswcQp6OQ=,tag:w9EuCt/BnQYnFR8j+eTDJg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.0


### PR DESCRIPTION
## Summary

- Generate and store 3 bootstrap secrets for the `infisical_docker` role: `INFISICAL_ENCRYPTION_KEY`, `INFISICAL_AUTH_SECRET`, `INFISICAL_DB_PASSWORD`
- These are required by `roles/infisical_docker/defaults/main.yml` via `lookup('env', ...) | mandatory(...)`
- All values are SOPS-encrypted in `secrets.enc.yaml`; no plaintext secrets committed

## Test plan

- [ ] CI passes (no role code changed, just the encrypted secrets file)
- [ ] `sops -d secrets.enc.yaml | grep INFISICAL` shows 3 keys present on the converge host

🤖 Generated with [Claude Code](https://claude.com/claude-code)