### PR TITLE
feat(ci): re-validate inventory data contract on upstream release

### DIFF
--- a/.github/workflows/upstream-revalidate.yml
+++ b/.github/workflows/upstream-revalidate.yml
@@ -1,0 +1,24 @@
+---
+# Re-validate the tofu inventory data contract when an upstream source-of-truth
+# repo (terraform-proxmox) cuts a release. Triggered in real time via
+# repository_dispatch (event_type=upstream-released), fanned out by
+# terraform-proxmox's release workflow. Catches drift between this repo's
+# inventory consumption and the freshly published inventory schema.
+#
+# Security: client_payload.* on repository_dispatch is sender-controlled and is
+# NOT interpolated anywhere here — this listener only calls a local reusable
+# workflow with no inputs, so there is no injection surface.
+name: Upstream Revalidate
+
+on:
+  repository_dispatch:
+    types: [upstream-released]
+
+permissions:
+  contents: read
+
+jobs:
+  revalidate:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/_data-contract.yml


### PR DESCRIPTION
Real-time `repository_dispatch` listener (`upstream-released`, fanned out by terraform-proxmox on release) that re-runs `_data-contract.yml` (tofu inventory schema + group assignments). Surfaces inventory-consumption drift the moment upstream releases.

Part of the upstream→downstream revalidation chain (terraform-proxmox#479, dryvist/.github#47).

🤖 Generated with [Claude Code](https://claude.com/claude-code)