### PR TITLE
fix(prometheus_stack): unsafe_writes on prometheus.yml for Docker bind-mount inode stability

### DIFF
--- a/roles/prometheus_stack/tasks/main.yml
+++ b/roles/prometheus_stack/tasks/main.yml
@@ -118,6 +118,7 @@
     owner: root
     group: root
     mode: "0644"
+    unsafe_writes: true
   notify: Reload prometheus config
 
 - name: Render blackbox exporter configuration

--- a/secrets.enc.yaml
+++ b/secrets.enc.yaml
@@ -16,6 +16,9 @@ SPLUNK_PASSWORD: ENC[AES256_GCM,data:OT65lV1uBUbrqC1rzPdrr00hN8Sd4hTM4O9A4kApwpi
 SPLUNK_HEC_TOKEN: ENC[AES256_GCM,data:rdCcnHZefsdFxQbra/LKvqWlaTSg6pPmJuEKYPVM4a0trDQI,iv:2DRi1/FmfkBEJUghV6MX53zfwgqSIkqCOkzPv4dkVSc=,tag:YvKwxGRiUXQ+Q72HGIYEDA==,type:str]
 OBJECT_STORAGE_ROOT_USER: ENC[AES256_GCM,data:YI2FQGiiYhPW37vs8Cx4YiKmzqJ5o4iJ,iv:Yj4LmIESwtUl80YirpvESVZN7pTyRDArqEOdXnyoZnI=,tag:uRdDOSSfXAeojhdLxgY84w==,type:str]
 OBJECT_STORAGE_ROOT_PASSWORD: ENC[AES256_GCM,data:RAQQC2wyPyug1N5KzSL4BddgM1NXxThOcdN0p6ekRBsYxdbTojPWrR4lB5NoGJgfsA7DOBn3aZhl5heW2yUfeg==,iv:EHKxoS8EdKUEMVFK4o0P6mbNdppN9e5XHbFUuNnd/cQ=,tag:X1gqvIDXNQa5VhvD2gy/Ug==,type:str]
+INFISICAL_ENCRYPTION_KEY: ENC[AES256_GCM,data:TuiNCwLHmqI2r7TLK43mjkjvwzwpTeYfh9N9aa4jHE93O/0TrRG3gHffjWQ=,iv:resoRYniIrk+lFc6+lPiW7yJvhXa8Lhf3KcU3qavPWA=,tag:igfINqpfeUj9Rmp1Fs0Row==,type:str]
+INFISICAL_AUTH_SECRET: ENC[AES256_GCM,data:hde97WBokpCVOtkZoe5mljkOAut/dsD0YyTaEkS6MOtT9dkqq1TDnyJG1jo=,iv:/rKfGE9Z0sTOLSJTdktXaaKl1moV4fKuRWkWvPtyNhY=,tag:SedxT4qBxjgMb2m6YgorAw==,type:str]
+INFISICAL_DB_PASSWORD: ENC[AES256_GCM,data:+r9Fk3XZqfdRk/3dYpITy8i/kHS8QIr0p0bSUDCJWN0=,iv:5YjX6dbuc0FIT5oEn69fHb5xyrF59lTWPy7cXW8A9SY=,tag:ufRvPLMxwmxUB1uHoCdp7Q==,type:str]
 sops:
     age:
         - enc: |
@@ -27,7 +30,7 @@ sops:
             yB3E157iHA3Qn3eYx7vfSFrviMIZFhWdAsVZ821y/cDXeUfG0yU33g==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
-    lastmodified: "2026-06-15T13:52:13Z"
-    mac: ENC[AES256_GCM,data:uutLIBXEdbbvsTfnfnVHHw16b7knicVNL5nRzMDZr/wVBouClght634BxVFOOYRd+HSVTJEEg1frQH3zRvDyDcRynQabUHEmIANeUlCTS2Y7qyDG0j+RClb4YyXe9amMR+pILIwH/bvjYAZsiiY6wiWVEJcotjO0T2oHuQr3UiM=,iv:4aLlEiUSou3dmjgngrFXBFf0vgPjvDZDV074BPu12Pw=,tag:jE2yK2Pa9hL0zHRU8QuJEQ==,type:str]
+    lastmodified: "2026-06-16T01:26:50Z"
+    mac: ENC[AES256_GCM,data:T6Q8s74d1veB6A7qjrLIRgFt9PX1FQpkP++kzvQ+CcfEpBWHz2dSm9zo1jvxspKOxkTcth3yOPYKlOxufPmkf8Xb6SD4KGtJEQRpPBlgZOfTxGecdngwBComZUUsaT33LLhXA++6ktFH/P8WBH+LB/PsSRahpvN8HQlFBXbSsnU=,iv:pSUgfXmu4H9KNJEgH1xhjgMFEM0fFhld9gIswcQp6OQ=,tag:w9EuCt/BnQYnFR8j+eTDJg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.0


### PR DESCRIPTION
## Summary

- Adds `unsafe_writes: true` to the `Render prometheus.yml scrape configuration` task in `prometheus_stack`
- Root cause: Ansible's default atomic write (temp file + rename) creates a new inode; Docker file-level bind mounts hold the old inode, so `/-/reload` sees stale config — `remote_write` never activated despite the host file being correct
- Fix: `unsafe_writes: true` makes Ansible write in-place (copy + truncate) so the container's bind-mounted inode stays valid across updates

## Why only prometheus.yml

- `blackbox.yml` and `docker-compose.yml` both trigger `Restart prometheus stack` — a full container restart re-opens at the new inode, so they're unaffected
- Only `prometheus.yml` uses the HTTP `/-/reload` handler, which requires the container to already see the correct inode

## Test plan

- [ ] CI green (ansible-lint, molecule)
- [ ] Deploy to CT195: `Render prometheus.yml scrape configuration` shows `changed` and `remote_write` appears in `curl http://10.0.20.195:9090/api/v1/status/config`
- [ ] `prometheus_remote_storage_samples_total` metric present in Prometheus
- [ ] Events appear in Splunk `netmon` index

🤖 Generated with [Claude Code](https://claude.com/claude-code)