### PR TITLE
fix: pin all timezones to UTC, disallow custom zones

### DIFF
--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -220,8 +220,8 @@ download_vpn_qbittorrent_max_connec: 1000
 download_vpn_qbittorrent_max_connec_per_torrent: 100
 
 # Container timezone. The qBittorrent scheduler evaluates SYSTEM LOCAL time, so
-# we pin the container to UTC and express the window above in UTC. Override to an
-# IANA zone (e.g. America/New_York) only to make the schedule track DST instead.
+# we pin the container to UTC and express the window above in UTC. Pinned to UTC
+# (workspace policy: no custom timezones) — do not set a non-UTC IANA zone.
 download_vpn_timezone: "UTC"
 
 # --- Prowlarr ----------------------------------------------------------------

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -32,9 +32,9 @@ hermes_agent_memory_provider: hindsight
 # --- Safety: cap the agentic loop so a runaway can't pin the GPU overnight ---
 hermes_agent_max_turns: 90
 
-# The play gathers facts, so use the TARGET host's timezone, not the control
-# node's $TZ (which is usually unset in CI/dev shells -> always the default).
-hermes_agent_timezone: "{{ ansible_facts['timezone'] | default('Etc/UTC', true) }}"
+# Pinned to UTC (workspace policy: no custom timezones), independent of the
+# target host's configured zone.
+hermes_agent_timezone: "UTC"
 
 # systemd ExecStart: the long-running gateway daemon. It drives the built-in cron
 # scheduler + the Kanban dispatcher even with no messaging platform configured.

--- a/roles/homeassistant/defaults/main.yml
+++ b/roles/homeassistant/defaults/main.yml
@@ -4,6 +4,9 @@ homeassistant_container_name: homeassistant
 homeassistant_data_dir: /opt/homeassistant
 homeassistant_storage_driver: "fuse-overlayfs"
 
+# Container timezone. Pinned to UTC (workspace policy: no custom timezones).
+homeassistant_tz: "UTC"
+
 # Port pulled from the OpenTofu pipeline_constants (DRY: no port literal here).
 _homeassistant_port_err: >-
   tofu_data.constants.service_ports.homeassistant_web missing —

--- a/roles/homeassistant/templates/docker-compose.yml.j2
+++ b/roles/homeassistant/templates/docker-compose.yml.j2
@@ -8,4 +8,4 @@ services:
     volumes:
       - {{ homeassistant_data_dir }}/config:/config
     environment:
-      TZ: America/Chicago
+      TZ: "{{ homeassistant_tz }}"

--- a/roles/immich/templates/docker-compose.yml.j2
+++ b/roles/immich/templates/docker-compose.yml.j2
@@ -7,7 +7,6 @@ services:
     image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
     volumes:
       - ${UPLOAD_LOCATION}:/data
-      - /etc/localtime:/etc/localtime:ro
     env_file:
       - .env
     ports:


### PR DESCRIPTION
## Summary

Enforce a UTC-only timezone policy across every role that handled local time. No custom timezones remain anywhere in the repo.

Three spots could previously resolve to a non-UTC zone:

| Role | Before | After |
| --- | --- | --- |
| `homeassistant` | compose hardcoded `TZ: America/Chicago` | new `homeassistant_tz: "UTC"` default, referenced as `TZ: "{{ homeassistant_tz }}"` (matches the `_tz` var convention used by immich/seerr/idrac_kvm_docker/download_vpn) |
| `hermes_agent` | `hermes_agent_timezone` derived from the **target host's** `ansible_facts['timezone']` (any zone) | pinned to `"UTC"` regardless of host config |
| `immich` | `/etc/localtime:/etc/localtime:ro` bind mount inherited the host's zone | mount removed; `TZ=UTC` in the sibling `.env` (`immich_tz`) already governs |

`download_vpn` was already UTC — only its comment changed (stopped suggesting an override to a custom IANA zone).

## Verification

- `ansible-lint` (production profile): **0 failures, 0 warnings**
- `pre-commit` on all changed files: **all hooks pass** (yamllint, check-yaml, ansible-lint, etc.)
- The template-render tests do not assert on homeassistant/immich compose, so no test updates were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)