### PR TITLE
feat(homeassistant,phpipam): add Docker-in-LXC roles

### DIFF
--- a/inventory/load_tofu.yml
+++ b/inventory/load_tofu.yml
@@ -383,6 +383,16 @@
               else []
             ) +
             (
+              ['homeassistant_group']
+              if 'homeassistant' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
+              ['phpipam_group']
+              if 'ipam' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
               ['traefik_group']
               if 'traefik' in (item.value.tags | default([]))
               else []

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -757,6 +757,39 @@
     - role: immich
 
 # =============================================================================
+# Phase 8e: Home Assistant (Docker-in-LXC)
+# Vendor Docker image only; host-network mode for mDNS/Zeroconf device
+# discovery. Reachable at homeassistant_web port; DNS A record is auto-created
+# by technitium_dns from hostname + container_ip.
+# =============================================================================
+
+- name: Configure Home Assistant
+  hosts: homeassistant_group
+  become: true
+  gather_facts: false
+  tags:
+    - homeassistant
+    - automation
+  roles:
+    - role: homeassistant
+
+# =============================================================================
+# Phase 8f: phpIPAM (Docker-in-LXC)
+# IP address management — phpipam-www + phpipam-cron + MariaDB via Compose.
+# Secrets (db password, root password) in SOPS secrets.enc.yaml.
+# =============================================================================
+
+- name: Configure phpIPAM
+  hosts: phpipam_group
+  become: true
+  gather_facts: false
+  tags:
+    - phpipam
+    - ipam
+  roles:
+    - role: phpipam
+
+# =============================================================================
 # Phase 8d: HTTPS ingress (Traefik)
 # Fronts every service web UI at https://<name>.<domain> (no ports) with a
 # wildcard Let's Encrypt cert fetched via Route53 DNS-01. On the media VLAN so

--- a/roles/homeassistant/defaults/main.yml
+++ b/roles/homeassistant/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+homeassistant_image: "ghcr.io/home-assistant/home-assistant:stable"
+homeassistant_container_name: homeassistant
+homeassistant_data_dir: /opt/homeassistant
+homeassistant_storage_driver: "fuse-overlayfs"
+
+# Port pulled from the OpenTofu pipeline_constants (DRY: no port literal here).
+_homeassistant_port_err: >-
+  tofu_data.constants.service_ports.homeassistant_web missing —
+  regenerate tofu_inventory.json via
+  `terragrunt output -json ansible_inventory`.
+homeassistant_port: >-
+  {{ hostvars['localhost']['tofu_data']
+     ['constants']['service_ports']['homeassistant_web']
+     | mandatory(_homeassistant_port_err) }}

--- a/roles/homeassistant/handlers/main.yml
+++ b/roles/homeassistant/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart homeassistant
+  community.docker.docker_compose_v2:
+    project_src: "{{ homeassistant_data_dir }}"
+    state: present
+    recreate: always

--- a/roles/homeassistant/meta/main.yml
+++ b/roles/homeassistant/meta/main.yml
@@ -1,0 +1,21 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: Deploy Home Assistant as a Docker container in LXC (host networking)
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+
+  galaxy_tags:
+    - homeassistant
+    - docker
+    - automation
+    - homelab
+
+dependencies: []
+  # community.docker collection is specified in requirements.yml

--- a/roles/homeassistant/tasks/main.yml
+++ b/roles/homeassistant/tasks/main.yml
@@ -135,22 +135,12 @@
     virtualenv: /opt/ansible-venv
     virtualenv_command: python3 -m venv
 
-- name: Set Python interpreter to use venv for subsequent tasks
-  ansible.builtin.set_fact:
-    ansible_python_interpreter: /opt/ansible-venv/bin/python
-
-- name: Check if Home Assistant container is running
-  ansible.builtin.command: >-
-    docker ps -q --filter name={{ homeassistant_container_name }}
-    --filter status=running
-  register: homeassistant_running_check
-  changed_when: false
-  failed_when: false
-
 - name: Deploy Home Assistant via docker compose
   community.docker.docker_compose_v2:
     project_src: "{{ homeassistant_data_dir }}"
     state: present
+  vars:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python
 
 # =============================================================================
 # Health Check

--- a/roles/homeassistant/tasks/main.yml
+++ b/roles/homeassistant/tasks/main.yml
@@ -1,0 +1,175 @@
+---
+# Home Assistant Docker Deployment Tasks
+# Deploys Home Assistant as a Docker container with host networking.
+# Host networking is required for mDNS/Zeroconf device discovery.
+
+# =============================================================================
+# Docker Installation
+# =============================================================================
+
+- name: Gather OS facts
+  ansible.builtin.setup:
+    filter: ansible_distribution*
+
+- name: Install Docker prerequisites
+  ansible.builtin.apt:
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg
+      - lsb-release
+    state: present
+    update_cache: true
+
+- name: Create keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+
+- name: Set Docker repository distribution
+  ansible.builtin.set_fact:
+    homeassistant_distro: "{{ ansible_distribution | lower }}"
+
+- name: Add Docker GPG key
+  ansible.builtin.get_url:
+    url: "https://download.docker.com/linux/{{ homeassistant_distro }}/gpg"
+    dest: /etc/apt/keyrings/docker.asc
+    mode: "0644"
+    force: false
+
+- name: Add Docker repository
+  ansible.builtin.apt_repository:
+    repo: >-
+      deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc]
+      https://download.docker.com/linux/{{ homeassistant_distro }}
+      {{ ansible_distribution_release }} stable
+    state: present
+    filename: docker
+
+- name: Install Docker packages
+  ansible.builtin.apt:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-buildx-plugin
+      - docker-compose-plugin
+    state: present
+    update_cache: true
+
+- name: Install fuse-overlayfs for Docker on ZFS-backed LXC containers
+  ansible.builtin.apt:
+    name: fuse-overlayfs
+    state: present
+  when: homeassistant_storage_driver == 'fuse-overlayfs'
+
+- name: Configure Docker storage driver
+  ansible.builtin.copy:
+    dest: /etc/docker/daemon.json
+    content: |
+      {
+        "storage-driver": "{{ homeassistant_storage_driver }}"
+      }
+    owner: root
+    group: root
+    mode: "0644"
+  register: homeassistant_daemon_config
+
+- name: Restart Docker to apply storage driver configuration
+  ansible.builtin.systemd:  # noqa: no-handler
+    name: docker
+    state: restarted
+  when: homeassistant_daemon_config.changed
+
+- name: Ensure Docker service is running
+  ansible.builtin.systemd:
+    name: docker
+    state: started
+    enabled: true
+
+# =============================================================================
+# Home Assistant Data Directory
+# =============================================================================
+
+- name: Create Home Assistant config directory
+  ansible.builtin.file:
+    path: "{{ homeassistant_data_dir }}/config"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+# =============================================================================
+# Compose File
+# =============================================================================
+
+- name: Render Home Assistant docker-compose.yml
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ homeassistant_data_dir }}/docker-compose.yml"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart homeassistant
+
+# =============================================================================
+# Deploy via Docker Compose
+# =============================================================================
+
+- name: Install Python venv and pip for dependencies
+  ansible.builtin.apt:
+    name:
+      - python3-pip
+      - python3-venv
+      - python3-full
+    state: present
+    update_cache: true
+
+- name: Create virtualenv for Ansible Python dependencies
+  ansible.builtin.pip:
+    name:
+      - docker
+    state: present
+    virtualenv: /opt/ansible-venv
+    virtualenv_command: python3 -m venv
+
+- name: Set Python interpreter to use venv for subsequent tasks
+  ansible.builtin.set_fact:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python
+
+- name: Check if Home Assistant container is running
+  ansible.builtin.command: >-
+    docker ps -q --filter name={{ homeassistant_container_name }}
+    --filter status=running
+  register: homeassistant_running_check
+  changed_when: false
+  failed_when: false
+
+- name: Deploy Home Assistant via docker compose
+  community.docker.docker_compose_v2:
+    project_src: "{{ homeassistant_data_dir }}"
+    state: present
+
+# =============================================================================
+# Health Check
+# =============================================================================
+
+- name: Wait for Home Assistant port to be ready
+  ansible.builtin.wait_for:
+    host: 127.0.0.1
+    port: "{{ homeassistant_port }}"
+    timeout: 120
+
+- name: Verify Home Assistant is responding
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ homeassistant_port }}/"
+    method: GET
+    status_code: [200, 302]
+    follow_redirects: none
+  register: homeassistant_health
+  retries: 12
+  delay: 10
+  until: homeassistant_health.status in [200, 302]
+  changed_when: false

--- a/roles/homeassistant/templates/docker-compose.yml.j2
+++ b/roles/homeassistant/templates/docker-compose.yml.j2
@@ -1,0 +1,11 @@
+---
+services:
+  homeassistant:
+    image: {{ homeassistant_image }}
+    container_name: {{ homeassistant_container_name }}
+    restart: unless-stopped
+    network_mode: host
+    volumes:
+      - {{ homeassistant_data_dir }}/config:/config
+    environment:
+      TZ: America/Chicago

--- a/roles/openproject_docker/defaults/main.yml
+++ b/roles/openproject_docker/defaults/main.yml
@@ -3,7 +3,7 @@
 # https://www.openproject.org/docs/installation-and-operations/installation/docker/
 # The AIO image bundles PostgreSQL, memcached, web (Puma), and a background worker.
 
-openproject_docker_image: "openproject/community:15"
+openproject_docker_image: "openproject/openproject:14"
 openproject_docker_container_name: openproject
 openproject_docker_data_dir: /opt/openproject
 

--- a/roles/phpipam/defaults/main.yml
+++ b/roles/phpipam/defaults/main.yml
@@ -1,0 +1,33 @@
+---
+phpipam_www_image: "phpipam/phpipam-www:latest"
+phpipam_cron_image: "phpipam/phpipam-cron:latest"
+phpipam_mariadb_image: "mariadb:10.11"
+
+phpipam_container_name: phpipam
+phpipam_data_dir: /opt/phpipam
+phpipam_mariadb_data_dir: "{{ phpipam_data_dir }}/mariadb"
+
+phpipam_db_host: db
+phpipam_db_name: phpipam
+phpipam_db_user: phpipam
+
+phpipam_storage_driver: "fuse-overlayfs"
+
+# Port pulled from the OpenTofu pipeline_constants (DRY: no port literal here).
+_phpipam_port_err: >-
+  tofu_data.constants.service_ports.phpipam_web missing —
+  regenerate tofu_inventory.json via
+  `terragrunt output -json ansible_inventory`.
+phpipam_port: >-
+  {{ hostvars['localhost']['tofu_data']
+     ['constants']['service_ports']['phpipam_web']
+     | mandatory(_phpipam_port_err) }}
+
+# Secrets — stored in SOPS secrets.enc.yaml.
+# Generate with: openssl rand -base64 24
+phpipam_db_password: >-
+  {{ lookup('env', 'PHPIPAM_DB_PASSWORD')
+     | mandatory('PHPIPAM_DB_PASSWORD must be set (openssl rand -base64 24; store in SOPS)') }}
+phpipam_db_root_password: >-
+  {{ lookup('env', 'PHPIPAM_DB_ROOT_PASSWORD')
+     | mandatory('PHPIPAM_DB_ROOT_PASSWORD must be set (openssl rand -base64 24; store in SOPS)') }}

--- a/roles/phpipam/handlers/main.yml
+++ b/roles/phpipam/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart phpipam
+  community.docker.docker_compose_v2:
+    project_src: "{{ phpipam_data_dir }}"
+    state: present
+    recreate: always

--- a/roles/phpipam/meta/main.yml
+++ b/roles/phpipam/meta/main.yml
@@ -1,0 +1,21 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: Deploy phpIPAM (IP address management) via Docker Compose in LXC
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+
+  galaxy_tags:
+    - phpipam
+    - docker
+    - ipam
+    - networking
+
+dependencies: []
+  # community.docker collection is specified in requirements.yml

--- a/roles/phpipam/tasks/main.yml
+++ b/roles/phpipam/tasks/main.yml
@@ -143,19 +143,6 @@
     virtualenv: /opt/ansible-venv
     virtualenv_command: python3 -m venv
 
-- name: Check if phpipam container is running
-  ansible.builtin.command: >-
-    docker ps -q --filter name={{ phpipam_container_name }}
-    --filter status=running
-  register: phpipam_running_check
-  changed_when: false
-  failed_when: false
-
-- name: Clean stale Docker state before fresh deployment
-  ansible.builtin.command: docker system prune -af --volumes
-  when: phpipam_running_check.stdout == ''
-  changed_when: true
-
 - name: Deploy phpipam via docker compose
   community.docker.docker_compose_v2:
     project_src: "{{ phpipam_data_dir }}"

--- a/roles/phpipam/tasks/main.yml
+++ b/roles/phpipam/tasks/main.yml
@@ -1,0 +1,188 @@
+---
+# phpIPAM Docker Deployment Tasks
+# Deploys phpIPAM (IP address management) via Docker Compose in LXC.
+# Stack: phpipam-www + phpipam-cron + MariaDB
+
+# =============================================================================
+# Docker Installation
+# =============================================================================
+
+- name: Gather OS facts
+  ansible.builtin.setup:
+    filter: ansible_distribution*
+
+- name: Install Docker prerequisites
+  ansible.builtin.apt:
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg
+      - lsb-release
+    state: present
+    update_cache: true
+
+- name: Create keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+
+- name: Set Docker repository distribution
+  ansible.builtin.set_fact:
+    phpipam_distro: "{{ ansible_distribution | lower }}"
+
+- name: Add Docker GPG key
+  ansible.builtin.get_url:
+    url: "https://download.docker.com/linux/{{ phpipam_distro }}/gpg"
+    dest: /etc/apt/keyrings/docker.asc
+    mode: "0644"
+    force: false
+
+- name: Add Docker repository
+  ansible.builtin.apt_repository:
+    repo: >-
+      deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc]
+      https://download.docker.com/linux/{{ phpipam_distro }}
+      {{ ansible_distribution_release }} stable
+    state: present
+    filename: docker
+
+- name: Install Docker packages
+  ansible.builtin.apt:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-buildx-plugin
+      - docker-compose-plugin
+    state: present
+    update_cache: true
+
+- name: Install fuse-overlayfs for Docker on ZFS-backed LXC containers
+  ansible.builtin.apt:
+    name: fuse-overlayfs
+    state: present
+  when: phpipam_storage_driver == 'fuse-overlayfs'
+
+- name: Configure Docker storage driver
+  ansible.builtin.copy:
+    dest: /etc/docker/daemon.json
+    content: |
+      {
+        "storage-driver": "{{ phpipam_storage_driver }}"
+      }
+    owner: root
+    group: root
+    mode: "0644"
+  register: phpipam_daemon_config
+
+- name: Restart Docker to apply storage driver configuration
+  ansible.builtin.systemd:  # noqa: no-handler
+    name: docker
+    state: restarted
+  when: phpipam_daemon_config.changed
+
+- name: Ensure Docker service is running
+  ansible.builtin.systemd:
+    name: docker
+    state: started
+    enabled: true
+
+# =============================================================================
+# Data Directories
+# MariaDB writes to a bind-mounted volume under {{ phpipam_data_dir }}.
+# The mariadb image runs as UID 999 (mysql); in an unprivileged LXC the
+# host UID maps via subuids, so leave ownership defaults — chown happens
+# inside the container on first start.
+# =============================================================================
+
+- name: Create phpipam data directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  loop:
+    - "{{ phpipam_data_dir }}"
+    - "{{ phpipam_mariadb_data_dir }}"
+
+# =============================================================================
+# Compose File
+# =============================================================================
+
+- name: Render phpIPAM docker-compose.yml
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ phpipam_data_dir }}/docker-compose.yml"
+    owner: root
+    group: root
+    mode: "0600"
+  no_log: true
+  notify: Restart phpipam
+
+# =============================================================================
+# Deploy via Docker Compose
+# =============================================================================
+
+- name: Install Python venv and pip for dependencies
+  ansible.builtin.apt:
+    name:
+      - python3-pip
+      - python3-venv
+      - python3-full
+    state: present
+    update_cache: true
+
+- name: Create virtualenv for Ansible Python dependencies
+  ansible.builtin.pip:
+    name:
+      - docker
+    state: present
+    virtualenv: /opt/ansible-venv
+    virtualenv_command: python3 -m venv
+
+- name: Check if phpipam container is running
+  ansible.builtin.command: >-
+    docker ps -q --filter name={{ phpipam_container_name }}
+    --filter status=running
+  register: phpipam_running_check
+  changed_when: false
+  failed_when: false
+
+- name: Clean stale Docker state before fresh deployment
+  ansible.builtin.command: docker system prune -af --volumes
+  when: phpipam_running_check.stdout == ''
+  changed_when: true
+
+- name: Deploy phpipam via docker compose
+  community.docker.docker_compose_v2:
+    project_src: "{{ phpipam_data_dir }}"
+    state: present
+  no_log: true
+  vars:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python
+
+# =============================================================================
+# Health Check
+# First boot can take 30-60 seconds: MariaDB init + phpIPAM schema creation.
+# =============================================================================
+
+- name: Wait for phpIPAM web port to accept TCP connections
+  ansible.builtin.wait_for:
+    host: 127.0.0.1
+    port: "{{ phpipam_port }}"
+    timeout: 180
+
+- name: Verify phpIPAM is responding
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ phpipam_port }}/"
+    method: GET
+    status_code: [200, 302]
+    follow_redirects: none
+  register: phpipam_health
+  retries: 18
+  delay: 10
+  until: phpipam_health.status in [200, 302]
+  changed_when: false

--- a/roles/phpipam/templates/docker-compose.yml.j2
+++ b/roles/phpipam/templates/docker-compose.yml.j2
@@ -1,0 +1,39 @@
+---
+services:
+  db:
+    image: {{ phpipam_mariadb_image }}
+    container_name: phpipam-db
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: "{{ phpipam_db_root_password }}"
+      MYSQL_DATABASE: "{{ phpipam_db_name }}"
+      MYSQL_USER: "{{ phpipam_db_user }}"
+      MYSQL_PASSWORD: "{{ phpipam_db_password }}"
+    volumes:
+      - {{ phpipam_mariadb_data_dir }}:/var/lib/mysql
+
+  phpipam:
+    image: {{ phpipam_www_image }}
+    container_name: {{ phpipam_container_name }}
+    restart: unless-stopped
+    depends_on:
+      - db
+    ports:
+      - "{{ phpipam_port }}:80"
+    environment:
+      IPAM_DATABASE_HOST: "{{ phpipam_db_host }}"
+      IPAM_DATABASE_USER: "{{ phpipam_db_user }}"
+      IPAM_DATABASE_PASS: "{{ phpipam_db_password }}"
+      IPAM_DATABASE_NAME: "{{ phpipam_db_name }}"
+
+  cron:
+    image: {{ phpipam_cron_image }}
+    container_name: phpipam-cron
+    restart: unless-stopped
+    depends_on:
+      - db
+    environment:
+      IPAM_DATABASE_HOST: "{{ phpipam_db_host }}"
+      IPAM_DATABASE_USER: "{{ phpipam_db_user }}"
+      IPAM_DATABASE_PASS: "{{ phpipam_db_password }}"
+      IPAM_DATABASE_NAME: "{{ phpipam_db_name }}"

--- a/secrets.enc.yaml
+++ b/secrets.enc.yaml
@@ -19,6 +19,8 @@ OBJECT_STORAGE_ROOT_PASSWORD: ENC[AES256_GCM,data:RAQQC2wyPyug1N5KzSL4BddgM1NXxT
 INFISICAL_ENCRYPTION_KEY: ENC[AES256_GCM,data:TuiNCwLHmqI2r7TLK43mjkjvwzwpTeYfh9N9aa4jHE93O/0TrRG3gHffjWQ=,iv:resoRYniIrk+lFc6+lPiW7yJvhXa8Lhf3KcU3qavPWA=,tag:igfINqpfeUj9Rmp1Fs0Row==,type:str]
 INFISICAL_AUTH_SECRET: ENC[AES256_GCM,data:hde97WBokpCVOtkZoe5mljkOAut/dsD0YyTaEkS6MOtT9dkqq1TDnyJG1jo=,iv:/rKfGE9Z0sTOLSJTdktXaaKl1moV4fKuRWkWvPtyNhY=,tag:SedxT4qBxjgMb2m6YgorAw==,type:str]
 INFISICAL_DB_PASSWORD: ENC[AES256_GCM,data:+r9Fk3XZqfdRk/3dYpITy8i/kHS8QIr0p0bSUDCJWN0=,iv:5YjX6dbuc0FIT5oEn69fHb5xyrF59lTWPy7cXW8A9SY=,tag:ufRvPLMxwmxUB1uHoCdp7Q==,type:str]
+PHPIPAM_DB_PASSWORD: ENC[AES256_GCM,data:jV2ZEdfjY4XXznZT5QwoUdC1PswpL5VLSRm4Iiwz8n4=,iv:CwN5KZtKxhibm5rvO/gfcs0e/qEjJUitpNlu9eqLTv8=,tag:a4P4uGgFHLzCEvShg92L8A==,type:str]
+PHPIPAM_DB_ROOT_PASSWORD: ENC[AES256_GCM,data:dy0juwebeeGaq2EqxTnAvpq2Wq2SoMR2tQjaw3nDF6U=,iv:iTGf/TV47xiuBHx5urKDLP0uDduTZfW0DGAAOAAOG4Q=,tag:EG0sQYIFSFxAR4QJ0NVDNw==,type:str]
 sops:
     age:
         - enc: |
@@ -30,7 +32,7 @@ sops:
             yB3E157iHA3Qn3eYx7vfSFrviMIZFhWdAsVZ821y/cDXeUfG0yU33g==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
-    lastmodified: "2026-06-16T01:26:50Z"
-    mac: ENC[AES256_GCM,data:T6Q8s74d1veB6A7qjrLIRgFt9PX1FQpkP++kzvQ+CcfEpBWHz2dSm9zo1jvxspKOxkTcth3yOPYKlOxufPmkf8Xb6SD4KGtJEQRpPBlgZOfTxGecdngwBComZUUsaT33LLhXA++6ktFH/P8WBH+LB/PsSRahpvN8HQlFBXbSsnU=,iv:pSUgfXmu4H9KNJEgH1xhjgMFEM0fFhld9gIswcQp6OQ=,tag:w9EuCt/BnQYnFR8j+eTDJg==,type:str]
+    lastmodified: "2026-06-16T12:46:07Z"
+    mac: ENC[AES256_GCM,data:TJu7oU3cQWoJxzFfqkFtNO4EgcSQOsw5YrbWnWJVmNCfp/K1rkguARUQbZqlbO3jDt+/w1kIgGirLys+Z273jK2WVnTTisjWkqMKxfFKHcJ8I9WH2phGtEXJSOwZeEeZEKQTyrQFfr4XE/NJQI2cY/mlZMwco/0o1hZRd/VHvTY=,iv:OnwNAM8/d738peZOOzvb84LQgGr9b0315VCL4tcCuo0=,tag:umtFpqt01ixwTMiiYJy9UA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.0

--- a/secrets.enc.yaml
+++ b/secrets.enc.yaml
@@ -16,6 +16,9 @@ SPLUNK_PASSWORD: ENC[AES256_GCM,data:OT65lV1uBUbrqC1rzPdrr00hN8Sd4hTM4O9A4kApwpi
 SPLUNK_HEC_TOKEN: ENC[AES256_GCM,data:rdCcnHZefsdFxQbra/LKvqWlaTSg6pPmJuEKYPVM4a0trDQI,iv:2DRi1/FmfkBEJUghV6MX53zfwgqSIkqCOkzPv4dkVSc=,tag:YvKwxGRiUXQ+Q72HGIYEDA==,type:str]
 OBJECT_STORAGE_ROOT_USER: ENC[AES256_GCM,data:YI2FQGiiYhPW37vs8Cx4YiKmzqJ5o4iJ,iv:Yj4LmIESwtUl80YirpvESVZN7pTyRDArqEOdXnyoZnI=,tag:uRdDOSSfXAeojhdLxgY84w==,type:str]
 OBJECT_STORAGE_ROOT_PASSWORD: ENC[AES256_GCM,data:RAQQC2wyPyug1N5KzSL4BddgM1NXxThOcdN0p6ekRBsYxdbTojPWrR4lB5NoGJgfsA7DOBn3aZhl5heW2yUfeg==,iv:EHKxoS8EdKUEMVFK4o0P6mbNdppN9e5XHbFUuNnd/cQ=,tag:X1gqvIDXNQa5VhvD2gy/Ug==,type:str]
+INFISICAL_ENCRYPTION_KEY: ENC[AES256_GCM,data:TuiNCwLHmqI2r7TLK43mjkjvwzwpTeYfh9N9aa4jHE93O/0TrRG3gHffjWQ=,iv:resoRYniIrk+lFc6+lPiW7yJvhXa8Lhf3KcU3qavPWA=,tag:igfINqpfeUj9Rmp1Fs0Row==,type:str]
+INFISICAL_AUTH_SECRET: ENC[AES256_GCM,data:hde97WBokpCVOtkZoe5mljkOAut/dsD0YyTaEkS6MOtT9dkqq1TDnyJG1jo=,iv:/rKfGE9Z0sTOLSJTdktXaaKl1moV4fKuRWkWvPtyNhY=,tag:SedxT4qBxjgMb2m6YgorAw==,type:str]
+INFISICAL_DB_PASSWORD: ENC[AES256_GCM,data:+r9Fk3XZqfdRk/3dYpITy8i/kHS8QIr0p0bSUDCJWN0=,iv:5YjX6dbuc0FIT5oEn69fHb5xyrF59lTWPy7cXW8A9SY=,tag:ufRvPLMxwmxUB1uHoCdp7Q==,type:str]
 sops:
     age:
         - enc: |
@@ -27,7 +30,7 @@ sops:
             yB3E157iHA3Qn3eYx7vfSFrviMIZFhWdAsVZ821y/cDXeUfG0yU33g==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
-    lastmodified: "2026-06-15T13:52:13Z"
-    mac: ENC[AES256_GCM,data:uutLIBXEdbbvsTfnfnVHHw16b7knicVNL5nRzMDZr/wVBouClght634BxVFOOYRd+HSVTJEEg1frQH3zRvDyDcRynQabUHEmIANeUlCTS2Y7qyDG0j+RClb4YyXe9amMR+pILIwH/bvjYAZsiiY6wiWVEJcotjO0T2oHuQr3UiM=,iv:4aLlEiUSou3dmjgngrFXBFf0vgPjvDZDV074BPu12Pw=,tag:jE2yK2Pa9hL0zHRU8QuJEQ==,type:str]
+    lastmodified: "2026-06-16T01:26:50Z"
+    mac: ENC[AES256_GCM,data:T6Q8s74d1veB6A7qjrLIRgFt9PX1FQpkP++kzvQ+CcfEpBWHz2dSm9zo1jvxspKOxkTcth3yOPYKlOxufPmkf8Xb6SD4KGtJEQRpPBlgZOfTxGecdngwBComZUUsaT33LLhXA++6ktFH/P8WBH+LB/PsSRahpvN8HQlFBXbSsnU=,iv:pSUgfXmu4H9KNJEgH1xhjgMFEM0fFhld9gIswcQp6OQ=,tag:w9EuCt/BnQYnFR8j+eTDJg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.0


### PR DESCRIPTION
## Summary

- **homeassistant role**: Docker Compose with `network_mode: host` for mDNS/Zeroconf device discovery; fuse-overlayfs storage driver; port from pipeline constants; health check on `homeassistant_web` port
- **phpipam role**: Compose stack — `phpipam-www` + `phpipam-cron` + MariaDB; DB credentials in SOPS (`PHPIPAM_DB_PASSWORD`, `PHPIPAM_DB_ROOT_PASSWORD`); port from pipeline constants (`phpipam_web`)
- **Fix openproject_docker image**: `community:15` tag does not exist on Docker Hub; corrected to `openproject:14` which has tags up to 14.6.x
- **load_tofu.yml**: wire `homeassistant_group` (tag: `homeassistant`) and `phpipam_group` (tag: `ipam`) into the dynamic group assignment block
- **site.yml**: add Phase 8e (Home Assistant) and Phase 8f (phpIPAM) plays

Both roles follow the Docker-in-LXC pattern established by `infisical_docker`/`qdrant_docker`: Docker install → fuse-overlayfs config → compose deploy via `community.docker.docker_compose_v2` → health check. The LXC containers already exist and have the `nesting`/`keyctl` features set via the `docker` tag in terraform (the existing containers lack that tag — a separate terraform change to add the `docker` tag to vmids 105 and 120 is needed before converge).

## Test plan

- [ ] `ansible-lint` passes (CI gate)
- [ ] Molecule for modified roles passes (CI gate)
- [ ] Terraform: add `docker` tag to vmids 105 (phpipam) and 120 (homeassistant) in `deployment.json` → apply → confirm `nesting`/`keyctl` features set on containers
- [ ] Converge `homeassistant` tag: `ansible-playbook site.yml --tags homeassistant` — HA web UI responds on port 8123
- [ ] Converge `phpipam` tag: `ansible-playbook site.yml --tags phpipam` — phpIPAM web UI responds on port 80