### PR TITLE
chore(secrets): drop duplicated SPLUNK_* from SOPS (Doppler single source)

### DIFF
--- a/secrets.enc.yaml
+++ b/secrets.enc.yaml
@@ -12,8 +12,6 @@ PROWLARR_API_KEY: ENC[AES256_GCM,data:c0Ufcx+weQyWfhxObJKGnKmd2NmRnSLNXJlh4iZqO9
 PLEX_CLAIM_TOKEN: ENC[AES256_GCM,data:EL74JqtcF7PLOvYHWOPWAkO8wTxZNxdNLvM=,iv:71eD4jhgRyjSXXYPekjxOqb1IkR7wMfF8iUd1+kkHM4=,tag:dW/vOlHJ3uQwnuxg1reMPw==,type:str]
 PLEX_TOKEN: ENC[AES256_GCM,data:KLX08kSX65wwqvwKbFrmm82c++k=,iv:SCZ0t+v6cvLCzjrBaDSdW4LFw0KxWKoGrr5s0mOTTKQ=,tag:owwha29J5b3UA3jDQn2azg==,type:str]
 SEERR_API_KEY: ENC[AES256_GCM,data:JH7jxyveO3+uIoRkKA+niEkOZ0kkltV1l5Lu/WFkqps=,iv:OdOi3siPjrT7CwLo+UynHT+LeCU6diXtnE88Fa5UuD4=,tag:W2qPUA35R0jlJNO78aWe/g==,type:str]
-SPLUNK_PASSWORD: ENC[AES256_GCM,data:OT65lV1uBUbrqC1rzPdrr00hN8Sd4hTM4O9A4kApwpiJOtdMLN6nzYXQ3g==,iv:vq2SghLJFALb1sPVWwmc/Gqmp2KHeyyWMzLsp9+SH7A=,tag:kKFbS0fMpbaclW4Xf0vRJQ==,type:str]
-SPLUNK_HEC_TOKEN: ENC[AES256_GCM,data:rdCcnHZefsdFxQbra/LKvqWlaTSg6pPmJuEKYPVM4a0trDQI,iv:2DRi1/FmfkBEJUghV6MX53zfwgqSIkqCOkzPv4dkVSc=,tag:YvKwxGRiUXQ+Q72HGIYEDA==,type:str]
 OBJECT_STORAGE_ROOT_USER: ENC[AES256_GCM,data:YI2FQGiiYhPW37vs8Cx4YiKmzqJ5o4iJ,iv:Yj4LmIESwtUl80YirpvESVZN7pTyRDArqEOdXnyoZnI=,tag:uRdDOSSfXAeojhdLxgY84w==,type:str]
 OBJECT_STORAGE_ROOT_PASSWORD: ENC[AES256_GCM,data:RAQQC2wyPyug1N5KzSL4BddgM1NXxThOcdN0p6ekRBsYxdbTojPWrR4lB5NoGJgfsA7DOBn3aZhl5heW2yUfeg==,iv:EHKxoS8EdKUEMVFK4o0P6mbNdppN9e5XHbFUuNnd/cQ=,tag:X1gqvIDXNQa5VhvD2gy/Ug==,type:str]
 INFISICAL_ENCRYPTION_KEY: ENC[AES256_GCM,data:OPmI13wioBw1m8jrVEI0rQfqk83HNipAzhF7pte2WnZ4sNyyXrpGvNNHOce5OVCtuomoVRHIaZfs8DjzA6zpWw==,iv:Aa2BKo9UgOYRwuY1gndLZdME50ZnEh8TMvxn/l03rD0=,tag:eipRIyP+Ixx1cWZRmTUgaQ==,type:str]
@@ -32,7 +30,7 @@ sops:
             yB3E157iHA3Qn3eYx7vfSFrviMIZFhWdAsVZ821y/cDXeUfG0yU33g==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
-    lastmodified: "2026-06-16T19:08:02Z"
-    mac: ENC[AES256_GCM,data:Q0Candtwv8MLqqW7pd3LNH7axzMIVYcG8IcyMN9Buuroc1LDOFoVJPXUSfa/HfppELEgqEs8nTSM8qqeX6NhRJ4L/qVX16GROMcEPgSMJZUxL7ZwANnc50I1RVFBzwQVSnDP5tnqB9MQJJyOyN+9a+ZEinxlkRmQbT9u6JSy5qE=,iv:N41TDXUSKOjVbLxJWhu29AS1jsaHC9QhuaoEaBdRUCw=,tag:7ZpMTEe11+yTSIHM3bPuLg==,type:str]
+    lastmodified: "2026-06-22T21:19:13Z"
+    mac: ENC[AES256_GCM,data:d8t0KWugxY2C9lE8HTL9awAJEvVGE0Gk/UJkS5gwpM5aZ4EwVFa+IiWd9f4eLBFPtnuqaJH6Cz/z0AoaXPyH6TxZPTBjgbN97oFMwoyaec2YDE5Ole3Yf7mYOLYr3Wf1Tlaj9NBAuEKSAR7qEf9ta+kqBiHBcFYkbBafCrQbClM=,iv:gDNJusUsv2pagzNe0pIZ0iMIYhUW8PhCG2a3hQhTvhc=,tag:VTNdSpMHMo3StAIyv9kgkg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.0


### PR DESCRIPTION
## Why

`SPLUNK_PASSWORD` and `SPLUNK_HEC_TOKEN` were stored in **two** places — Doppler
(`iac-conf-mgmt/prd`, the canonical credential store per `SECRETS_ROADMAP.md`)
**and** this `secrets.enc.yaml`. Every converge runs under `doppler run`, so the
SOPS copies are redundant and a rotation hazard: rotate in Doppler, forget the
SOPS file, and a non-`doppler run` path silently uses a stale value. The goal is
each Splunk secret handled in exactly one place.

## What

- Remove `SPLUNK_PASSWORD` and `SPLUNK_HEC_TOKEN` from `secrets.enc.yaml`
  (via `sops unset`, so every other key's ciphertext is untouched). All
  remaining app-specific secrets (*arr keys, object-storage, Infisical, phpIPAM,
  Plex, qBittorrent, OpenProject) stay — those are legitimately SOPS-owned.

## Safety

- Verified the Doppler and SOPS copies were **byte-identical** before removal, so
  this is functionally a no-op today.
- The only SOPS-only consumer is the (currently offline) E2E runner's
  `tests/e2e/conftest.py`, which `pytest.skip`s when `SPLUNK_*` is unset — CI does
  not go red.

## Follow-up (not in this PR)

- Wrap the Splunk-touching E2E pytest steps in `_e2e-tests.yml` with `doppler run`
  so coverage returns from the single Doppler source once the runner is back.
- Longer term, retire the shared `SPLUNK_HEC_TOKEN` in favour of
  `HEC_NAMESPACE`-derived per-index tokens (store one namespace UUID, derive
  everywhere) — already half-built in `ansible-splunk` `site.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)