### PR TITLE
fix(inventory): localhost loader discovers a boto3-capable interpreter

### DIFF
--- a/inventory/load_tofu.yml
+++ b/inventory/load_tofu.yml
@@ -20,6 +20,14 @@
   vars:
     # Override global ansible_become for localhost tasks
     ansible_become: false
+    # The global inventory pins ansible_python_interpreter to /usr/bin/python3
+    # (correct for the Debian LXC targets). That system python lacks boto3, so
+    # the amazon.aws S3 fetch below fails to import it. Discover the interpreter
+    # for this localhost play instead, so it picks the dev-shell python that
+    # carries boto3/botocore. Scoped to this play only — remote-host resolution
+    # is untouched. (ansible-proxmox sets interpreter_python=auto_silent globally
+    # and has no such pin, which is why its identical loader already works.)
+    ansible_python_interpreter: auto_silent
     tofu_inventory_path: "{{ lookup('env', 'TOFU_INVENTORY_PATH') | default('', true) }}"
     tofu_inventory_local: "{{ playbook_dir }}/../inventory/tofu_inventory.json"
     tofu_inventory_s3_uri: "{{ lookup('env', 'TOFU_INVENTORY_S3_URI') | default('', true) }}"


### PR DESCRIPTION
## Problem

Running any apps playbook that imports `inventory/load_tofu.yml` (i.e. `site.yml`) with AWS creds present fatally fails at the S3 inventory fetch:

```
Failed to import the required Python library (botocore and boto3) on <host>'s
Python /nix/store/...python3.13. ... boto3/botocore is not importable in this interpreter
```

The resolver then correctly refuses to fall back to a possibly-stale local cache (fail-loud by design), so the whole converge stops.

## Root cause

- `inventory/hosts.yml` sets `all.vars.ansible_python_interpreter: /usr/bin/python3` — correct for the Debian LXC targets, but that system python has no boto3.
- The loader's `amazon.aws` modules run on **localhost**, where they inherit that pin and can't import boto3.
- The dev shell (`nix-devenv#ansible-apps`) **does** ship boto3/botocore — they were just never reachable from the pinned interpreter.
- `ansible-proxmox`'s identical loader works because it sets `interpreter_python = auto_silent` globally and does **not** pin the interpreter.

## Fix

Override `ansible_python_interpreter: auto_silent` for the **localhost loader play only**, so it discovers the dev-shell python that carries boto3. Scoped to that one play — remote LXC interpreter resolution is untouched (zero risk to the ~40 other roles).

## Verification

Ran `ansible-playbook inventory/load_tofu.yml` from a worktree with the fix: the `boto3 not importable` fatal is **gone** — `aws_caller_info` now imports boto3 and reaches AWS (test only stopped on an unrelated expired local aws-vault token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzUXQk78Vou8n1o7itS3Md