### PR TITLE
fix(cribl): coerce non-finite netmon metric values; rename index to netmon_metrics

### DIFF
--- a/inventory/group_vars/prometheus_group.yml
+++ b/inventory/group_vars/prometheus_group.yml
@@ -19,7 +19,7 @@ prometheus_stack_extra_scrape_configs: |
     static_configs:
       - targets: ["127.0.0.1:{{ smokeping_scrape_port }}"]
 
-# Forward blackbox + smokeping metrics to Cribl Stream → Splunk (index=netmon).
+# Forward blackbox + smokeping metrics to Cribl Stream → Splunk (index=netmon_metrics).
 # Points at cribl-stream-01 directly (no HAProxy — WAL provides delivery durability).
 prometheus_stack_remote_write_url: >-
   http://{{ hostvars['localhost']['tofu_data']['containers']['cribl-stream-01']['ip']

--- a/roles/cribl_edge/defaults/main.yml
+++ b/roles/cribl_edge/defaults/main.yml
@@ -72,7 +72,7 @@ cribl_edge_per_index_indexes:
 
 # netmon Telegraf HEC ingestion. The per-WAN probers (roles/netmon) push
 # Splunk-HEC to this Edge on cribl_hec_input_port (group_vars/all.yml); the
-# netmon pipeline stamps index=netmon and reuses the splunk_hec output above.
+# netmon pipeline stamps index=netmon_metrics and reuses the splunk_hec output above.
 # Token is optional — empty accepts unauthenticated pushes from the mgmt VLAN.
 cribl_edge_hec_input_port: "{{ cribl_hec_input_port | default(8088) }}"
 cribl_edge_hec_input_token: "{{ lookup('env', 'NETMON_HEC_TOKEN') | default('', true) }}"

--- a/roles/cribl_edge/templates/pipelines/netmon/conf.yml.j2
+++ b/roles/cribl_edge/templates/pipelines/netmon/conf.yml.j2
@@ -5,7 +5,7 @@
 # Telegraf agents push Splunk-HEC to the in_netmon_hec source; this pipeline
 # stamps the Splunk index/sourcetype and reuses the shared splunk_hec output.
 # Two streams share the input, distinguished by the `stream` global tag:
-#   - per-WAN probers (roles/netmon, no stream tag) -> index=netmon
+#   - per-WAN probers (roles/netmon, no stream tag) -> index=netmon_metrics
 #   - UniFi controller telemetry (roles/unifi_metrics, stream=unifi_metrics)
 #       -> index=unifi_metrics
 # Per-stream tags (prober/uplink, or unpoller dimensions) ride along.
@@ -21,7 +21,7 @@ functions:
     conf:
       add:
         - name: index
-          value: "(stream || '') === 'unifi_metrics' ? 'unifi_metrics' : 'netmon'"
+          value: "(stream || '') === 'unifi_metrics' ? 'unifi_metrics' : 'netmon_metrics'"
         - name: sourcetype
           value: "(stream || '') === 'unifi_metrics' ? 'telegraf:unifi' : 'telegraf:netmon'"
         - name: source

--- a/roles/cribl_stream/templates/pipelines/prometheus_to_netmon/conf.yml.j2
+++ b/roles/cribl_stream/templates/pipelines/prometheus_to_netmon/conf.yml.j2
@@ -5,7 +5,7 @@
 # The prometheus_rw source emits one event per sample with fields:
 #   metric_name, value, _time, and one field per label (job, instance, etc.)
 # We stamp index/sourcetype and derive host from the job label so SPL
-# queries read: index=netmon sourcetype="prometheus:metrics" metric_name=probe_success
+# queries read: index=netmon_metrics sourcetype="prometheus:metrics" metric_name=probe_success
 output: splunk_hec
 streamtags: []
 groups: {}
@@ -16,8 +16,14 @@ functions:
     disabled: false
     conf:
       add:
+        # ponytail: coerce null/NaN/string metric values to -1 so the Splunk
+        # metric index never rejects them (blackbox emits NaN series, e.g.
+        # probe_ssl_earliest_cert_expiry on a failed/non-TLS probe, which arrive
+        # as null). -1 = "no valid measurement". Also upgrades numeric strings.
+        - name: value
+          value: "Number.isFinite(Number(value)) ? Number(value) : -1"
         - name: index
-          value: "'netmon'"
+          value: "'netmon_metrics'"
         - name: sourcetype
           value: "'prometheus:metrics'"
         - name: host

--- a/roles/netmon/defaults/main.yml
+++ b/roles/netmon/defaults/main.yml
@@ -6,7 +6,7 @@
 #   cable     -> DOCSIS modem SNMP
 #   satellite -> Starlink dish gRPC exporter (sidecar) scraped via Prometheus
 #   generic   -> active probes only
-# Output is Splunk-HEC format to Cribl Edge, which stamps index=netmon.
+# Output is Splunk-HEC format to Cribl Edge, which stamps index=netmon_metrics.
 # See docs/NETWORK_DIAGNOSIS.md in terraform-proxmox for the design.
 
 # --- container images (pinned; bump via Renovate or manual review) ---

--- a/roles/netmon/templates/telegraf.conf.j2
+++ b/roles/netmon/templates/telegraf.conf.j2
@@ -78,8 +78,8 @@
 {% endif %}
 
 # ---------------------------------------------------------------------------
-# Output: Splunk-HEC format -> Cribl Edge -> Splunk netmon index.
-# Cribl's netmon pipeline stamps index=netmon; this agent only ships the data.
+# Output: Splunk-HEC format -> Cribl Edge -> Splunk netmon_metrics index.
+# Cribl's netmon pipeline stamps index=netmon_metrics; this agent only ships the data.
 # ---------------------------------------------------------------------------
 [[outputs.http]]
   url = "{{ netmon_hec_url }}"

--- a/roles/unifi_metrics/README.md
+++ b/roles/unifi_metrics/README.md
@@ -29,7 +29,7 @@ scripts.
 The Telegraf agent tags every metric `stream=unifi_metrics`. It reuses the
 shared Cribl Edge HEC input (`in_netmon_hec`); the Cribl `netmon` pipeline
 branches on the `stream` tag so these events land in `index=unifi_metrics`
-while the per-WAN probers (no `stream` tag) continue to `index=netmon`.
+while the per-WAN probers (no `stream` tag) continue to `index=netmon_metrics`.
 
 ## Installation
 

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1426,7 +1426,7 @@
           cribl_stream template assertions passed:
           - inputs.yml.j2: tcpjson S2S (10300/force_splunk_meta) + prometheus_rw (9201/prometheus_to_netmon)
           - force_splunk_meta: conditional evals + valid mask schema (matchRegex/replaceExpr)
-          - prometheus_to_netmon: eval coerces non-finite values + stamps index=netmon_metrics + sourcetype=prometheus:metrics
+          - prometheus_to_netmon: eval coerces non-finite values + stamps index=netmon_metrics
 
 - name: Render and verify unifi_metrics templates
   hosts: localhost

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1408,15 +1408,17 @@
           - "(_cribl_stream_meta_pipeline | from_yaml).functions | length == 2"
         fail_msg: "force_splunk_meta conf.yml must parse as YAML with eval + mask functions"
 
-    - name: Assert prometheus_to_netmon stamps index=netmon and sourcetype=prometheus:metrics
+    - name: Assert prometheus_to_netmon stamps index=netmon_metrics and sourcetype=prometheus:metrics
       ansible.builtin.assert:
         that:
           - "(_cribl_stream_prom_pipeline | from_yaml).functions | length == 1"
-          - "'netmon' in _cribl_stream_prom_pipeline"
+          - "'netmon_metrics' in _cribl_stream_prom_pipeline"
           - "'prometheus:metrics' in _cribl_stream_prom_pipeline"
+          - "'Number.isFinite' in _cribl_stream_prom_pipeline"
         fail_msg: >-
           prometheus_to_netmon pipeline must have exactly one eval function
-          that stamps index=netmon and sourcetype=prometheus:metrics
+          that coerces non-finite metric values and stamps index=netmon_metrics
+          and sourcetype=prometheus:metrics
 
     - name: Cribl Stream template rendering PASSED
       ansible.builtin.debug:
@@ -1424,7 +1426,7 @@
           cribl_stream template assertions passed:
           - inputs.yml.j2: tcpjson S2S (10300/force_splunk_meta) + prometheus_rw (9201/prometheus_to_netmon)
           - force_splunk_meta: conditional evals + valid mask schema (matchRegex/replaceExpr)
-          - prometheus_to_netmon: eval stamps index=netmon + sourcetype=prometheus:metrics
+          - prometheus_to_netmon: eval coerces non-finite values + stamps index=netmon_metrics + sourcetype=prometheus:metrics
 
 - name: Render and verify unifi_metrics templates
   hosts: localhost
@@ -1502,12 +1504,12 @@
       ansible.builtin.assert:
         that:
           - "'unifi_metrics' in _um_pipeline"
-          - "'netmon' in _um_pipeline"
+          - "'netmon_metrics' in _um_pipeline"
           - "'stream' in _um_pipeline"
         fail_msg: >-
           the shared cribl netmon pipeline must branch index/sourcetype on the
           stream tag so unifi_metrics events land in index=unifi_metrics while
-          netmon (no stream tag) stays index=netmon
+          netmon (no stream tag) stays index=netmon_metrics
 
     - name: UniFi metrics template rendering PASSED
       ansible.builtin.debug:


### PR DESCRIPTION
## Why

The Splunk metric index logged an `IndexProcessor` WARN for a metric `value=null`. Root cause: the Prometheus blackbox-exporter emits `NaN` series (e.g. `probe_ssl_earliest_cert_expiry` on a failed/non-TLS HTTPS probe), which Cribl forwards as `null`; the `prometheus_to_netmon` pipeline stamps index/sourcetype but never validates the value is numeric, so the null reaches the metric index and is rejected.

## What

- **Null-guard (the fix):** `prometheus_to_netmon` eval now coerces any non-finite/string metric value to `-1` (sentinel = "no valid measurement") before the Splunk HEC output. Also upgrades numeric strings → numbers.
- **Rename:** stamped metric index `netmon` → `netmon_metrics` (convention `{name}_metrics`) in both the `prometheus_to_netmon` and shared `netmon` pipelines. Cribl-internal object names (`in_netmon_hec`, pipeline id, `type` tag) and the prober role/dir keep the `netmon` name.
- Template-render asserts + comments updated.

## Scope note

The coercion is added to the **active** path (`prometheus_to_netmon`, value field confirmed `value`). The shared `netmon` (Telegraf/unifi_metrics) pipeline gets the rename only — its splunkmetric value field isn't confirmed, and blindly overwriting `_value` could corrupt unifi_metrics. The parallel `unifi_metrics` null warning (host=`8088`) is left as a follow-up pending a live Cribl field capture.

## Deploy note

Apply **after** `dryvist/ansible-splunk` creates the `netmon_metrics` index, so events land in an existing index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)