### PR TITLE
feat(github-runner): add dryvist/tofu-github runner for Terrakube CI

### DIFF
--- a/inventory/group_vars/docker_vms.yml
+++ b/inventory/group_vars/docker_vms.yml
@@ -21,3 +21,8 @@ github_runner_repositories:
   - repo: "dryvist/ansible-proxmox"
     replicas: 1
     labels: "self-hosted,Linux,X64,proxmox"
+  # tofu-github triggers remote Terrakube plan/apply (LAN-only platform);
+  # the runner just needs outbound reach to terrakube-api.<domain>.
+  - repo: "dryvist/tofu-github"
+    replicas: 1
+    labels: "self-hosted,Linux,X64,proxmox,terrakube"


### PR DESCRIPTION
## Summary

Adds a `dryvist/tofu-github` entry to `github_runner_repositories` (1 replica, labels `self-hosted,Linux,X64,proxmox,terrakube`). tofu-github's new [Terrakube workflow](https://github.com/dryvist/tofu-github/pull/23) runs remote plan/apply against the LAN-only platform ([dryvist/iac-platform](https://github.com/dryvist/iac-platform)), which GitHub-hosted runners cannot reach.

Apply: re-run the `github_runner` role against docker-host after merge.

Part of the Terrakube migration: terraform-proxmox [#523](https://github.com/dryvist/terraform-proxmox/pull/523) → iac-platform → tofu-github [#23](https://github.com/dryvist/tofu-github/pull/23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qna3JuDp5y7MB2it6RqUKn