### PR TITLE
feat(download_vpn): seed-then-clean qBittorrent policy (ratio 10 / 45d / 14d inactive)

### DIFF
--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -145,15 +145,21 @@ download_vpn_qbittorrent_interface: "{{ download_vpn_wg_interface }}"
 # anonymous_mode: false — private trackers ban anonymous mode (strips passkey
 # announce used for ratio credit). Override true only for public-only setups.
 download_vpn_qbittorrent_anonymous_mode: false
-# Global ratio + seed-time goals. Per-torrent limits (set by Prowlarr fullSync)
-# take priority — set permissively so private tracker indexers can be stricter.
-download_vpn_qbittorrent_max_ratio: 5
-# -1 = disabled ("When total seeding time reaches" checkbox left unchecked).
-# If ever enabled, set to 15000 minutes (~10 days).
-download_vpn_qbittorrent_max_seeding_minutes: -1
-# 0=Pause when goal is reached. NEVER 1=Delete — *arr handles removal after
-# import and seed completion. Auto-delete races the importer and can nuke a hardlink.
-download_vpn_qbittorrent_max_ratio_action: 0
+# Seed-then-clean policy: a completed torrent is removed (with its files) when ANY
+# limit below is hit, so finished downloads don't hoard the shared /data pool.
+# Hardlink-safe — removing a torrent's files drops only the torrent's hardlink; the
+# *arr library copy is a separate hardlink and survives. Limits trigger long after
+# import, so they don't race the importer.
+download_vpn_qbittorrent_max_ratio: 10
+# Total seed time before cleanup, in minutes (45 days). -1 disables.
+download_vpn_qbittorrent_max_seeding_minutes: 64800
+# Inactive (zero upload activity) seed time before cleanup, in minutes (14 days,
+# qBittorrent 4.5+). The "good seeder, drop the dead torrents nobody pulls" lever.
+# -1 disables.
+download_vpn_qbittorrent_max_inactive_seeding_minutes: 20160
+# Action at the limit. ShareLimitAction enum: 0=Stop, 1=Remove, 2=EnableSuperSeeding,
+# 3=RemoveWithContent. 3 reclaims the seed copy; the hardlinked library is untouched.
+download_vpn_qbittorrent_max_ratio_action: 3
 # 1=require encrypted peers (defeats ISP throttling; expected on private trackers).
 download_vpn_qbittorrent_encryption: 1
 # DHT/PeX/LSD: on for public swarm discovery. Per-torrent private flag disables

--- a/roles/download_vpn/templates/qBittorrent.conf.j2
+++ b/roles/download_vpn/templates/qBittorrent.conf.j2
@@ -24,7 +24,7 @@ Session\AnonymousModeEnabled={{ download_vpn_qbittorrent_anonymous_mode | lower 
 # via fullSync override these per-torrent (stricter indexer rules win).
 Session\GlobalMaxRatio={{ download_vpn_qbittorrent_max_ratio }}
 Session\GlobalMaxSeedingMinutes={{ download_vpn_qbittorrent_max_seeding_minutes }}
-# MaxRatioAction 0=Pause. Never 1=Delete — *arr removes after import + seed done.
+Session\GlobalMaxInactiveSeedingMinutes={{ download_vpn_qbittorrent_max_inactive_seeding_minutes }}
 Session\MaxRatioAction={{ download_vpn_qbittorrent_max_ratio_action }}
 # Encryption 1=require encrypted peers. Defeats ISP throttling; expected on private.
 Session\Encryption={{ download_vpn_qbittorrent_encryption }}


### PR DESCRIPTION
## What

Replace qBittorrent's "seed to ratio 5 then pause forever" with a **seed-then-clean**
policy so completed torrents stop hoarding the shared `/data` pool.

## Why

The pool was filling with completed torrents, not the library. qBittorrent seeded to
ratio 5 and **paused** (`max_ratio_action=0`), so nothing was ever removed — 3.7 TB of
seed data vs ~400 GB of actual library. Because imports are hardlinks of the seeding
torrents, deleting media doesn't free space; the **torrent** has to be removed.

## Change

A torrent is now removed **with its files** when it hits **ratio 10**, OR **45 days**
total seed time, OR **14 days inactive** (no upload activity — the "good seeder, drop
the dead torrents nobody pulls" lever, qBittorrent 4.5+).

- `defaults/main.yml`: `max_ratio` 5→10, `max_seeding_minutes` -1→64800,
  `max_ratio_action` 0→3 (`ShareLimitAction::RemoveWithContent`), add
  `max_inactive_seeding_minutes` 20160.
- `templates/qBittorrent.conf.j2`: add `Session\GlobalMaxInactiveSeedingMinutes`;
  remove the old `# MaxRatioAction…` comment (it contains `=`, so the daemon mangled
  it into a junk `%23…` key in the live conf).

**Hardlink-safe:** removing a torrent's files drops only the torrent's hardlink — the
`*arr` library copy is a separate hardlink and survives. The high limits trigger long
after import, so they don't race the importer (the prior comment's concern).

## Verification

- Applied live via `setPreferences` and read back: `max_ratio=10`,
  `max_seeding_time=64800`, `max_inactive_seeding_time=20160`, `max_ratio_act=3` — all OK.
- Live conf confirms the template key name: `Session\GlobalMaxInactiveSeedingMinutes=20160`.
- `ShareLimitAction` enum (qBittorrent source): `Stop=0, Remove=1, EnableSuperSeeding=2,
  RemoveWithContent=3`.
- `pre-commit` (yamllint, ansible-lint) passes; no template-render fixture references these keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GftpCDe9UqmXGv6FoNftn
