### PR TITLE
fix(seerr): default new requests to a named quality profile, not "Any"

### DIFF
--- a/roles/seerr/defaults/main.yml
+++ b/roles/seerr/defaults/main.yml
@@ -59,6 +59,15 @@ seerr_radarr_use_ssl: false
 seerr_sonarr_root_folder: "/data/media/tv"
 seerr_radarr_root_folder: "/data/media/movies"
 
+# Default quality profile Seerr assigns to new requests, resolved by NAME to the
+# profile id at register time. These must match a profile the `configarr` role
+# creates in Sonarr/Radarr (x264-preferred, 1080p-capped) so requests do NOT
+# default to the *arr "Any" profile (unbounded codec AND resolution — the source
+# of x265 grabs and 2160p remuxes). If the named profile is absent the role falls
+# back to the *arr's first profile. Override in inventory to track a different one.
+seerr_sonarr_quality_profile: "WEB-1080p"
+seerr_radarr_quality_profile: "HD Bluray + WEB"
+
 # Plex registration needs an ACCOUNT-scoped Plex token (X-Plex-Token). Rather than
 # requiring it by hand, the role DISCOVERS it from the Plex server's
 # Preferences.xml (the `PlexOnlineToken` present once the server is claimed —

--- a/roles/seerr/tasks/register.yml
+++ b/roles/seerr/tasks/register.yml
@@ -151,6 +151,7 @@
              | selectattr('name', 'equalto', seerr_radarr_quality_profile)
              | list | first)
             | default((seerr_radarr_profiles.json | first), true)
+            | default({'id': 0, 'name': ''}, true)
           }}
       no_log: true
 
@@ -282,6 +283,7 @@
              | selectattr('name', 'equalto', seerr_sonarr_quality_profile)
              | list | first)
             | default((seerr_sonarr_profiles.json | first), true)
+            | default({'id': 0, 'name': ''}, true)
           }}
       no_log: true
 

--- a/roles/seerr/tasks/register.yml
+++ b/roles/seerr/tasks/register.yml
@@ -143,6 +143,17 @@
       changed_when: false
       no_log: true
 
+    - name: Resolve the desired Radarr quality profile (by name; fall back to first)
+      ansible.builtin.set_fact:
+        seerr_radarr_profile: >-
+          {{
+            (seerr_radarr_profiles.json
+             | selectattr('name', 'equalto', seerr_radarr_quality_profile)
+             | list | first)
+            | default((seerr_radarr_profiles.json | first), true)
+          }}
+      no_log: true
+
     - name: Read existing Seerr Radarr servers
       ansible.builtin.uri:
         url: "http://127.0.0.1:{{ seerr_web_port }}/api/v1/settings/radarr"
@@ -177,8 +188,8 @@
           port: "{{ seerr_radarr_port | int }}"
           useSsl: "{{ seerr_radarr_use_ssl }}"
           apiKey: "{{ seerr_radarr_api_key }}"
-          activeProfileId: "{{ (seerr_radarr_profiles.json | first).id }}"
-          activeProfileName: "{{ (seerr_radarr_profiles.json | first).name }}"
+          activeProfileId: "{{ seerr_radarr_profile.id }}"
+          activeProfileName: "{{ seerr_radarr_profile.name }}"
           activeDirectory: "{{ seerr_radarr_root_folder }}"
           is4k: false
           isDefault: true
@@ -194,12 +205,13 @@
         - seerr_radarr_entry == {}
 
     # Self-heal: PUT only when the stored entry drifts from the desired
-    # connection or library root (apiKey rotation, port/SSL change, or a root
-    # folder that moved — e.g. a ZFS dataset split). Comparing before PUT keeps
+    # connection, library root, or default quality profile (apiKey rotation,
+    # port/SSL change, a moved root folder, or a configarr profile change).
+    # Comparing before PUT keeps
     # the task idempotent — no change on a converged host. The PUT body preserves
     # the entry's existing fields (combine) and overlays only the reconciled
     # values, so unrelated settings are untouched.
-    - name: Update Radarr in Seerr (reconcile drifted apiKey/port/ssl/root-folder)
+    - name: Update Radarr in Seerr (reconcile drifted apiKey/port/ssl/root-folder/profile)
       ansible.builtin.uri:
         url: "http://127.0.0.1:{{ seerr_web_port }}/api/v1/settings/radarr/{{ seerr_radarr_entry.id }}"
         method: PUT
@@ -215,7 +227,9 @@
               'port': seerr_radarr_port | int,
               'useSsl': seerr_radarr_use_ssl,
               'apiKey': seerr_radarr_api_key,
-              'activeDirectory': seerr_radarr_root_folder
+              'activeDirectory': seerr_radarr_root_folder,
+              'activeProfileId': seerr_radarr_profile.id | int,
+              'activeProfileName': seerr_radarr_profile.name
             })) | dict2items | rejectattr('key', 'equalto', 'id') | items2dict
           }}
         status_code: [200, 201]
@@ -229,6 +243,7 @@
           or (seerr_radarr_entry.port | default(0) | int) != (seerr_radarr_port | int)
           or (seerr_radarr_entry.useSsl | default(false) | bool) != (seerr_radarr_use_ssl | bool)
           or seerr_radarr_entry.activeDirectory | default('') != seerr_radarr_root_folder
+          or (seerr_radarr_entry.activeProfileId | default(0) | int) != (seerr_radarr_profile.id | int)
 
   # Non-fatal: a Radarr that is down/unreachable (e.g. its role has not converged
   # yet, or it is mid-restart) must NOT abort the play. The seerr container still
@@ -257,6 +272,17 @@
         status_code: 200
       register: seerr_sonarr_profiles
       changed_when: false
+      no_log: true
+
+    - name: Resolve the desired Sonarr quality profile (by name; fall back to first)
+      ansible.builtin.set_fact:
+        seerr_sonarr_profile: >-
+          {{
+            (seerr_sonarr_profiles.json
+             | selectattr('name', 'equalto', seerr_sonarr_quality_profile)
+             | list | first)
+            | default((seerr_sonarr_profiles.json | first), true)
+          }}
       no_log: true
 
     - name: Read existing Seerr Sonarr servers
@@ -310,8 +336,8 @@
           port: "{{ seerr_sonarr_port | int }}"
           useSsl: "{{ seerr_sonarr_use_ssl }}"
           apiKey: "{{ seerr_sonarr_api_key }}"
-          activeProfileId: "{{ (seerr_sonarr_profiles.json | first).id }}"
-          activeProfileName: "{{ (seerr_sonarr_profiles.json | first).name }}"
+          activeProfileId: "{{ seerr_sonarr_profile.id }}"
+          activeProfileName: "{{ seerr_sonarr_profile.name }}"
           activeLanguageProfileId: "{{ _sonarr_langprofile_id }}"
           activeDirectory: "{{ seerr_sonarr_root_folder }}"
           enableSeasonFolders: true
@@ -328,10 +354,11 @@
         - seerr_sonarr_entry == {}
 
     # Self-heal: PUT only when the stored entry drifts from the desired
-    # connection or library root (apiKey rotation, port/SSL change, or a root
-    # folder that moved — e.g. a ZFS dataset split). Body preserves the existing
+    # connection, library root, or default quality profile (apiKey rotation,
+    # port/SSL change, a moved root folder, or a configarr profile change).
+    # Body preserves the existing
     # entry (combine) and overlays only the reconciled values.
-    - name: Update Sonarr in Seerr (reconcile drifted apiKey/port/ssl/root-folder)
+    - name: Update Sonarr in Seerr (reconcile drifted apiKey/port/ssl/root-folder/profile)
       ansible.builtin.uri:
         url: "http://127.0.0.1:{{ seerr_web_port }}/api/v1/settings/sonarr/{{ seerr_sonarr_entry.id }}"
         method: PUT
@@ -347,7 +374,9 @@
               'port': seerr_sonarr_port | int,
               'useSsl': seerr_sonarr_use_ssl,
               'apiKey': seerr_sonarr_api_key,
-              'activeDirectory': seerr_sonarr_root_folder
+              'activeDirectory': seerr_sonarr_root_folder,
+              'activeProfileId': seerr_sonarr_profile.id | int,
+              'activeProfileName': seerr_sonarr_profile.name
             })) | dict2items | rejectattr('key', 'equalto', 'id') | items2dict
           }}
         status_code: [200, 201]
@@ -361,6 +390,7 @@
           or (seerr_sonarr_entry.port | default(0) | int) != (seerr_sonarr_port | int)
           or (seerr_sonarr_entry.useSsl | default(false) | bool) != (seerr_sonarr_use_ssl | bool)
           or seerr_sonarr_entry.activeDirectory | default('') != seerr_sonarr_root_folder
+          or (seerr_sonarr_entry.activeProfileId | default(0) | int) != (seerr_sonarr_profile.id | int)
 
   # Non-fatal: a Sonarr that is down/unreachable (e.g. its role has not converged
   # yet, or it is mid-restart) must NOT abort the play. The seerr container still


### PR DESCRIPTION
## What

Make the seerr role assign a **named, configurable** default quality profile to
new Sonarr/Radarr requests instead of always picking the *arr's first profile
(`Any`).

## Why

`roles/seerr/tasks/register.yml` resolved `activeProfileId` from
`(qualityprofile | first)`. The first profile Sonarr/Radarr return is the
built-in **`Any`** — no codec preference and **no resolution cap**. So every
Seerr request bypassed the configarr-managed x264/1080p profiles and pulled
**x265 episodes and 2160p movie remuxes** (40–90 GB each). This was the root
cause behind both the Apple TV transcode/remux friction and a large chunk of
the storage blowout.

## Change

- New role vars `seerr_sonarr_quality_profile` (default `WEB-1080p`) and
  `seerr_radarr_quality_profile` (default `HD Bluray + WEB`) — the
  configarr-managed, x264-preferred, 1080p-capped profiles.
- Resolve the profile **by name** from the live `/api/v3/qualityprofile`,
  falling back to the first profile only if the named one is absent (e.g.
  configarr hasn't run yet).
- Enforce on **create** and on the **self-heal PUT** (added to the drift
  check), so an entry sitting on `Any` is reconciled on the next converge.
  Idempotent — no change once correct.
- Updated the affected task names + comments to match.

## Verification

- `pre-commit run --files roles/seerr/tasks/register.yml roles/seerr/defaults/main.yml`
  passes (yamllint, ansible-lint, check-yaml).
- Logic mirrors the existing `seerr_*_entry` resolution pattern already in the
  file.
- Live Seerr was already pointed at these profiles manually during debugging;
  this makes that the durable, declarative default so it survives converges and
  rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GftpCDe9UqmXGv6FoNftn
