### PR TITLE
chore: adopt dryvist org-default gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,86 @@ secrets.dec.yaml
 
 # Local ai-workflows checkout (upstream reusable workflows repo, not a submodule)
 .ai-workflows/
+
+# ---------------------------------------------------------------------
+# dryvist org-default: secrets, credentials & AI-assistant local state
+# Source of truth: dryvist/.github -> configs/gitignore (PR #43).
+# Carve-outs intentionally absent (committed by convention): .envrc,
+# *.sops.*, .terraform.lock.hcl
+# ---------------------------------------------------------------------
+
+# Environment files (committed examples kept via negation)
+.env.*
+!.env.example
+!.env.*.example
+
+# Private keys & certificates
+*.pem
+*.key
+*.p12
+*.pfx
+*.ppk
+id_rsa
+id_rsa*
+id_ed25519
+id_ed25519*
+
+# SOPS / age private keys (*.sops.* ciphertext stays committed)
+*.age
+keys.txt
+
+# Ansible Vault
+*.vault
+vault.yml
+vault.yaml
+.vault_pass
+.vault_password
+
+# Generic secret material
+*.secrets.yaml
+*credentials*
+aws-credentials
+SECRETS_SETUP.md
+
+# Cloud provider credentials
+.aws/
+.azure/
+gcloud-credentials.json
+kubeconfig
+*.kubeconfig
+
+# Doppler secrets fallback cache (encrypted snapshot of the WHOLE config) + setup
+doppler.json
+.doppler/
+.doppler.yaml
+
+# Terraform / OpenTofu state & tfvars are secret-bearing
+.terraform/
+**/.terraform/*
+.terraformrc
+*.tfstate
+*.tfstate.*
+*.tfstate.backup
+*.tfplan
+crash.log
+terragrunt-debug.tfvars.json
+*.tfvars
+*.tfvars.json
+!*.tfvars.example
+
+# AI assistant machine-local state (committed .claude/settings.json, rules, CLAUDE.md stay)
+.claude/settings.local.json
+.claude/.credentials.json
+.claude/projects/
+.claude/shell-snapshots/
+.claude/statsig/
+.claude/todos/
+.claude/local/
+.claude/worktrees/
+.claude-wt/
+CLAUDE.local.md
+.CLAUDE.local.md
+GEMINI.local.md
+AGENTS.local.md
+.aider*
+.specstory/


### PR DESCRIPTION
## Summary

Standardizes `.gitignore` coverage as part of an org-wide hygiene initiative.
Ensures common credential, secret-material, infrastructure-state, and tool-local
artifact paths are ignored consistently across dryvist repos, so files that
shouldn't be in version control aren't tracked by accident.

Adopts the relevant subset of the org-default baseline (`dryvist/.github` →
`configs/gitignore`). Append-only and de-duplicated — no existing entries are
modified or removed. Verified that no currently-tracked file becomes ignored.

Intentional carve-outs preserved (committed by convention): `.envrc`,
`*.sops.*`, and `.terraform.lock.hcl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
