### PR TITLE
docs: correct stale media-stack ownership and drop wrong seerr vmid

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,9 +31,13 @@ this repo handles app config only.
   Proton WireGuard with a fail-closed dual-stack nftables killswitch, NAT-PMP
   port forwarding, and three layers of continuous killswitch validation), plus
   LAN-only `sonarr`, `radarr`, `plex` (install + idempotent non-fatal claim +
-  library-section creation), `seerr` (request UI, Docker-in-LXC 214), and
-  `servarr_wiring` (idempotent API self-wiring: public Prowlarr indexers,
-  Prowlarr apps sync, qBittorrent download clients, root folders).
+  library-section creation), `seerr` (request UI, Docker-in-LXC), and
+  `servarr_wiring` (idempotent API self-wiring: deterministic API keys, public
+  Prowlarr indexers, Prowlarr -> Sonarr/Radarr app sync, and media-management
+  settings — hardlinks + recycler bin). Root folders + qBittorrent download
+  clients are owned by the devopsarr `servarr-config` tofu module
+  (`terraform-proxmox`); quality profiles + custom formats by the `configarr`
+  role (TRaSH-Guides). `servarr_wiring` no longer touches those.
 
 **This repo does NOT own Splunk.** Splunk is managed by `ansible-splunk`.
 

--- a/roles/seerr/README.md
+++ b/roles/seerr/README.md
@@ -2,7 +2,7 @@
 
 Runs [Seerr](https://github.com/seerr-team/seerr) (the self-hosted
 movie/TV request UI) as a single Docker container on a dedicated
-Docker-in-LXC (`seerr`, LXC 214), publishes the web UI on the
+Docker-in-LXC (`seerr`), publishes the web UI on the
 OpenTofu-derived port (`media_ports.seerr_web` = 5055), persists its
 config to a host directory, and registers Sonarr + Radarr (and optionally
 Plex) via the Seerr settings API.
@@ -18,12 +18,12 @@ Seerr is **config-only** — it has no `/tank` bind-mounts and reaches the
 
 Wired into `playbooks/site.yml` (Phase 8c, media stack) against any host in
 `seerr_group`. The group is populated by `inventory/load_tofu.yml`
-from `containers` tagged `seerr` in the OpenTofu inventory (terraform-proxmox
-LXC 214 `seerr`), reached over `proxmox_pct_remote`.
+from `containers` tagged `seerr` in the OpenTofu inventory
+(terraform-proxmox `seerr` LXC), reached over `proxmox_pct_remote`.
 
 Prerequisites:
 
-- LXC 214 `seerr` exists (OpenTofu-managed; tags include `container`,
+- The `seerr` LXC exists (OpenTofu-managed; tags include `container`,
   `media`, `seerr`; `nesting=true` for Docker).
 - SOPS `secrets.enc.yaml` populated with `SEERR_API_KEY` (and, to register
   the `*arr` apps, `SONARR_API_KEY` / `RADARR_API_KEY`). Generate each with
@@ -48,11 +48,11 @@ fast with a pointer to SOPS if it is missing.
 
 ## Access
 
-After a successful run on LXC 214:
+After a successful run on the `seerr` LXC:
 
 | Service | URL                          | Container |
 | ------- | ---------------------------- | --------- |
-| Seerr   | `http://<lxc-214-ip>:5055/`  | `seerr`   |
+| Seerr   | `http://<seerr-host>:5055/`  | `seerr`   |
 
 ## Deterministic API key
 

--- a/roles/seerr/defaults/main.yml
+++ b/roles/seerr/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# seerr role defaults — Seerr request UI (Docker in LXC 214).
+# seerr role defaults — Seerr request UI (Docker in LXC).
 #
 # Docker-in-LXC, mirrors the idrac_kvm_docker role pattern: install Docker,
 # run a single container via Compose, persist config to a host dir. Seerr
@@ -54,8 +54,9 @@ seerr_radarr_api_key: "{{ lookup('env', 'RADARR_API_KEY') | default('', true) }}
 seerr_radarr_use_ssl: false
 
 # Root folders inside the *arr LXCs — the TRaSH single-filesystem /data layout
-# (Sonarr -> /data/media/tv, Radarr -> /data/media/movies). Must match
-# servarr_wiring_{sonarr,radarr}_root_folder.
+# (Sonarr -> /data/media/tv, Radarr -> /data/media/movies). Must match the root
+# folders configured in Sonarr/Radarr by the devopsarr `servarr-config` tofu
+# module (terraform-proxmox), which owns root folders + download clients.
 seerr_sonarr_root_folder: "/data/media/tv"
 seerr_radarr_root_folder: "/data/media/movies"
 


### PR DESCRIPTION
## What

Corrects stale media-stack ownership docs and removes the wrong `214` seerr vmid.

## Why

While debugging the media import pipeline, AGENTS.md and the seerr role docs
no longer matched reality:

- **`servarr_wiring` ownership** — AGENTS.md claimed it owns qBittorrent
  download clients + root folders. The role README (source of truth) says those
  moved to the devopsarr `servarr-config` tofu module (`terraform-proxmox`), and
  quality profiles + custom formats to the `configarr` role (TRaSH-Guides).
  AGENTS.md now states `servarr_wiring`'s actual scope and names the correct
  owners.
- **Wrong seerr vmid** — the seerr LXC is not vmid `214`. The hard-coded value
  appeared in AGENTS.md, `roles/seerr/README.md` (×4), and the role defaults
  header. Dropped per the repo's "don't document terraform-owned values" rule
  (`.claude/rules/ip-addressing.md`).
- **Removed-var reference** — the seerr defaults comment pointed at the
  long-removed `servarr_wiring_{sonarr,radarr}_root_folder` vars; now points at
  the `servarr-config` tofu module.

## Verification

- `pre-commit run --files AGENTS.md roles/seerr/README.md roles/seerr/defaults/main.yml`
  passes (markdownlint, yamllint, ansible-lint).
- No `214` references remain under `AGENTS.md` or `roles/seerr/`.
- Ownership wording mirrors `roles/servarr_wiring/README.md` and
  `roles/configarr/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GftpCDe9UqmXGv6FoNftn
