### PR TITLE
docs(traefik): drop the hardcoded VMID from the role README

### DIFF
--- a/roles/traefik/README.md
+++ b/roles/traefik/README.md
@@ -1,7 +1,7 @@
 # traefik
 
 HTTPS reverse-proxy / TLS ingress for **every** service web UI. Traefik runs as a
-pinned static binary under systemd on the ingress LXC (`media_svc` VLAN, vmid 215)
+pinned static binary under systemd on the ingress LXC (`media_svc` VLAN)
 and fronts each service at `https://<name>.{{ proxmox_domain }}` — no ports. It
 fetches and **auto-renews a single wildcard `*.{{ proxmox_domain }}`** Let's
 Encrypt certificate **itself** via the **Route53 DNS-01 challenge** (lego, built


### PR DESCRIPTION
## What

The traefik role README stated the ingress LXC's real production VMID (`215`) in prose. A VM ID
belongs only in `deployment.json` (resolved at runtime from the published inventory), not
duplicated in committed docs. The `media_svc` VLAN is enough to identify the guest — drop the vmid.

## Context

Part of the VMID single-source sweep. The other apps flag — `tests/inventory_load/tofu_inventory.json` —
is a mock loader fixture on a deliberately-fake `192.168.0.<vmid>` subnet (`vmid==octet`); its
3-digit octet values are test data, not a meaningful duplication of the 6-digit production scheme,
so it's left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128QwhN5mvem4ARsS55HqKH