### PR TITLE
fix(idrac): anon-read bucket + default build URL to RustFS mirror

### DIFF
--- a/roles/idrac_kvm_docker/defaults/main.yml
+++ b/roles/idrac_kvm_docker/defaults/main.yml
@@ -1,18 +1,22 @@
 ---
 # Locally rebuilt image: the vendor base + Dell/Avocent AVCT KVM client baked into
-# /app. domistyle/idrac6 does NOT ship the AVCT client; it is fetched from private
-# storage at build time (idrac_kvm_docker_avct_artifact_url) and never committed.
+# /app. domistyle/idrac6 does NOT ship the AVCT client; it is fetched from the
+# internal object-storage mirror at build time (idrac_kvm_docker_avct_artifact_url).
 idrac_kvm_docker_base_image: "domistyle/idrac6"
 idrac_kvm_docker_image: "idrac6-avct:local"
 idrac_kvm_docker_data_dir: /opt/idrac-kvm
 idrac_kvm_docker_build_dir: /opt/idrac-kvm/build
 # URL of a tar archive whose top level is an `app/` directory holding the AVCT client
-# (app/avctKVM.jar, app/lib/*.jar, app/lib/*.so, app/lib/META-INF/*). Stage it privately
-# (object-storage `idrac` bucket / NAS) — REQUIRED for the build. Empty = the
-# build asserts and fails fast.
-idrac_kvm_docker_avct_artifact_url: ""
-# Optional sha256 of the artifact for integrity verification (recommended).
-idrac_kvm_docker_avct_artifact_sha256: ""
+# (app/avctKVM.jar, app/lib/*.jar, app/lib/*.so, app/lib/META-INF/*). Defaults to the
+# internal object-storage `idrac` bucket (anonymous-read on the internal network); the
+# host + port resolve from the published inventory — never a committed literal. The
+# container key is hyphenated, so bracket notation is required. Override wholesale to
+# stage from a different mirror / NAS. On a re-stage, update the sha256 below to match.
+idrac_kvm_docker_avct_artifact_url: >-
+  http://{{ tofu_data.containers['object-storage'].ip }}:{{
+  tofu_data.constants.service_ports.object_storage_s3 }}/idrac/app.tar
+# sha256 of the artifact — pins the exact build (integrity verification at fetch time).
+idrac_kvm_docker_avct_artifact_sha256: "66d6df8c566f096bde20e99902a4ba679c95162eaf7f4633b843bb5534948ac9"
 idrac_kvm_docker_bind_address: "0.0.0.0"
 idrac_kvm_docker_tz: "UTC"
 idrac_kvm_docker_prune_unused: false

--- a/roles/object_storage/defaults/main.yml
+++ b/roles/object_storage/defaults/main.yml
@@ -62,8 +62,11 @@ object_storage_aws_env:
 #   DNS app distribution, etc.) that egress-restricted LXCs fetch anonymously.
 #   Objects are operator-staged (no public upstream URL — captured from the
 #   official container image), so they are not in object_storage_infra_mirrors.
-# - idrac: PRIVATE store for the proprietary iDRAC KVM (AVCT) client build
-#   artifact. No anonymous policy — operator-staged, fetched at image-build time.
+# - idrac: store for the proprietary iDRAC KVM (AVCT) client build artifact.
+#   Anonymous-read on the internal network (mirrors how the retired MinIO bucket
+#   served it — the build fetches via plain get_url with no auth); the artifact
+#   is gated by the internal-network boundary, not a bucket ACL, exactly like the
+#   other buckets. Operator-staged.
 object_storage_default_buckets:
   - name: splunk-addons
     policy: download
@@ -72,6 +75,7 @@ object_storage_default_buckets:
     policy: download
     versioning: true
   - name: idrac
+    policy: download
     versioning: true
 
 # Lifecycle: expire noncurrent object versions after this many days, bounding


### PR DESCRIPTION
## What

Follow-up to #497. That PR left the `idrac` bucket **private** and the build URL
**empty** — which would break the `idrac_kvm_docker` build:

- The build fetches the AVCT client via plain `get_url` (no auth), so the bucket
  must be **anonymous-read** on the internal network — exactly how the retired
  MinIO `idrac` bucket served it (verified: MinIO anon GET = 200).
- The build URL was operator-supplied/empty; now it **defaults** to the internal
  object-storage mirror with a pinned sha256, mirroring the `technitium` pattern.

## Changes

- `object_storage` role — `idrac` bucket → `policy: download` (anon-read).
- `idrac_kvm_docker` — default `idrac_kvm_docker_avct_artifact_url` to
  `…/idrac/app.tar` on object-storage + pin `idrac_kvm_docker_avct_artifact_sha256`.

## Done live (verified)

- Copied the proprietary `app.tar` (5.5 MB) from MinIO → RustFS `idrac` bucket.
- Converged `object_storage`: applied the `idrac` anon-read policy (`changed=3`).
- **Verified**: anon `GET idrac/app.tar` = `200`, sha256 `66d6df8c…` matches the
  MinIO source exactly.

With this, **RustFS holds every bucket MinIO served** — the data migration is
complete and MinIO has no remaining unique data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)