### PR TITLE
fix(openbao): remove mlock config, render policies on target, drop WAN apt dependency

### DIFF
--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -168,10 +168,9 @@ openbao_recovery_file: "{{ playbook_dir }}/.openbao-recovery-{{ inventory_hostna
 openbao_approle_file_prefix: "{{ playbook_dir }}/.openbao-approle"
 
 # --- systemd hardening -------------------------------------------------------
-# OpenBao mlock()s memory to keep secrets out of swap; that needs CAP_IPC_LOCK.
-# Set to false ONLY if the platform cannot grant the capability (then add
-# disable_mlock=true to the config) — see templates.
-openbao_enable_mlock: true
+# NOTE: OpenBao 2.x dropped mlock support (a `disable_mlock` line is a fatal
+# config error since 2.5), so there is no mlock toggle here. Swap hygiene comes
+# from the guest itself: the OpenBao LXCs set memory_swap = 0 in deployment.json.
 openbao_service_state: started
 openbao_service_enabled: true
 

--- a/roles/openbao/tasks/init.yml
+++ b/roles/openbao/tasks/init.yml
@@ -120,7 +120,11 @@
     - (openbao_kv_mount ~ '/') not in (openbao_mounts_raw.stdout | from_json).keys()
 
 # --- RBAC policies (write-if-missing) ---------------------------------------
-- name: Render the RBAC policies to the controller
+# Rendered on the TARGET: `bao policy write` below executes there and reads
+# the file from its local filesystem (a controller-side render is unreachable
+# from the target). Policy HCL is non-secret — it comes from the committed
+# templates.
+- name: Render the RBAC policies to the target
   ansible.builtin.template:
     src: "{{ item.template }}"
     dest: "/tmp/openbao-policy-{{ item.name }}-{{ inventory_hostname }}.hcl"
@@ -128,11 +132,6 @@
   loop: "{{ openbao_policies }}"
   loop_control:
     label: "{{ item.name }}"
-  delegate_to: localhost
-  connection: local
-  become: false
-  vars:
-    ansible_become: false
   changed_when: false
   when: openbao_bootstrap_token is defined
 
@@ -164,18 +163,13 @@
     - openbao_bootstrap_token is defined
     - item.name not in (openbao_policies_raw.stdout | from_json)
 
-- name: Remove the rendered policies from the controller
+- name: Remove the rendered policies from the target
   ansible.builtin.file:
     path: "/tmp/openbao-policy-{{ item.name }}-{{ inventory_hostname }}.hcl"
     state: absent
   loop: "{{ openbao_policies }}"
   loop_control:
     label: "{{ item.name }}"
-  delegate_to: localhost
-  connection: local
-  become: false
-  vars:
-    ansible_become: false
   changed_when: false
   when: openbao_bootstrap_token is defined
 

--- a/roles/openbao/tasks/init.yml
+++ b/roles/openbao/tasks/init.yml
@@ -123,11 +123,13 @@
 # Rendered on the TARGET: `bao policy write` below executes there and reads
 # the file from its local filesystem (a controller-side render is unreachable
 # from the target). Policy HCL is non-secret — it comes from the committed
-# templates.
+# templates. Rendered into openbao_config_dir (/etc/openbao, 0750 root:openbao)
+# rather than world-writable /tmp, so the write is not exposed to symlink races
+# or other local users on the host.
 - name: Render the RBAC policies to the target
   ansible.builtin.template:
     src: "{{ item.template }}"
-    dest: "/tmp/openbao-policy-{{ item.name }}-{{ inventory_hostname }}.hcl"
+    dest: "{{ openbao_config_dir }}/.policy-{{ item.name }}.hcl"
     mode: "0600"
   loop: "{{ openbao_policies }}"
   loop_control:
@@ -150,7 +152,7 @@
   ansible.builtin.command:
     cmd: >-
       bao policy write {{ item.name }}
-      /tmp/openbao-policy-{{ item.name }}-{{ inventory_hostname }}.hcl
+      {{ openbao_config_dir }}/.policy-{{ item.name }}.hcl
   environment:
     BAO_ADDR: "{{ openbao_api_addr }}"
     BAO_TOKEN: "{{ openbao_bootstrap_token }}"
@@ -165,7 +167,7 @@
 
 - name: Remove the rendered policies from the target
   ansible.builtin.file:
-    path: "/tmp/openbao-policy-{{ item.name }}-{{ inventory_hostname }}.hcl"
+    path: "{{ openbao_config_dir }}/.policy-{{ item.name }}.hcl"
     state: absent
   loop: "{{ openbao_policies }}"
   loop_control:

--- a/roles/openbao/tasks/main.yml
+++ b/roles/openbao/tasks/main.yml
@@ -4,14 +4,23 @@
 # to tasks/init.yml, included after the service is up.
 
 # --- Phase 1: prerequisites --------------------------------------------------
-- name: Install OpenBao prerequisites
+# These containers are firewalled to internal-only egress (policy_out: DROP +
+# the `outbound-internal` security group) — a secrets service has no business
+# reaching the public internet, and it never does at runtime. So the role must
+# NOT depend on WAN apt: every package it needs is either in the Debian base
+# template (ca-certificates) or staged from the controller (the OpenBao .deb,
+# below). jq was listed but is unused anywhere in the role — dropped rather than
+# carried as a phantom WAN dependency. `update_cache: false` is deliberate: an
+# apt cache refresh can never succeed behind the internal-only firewall, and
+# forcing one is what wedged bring-up on any node whose pve-firewall is actually
+# running. If a future prereq isn't in the base template, stage it from the
+# controller like the .deb — do not reintroduce a mirror fetch here.
+- name: Ensure OpenBao base prerequisites are present (no WAN; base-template pkgs)
   ansible.builtin.apt:
     name:
       - ca-certificates
-      - jq
     state: present
-    update_cache: true
-    cache_valid_time: 3600
+    update_cache: false
 
 # --- Phase 2: system user / group -------------------------------------------
 - name: Create openbao system group

--- a/roles/openbao/templates/openbao.hcl.j2
+++ b/roles/openbao/templates/openbao.hcl.j2
@@ -47,14 +47,10 @@ listener "tcp" {
 api_addr     = "{{ openbao_api_addr }}"
 cluster_addr = "{{ openbao_cluster_addr }}"
 
-{% if openbao_enable_mlock %}
-# mlock() keeps the in-memory root/encryption keys out of swap. The systemd
-# unit grants CAP_IPC_LOCK so this succeeds without running as root.
-disable_mlock = false
-{% else %}
-# mlock disabled: the platform could not grant CAP_IPC_LOCK. Secrets may touch
-# swap — ensure swap is disabled or encrypted on this host.
-disable_mlock = true
-{% endif %}
+# OpenBao 2.x dropped mlock support entirely — any `disable_mlock` line is a
+# fatal config error since 2.5 (the server refuses to start). Swap hygiene is
+# the host's job instead: the OpenBao LXCs carry memory_swap = 0 in
+# deployment.json, so secrets cannot page to disk.
+# https://openbao.org/docs/install/#post-installation-hardening
 
 ui = {{ openbao_enable_ui | ternary('true', 'false') }}

--- a/roles/openbao/templates/openbao.service.j2
+++ b/roles/openbao/templates/openbao.service.j2
@@ -15,12 +15,9 @@ Group={{ openbao_group }}
 # Static-key auto-unseal material (0600, root:openbao). Keeping it in an
 # EnvironmentFile rather than the unit keeps it out of `systemctl show`.
 EnvironmentFile={{ openbao_env_file }}
-{% if openbao_enable_mlock %}
-# CAP_IPC_LOCK lets OpenBao mlock() its memory (disable_mlock=false in config)
-# without running as root.
-AmbientCapabilities=CAP_IPC_LOCK
-CapabilityBoundingSet=CAP_IPC_LOCK CAP_SYSLOG
-{% endif %}
+# OpenBao 2.x dropped mlock, so no CAP_IPC_LOCK is needed; swap hygiene comes
+# from the LXC's memory_swap = 0 in deployment.json.
+CapabilityBoundingSet=CAP_SYSLOG
 ExecStart={{ openbao_install_dir }}/bao server -config={{ openbao_config_file }}
 ExecReload=/bin/kill --signal HUP $MAINPID
 KillSignal=SIGINT


### PR DESCRIPTION
## Summary

Three fixes surfaced while bringing up the `openbao-01`/`openbao-02` Raft cluster (both nodes now healthy: openbao-01 leader, openbao-02 follower, both voters, self-unsealing via the static seal).

### 1. mlock removal (was fatal)
OpenBao 2.x dropped `mlock` support, and a `disable_mlock` line is a **fatal config error since 2.5** — the server refused to start. Removes the `openbao_enable_mlock` toggle, the `disable_mlock` config block, and the `AmbientCapabilities=CAP_IPC_LOCK` grant in the unit. Swap hygiene now comes from the LXC itself (`memory_swap = 0` in `deployment.json`).

### 2. RBAC policies rendered on the target
`bao policy write` executes **on the target** and reads the policy HCL from the target's own filesystem, so the previous `delegate_to: localhost` render left the file unreachable. Render on the target instead. Policy HCL is non-secret (committed templates), so nothing sensitive crosses the wire.

### 3. No-WAN apt prerequisites
These OpenBao LXCs are firewalled to **internal-only egress** (`policy_out: DROP` + the `outbound-internal` security group) — correct posture for a secrets service. The role must therefore not depend on WAN apt:
- Drop the unused `jq` package (referenced nowhere in the role).
- Stop forcing `update_cache` — `ca-certificates` ships in the Debian base template, and an apt cache refresh can never succeed behind the firewall.

This is what wedged bring-up on any node whose `pve-firewall` is actually running (openbao-01 only installed earlier because pve1's firewall service happened to be stopped).

## Verification
- `ansible-lint roles/openbao/` → **0 failures, production profile** ✅
- Live re-run against `openbao-02`: `ok=20 changed=12 failed=0` ✅
- `bao operator raft list-peers` shows both nodes as voters ✅

## Notes for reviewer
- Related security follow-up (not in this PR): pve1's `pve-firewall` is `enabled/stopped`, so openbao-01 currently has unintended WAN egress. Starting it brings pve1 in line with pve2 and the intended internal-only posture.
- `openbao-03` (pve3) deferred until pve3 is back online.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqwA7ZGx6J9NRyFDVnX6iY