### PR TITLE
fix(technitium_dns): forward over encrypted DoH, disable EDNS Client Subnet

### DIFF
--- a/molecule/technitium_dns/verify.yml
+++ b/molecule/technitium_dns/verify.yml
@@ -82,7 +82,10 @@
         that:
           - technitium_dns_zone == 'svc.example.net'
           - technitium_dns_apex_domain == 'example.net'
-          - technitium_dns_forwarders == ["https://cloudflare-dns.com/dns-query (1.1.1.1)", "https://dns.google/dns-query (8.8.8.8)"]
+          - >-
+            technitium_dns_forwarders ==
+            ["https://cloudflare-dns.com/dns-query (1.1.1.1)",
+            "https://dns.google/dns-query (8.8.8.8)"]
         fail_msg: >-
           Zone/forwarder mismatch: zone='{{ technitium_dns_zone }}'
           apex='{{ technitium_dns_apex_domain }}'

--- a/molecule/technitium_dns/verify.yml
+++ b/molecule/technitium_dns/verify.yml
@@ -82,7 +82,7 @@
         that:
           - technitium_dns_zone == 'svc.example.net'
           - technitium_dns_apex_domain == 'example.net'
-          - technitium_dns_forwarders == ['192.168.5.1']
+          - technitium_dns_forwarders == ["https://cloudflare-dns.com/dns-query (1.1.1.1)", "https://dns.google/dns-query (8.8.8.8)"]
         fail_msg: >-
           Zone/forwarder mismatch: zone='{{ technitium_dns_zone }}'
           apex='{{ technitium_dns_apex_domain }}'

--- a/roles/technitium_dns/defaults/main.yml
+++ b/roles/technitium_dns/defaults/main.yml
@@ -15,7 +15,8 @@ technitium_dns_api_token: "{{ lookup('env', 'TECHNITIUM_DNS_API_TOKEN') }}"
 
 # Authoritative zone = the homelab SUBDOMAIN only (a child zone). Technitium is
 # authoritative for this and forwards everything else (the apex + public) to the
-# gateway. All internal A-records and service CNAMEs live under this subdomain.
+# encrypted upstreams below. All internal A-records and service CNAMEs live under
+# this subdomain.
 technitium_dns_zone: "{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
 # Apex domain — referenced ONLY to remove a stale apex Primary zone if a
 # pre-existing server still owns one (so non-subdomain names forward, not
@@ -71,11 +72,19 @@ technitium_dns_ingress_apex: >-
 # subdomain zone directly.
 technitium_dns_ingress_domain: "{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
 
-# Upstream forwarder for every non-authoritative query. Points at the gateway
-# (which owns the apex + public DNS), sourced from Doppler — never a committed
-# literal. This is what makes non-subdomain names resolve instead of NXDOMAIN.
+# Upstream forwarders for every non-authoritative query (the apex + public
+# names). Encrypted DNS-over-HTTPS (DoH) to Cloudflare + Google so the
+# resolver->upstream hop is never sent in plaintext. The IP in parentheses is
+# the bootstrap endpoint: Technitium dials that address directly instead of
+# resolving the DoH hostname through itself (avoids a chicken-and-egg lookup),
+# while still validating the TLS certificate against the hostname. These DoH
+# URLs and resolver IPs are public constants, not secrets.
+technitium_dns_forwarder_protocol: "Https" # Udp | Tcp | Tls | Https | Quic
 technitium_dns_forwarders:
-  - "{{ lookup('env', 'PROXMOX_VE_GATEWAY') }}"
+  - "https://cloudflare-dns.com/dns-query (1.1.1.1)"
+  - "https://dns.google/dns-query (8.8.8.8)"
+# Do not volunteer the client subnet (EDNS Client Subnet) to upstream resolvers.
+technitium_dns_edns_client_subnet: false
 
 # DNS server settings
 technitium_dns_recursion: true

--- a/roles/technitium_dns/tasks/main.yml
+++ b/roles/technitium_dns/tasks/main.yml
@@ -165,16 +165,21 @@
       {{ technitium_dns_zones_response.json.response.zones | default([]) | map(attribute='name') | list }}
   when: technitium_dns_apply | bool
 
-# Forward every non-authoritative query (the apex + public names) to the gateway.
+# Forward every non-authoritative query (the apex + public names) over encrypted
+# DoH to the configured upstreams, with EDNS Client Subnet disabled so the
+# client subnet is never sent to upstream resolvers. DNSSEC validation stays on.
 # This is a server-level setting, so it runs on EVERY node: each instance is a
 # full resolver — authoritative/secondary for the subdomain, forward the rest.
-- name: Configure upstream forwarders (to the gateway)
+- name: Configure upstream forwarders (encrypted DoH)
   ansible.builtin.uri:
     url: "{{ technitium_dns_api_url }}/api/settings/set?token={{ technitium_dns_api_token }}"
     method: POST
     body_format: form-urlencoded
     body:
       forwarders: "{{ technitium_dns_forwarders | join(',') }}"
+      forwarderProtocol: "{{ technitium_dns_forwarder_protocol }}"
+      eDnsClientSubnet: "{{ technitium_dns_edns_client_subnet | lower }}"
+      dnssecValidation: "true"
     return_content: true
     timeout: "{{ technitium_dns_api_timeout }}"
   register: technitium_dns_forwarders_result
@@ -201,7 +206,7 @@
     - technitium_dns_zone not in technitium_dns_existing_zones
   no_log: true
 
-# Remove a stale apex Primary zone so non-subdomain names FORWARD to the gateway
+# Remove a stale apex Primary zone so non-subdomain names FORWARD upstream
 # instead of resolving NXDOMAIN here. Destructive but guarded: only fires if a
 # pre-existing server still owns the apex zone (a no-op on a freshly built node,
 # which never had it). Idempotent via the existing-zones membership check.

--- a/roles/technitium_dns/tasks/main.yml
+++ b/roles/technitium_dns/tasks/main.yml
@@ -178,7 +178,7 @@
     body:
       forwarders: "{{ technitium_dns_forwarders | join(',') }}"
       forwarderProtocol: "{{ technitium_dns_forwarder_protocol }}"
-      eDnsClientSubnet: "{{ technitium_dns_edns_client_subnet | lower }}"
+      eDnsClientSubnet: "{{ technitium_dns_edns_client_subnet | string | lower }}"
       dnssecValidation: "true"
     return_content: true
     timeout: "{{ technitium_dns_api_timeout }}"


### PR DESCRIPTION
## What

Configure the Technitium resolver to forward external (non-authoritative)
queries over **encrypted DNS-over-HTTPS (DoH)** to Cloudflare + Google, and
**disable EDNS Client Subnet** so the client subnet is not forwarded to
upstream resolvers. DNSSEC validation remains enabled.

## Changes

- `roles/technitium_dns/defaults/main.yml`
  - `technitium_dns_forwarder_protocol: "Https"`
  - Forwarders → DoH endpoints with bootstrap IPs in parentheses
    (`https://cloudflare-dns.com/dns-query (1.1.1.1)`,
    `https://dns.google/dns-query (8.8.8.8)`) so the DoH hostnames need no
    self-lookup to resolve.
  - `technitium_dns_edns_client_subnet: false`
- `roles/technitium_dns/tasks/main.yml`
  - Extend the `settings/set` POST to also send `forwarderProtocol`,
    `eDnsClientSubnet`, and `dnssecValidation: true`.

## Notes

- The forwarder task is server-level and already runs on every node
  (`technitium_dns_apply | bool`), so DoH applies to the primary and all HA
  secondaries.
- DoH URLs and public resolver IPs are public constants — no secrets added.

## Verification

- `ansible-lint roles/technitium_dns/` — passes (production profile).
- Post-merge: `--tags technitium_dns,localhost` converge, then confirm the
  Technitium API reports `forwarderProtocol=Https` and `eDnsClientSubnet=false`.


Refs: dryvist/docs#76
