### PR TITLE
docs(agents): link deployment state to the canonical ACID contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,12 @@ toolchain, only AWS read creds) → the local gitignored
 Port constants come from `tofu_data.constants`
 (defined in terraform-proxmox `locals.tf`).
 
+This repo is a **read-only consumer** — it never reads `deployment.json`; the
+published inventory is the source of truth, fetched fresh with no authoritative
+local copy. The upstream desired-state's ACID single-writer contract is
+documented once at
+[Deployment state contract](https://docs.jacobpevans.com/infrastructure/deployment-state-contract).
+
 ### Groups (from tofu inventory)
 
 - `lxc_containers`: All LXC containers (`proxmox_pct_remote` connection)


### PR DESCRIPTION
Read-only inventory consumer. Points the Inventory section at the single canonical deployment.json contract (dryvist/docs#88) instead of restating the upstream single-writer mechanics here. This repo never reads deployment.json directly; the tofu-published inventory is the source of truth.

Part of aligning every tofu/ansible repo to one definition of how deployment.json is read and written.

Verification: docs-only (AGENTS.md); markdownlint clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8De2aQvYqr5cFZ7Tz2ntG