### PR TITLE
feat(object-storage): add artifacts + idrac buckets, repoint technitium off minio

### DIFF
--- a/roles/idrac_kvm_docker/README.md
+++ b/roles/idrac_kvm_docker/README.md
@@ -79,7 +79,8 @@ viewer cannot connect. This role rebuilds a small local image instead:
 - `templates/Dockerfile.j2` → `FROM domistyle/idrac6` + `COPY app/ /app/`.
 - The `app/` payload is fetched at build time from
   `idrac_kvm_docker_avct_artifact_url` (a tar archive whose top level is `app/`),
-  staged in private storage (MinIO/NAS) — it is **never** committed to git.
+  staged in private storage (the object-storage `idrac` bucket / NAS) — it is
+  **never** committed to git.
 - The image is tagged `idrac_kvm_docker_image` (default `idrac6-avct:local`) and
   compose runs it with `pull: never` (local-only tag).
 

--- a/roles/idrac_kvm_docker/defaults/main.yml
+++ b/roles/idrac_kvm_docker/defaults/main.yml
@@ -8,7 +8,8 @@ idrac_kvm_docker_data_dir: /opt/idrac-kvm
 idrac_kvm_docker_build_dir: /opt/idrac-kvm/build
 # URL of a tar archive whose top level is an `app/` directory holding the AVCT client
 # (app/avctKVM.jar, app/lib/*.jar, app/lib/*.so, app/lib/META-INF/*). Stage it privately
-# (MinIO/NAS) — REQUIRED for the build. Empty = the build asserts and fails fast.
+# (object-storage `idrac` bucket / NAS) — REQUIRED for the build. Empty = the
+# build asserts and fails fast.
 idrac_kvm_docker_avct_artifact_url: ""
 # Optional sha256 of the artifact for integrity verification (recommended).
 idrac_kvm_docker_avct_artifact_sha256: ""

--- a/roles/idrac_kvm_docker/tasks/main.yml
+++ b/roles/idrac_kvm_docker/tasks/main.yml
@@ -189,8 +189,9 @@
       - idrac_kvm_docker_avct_artifact_url | length > 0
     fail_msg: >-
       idrac_kvm_docker_avct_artifact_url must point to the private AVCT client
-      tarball (top-level app/ dir). Stage the captured app.tar in MinIO/NAS and
-      set the variable (see role README "Viewer image").
+      tarball (top-level app/ dir). Stage the captured app.tar in the
+      object-storage `idrac` bucket / NAS and set the variable (see role README
+      "Viewer image").
 
 - name: Create build context directory
   ansible.builtin.file:

--- a/roles/object_storage/defaults/main.yml
+++ b/roles/object_storage/defaults/main.yml
@@ -56,9 +56,22 @@ object_storage_aws_env:
 
 # Default buckets (same contract as the MinIO role: anonymous read on the
 # internal network, versioned, lifecycle-bounded).
+#
+# - splunk-addons: Splunk apps + the Cribl infra mirror (anonymous read).
+# - artifacts: public-read mirror of non-secret infra binaries (the Technitium
+#   DNS app distribution, etc.) that egress-restricted LXCs fetch anonymously.
+#   Objects are operator-staged (no public upstream URL — captured from the
+#   official container image), so they are not in object_storage_infra_mirrors.
+# - idrac: PRIVATE store for the proprietary iDRAC KVM (AVCT) client build
+#   artifact. No anonymous policy — operator-staged, fetched at image-build time.
 object_storage_default_buckets:
   - name: splunk-addons
     policy: download
+    versioning: true
+  - name: artifacts
+    policy: download
+    versioning: true
+  - name: idrac
     versioning: true
 
 # Lifecycle: expire noncurrent object versions after this many days, bounding

--- a/roles/technitium_install/defaults/main.yml
+++ b/roles/technitium_install/defaults/main.yml
@@ -28,22 +28,28 @@ technitium_install_api_timeout: 30
 # coupling every install to that single vendor host (which went down and blocked
 # the DNS-secondary bring-up entirely). Instead: the .NET runtime comes from
 # Microsoft's apt repo, and the Technitium app distribution is mirrored in our
-# own MinIO `artifacts` bucket (public-read, non-secret binaries), seeded from
-# the same 14.3 / .NET 9 build the primary already runs. Same bare-metal layout
-# as the primary; no single-vendor-host SPOF.
+# own object-storage (RustFS) `artifacts` bucket (public-read, non-secret
+# binaries), captured from the official `technitium/dns-server:14.3.0` image's
+# `/opt/technitium/dns` (the 14.3 / .NET 9 build). Same bare-metal layout as the
+# primary; no single-vendor-host SPOF.
 
 # ASP.NET Core runtime package (installed from the Microsoft apt repo).
 technitium_install_dotnet_pkg: "aspnetcore-runtime-9.0"
 
-# Mirror endpoint for the Technitium app tarball. The host resolves from the
-# published inventory (the minio container) — never a committed IP literal.
-# Override technitium_install_app_url wholesale to point at a different mirror.
-technitium_install_mirror_endpoint: "http://{{ tofu_data.containers.minio.ip }}:9000/artifacts"
+# Mirror endpoint for the Technitium app tarball. The host + port resolve from
+# the published inventory (the object-storage container) — never a committed
+# literal. The container key is hyphenated, so bracket notation is required
+# (dot notation mis-parses as subtraction). Override technitium_install_app_url
+# wholesale to point at a different mirror.
+technitium_install_mirror_endpoint: >-
+  http://{{ tofu_data.containers['object-storage'].ip }}:{{
+  tofu_data.constants.service_ports.object_storage_s3 }}/artifacts
 # Version matches the upstream Docker tag so Renovate can compare + flag updates.
 # IMPORTANT: the artifact is mirror-hosted, so a Renovate version bump is only a
-# SIGNAL — it cannot re-host or re-checksum a private MinIO object. On every bump
-# you MUST also: (1) re-seed artifacts/technitium/ in MinIO from the new official
-# build (the technitium/dns-server image or a primary's /opt/technitium/dns), and
+# SIGNAL — it cannot re-host or re-checksum a private object-storage object. On
+# every bump you MUST also: (1) re-seed artifacts/technitium/ in object-storage
+# from the new official build — extract /opt/technitium/dns from the matching
+# technitium/dns-server image and tar it with `dns/` as the archive root — and
 # (2) update technitium_install_app_sha256 below to the new tarball's digest.
 # renovate: datasource=docker depName=technitium/dns-server
 technitium_install_app_version: "14.3.0"
@@ -51,7 +57,7 @@ technitium_install_app_filename: "technitium-dns-app-{{ technitium_install_app_v
 technitium_install_app_url: "{{ technitium_install_mirror_endpoint }}/technitium/{{ technitium_install_app_filename }}"
 # sha256 of the mirror object — pins the exact build (the vendor installer
 # offered no such guarantee). Update together with the version on every re-seed.
-technitium_install_app_sha256: "655ebf0742ccb3efe8d529d0eee305f3150226e420d1fd21320ff193b620e2b6"
+technitium_install_app_sha256: "c34d32e73502067dabaa1803234eb4921c3986bfe3e4bc7e070b584571a99d25"
 
 # Install + data dirs (match the existing primary's bare-metal layout).
 technitium_install_app_dir: "/opt/technitium"


### PR DESCRIPTION
## What

Completes the RustFS migration for the two MinIO buckets that were **never
carried over** during the cutover, so MinIO can be decommissioned without data
loss or breaking Technitium installs.

Live discovery: RustFS held only `splunk-addons` + `iac-inventory`. MinIO's
`artifacts` (Technitium DNS app mirror) and `idrac` (proprietary AVCT client)
buckets were hand-seeded out-of-band and absent from RustFS — neither role
declared them.

## Changes

- **`object_storage` role** — declare `artifacts` (public-read, versioned) and
  `idrac` (private, versioned) alongside `splunk-addons`.
- **`technitium_install`** — repoint the app mirror from the `minio` container to
  the `object-storage` container (bracket notation for the hyphenated key +
  `object_storage_s3` port). New sha256 for the re-captured tarball.
- **`idrac_kvm_docker`** — comment sweep (MinIO/NAS → object-storage `idrac`
  bucket / NAS). No logic change (URL is operator-supplied).

## Done live (verified)

- Converged the `object_storage` role: both buckets created on RustFS
  (`ok=26 changed=9 failed=0`); `artifacts` got the anonymous-read policy,
  `idrac` is private.
- Re-captured the Technitium **14.3.0 / .NET 9** app from the official
  `technitium/dns-server:14.3.0` image (`/opt/technitium/dns`, archived with
  `dns/` as the root — pure app distribution, no host runtime cruft), seeded into
  `artifacts/technitium/`.
- **Verified**: anonymous `GET` of the tarball returns `200`; the downloaded
  sha256 matches the pinned `technitium_install_app_sha256` (so `get_url`'s
  checksum passes); `idrac` anon `GET` returns `403` (private).

## Follow-up (operator)

The `idrac` bucket exists but is **empty** — the proprietary `app.tar` could not
be re-captured (no upstream source). It must be re-staged into the bucket before
MinIO is destroyed, or that artifact is lost. Not blocking: `idrac_kvm_docker`
only needs it on an image rebuild and the URL is operator-supplied.

Together with the Cribl repoint (sibling PR), this clears the last
`tofu_data.containers.minio` references in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)