### PR TITLE
fix(cribl): serve tarball from object-storage (RustFS), not minio

### DIFF
--- a/inventory/group_vars/cribl_edge.yml
+++ b/inventory/group_vars/cribl_edge.yml
@@ -4,12 +4,13 @@ systemd_restart_policy_services:
 
 # Cribl Edge containers have the `outbound-internal` firewall group applied
 # (RFC1918 only), so they cannot reach cdn.cribl.io directly. Serve the
-# tarball from the MinIO artifact store on CT 107, reusing the same
+# tarball from the object-storage (RustFS) artifact store, reusing the same
 # anonymous-read `splunk-addons` bucket already populated for Splunk.
 # The `infra/cribl-linux-x64.tgz` object is staged by the workstation
 # during initial bootstrap (upstream has no stable versioned URL for
 # "latest", so we mirror the current build rather than chasing a moving
-# target).
+# target). The container key is hyphenated, so bracket notation is required
+# (dot notation mis-parses as subtraction).
 cribl_edge_tarball_url: >-
-  http://{{ tofu_data.containers.minio.ip }}:{{
-  tofu_data.constants.service_ports.minio_api }}/splunk-addons/infra/cribl-linux-x64.tgz
+  http://{{ tofu_data.containers['object-storage'].ip }}:{{
+  tofu_data.constants.service_ports.object_storage_s3 }}/splunk-addons/infra/cribl-linux-x64.tgz

--- a/inventory/group_vars/cribl_stream_group.yml
+++ b/inventory/group_vars/cribl_stream_group.yml
@@ -4,8 +4,9 @@ systemd_restart_policy_services:
 
 # Cribl Stream containers have the `outbound-internal` firewall group applied
 # (RFC1918 only), so they cannot reach cdn.cribl.io directly. Serve the
-# tarball from the MinIO artifact store on CT 107 — same binary as Cribl
-# Edge, different runtime configuration.
+# tarball from the object-storage (RustFS) artifact store — same binary as
+# Cribl Edge, different runtime configuration. The container key is hyphenated,
+# so bracket notation is required (dot notation mis-parses as subtraction).
 cribl_stream_tarball_url: >-
-  http://{{ tofu_data.containers.minio.ip }}:{{
-  tofu_data.constants.service_ports.minio_api }}/splunk-addons/infra/cribl-linux-x64.tgz
+  http://{{ tofu_data.containers['object-storage'].ip }}:{{
+  tofu_data.constants.service_ports.object_storage_s3 }}/splunk-addons/infra/cribl-linux-x64.tgz


### PR DESCRIPTION
## What

Repoint the Cribl Edge and Cribl Stream tarball URLs from the deprecated
`minio` container to the `object-storage` (RustFS) container.

- `inventory/group_vars/cribl_edge.yml`
- `inventory/group_vars/cribl_stream_group.yml`

Both now use `containers['object-storage'].ip` (bracket notation — the
hyphenated key mis-parses as subtraction under dot notation) and the
`object_storage_s3` port constant, mirroring the already-migrated
`splunk_docker` reader.

## Why

Part of completing the MinIO→RustFS cutover. MinIO's OSS repo was archived
upstream; these were two of the three remaining live consumers still resolving
their artifact mirror from the `minio` container. Once they resolve from
RustFS, MinIO has no live Cribl dependency.

## Verification

The `infra/cribl-linux-x64.tgz` object is served anonymously (HTTP 200) from
the RustFS `splunk-addons` bucket — same bucket/key the Splunk reader already
uses — so the cutover is safe ahead of the MinIO decommission.

Config-only change; the next Cribl converge picks up the new URL. No live
change on merge.

> Note: the third consumer (`technitium_install` mirror) is **not** repointed
> here — its `artifacts` bucket was never migrated to RustFS and needs the
> bucket + object + anonymous-read policy first. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)