### PR TITLE
fix(download_vpn): qBittorrent bandwidth/queue config + service auto-recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,6 +213,11 @@ sops exec-env secrets.enc.yaml 'doppler run -- ansible-playbook \
   -i inventory/hosts.yml playbooks/validate-media.yml'
 # Add --tags deep to actively test each indexer against its tracker (slow, live)
 
+# Re-trigger searches for pending monitored items (Sonarr + Radarr). Standalone,
+# on-demand; never part of site.yml. Scope with --tags sonarr (or --tags radarr).
+sops exec-env secrets.enc.yaml 'doppler run -- ansible-playbook \
+  -i inventory/hosts.yml playbooks/search-missing.yml'
+
 # Lint
 ansible-lint
 ```

--- a/playbooks/search-missing.yml
+++ b/playbooks/search-missing.yml
@@ -1,0 +1,95 @@
+---
+# Re-trigger searches for monitored items that are not yet present.
+#
+# The media managers (Sonarr, Radarr) only act on an item once they have searched
+# for and located it; items that are monitored but not yet found stay pending
+# until a search runs. This standalone, on-demand playbook asks each manager to
+# search for all currently-pending monitored items. It is never part of site.yml.
+#
+# Usage (API keys come from SOPS/Doppler env, same as servarr_wiring):
+#   sops exec-env secrets.enc.yaml 'doppler run -- ansible-playbook \
+#     -i inventory/hosts.yml playbooks/search-missing.yml'
+#
+# Scope to one manager with --tags sonarr (or --tags radarr).
+
+- name: Import OpenTofu infrastructure inventory
+  import_playbook: ../inventory/load_tofu.yml
+
+- name: Search for pending Sonarr items
+  hosts: sonarr_group
+  become: false
+  gather_facts: false
+  tags:
+    - sonarr
+  # Reuse servarr_wiring defaults for the deterministic API key + port (one source).
+  vars_files:
+    - ../roles/servarr_wiring/defaults/main.yml
+  tasks:
+    - name: Verify SONARR_API_KEY is set
+      ansible.builtin.assert:
+        that:
+          - servarr_wiring_sonarr_api_key | length > 0
+        fail_msg: >-
+          SONARR_API_KEY is not set. Run with sops exec-env + doppler run so
+          servarr_wiring's deterministic key is in the environment.
+        quiet: true
+
+    - name: Trigger Sonarr search for pending monitored items
+      ansible.builtin.uri:
+        url: >-
+          http://127.0.0.1:{{ servarr_wiring_sonarr_port }}/api/v3/command
+        method: POST
+        headers:
+          X-Api-Key: "{{ servarr_wiring_sonarr_api_key }}"
+        body_format: json
+        body:
+          name: MissingEpisodeSearch
+        status_code: [200, 201]
+      register: search_missing_sonarr
+      changed_when: true
+      no_log: true
+
+    - name: Show Sonarr command result
+      ansible.builtin.debug:
+        msg: >-
+          Sonarr search queued (command id
+          {{ search_missing_sonarr.json.id | default('?') }}).
+
+- name: Search for pending Radarr items
+  hosts: radarr_group
+  become: false
+  gather_facts: false
+  tags:
+    - radarr
+  vars_files:
+    - ../roles/servarr_wiring/defaults/main.yml
+  tasks:
+    - name: Verify RADARR_API_KEY is set
+      ansible.builtin.assert:
+        that:
+          - servarr_wiring_radarr_api_key | length > 0
+        fail_msg: >-
+          RADARR_API_KEY is not set. Run with sops exec-env + doppler run so
+          servarr_wiring's deterministic key is in the environment.
+        quiet: true
+
+    - name: Trigger Radarr search for pending monitored items
+      ansible.builtin.uri:
+        url: >-
+          http://127.0.0.1:{{ servarr_wiring_radarr_port }}/api/v3/command
+        method: POST
+        headers:
+          X-Api-Key: "{{ servarr_wiring_radarr_api_key }}"
+        body_format: json
+        body:
+          name: MissingMoviesSearch
+        status_code: [200, 201]
+      register: search_missing_radarr
+      changed_when: true
+      no_log: true
+
+    - name: Show Radarr command result
+      ansible.builtin.debug:
+        msg: >-
+          Radarr search queued (command id
+          {{ search_missing_radarr.json.id | default('?') }}).

--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -183,11 +183,13 @@ download_vpn_qbittorrent_categories:
 # file on save, so file-based limits silently never took effect. The API is the
 # stable, documented contract — same pattern the role uses for the admin password.
 #
-# Units: KiB/s (1 Mbps ≈ 122 KiB/s). 0 = unlimited.
-download_vpn_qbittorrent_up_limit: 3125        # 25 Mbps — 24/7 global upload cap
-download_vpn_qbittorrent_dl_limit: 9766         # ~75 Mbps — 24/7 global download cap
-download_vpn_qbittorrent_alt_up_limit: 1250     # work-hours 10 Mbps upload
-download_vpn_qbittorrent_alt_dl_limit: 1250     # work-hours 10 Mbps download
+# Units: BYTES/s — the qBittorrent WebUI API contract (NOT KiB/s; the daemon
+# stores these as KiB/s in qBittorrent.conf and converts). 1 Mbps = 125000 bytes/s.
+# 0 = unlimited.
+download_vpn_qbittorrent_up_limit: 3750000      # 30 Mbps — 24/7 global upload cap
+download_vpn_qbittorrent_dl_limit: 31250000     # 250 Mbps — 24/7 global download cap
+download_vpn_qbittorrent_alt_up_limit: 2500000  # work-hours 20 Mbps upload
+download_vpn_qbittorrent_alt_dl_limit: 12500000 # work-hours 100 Mbps download
 download_vpn_qbittorrent_scheduler_enabled: true
 # scheduler_days: 0=every day, 1=weekdays (Mon–Fri), 2=weekends, 3–9=Mon..Sun.
 download_vpn_qbittorrent_scheduler_days: 1
@@ -197,6 +199,19 @@ download_vpn_qbittorrent_schedule_from_hour: 12
 download_vpn_qbittorrent_schedule_from_min: 0
 download_vpn_qbittorrent_schedule_to_hour: 22
 download_vpn_qbittorrent_schedule_to_min: 0
+
+# --- Concurrency + connection limits -----------------------------------------
+# Concurrency caps (applied via setPreferences). dont_count_slow_torrents keeps
+# idle transfers from consuming active slots so completed items do not block new
+# ones. Raised above the client defaults (5/3/5) for more parallelism.
+download_vpn_qbittorrent_max_active_downloads: 10
+download_vpn_qbittorrent_max_active_uploads: 20
+download_vpn_qbittorrent_max_active_torrents: 100
+download_vpn_qbittorrent_dont_count_slow_torrents: true
+# Connection caps. More global connections improve throughput; per-item kept
+# moderate so a single item cannot monopolize them.
+download_vpn_qbittorrent_max_connec: 1000
+download_vpn_qbittorrent_max_connec_per_torrent: 100
 
 # Container timezone. The qBittorrent scheduler evaluates SYSTEM LOCAL time, so
 # we pin the container to UTC and express the window above in UTC. Override to an

--- a/roles/download_vpn/tasks/main.yml
+++ b/roles/download_vpn/tasks/main.yml
@@ -350,13 +350,16 @@
   changed_when: false
   when: download_vpn_manage_services
 
-# QoS: bandwidth limits + work-hours scheduler via the API (the .conf keys are
-# version-fragile and the daemon overwrites them — see qBittorrent.conf.j2).
-# Limits in KiB/s, -1 = unlimited. The scheduler applies the alt_* (heavy) limits
-# during the window and the normal limits outside it, evaluated in the container's
-# local time (pinned to UTC in Phase 1b). LocalHostAuth=false lets 127.0.0.1 POST
-# without a login cookie, same as the password task above.
-- name: Apply qBittorrent bandwidth limits + work-hours scheduler via API
+# QoS: bandwidth + concurrency limits + work-hours scheduler via the API (the
+# .conf keys are version-fragile and the daemon overwrites them — see
+# qBittorrent.conf.j2). Speed limits are BYTES/s (the WebUI API contract — the
+# daemon stores KiB/s); concurrency + connection caps are plain counts. The
+# scheduler applies the alt_* limits during the window and the normal limits
+# outside it, in the container's local time (pinned to UTC in Phase 1b).
+# LocalHostAuth=false lets 127.0.0.1 POST without a login cookie. limit_lan_peers
+# is required for the caps to apply over the VPN interface (see the docs-starlight
+# media-download runbook for the rationale).
+- name: Apply qBittorrent bandwidth + concurrency limits + scheduler via API
   ansible.builtin.uri:
     url: "http://127.0.0.1:{{ download_vpn_qbittorrent_web_port }}/api/v2/app/setPreferences"
     method: POST
@@ -373,6 +376,13 @@
          "schedule_to_hour":{{ download_vpn_qbittorrent_schedule_to_hour | int }},
          "schedule_to_min":{{ download_vpn_qbittorrent_schedule_to_min | int }},
          "scheduler_days":{{ download_vpn_qbittorrent_scheduler_days | int }},
+         "queueing_enabled":true,
+         "max_active_downloads":{{ download_vpn_qbittorrent_max_active_downloads | int }},
+         "max_active_uploads":{{ download_vpn_qbittorrent_max_active_uploads | int }},
+         "max_active_torrents":{{ download_vpn_qbittorrent_max_active_torrents | int }},
+         "dont_count_slow_torrents":{{ download_vpn_qbittorrent_dont_count_slow_torrents | bool | lower }},
+         "max_connec":{{ download_vpn_qbittorrent_max_connec | int }},
+         "max_connec_per_torrent":{{ download_vpn_qbittorrent_max_connec_per_torrent | int }},
          "limit_utp_rate":true,
          "limit_tcp_overhead":true,
          "limit_lan_peers":true}

--- a/roles/download_vpn/tasks/main.yml
+++ b/roles/download_vpn/tasks/main.yml
@@ -307,6 +307,17 @@
     daemon_reload: true
   when: download_vpn_manage_services
 
+- name: Apply the pending qBittorrent restart before the setPreferences API writes
+  # On re-runs the daemon is already running with the OLD in-memory config; the
+  # setPreferences calls below would make it flush that stale config back over the
+  # freshly templated qBittorrent.conf, silently reverting template-managed
+  # settings (port, interface binding, encryption). Flushing the queued Restart
+  # handler here reloads the new conf first; the WebUI readiness wait below covers
+  # the restart. meta: flush_handlers ignores `when`, but the Restart is only
+  # queued when the config template above reported changed, so this is a no-op on
+  # unchanged runs.
+  ansible.builtin.meta: flush_handlers
+
 - name: Wait for the qBittorrent WebUI to answer
   ansible.builtin.uri:
     url: "http://127.0.0.1:{{ download_vpn_qbittorrent_web_port }}/api/v2/app/version"

--- a/roles/download_vpn/templates/killswitch-validate.sh.j2
+++ b/roles/download_vpn/templates/killswitch-validate.sh.j2
@@ -127,13 +127,15 @@ fi
 # VPN has since recovered (the validator otherwise only ever stops, never starts).
 # The breach checks are VPN-integrity only and never trip on a stopped service, so
 # reviving it here cannot mask a leak. Mask/disable the unit to suppress during
-# maintenance.
+# maintenance. --no-block queues the start asynchronously so a slow or hung
+# service start can never stall this validator — it must stay responsive so the
+# next cycle can still catch a leak.
 for svc in qbittorrent-nox.service download-vpn-natpmp.service; do
   if [[ "$(systemctl is-enabled "${svc}" 2>/dev/null)" == "enabled" \
      && "$(systemctl is-active "${svc}" 2>/dev/null)" != "active" ]]; then
     logger -t killswitch-validate \
       "download-vpn: VPN healthy, ${svc} down — auto-starting (post-breach recovery)"
-    systemctl start "${svc}" || true
+    systemctl start --no-block "${svc}" || true
   fi
 done
 

--- a/roles/download_vpn/templates/killswitch-validate.sh.j2
+++ b/roles/download_vpn/templates/killswitch-validate.sh.j2
@@ -122,6 +122,21 @@ if [[ "{% raw %}${#breaches[@]}{% endraw %}" -gt 0 ]]; then
   exit 1
 fi
 
+# Self-heal: on a clean (no-breach) cycle the VPN/killswitch is intact, so it is
+# safe to (re)start the services if a prior transient breach stopped them and the
+# VPN has since recovered (the validator otherwise only ever stops, never starts).
+# The breach checks are VPN-integrity only and never trip on a stopped service, so
+# reviving it here cannot mask a leak. Mask/disable the unit to suppress during
+# maintenance.
+for svc in qbittorrent-nox.service download-vpn-natpmp.service; do
+  if [[ "$(systemctl is-enabled "${svc}" 2>/dev/null)" == "enabled" \
+     && "$(systemctl is-active "${svc}" 2>/dev/null)" != "active" ]]; then
+    logger -t killswitch-validate \
+      "download-vpn: VPN healthy, ${svc} down — auto-starting (post-breach recovery)"
+    systemctl start "${svc}" || true
+  fi
+done
+
 # Healthy: ping the deadman OK endpoint so a stalled validator also pages.
 if [[ -n "${HC_URL}" ]]; then
   curl -fsS --max-time 8 "${HC_URL}" >/dev/null 2>&1 || true


### PR DESCRIPTION
## What

Fixes the `download_vpn` qBittorrent app configuration and adds VPN-killswitch
service auto-recovery, plus an on-demand playbook to re-trigger media-manager
(Sonarr/Radarr) searches for monitored items not yet present.

## Changes

- **download_vpn role** — the WebUI API speed-limit fields are bytes/s (the role
  treated them as KiB/s); corrected the units and set sane global + scheduled
  bandwidth caps. Raised the app's concurrency limits and set the LAN-peer
  rate-limit flag so the caps apply over the VPN interface (the app binds an
  RFC1918 address, so peers were otherwise treated as local and exempted).
- **Killswitch validator** — symmetric service auto-recovery. The validator
  stopped the app on a VPN breach but never restarted it once the VPN recovered,
  so a transient blip downed the service indefinitely. It now restarts the
  enabled-but-inactive services on a clean (no-breach) cycle. Safe: the breach
  checks are VPN-integrity only and never trip on a stopped service.
- **playbooks/search-missing.yml** — standalone, on-demand playbook to ask
  Sonarr/Radarr to search for monitored items not yet on disk.

## Verification

- `ansible-lint` passes (production profile).
- Applied and confirmed live on the target LXC; caps enforce and persist.

## Follow-ups (separate, not in this PR)

- Converge currently fails at the app config-directory step: container-root
  cannot access the service user's `~/.config` directory (perms). Needs a
  `become_user`/perms fix.
- The `/data` mount's base dirs are host-root owned (unprivileged-LXC idmap), so
  the service user cannot write there. Worked around live; durable fix belongs in
  terraform-proxmox (LXC idmap / mount ownership).

🤖 Generated with [Claude Code](https://claude.com/claude-code)