### PR TITLE
feat(llm): llama.cpp light tier + LiteLLM router; repoint consumers

### DIFF
--- a/.github/workflows/ai-pr-care.yml
+++ b/.github/workflows/ai-pr-care.yml
@@ -1,3 +1,4 @@
+---
 # AI PR care: dependency risk review + release highlights.
 #
 # - cc-dep-review: one AI risk-assessment comment on Renovate major/minor PRs.

--- a/inventory/group_vars/ai_orchestration_group.yml
+++ b/inventory/group_vars/ai_orchestration_group.yml
@@ -18,15 +18,17 @@ ai_otel_http_port: >-
 # before the source exists.
 ai_orchestration_otel_endpoint: "http://cribl-edge.{{ ai_subdomain }}:{{ ai_otel_http_port }}"
 
-# OpenAI-compatible model endpoints — two active tiers; each tool/flow selects per
-# its own config (never forced):
-#   light tier — hermes-infer (Ollama): lower-requirement workloads + long-term
-#     soak testing; fronted by Traefik at the `ollama` ingress.
-#   large tier — reached at the neutral `llm-large` name (Technitium auto-creates a
-#     CNAME from it to the runner's FQDN, sourced from LLM_LARGE_RUNNER_HOST), so
-#     the host behind it is swappable with no app change and no IP is stored.
-ai_orchestration_ollama_base_url: "https://ollama.{{ ai_subdomain }}/v1"
-ai_orchestration_model_large_base_url: "http://llm-large.{{ ai_subdomain }}:11434/v1"
+# OpenAI-compatible model endpoint — the LiteLLM router (the fabric front door) at
+# https://llm.<subdomain>/v1. The tier is now expressed by the MODEL ALIAS the tool
+# requests (large: gpt-oss-120b/qwen3-coder; light: hermes-4-14b/qwen3-4b/embeddings),
+# so both endpoints below point at the SAME router — the host topology behind each
+# alias is swappable with no app change and no IP is stored. Both var NAMES are kept
+# so downstream app/systemd configs that read them don't churn.
+ai_orchestration_ollama_base_url: "https://llm.{{ ai_subdomain }}/v1"
+ai_orchestration_model_large_base_url: "https://llm.{{ ai_subdomain }}/v1"
+# Router API key (master key), env-sourced (SOPS/Doppler) like its siblings.
+ai_orchestration_model_api_key: >-
+  {{ lookup('env', 'AI_ORCHESTRATION_MODEL_API_KEY') | default('', true) }}
 
 # Restart the Docker stack on failure (Phase 9 systemd restart policy).
 systemd_restart_policy_services:

--- a/inventory/group_vars/llm_fast_group.yml
+++ b/inventory/group_vars/llm_fast_group.yml
@@ -1,0 +1,11 @@
+---
+# Config for the light serving tier (llama.cpp + llama-swap on the GPU `llm-fast`
+# guest). Guests carry the `llm-fast` tag -> llm_fast_group (load_tofu.yml).
+
+# GPU build (RX 6800 / gfx1030 ROCm). Set false on a future CPU-only `llm-light`
+# standby guest to skip every ROCm/GPU task.
+llama_cpp_gpu: true
+
+# Restart the llama-swap service on failure (Phase 9 systemd restart policy).
+systemd_restart_policy_services:
+  - llama-swap

--- a/inventory/group_vars/llm_router_group.yml
+++ b/inventory/group_vars/llm_router_group.yml
@@ -1,0 +1,8 @@
+---
+# Config for the LiteLLM proxy tier (the fabric front door). Guests carry the
+# `llm-router` tag -> llm_router_group (load_tofu.yml). Three instances behind
+# Traefik at https://llm.<subdomain>.
+
+# Restart the litellm service on failure (Phase 9 systemd restart policy).
+systemd_restart_policy_services:
+  - litellm

--- a/inventory/load_tofu.yml
+++ b/inventory/load_tofu.yml
@@ -306,6 +306,16 @@
               else []
             ) +
             (
+              ['llm_fast_group']
+              if 'llm-fast' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
+              ['llm_router_group']
+              if 'llm-router' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
               ['ai_orchestration_group']
               if 'ai-orchestration' in (item.value.tags | default([]))
               else []

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -614,6 +614,35 @@
     - role: hermes_agent
 
 # =============================================================================
+# Phase 8a3: LLM serving fabric — llama.cpp light tier + LiteLLM front door.
+# llama.cpp + llama-swap (llm-fast, RX 6800) serves the co-resident light models;
+# the LiteLLM proxy (llm-router x3) is the single OpenAI-compatible endpoint,
+# fronted by Traefik at https://llm.<subdomain>, routing large vs light by alias.
+# =============================================================================
+
+- name: Configure llama.cpp light-tier serving (llama-swap, AMD ROCm)
+  hosts: llm_fast_group
+  become: true
+  gather_facts: true
+  tags:
+    - llama_cpp
+    - llm
+    - ai
+  roles:
+    - role: llama_cpp
+
+- name: Configure the LiteLLM router (fabric front door)
+  hosts: llm_router_group
+  become: true
+  gather_facts: true
+  tags:
+    - llm_router
+    - llm
+    - ai
+  roles:
+    - role: llm_router
+
+# =============================================================================
 # Phase 8a-bis: AI Orchestration Layer
 # Visual builders (Dify, LangFlow) + a CrewAI/LangChain runtime on the ai
 # VLAN; Langfuse LLM-observability on siem. Docker-in-LXC except agent-exec

--- a/roles/agent_exec/README.md
+++ b/roles/agent_exec/README.md
@@ -22,7 +22,7 @@ it with your own agents — your edits survive re-converges.
 - Runs `main.py` under systemd (`Restart=on-failure`) with the `OTEL_*` and
   two-tier model-endpoint env preset. The seeded `main.py` loops every
   `agent_exec_interval_seconds`, running a small traced crew against the large
-  tier (real work) and the light tier (hermes-infer soak path); a failed run is
+  tier (real work) and the light tier (soak path); a failed run is
   logged and the loop continues.
 
 ## Your agent code
@@ -67,7 +67,7 @@ Or include the role directly against the group:
 | `agent_exec_pip_packages` | runtime + instrumentation | venv package set |
 | `agent_exec_interval_seconds` | `900` | seconds between autonomy-seed cycles |
 | `agent_exec_model_large` | `openai/default` | large-tier model name (LiteLLM form) |
-| `agent_exec_model_light` | `openai/hermes4` | light-tier (hermes-infer) model name |
+| `agent_exec_model_light` | `openai/hermes4` | light-tier model alias (via the router) |
 | `agent_exec_api_key` | `sk-noauth` | OpenAI-compatible key (runners ignore it) |
 
 `ai_orchestration_otel_endpoint` (OTLP collector) and the two model base URLs

--- a/roles/agent_exec/defaults/main.yml
+++ b/roles/agent_exec/defaults/main.yml
@@ -29,7 +29,7 @@ agent_exec_pip_packages:
   - opentelemetry-instrumentation-langchain
 
 # Autonomy seed loop: every interval the seed runs a tiny traced crew against
-# BOTH model tiers (large = real work; light = hermes-infer soak path). Override
+# BOTH model tiers (large = real work; light = soak path). Override
 # the model names to match what each endpoint serves; the loop is resilient to a
 # single failed run. The large/light base URLs come from the ai_orchestration
 # group vars (ai_orchestration_model_large_base_url / ai_orchestration_ollama_base_url).

--- a/roles/agent_exec/templates/agent-exec.service.j2
+++ b/roles/agent_exec/templates/agent-exec.service.j2
@@ -13,7 +13,7 @@ Environment=OTEL_EXPORTER_OTLP_ENDPOINT={{ ai_orchestration_otel_endpoint }}
 Environment=OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 Environment=OTEL_SERVICE_NAME={{ agent_exec_service }}
 # Two-tier model fabric (re-rendered each converge, so the backend is swappable):
-# large = high-capability runner; light = hermes-infer (Ollama), the soak path.
+# both tiers now reach the LiteLLM router, which routes by model alias.
 Environment=AGENT_EXEC_MODEL_LARGE_BASE_URL={{ ai_orchestration_model_large_base_url }}
 Environment=AGENT_EXEC_MODEL_LIGHT_BASE_URL={{ ai_orchestration_ollama_base_url }}
 Environment=AGENT_EXEC_MODEL_LARGE={{ agent_exec_model_large }}

--- a/roles/agent_exec/templates/main.py.j2
+++ b/roles/agent_exec/templates/main.py.j2
@@ -5,7 +5,7 @@ with your own crews. Keep `import otel_bootstrap` first so every CrewAI run is
 traced to the homelab OTLP collector (and on to Langfuse + Splunk).
 
 Each interval the loop exercises BOTH model tiers: the large tier for real work
-and the light tier (hermes-infer) as the continuous soak path. It is resilient —
+and the light tier as the continuous soak path. It is resilient —
 a failed run is logged and the loop continues, so the systemd service stays
 active. Endpoints, model names, cadence, and key come from the systemd unit
 environment (re-rendered by the agent_exec role each converge), so the inference

--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -19,8 +19,8 @@ VLAN.
 - `HERMES_HOME` (`/var/lib/hermes/.hermes`) lives on a dedicated ZFS data volume —
   memory, skills, profiles, the Kanban DB, sessions and logs — so it is snapshotted
   + replicated pve→pve3 (the agent's accumulated knowledge is irreplaceable).
-- Points the model backend at the always-on homelab GPU Ollama (`hermes4`,
-  OpenAI-compatible `/v1`); sets memory provider to **Hindsight** (best self-hostable
+- Points the model backend at the LiteLLM router (`hermes-4-14b` via
+  `llm.<subdomain>/v1`, OpenAI-compatible); sets memory provider to **Hindsight** (best self-hostable
   June 2026) alongside the always-on `MEMORY.md`/`USER.md`; caps `agent.max_turns`
   so a runaway loop can't pin the GPU overnight.
 
@@ -29,8 +29,8 @@ VLAN.
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `hermes_agent_home` | `/var/lib/hermes` | data-volume mount = the user home |
-| `hermes_agent_model_base_url` | inventory-derived Ollama `/v1` | the brain endpoint |
-| `hermes_agent_model` | `hermes4` | model id |
+| `hermes_agent_model_base_url` | `https://llm.{{ PROXMOX_SUBDOMAIN }}/v1` (router) | the brain endpoint |
+| `hermes_agent_model` | `hermes-4-14b` | model id |
 | `hermes_agent_memory_provider` | `hindsight` | external memory provider |
 | `hermes_agent_max_turns` | `90` | agentic-loop budget |
 

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -15,14 +15,14 @@ hermes_agent_hermes_home: "{{ hermes_agent_home }}/.hermes" # $HERMES_HOME
 hermes_agent_bin: /usr/local/bin/hermes                     # system-wide install
 hermes_agent_install_url: "https://hermes-agent.nousresearch.com/install.sh"
 
-# --- Brain: the always-on homelab GPU Ollama (OpenAI-compatible /v1) ---
-# Matches the open_webui sibling: intra-VLAN container endpoint from the tofu
-# inventory (derived, never a hardcoded literal), no Traefik dependency. FQDN
-# alternative once that ingress is applied: https://ollama.{{ PROXMOX_SUBDOMAIN }}/v1
-hermes_agent_model: hermes4
-hermes_agent_model_base_url: >-
-  http://{{ hostvars['hermes-infer'].container_ip }}:{{ tofu_data.constants.service_ports.ollama_api }}/v1
+# --- Brain: the LiteLLM router (the fabric front door, OpenAI-compatible /v1) ---
+# Reached by its neutral Traefik FQDN — never a hardcoded IP. The router routes by
+# model alias, so the agent just names the model it wants (the light Hermes-4-14B
+# here). The api key is the router master key, env-sourced (SOPS/Doppler).
+hermes_agent_model: hermes-4-14b
+hermes_agent_model_base_url: "https://llm.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}/v1"
 hermes_agent_model_api_mode: chat_completions
+hermes_agent_model_api_key: "{{ lookup('env', 'HERMES_AGENT_MODEL_API_KEY') | default('', true) }}"
 
 # --- Memory: best self-hostable as of June 2026 (Agy-validated) ---
 # Hindsight: local knowledge-graph + multi-strategy retrieval. Runs alongside the

--- a/roles/hermes_agent/templates/config.yaml.j2
+++ b/roles/hermes_agent/templates/config.yaml.j2
@@ -8,6 +8,8 @@ model:
   default: {{ hermes_agent_model }}
   base_url: '{{ hermes_agent_model_base_url }}'
   api_mode: {{ hermes_agent_model_api_mode }}
+  # Resolved from .env at runtime (the LiteLLM router master key).
+  api_key: '${HERMES_AGENT_MODEL_API_KEY}'
 
 memory:
   provider: {{ hermes_agent_memory_provider }}

--- a/roles/hermes_agent/templates/hermes-env.j2
+++ b/roles/hermes_agent/templates/hermes-env.j2
@@ -1,5 +1,6 @@
 {{ ansible_managed | comment }}
-# Secrets for the Hermes Agent, referenced from config.yaml via ${VAR}. The local
-# Ollama "custom" provider needs no API key, so this starts empty. Add messaging-
-# platform / tool tokens here when wiring a gateway (W7), sourced from SOPS/Doppler
-# at converge time — never commit real values.
+# Secrets for the Hermes Agent, referenced from config.yaml via ${VAR}, sourced from
+# SOPS/Doppler at converge time — never commit real values. Add messaging-platform /
+# tool tokens here when wiring a gateway (W7).
+# Brain API key = the LiteLLM router master key.
+HERMES_AGENT_MODEL_API_KEY={{ hermes_agent_model_api_key }}

--- a/roles/llama_cpp/README.md
+++ b/roles/llama_cpp/README.md
@@ -1,0 +1,81 @@
+# llama_cpp
+
+Deploys the **light serving tier**: [llama.cpp](https://github.com/ggml-org/llama.cpp)
+(`llama-server`) behind [llama-swap](https://github.com/mostlygeek/llama-swap) on an
+AMD **ROCm** GPU, inside a privileged LXC (guest `llm-fast`, RX 6800 = gfx1030).
+llama-swap presents **one** OpenAI-compatible endpoint and keeps the configured
+models co-resident, so Hermes-4-14B + a small general model + an embeddings model
+all fit in 16 GB at Q4 and answer without reload churn.
+
+## Installation
+
+Ships with the `ansible-proxmox-apps` repo; no external install. The container is
+provisioned by `terraform-proxmox` and the GPU device nodes (`/dev/kfd`, `/dev/dri`)
+are passed in by `ansible-proxmox` (role `lxc_gpu_features`) — both must be in place
+first. Wired into `playbooks/site.yml` against `llm_fast_group` (guests tagged
+`llm-fast` in the tofu inventory). Tools come from the repo's Nix dev shell
+(`direnv allow`).
+
+Ordering: `terraform-proxmox` (LXC shell) → `ansible-proxmox` (GPU passthrough) →
+**this role** (llama.cpp + llama-swap + models) → `llm_router` (LiteLLM front door).
+
+## What it does
+
+- Installs `curl`, `ca-certificates`, `tar`, `gzip`.
+- Resolves and installs the **latest** llama.cpp release (the `ubuntu-rocm` asset,
+  selected by name pattern so both the build tag and the embedded ROCm version can
+  move without a role change) and the **latest** llama-swap release, each once
+  behind a presence guard.
+- Adds the `llama-cpp` service user to whatever groups own the passed-in GPU device
+  nodes (resolved at runtime via `stat`), so the server can open `/dev/kfd` +
+  `/dev/dri` regardless of how host GIDs map to container group names (same idiom as
+  `roles/ollama`).
+- Stages the model GGUFs as local files (downloads only when absent).
+- Renders the llama-swap config (a co-resident model group) + a systemd unit,
+  listening on `service_ports.llm_fast_api`. Restart-on-failure is applied by the
+  shared `systemd_restart_policy` role via `group_vars/llm_fast_group.yml`.
+
+## Models
+
+| model_name | aliases | kind |
+| --- | --- | --- |
+| `hermes-4-14b` | `hermes4` | chat (`--jinja`) |
+| `qwen3-4b` | — | chat (`--jinja`) |
+| `embeddings` | `nomic-embed-text-v1.5` | `--embeddings` |
+
+All three are members of the `resident` llama-swap group (`swap: false`), so they
+stay loaded together.
+
+## GPU toggle
+
+`llama_cpp_gpu: true` (default) builds the ROCm path: all layers offloaded
+(`-ngl 99`), `HSA_OVERRIDE_GFX_VERSION=10.3.0` for gfx1030. Setting it `false` (for a
+future CPU-only `llm-light` standby guest) skips every ROCm/GPU task, runs `-ngl 0`
+with a smaller context, and drops the GPU env from the unit.
+
+## Key variables (`defaults/main.yml`)
+
+| Var | Default | Purpose |
+| --- | --- | --- |
+| `llama_cpp_api_port` | `tofu_data.constants.service_ports.llm_fast_api` | llama-swap listen port (no hardcode) |
+| `llama_cpp_gpu` | `true` | ROCm GPU vs CPU-only standby |
+| `llama_cpp_models` | 3-model list | served models + GGUF sources |
+| `llama_cpp_install_dir` | `/opt/llama-cpp` | binary + bundled ROCm `.so` files (also `LD_LIBRARY_PATH`) |
+| `llama_cpp_models_dir` | `/var/lib/llama-cpp/models` | staged GGUFs (persistent volume) |
+| `llama_cpp_rocm_packages` | `[]` | best-effort container ROCm runtime packages |
+
+## Usage
+
+```bash
+# Deploy (after terraform + ansible-proxmox GPU passthrough)
+env -u DOPPLER_PROJECT -u DOPPLER_CONFIG -u DOPPLER_ENVIRONMENT doppler run -- \
+  ./scripts/run-ansible.sh playbooks/site.yml --limit llm-fast --tags llama_cpp,ai
+```
+
+## Not yet live-validated
+
+Verify on the first converge (W6): (a) the prebuilt ROCm llama.cpp binary runs
+against the container's ROCm userspace (it is dynamically linked to the ROCm runtime
+— the LXC must provide it; see `llama_cpp_rocm_packages`); (b)
+`HSA_OVERRIDE_GFX_VERSION=10.3.0` is honoured by the release build for gfx1030; (c)
+the GGUF asset filenames still resolve on HuggingFace.

--- a/roles/llama_cpp/defaults/main.yml
+++ b/roles/llama_cpp/defaults/main.yml
@@ -1,0 +1,112 @@
+---
+# llama_cpp role defaults — the light serving tier: llama.cpp (llama-server) behind
+# llama-swap, on an AMD ROCm GPU inside a privileged LXC (guest `llm-fast`, RX 6800
+# = gfx1030). llama-swap presents ONE OpenAI-compatible endpoint and keeps the
+# configured models co-resident (a group with swap:false), so hermes-4-14b + a
+# small general model + an embeddings model all fit in 16 GB at Q4 and answer
+# without reload churn.
+#
+# GPU device nodes (/dev/kfd, /dev/dri) are passed into the container UPSTREAM by
+# ansible-proxmox (role lxc_gpu_features); this role assumes they already exist and
+# makes the `llama-cpp` service user able to open them (same runtime-group-resolution
+# idiom as roles/ollama). Restart-on-failure is applied DRY by the shared
+# systemd_restart_policy role via group_vars, not here.
+#
+# NOT YET LIVE-VALIDATED (verify on first converge, W6): (a) the ROCm llama.cpp
+# release tarball runs against the container's ROCm userspace — the prebuilt
+# `ubuntu-rocm` binary is dynamically linked to the ROCm runtime, so the LXC must
+# provide it (see llama_cpp_rocm_packages); (b) HSA_OVERRIDE_GFX_VERSION=10.3.0 is
+# honoured by the release build for gfx1030; (c) the exact GGUF asset filenames
+# below still resolve on HuggingFace.
+
+llama_cpp_user: llama-cpp
+llama_cpp_group: llama-cpp
+
+# Release binaries land here (flattened: the binary + its bundled .so files share
+# one dir, which also becomes LD_LIBRARY_PATH). Models live on the persistent
+# data volume beside them.
+llama_cpp_install_dir: /opt/llama-cpp
+llama_cpp_server_bin: "{{ llama_cpp_install_dir }}/llama-server"
+llama_cpp_swap_bin: /usr/local/bin/llama-swap
+llama_cpp_data_dir: /var/lib/llama-cpp
+llama_cpp_models_dir: "{{ llama_cpp_data_dir }}/models"
+llama_cpp_config_dir: /etc/llama-swap
+llama_cpp_config_file: "{{ llama_cpp_config_dir }}/config.yaml"
+
+# --- GPU toggle -------------------------------------------------------------
+# true  -> ROCm build, all layers offloaded (-ngl 99), gfx-version override.
+# false -> CPU-only standby (future `llm-light` guest): skips every ROCm/GPU task,
+#          runs -ngl 0 with a smaller context so it still answers on CPU.
+llama_cpp_gpu: true
+
+# AMD RX 6800 = Navi 21 / gfx1030; ROCm needs the gfx-version override for this card.
+llama_cpp_hsa_override_gfx_version: "10.3.0"
+
+# GPU-layer offload + context: full offload + full context on GPU; none + a smaller
+# context on CPU (a 14B at Q4 is slow on CPU, so keep the working set small).
+llama_cpp_ngl: "{{ 99 if llama_cpp_gpu | bool else 0 }}"
+llama_cpp_ctx_size: "{{ 8192 if llama_cpp_gpu | bool else 2048 }}"
+
+# GPU device nodes passed in by ansible-proxmox lxc_gpu_features. The role stats
+# these at runtime and adds the service user to whatever groups own them, so device
+# access works regardless of how host GIDs map to container groups.
+llama_cpp_gpu_device_nodes:
+  - /dev/kfd
+  - /dev/dri/card0
+  - /dev/dri/renderD128
+
+# Best-effort ROCm runtime packages for the container (the prebuilt ROCm llama.cpp
+# binary links against them). Left empty by default: exact provisioning is resolved
+# at the first live converge (the LXC template may already ship ROCm, or an AMD apt
+# repo may be needed). Override per host/group as validated.
+llama_cpp_rocm_packages: []
+
+# --- Release resolution (never pin a version — resolve latest at converge) ----
+# Query the GitHub "latest release" and pick the asset by NAME pattern, so both the
+# build tag AND the embedded ROCm version can move without a role change.
+llama_cpp_llamacpp_releases_api: "https://api.github.com/repos/ggml-org/llama.cpp/releases/latest"
+llama_cpp_swap_releases_api: "https://api.github.com/repos/mostlygeek/llama-swap/releases/latest"
+# GPU build -> the ubuntu ROCm tarball; CPU build -> the plain ubuntu x64 tarball.
+llama_cpp_llamacpp_asset_regex: >-
+  {{ '^llama-.*-bin-ubuntu-rocm-.*-x64\\.tar\\.gz$'
+     if llama_cpp_gpu | bool
+     else '^llama-.*-bin-ubuntu-x64\\.tar\\.gz$' }}
+llama_cpp_swap_asset_regex: '^llama-swap_.*_linux_amd64\\.tar\\.gz$'
+
+# --- llama-swap listener -----------------------------------------------------
+# The single OpenAI-compatible port llama-swap listens on. From the tofu ports
+# registry (no hardcoded ports — see the ip-addressing rule); hard-required like
+# every other role's port so a missing constant fails loud rather than guessing.
+llama_cpp_api_port: "{{ tofu_data.constants.service_ports.llm_fast_api }}"
+
+# Per-model upstream ports llama-swap hands to each llama-server it spawns start here
+# (well clear of the public API port). llama-swap assigns ${PORT} from this base.
+llama_cpp_start_port: 9200
+
+# How long llama-swap waits for a model to become healthy before declaring it
+# unhealthy (a 14B cold-loads from disk into VRAM; give it headroom).
+llama_cpp_health_check_timeout: 300
+
+# --- Models (co-resident) ----------------------------------------------------
+# All three stay loaded together (see the group in the template): Hermes-4-14B Q4
+# (~8.4 GB) + a small general model + a tiny embeddings model fit in 16 GB at Q4.
+# Each entry: the served model_name, extra OpenAI aliases, the HuggingFace repo +
+# GGUF filename (the URL is composed in the task), and whether it is an embeddings
+# server. Repo/quant are role vars so a change needs no task edit.
+llama_cpp_hf_base: "https://huggingface.co"
+llama_cpp_models:
+  - name: hermes-4-14b
+    aliases: [hermes4]
+    hf_repo: "bartowski/NousResearch_Hermes-4-14B-GGUF"
+    gguf: "NousResearch_Hermes-4-14B-Q4_K_M.gguf"
+    embeddings: false
+  - name: qwen3-4b
+    aliases: []
+    hf_repo: "bartowski/Qwen_Qwen3-4B-Instruct-2507-GGUF"
+    gguf: "Qwen_Qwen3-4B-Instruct-2507-Q4_K_M.gguf"
+    embeddings: false
+  - name: embeddings
+    aliases: [nomic-embed-text-v1.5]
+    hf_repo: "nomic-ai/nomic-embed-text-v1.5-GGUF"
+    gguf: "nomic-embed-text-v1.5.Q4_K_M.gguf"
+    embeddings: true

--- a/roles/llama_cpp/handlers/main.yml
+++ b/roles/llama_cpp/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart llama-swap
+  ansible.builtin.systemd:
+    name: llama-swap
+    state: restarted
+    daemon_reload: true

--- a/roles/llama_cpp/tasks/main.yml
+++ b/roles/llama_cpp/tasks/main.yml
@@ -1,0 +1,299 @@
+---
+# llama.cpp (llama-server) + llama-swap on AMD ROCm in an LXC. Idempotent.
+# Prereqs (upstream): ansible-proxmox lxc_gpu_features has bound /dev/kfd + /dev/dri
+# into this CT (GPU build only). We only need the service user to be able to use them.
+
+- name: Install llama.cpp / llama-swap prerequisites
+  ansible.builtin.apt:
+    name:
+      - curl
+      - ca-certificates
+      - tar
+      - gzip
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+# Best-effort ROCm runtime for the container (prebuilt ROCm build links against it).
+# Empty by default — a no-op until a validated package list is supplied per host.
+- name: Install ROCm runtime packages (GPU build)
+  ansible.builtin.apt:
+    name: "{{ llama_cpp_rocm_packages }}"
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  when:
+    - llama_cpp_gpu | bool
+    - llama_cpp_rocm_packages | length > 0
+
+- name: Create the llama-cpp service group
+  ansible.builtin.group:
+    name: "{{ llama_cpp_group }}"
+    system: true
+
+- name: Create the llama-cpp service user
+  ansible.builtin.user:
+    name: "{{ llama_cpp_user }}"
+    group: "{{ llama_cpp_group }}"
+    home: "{{ llama_cpp_data_dir }}"
+    system: true
+    shell: /usr/sbin/nologin
+    create_home: true
+
+- name: Create the install, models and config directories
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
+    mode: "{{ item.mode }}"
+  loop:
+    - { path: "{{ llama_cpp_install_dir }}", owner: root, group: root, mode: "0755" }
+    - { path: "{{ llama_cpp_config_dir }}", owner: root, group: root, mode: "0755" }
+    - path: "{{ llama_cpp_models_dir }}"
+      owner: "{{ llama_cpp_user }}"
+      group: "{{ llama_cpp_group }}"
+      mode: "0750"
+
+# --- GPU device access (clone of roles/ollama; GPU build only) ---------------
+# lxc_gpu_features binds the device nodes in with the HOST's group GIDs, which
+# rarely match the container's own render/video groups. Instead of forcing GIDs
+# (which collides), add the service user to whatever groups actually own the nodes,
+# resolved at runtime from the files themselves.
+- name: Stat the GPU device nodes to learn their owning groups
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  loop: "{{ llama_cpp_gpu_device_nodes }}"
+  register: llama_cpp_gpu_dev_stat
+  when: llama_cpp_gpu | bool
+
+- name: Assert the GPU device nodes are present (passed in by lxc_gpu_features)
+  ansible.builtin.assert:
+    that:
+      - llama_cpp_gpu_dev_stat.results | rejectattr('stat.exists') | list | length == 0
+    fail_msg: >-
+      One or more GPU device nodes are missing in this container
+      ({{ llama_cpp_gpu_device_nodes | join(', ') }}). Run ansible-proxmox
+      lxc_gpu_features against this CT first.
+  when: llama_cpp_gpu | bool
+
+- name: Add the llama-cpp user to the GPU device-owning groups
+  ansible.builtin.user:
+    name: "{{ llama_cpp_user }}"
+    groups: "{{ llama_cpp_gpu_dev_stat.results | map(attribute='stat.gr_name') | list | unique }}"
+    append: true
+  when: llama_cpp_gpu | bool
+  notify: Restart llama-swap
+
+# --- llama.cpp release (resolve latest, install once) ------------------------
+# Presence-guarded: the build tag moves every release, so we install once behind
+# the binary's existence and let operators refresh by removing it. The GitHub API
+# call only runs on first install, so re-converge does not spend rate limit.
+- name: Check whether the llama-server binary is already installed
+  ansible.builtin.stat:
+    path: "{{ llama_cpp_server_bin }}"
+  register: llama_cpp_server_stat
+
+- name: Install the llama.cpp release binary
+  when: not llama_cpp_server_stat.stat.exists
+  block:
+    - name: Resolve the latest llama.cpp release metadata
+      ansible.builtin.uri:
+        url: "{{ llama_cpp_llamacpp_releases_api }}"
+        return_content: true
+        headers:
+          Accept: application/vnd.github+json
+      register: llama_cpp_llamacpp_release
+
+    - name: Select the llama.cpp release asset by name pattern
+      ansible.builtin.set_fact:
+        llama_cpp_llamacpp_asset_url: >-
+          {{ llama_cpp_llamacpp_release.json.assets
+             | selectattr('name', 'match', llama_cpp_llamacpp_asset_regex)
+             | map(attribute='browser_download_url') | list | first }}
+
+    - name: Assert a matching llama.cpp asset was found
+      ansible.builtin.assert:
+        that:
+          - llama_cpp_llamacpp_asset_url | default('') | length > 0
+        fail_msg: >-
+          No llama.cpp release asset matched {{ llama_cpp_llamacpp_asset_regex }}
+          in {{ llama_cpp_llamacpp_releases_api }} — the asset naming may have changed.
+
+    - name: Create a temporary extraction directory
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: llama-cpp
+      register: llama_cpp_extract_tmp
+
+    - name: Download and extract the llama.cpp release tarball
+      ansible.builtin.unarchive:
+        src: "{{ llama_cpp_llamacpp_asset_url }}"
+        dest: "{{ llama_cpp_extract_tmp.path }}"
+        remote_src: true
+
+    - name: Locate the extracted llama-server binary
+      ansible.builtin.find:
+        paths: "{{ llama_cpp_extract_tmp.path }}"
+        patterns: llama-server
+        file_type: file
+        recurse: true
+      register: llama_cpp_server_find
+
+    - name: Assert the llama-server binary was found in the archive
+      ansible.builtin.assert:
+        that:
+          - llama_cpp_server_find.matched | int > 0
+        fail_msg: "No 'llama-server' binary found in the llama.cpp release archive — the layout may have changed."
+
+    # Flatten the release's bin dir into the install dir so the binary and its
+    # bundled .so files share one directory (also LD_LIBRARY_PATH in the unit).
+    - name: Install the llama.cpp bin directory contents
+      ansible.builtin.copy:
+        src: "{{ llama_cpp_server_find.files[0].path | dirname }}/"
+        dest: "{{ llama_cpp_install_dir }}/"
+        remote_src: true
+        owner: root
+        group: root
+        mode: preserve
+      notify: Restart llama-swap
+
+    - name: Remove the temporary extraction directory
+      ansible.builtin.file:
+        path: "{{ llama_cpp_extract_tmp.path }}"
+        state: absent
+
+# --- llama-swap release (resolve latest, install once) -----------------------
+- name: Check whether the llama-swap binary is already installed
+  ansible.builtin.stat:
+    path: "{{ llama_cpp_swap_bin }}"
+  register: llama_cpp_swap_stat
+
+- name: Install the llama-swap release binary
+  when: not llama_cpp_swap_stat.stat.exists
+  block:
+    - name: Resolve the latest llama-swap release metadata
+      ansible.builtin.uri:
+        url: "{{ llama_cpp_swap_releases_api }}"
+        return_content: true
+        headers:
+          Accept: application/vnd.github+json
+      register: llama_cpp_swap_release
+
+    - name: Select the llama-swap release asset by name pattern
+      ansible.builtin.set_fact:
+        llama_cpp_swap_asset_url: >-
+          {{ llama_cpp_swap_release.json.assets
+             | selectattr('name', 'match', llama_cpp_swap_asset_regex)
+             | map(attribute='browser_download_url') | list | first }}
+
+    - name: Assert a matching llama-swap asset was found
+      ansible.builtin.assert:
+        that:
+          - llama_cpp_swap_asset_url | default('') | length > 0
+        fail_msg: >-
+          No llama-swap release asset matched {{ llama_cpp_swap_asset_regex }}
+          in {{ llama_cpp_swap_releases_api }} — the asset naming may have changed.
+
+    - name: Create a temporary llama-swap extraction directory
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: llama-swap
+      register: llama_cpp_swap_tmp
+
+    - name: Download and extract the llama-swap release tarball
+      ansible.builtin.unarchive:
+        src: "{{ llama_cpp_swap_asset_url }}"
+        dest: "{{ llama_cpp_swap_tmp.path }}"
+        remote_src: true
+
+    - name: Locate the extracted llama-swap binary
+      ansible.builtin.find:
+        paths: "{{ llama_cpp_swap_tmp.path }}"
+        patterns: llama-swap
+        file_type: file
+        recurse: true
+      register: llama_cpp_swap_find
+
+    - name: Assert the llama-swap binary was found in the archive
+      ansible.builtin.assert:
+        that:
+          - llama_cpp_swap_find.matched | int > 0
+        fail_msg: "No 'llama-swap' binary found in the release archive — the layout may have changed."
+
+    - name: Install the llama-swap binary
+      ansible.builtin.copy:
+        src: "{{ llama_cpp_swap_find.files[0].path }}"
+        dest: "{{ llama_cpp_swap_bin }}"
+        remote_src: true
+        owner: root
+        group: root
+        mode: "0755"
+      notify: Restart llama-swap
+
+    - name: Remove the temporary llama-swap extraction directory
+      ansible.builtin.file:
+        path: "{{ llama_cpp_swap_tmp.path }}"
+        state: absent
+
+# --- Model staging -----------------------------------------------------------
+- name: Stage the model GGUFs (download only if absent)
+  ansible.builtin.get_url:
+    url: "{{ llama_cpp_hf_base }}/{{ item.hf_repo }}/resolve/main/{{ item.gguf }}"
+    dest: "{{ llama_cpp_models_dir }}/{{ item.gguf }}"
+    owner: "{{ llama_cpp_user }}"
+    group: "{{ llama_cpp_group }}"
+    mode: "0640"
+  loop: "{{ llama_cpp_models }}"
+  loop_control:
+    label: "{{ item.name }} ({{ item.gguf }})"
+  register: llama_cpp_gguf_download
+  until: llama_cpp_gguf_download is succeeded
+  retries: 3
+  delay: 10
+
+# --- Config + service --------------------------------------------------------
+- name: Deploy the llama-swap configuration
+  ansible.builtin.template:
+    src: llama-swap.yaml.j2
+    dest: "{{ llama_cpp_config_file }}"
+    owner: root
+    group: "{{ llama_cpp_group }}"
+    mode: "0640"
+  notify: Restart llama-swap
+
+- name: Deploy the llama-swap systemd unit
+  ansible.builtin.template:
+    src: llama-swap.service.j2
+    dest: /etc/systemd/system/llama-swap.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart llama-swap
+
+- name: Enable and start llama-swap
+  ansible.builtin.systemd:
+    name: llama-swap
+    state: started
+    enabled: true
+    daemon_reload: true
+
+- name: Flush handlers so config / unit changes apply before verification
+  ansible.builtin.meta: flush_handlers
+
+# --- Verify ------------------------------------------------------------------
+# Type=simple reports 'active' the instant the process forks; poll until it settles
+# so a service that crashes a moment later fails loud here (mirrors roles/agent_exec).
+- name: Verify the llama-swap service is active
+  ansible.builtin.systemd:
+    name: llama-swap
+  register: llama_cpp_service_state
+  until: llama_cpp_service_state.status.ActiveState | default('') == 'active'
+  retries: 5
+  delay: 3
+
+- name: Verify the llama-swap API is listening
+  ansible.builtin.wait_for:
+    host: 127.0.0.1
+    port: "{{ llama_cpp_api_port }}"
+    timeout: 60

--- a/roles/llama_cpp/templates/llama-swap.service.j2
+++ b/roles/llama_cpp/templates/llama-swap.service.j2
@@ -1,0 +1,21 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=llama-swap — OpenAI-compatible proxy over llama.cpp (ROCm light tier)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ llama_cpp_user }}
+Group={{ llama_cpp_group }}
+WorkingDirectory={{ llama_cpp_data_dir }}
+# The ROCm release binary and its bundled .so files share the install dir.
+Environment=LD_LIBRARY_PATH={{ llama_cpp_install_dir }}
+{% if llama_cpp_gpu | bool %}
+Environment=HSA_OVERRIDE_GFX_VERSION={{ llama_cpp_hsa_override_gfx_version }}
+{% endif %}
+ExecStart={{ llama_cpp_swap_bin }} --config {{ llama_cpp_config_file }} --listen 0.0.0.0:{{ llama_cpp_api_port }}
+# Restart policy is managed by the systemd_restart_policy role (99-restart-policy.conf).
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/llama_cpp/templates/llama-swap.yaml.j2
+++ b/roles/llama_cpp/templates/llama-swap.yaml.j2
@@ -1,0 +1,50 @@
+{{ ansible_managed | comment }}
+# llama-swap config (managed by the llama_cpp role). One OpenAI-compatible endpoint
+# in front of llama.cpp's llama-server. The models below are kept co-resident (a
+# group with swap:false), so there is no per-request reload churn.
+
+healthCheckTimeout: {{ llama_cpp_health_check_timeout }}
+startPort: {{ llama_cpp_start_port }}
+logLevel: info
+
+# Shared llama-server invocation. ${PORT} is assigned per model by llama-swap.
+macros:
+  "server-base": >-
+    {{ llama_cpp_server_bin }}
+    --host 127.0.0.1 --port ${PORT}
+    -ngl {{ llama_cpp_ngl }}
+    --no-mmap
+
+groups:
+  # Keep every member loaded together: 16 GB fits Hermes-4-14B Q4 + a small general
+  # model + embeddings. swap:false = do not unload a member when another is
+  # requested; exclusive:false = this group is always resident.
+  "resident":
+    swap: false
+    exclusive: false
+    members:
+{% for m in llama_cpp_models %}
+      - "{{ m.name }}"
+{% endfor %}
+
+models:
+{% for m in llama_cpp_models %}
+  "{{ m.name }}":
+{% if m.aliases | length > 0 %}
+    aliases:
+{% for a in m.aliases %}
+      - "{{ a }}"
+{% endfor %}
+{% endif %}
+    cmd: |
+      ${server-base}
+      --model {{ llama_cpp_models_dir }}/{{ m.gguf }}
+      --ctx-size {{ llama_cpp_ctx_size }}
+{% if m.embeddings %}
+      --embeddings
+      --pooling mean
+{% else %}
+      --flash-attn
+      --jinja
+{% endif %}
+{% endfor %}

--- a/roles/llm_router/README.md
+++ b/roles/llm_router/README.md
@@ -1,0 +1,71 @@
+# llm_router
+
+Deploys a [LiteLLM](https://github.com/BerriAI/litellm) proxy — the LLM fabric's
+single OpenAI-compatible front door — on each guest tagged `llm-router`. Native
+install: a Python venv + systemd, config at `/etc/litellm/config.yaml`. Fronted by
+Traefik at `https://llm.<subdomain>`; consumers select a tier purely by model alias,
+so the backend topology is swappable with no app change.
+
+## Installation
+
+Ships with the `ansible-proxmox-apps` repo; no external install. Wired into
+`playbooks/site.yml` against `llm_router_group` (guests tagged `llm-router` in the
+tofu inventory). Tools come from the repo's Nix dev shell (`direnv allow`).
+
+## Tiers (one proxy, two backends)
+
+| Alias(es) | Backend | Auth |
+| --- | --- | --- |
+| `gpt-oss-120b`, `qwen3-coder` | `llm-large` runner (`/v1`, bearer) | `LLM_LARGE_BEARER_TOKEN` |
+| `hermes-4-14b`, `hermes4`, `qwen3-4b`, `embeddings` | `llm-fast` (GPU) **and** `llm-light` (CPU) | none |
+
+Each light alias is registered as **two deployments** with the same `model_name`
+(the GPU `llm-fast` box and the CPU `llm-light` standby). LiteLLM load-balances the
+pair and cools a failed deployment down (`allowed_fails` / `cooldown_time`), so a GPU
+outage drains to CPU automatically. There is **no** cross-tier fallback — a large
+request that fails surfaces the error rather than silently degrading to a small model.
+
+## Observability
+
+`litellm_settings.callbacks: ["langfuse", "otel"]`:
+
+- **Langfuse** success logging (`LANGFUSE_*` env; empty keys → the callback no-ops,
+  so a converge before Langfuse exists still comes up).
+- **OTLP/HTTP** traces to the Cribl Edge collector
+  (`http://cribl-edge.<subdomain>:<otel_traces_http>/v1/traces`).
+
+`/health/liveliness` is unauthenticated by design (LiteLLM load-balancer probe), so
+Traefik health checks need no credential.
+
+## Key variables (`defaults/main.yml`)
+
+| Var | Default | Purpose |
+| --- | --- | --- |
+| `llm_router_api_port` | `service_ports.llm_router_api` | proxy listen port (no hardcode) |
+| `llm_router_light_port` | `service_ports.llm_fast_api` | llm-fast / llm-light backend port |
+| `llm_router_large_port` | `service_ports.ollama_api` | llm-large backend port |
+| `llm_router_routing_strategy` | `simple-shuffle` | load-balancing across same-name deployments |
+| `llm_router_master_key` | `env LLM_ROUTER_MASTER_KEY` (mandatory) | proxy master key |
+| `llm_router_llm_large_bearer` | `env LLM_LARGE_BEARER_TOKEN` (mandatory) | llm-large bearer |
+
+## Dependencies
+
+- `terraform-proxmox` constants must expose `service_ports.llm_router_api` **and**
+  `service_ports.llm_fast_api` (added by the parallel constants PR). Both are
+  hard-required — a missing constant fails loud.
+- Secrets `LLM_ROUTER_MASTER_KEY` + `LLM_LARGE_BEARER_TOKEN` are env-sourced
+  (SOPS/Doppler) today; the OpenBao migration is a separate phase.
+
+## Usage
+
+```bash
+env -u DOPPLER_PROJECT -u DOPPLER_CONFIG -u DOPPLER_ENVIRONMENT doppler run -- \
+  ./scripts/run-ansible.sh playbooks/site.yml --limit llm_router_group --tags llm_router,ai
+```
+
+## Not yet live-validated
+
+Verify on the first converge: (a) `litellm[proxy]` + the `langfuse` / `otel`
+callbacks import cleanly in the venv; (b) the `llm-large` runner accepts the bearer
+on `/v1`; (c) the same-name GPU/CPU deployment pair drains as intended when the GPU
+box is stopped.

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -1,0 +1,99 @@
+---
+# llm_router role defaults — a LiteLLM proxy (the fabric's single OpenAI-compatible
+# front door) on each guest tagged `llm-router`. Native install: a Python venv +
+# systemd, config at /etc/litellm/config.yaml. Fronted by Traefik at
+# https://llm.<subdomain>; consumers select a tier purely by model alias.
+#
+# Two tiers, both reached through this one proxy:
+#   large — gpt-oss-120b / qwen3-coder on the neutral `llm-large` runner (bearer
+#           auth). One deployment each; no cross-tier fallback.
+#   light — hermes-4-14b / hermes4 / qwen3-4b / embeddings. TWO deployments per
+#           alias: the GPU `llm-fast` box AND the CPU `llm-light` standby, same
+#           model_name. LiteLLM load-balances the pair and cools a failed
+#           deployment down, so a GPU outage drains to CPU automatically.
+#
+# Restart-on-failure is applied DRY by the shared systemd_restart_policy role via
+# group_vars, not here.
+
+llm_router_user: litellm
+llm_router_group: litellm
+llm_router_home: /var/lib/litellm
+llm_router_venv: /opt/litellm-venv
+llm_router_service: litellm
+llm_router_config_dir: /etc/litellm
+llm_router_config_file: "{{ llm_router_config_dir }}/config.yaml"
+llm_router_env_file: "{{ llm_router_config_dir }}/litellm.env"
+
+# Installed into the venv (state: present — pinned by the ecosystem, never here).
+# langfuse + the opentelemetry exporter back the two logging callbacks below.
+llm_router_pip_packages:
+  - "litellm[proxy]"
+  - langfuse
+  - opentelemetry-api
+  - opentelemetry-sdk
+  - opentelemetry-exporter-otlp
+
+# Internal subdomain (pve.<apex>), never hardcoded — the derived model endpoints
+# and the Langfuse host are built from it.
+llm_router_subdomain: >-
+  {{ lookup('env', 'PROXMOX_SUBDOMAIN') | mandatory('PROXMOX_SUBDOMAIN required') }}
+
+# --- Ports (DRY from the tofu ports registry; no hardcodes) ------------------
+# The proxy's own listen port + the two backend tiers' ports. Hard-required like
+# every other role's port so a missing constant fails loud rather than guessing.
+# NOTE: service_ports.llm_router_api and service_ports.llm_fast_api are added by
+# the parallel terraform-proxmox constants PR — this role depends on both.
+llm_router_api_port: "{{ tofu_data.constants.service_ports.llm_router_api }}"
+llm_router_light_port: "{{ tofu_data.constants.service_ports.llm_fast_api }}"
+# llm-large speaks the Ollama-compatible API on the standard Ollama port.
+llm_router_large_port: "{{ tofu_data.constants.service_ports.ollama_api }}"
+
+# --- Backend base URLs (derived; never a hardcoded IP) -----------------------
+llm_router_llm_fast_base_url: "http://llm-fast.{{ llm_router_subdomain }}:{{ llm_router_light_port }}/v1"
+llm_router_llm_light_base_url: "http://llm-light.{{ llm_router_subdomain }}:{{ llm_router_light_port }}/v1"
+llm_router_llm_large_base_url: "https://llm-large.{{ llm_router_subdomain }}:{{ llm_router_large_port }}/v1"
+
+# --- Model groups ------------------------------------------------------------
+# large: one deployment each, bearer-authed to llm-large.
+llm_router_large_models:
+  - gpt-oss-120b
+  - qwen3-coder
+# light: exposed aliases -> the llama-swap model_name they map to. Each becomes two
+# same-name deployments (llm-fast GPU + llm-light CPU) in the rendered config.
+# `embedding: true` marks the entry as an embeddings model_group.
+llm_router_light_models:
+  - { alias: hermes-4-14b, backend: hermes-4-14b }
+  - { alias: hermes4, backend: hermes-4-14b }
+  - { alias: qwen3-4b, backend: qwen3-4b }
+  - { alias: embeddings, backend: embeddings, embedding: true }
+
+# --- Routing behaviour -------------------------------------------------------
+# Load-balance across same-name deployments; cool a failed one down so traffic
+# drains to its sibling (GPU -> CPU). No cross-tier fallbacks.
+llm_router_routing_strategy: simple-shuffle
+llm_router_allowed_fails: 2
+llm_router_cooldown_time: 30
+# Background health checks so a drained deployment is probed back in on its own.
+llm_router_health_check_interval: 300
+
+# --- Secrets (env-sourced; OpenBao migration is a later phase) ----------------
+# Mandatory, fail-loud (mirrors the ai_orchestration group_vars pattern).
+llm_router_master_key: >-
+  {{ lookup('env', 'LLM_ROUTER_MASTER_KEY')
+     | mandatory('LLM_ROUTER_MASTER_KEY must be set (SOPS/Doppler; the LiteLLM master key)') }}
+llm_router_llm_large_bearer: >-
+  {{ lookup('env', 'LLM_LARGE_BEARER_TOKEN')
+     | mandatory('LLM_LARGE_BEARER_TOKEN must be set (SOPS/Doppler; bearer for the llm-large runner)') }}
+# The GPU/CPU light backends need no auth; a placeholder keeps the OpenAI client happy.
+llm_router_light_api_key: "sk-noauth"
+
+# --- Observability -----------------------------------------------------------
+# Langfuse success logging + OTLP traces. Keys are optional (empty -> callbacks
+# no-op) so a converge before Langfuse is provisioned still comes up.
+llm_router_langfuse_public_key: "{{ lookup('env', 'LANGFUSE_PUBLIC_KEY') | default('', true) }}"
+llm_router_langfuse_secret_key: "{{ lookup('env', 'LANGFUSE_SECRET_KEY') | default('', true) }}"
+llm_router_langfuse_host: "https://langfuse.{{ llm_router_subdomain }}"
+# Cribl Edge OTLP/HTTP receiver (base URL; the exporter appends the signal path).
+llm_router_otel_http_port: >-
+  {{ hostvars['localhost']['tofu_data']['constants']['service_ports']['otel_traces_http'] }}
+llm_router_otel_endpoint: "http://cribl-edge.{{ llm_router_subdomain }}:{{ llm_router_otel_http_port }}"

--- a/roles/llm_router/handlers/main.yml
+++ b/roles/llm_router/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart litellm
+  ansible.builtin.systemd:
+    name: "{{ llm_router_service }}"
+    state: restarted
+    daemon_reload: true

--- a/roles/llm_router/tasks/main.yml
+++ b/roles/llm_router/tasks/main.yml
@@ -1,0 +1,105 @@
+---
+# llm_router — a LiteLLM proxy in a plain LXC (no Docker): a Python venv + a systemd
+# service. Ansible owns the whole platform (user, venv, config, unit). Idempotent.
+
+- name: Install the Python runtime and git
+  ansible.builtin.apt:
+    name:
+      - python3
+      - python3-pip
+      - python3-venv
+      - git
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Create the litellm service group
+  ansible.builtin.group:
+    name: "{{ llm_router_group }}"
+    system: true
+
+- name: Create the litellm service user
+  ansible.builtin.user:
+    name: "{{ llm_router_user }}"
+    group: "{{ llm_router_group }}"
+    home: "{{ llm_router_home }}"
+    system: true
+    shell: /usr/sbin/nologin
+    create_home: true
+
+- name: Ensure the litellm config directory exists
+  ansible.builtin.file:
+    path: "{{ llm_router_config_dir }}"
+    state: directory
+    owner: root
+    group: "{{ llm_router_group }}"
+    mode: "0750"
+
+# One idempotent task: virtualenv_command builds the venv with the stdlib `venv`
+# module (no `virtualenv` pip package on a minimal LXC), then pip populates it.
+# Re-runs are no-ops once the packages are present.
+- name: Create the venv and install LiteLLM (proxy extras)
+  ansible.builtin.pip:
+    name: "{{ llm_router_pip_packages }}"
+    state: present
+    virtualenv: "{{ llm_router_venv }}"
+    virtualenv_command: python3 -m venv
+
+- name: Deploy the LiteLLM secrets env file
+  ansible.builtin.template:
+    src: litellm.env.j2
+    dest: "{{ llm_router_env_file }}"
+    owner: root
+    group: "{{ llm_router_group }}"
+    mode: "0640"
+  no_log: true
+  notify: Restart litellm
+
+- name: Deploy the LiteLLM proxy config
+  ansible.builtin.template:
+    src: config.yaml.j2
+    dest: "{{ llm_router_config_file }}"
+    owner: root
+    group: "{{ llm_router_group }}"
+    mode: "0640"
+  notify: Restart litellm
+
+- name: Deploy the litellm systemd unit
+  ansible.builtin.template:
+    src: litellm.service.j2
+    dest: "/etc/systemd/system/{{ llm_router_service }}.service"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart litellm
+
+- name: Enable and start litellm
+  ansible.builtin.systemd:
+    name: "{{ llm_router_service }}"
+    state: started
+    enabled: true
+    daemon_reload: true
+
+- name: Flush handlers so config / unit changes apply before verification
+  ansible.builtin.meta: flush_handlers
+
+# Type=simple reports 'active' the instant the process forks; poll until it settles
+# so a proxy that crashes a moment later fails loud here (mirrors roles/agent_exec).
+- name: Verify the litellm service is active
+  ansible.builtin.systemd:
+    name: "{{ llm_router_service }}"
+  register: llm_router_service_state
+  until: llm_router_service_state.status.ActiveState | default('') == 'active'
+  retries: 5
+  delay: 3
+
+# /health/liveliness is unauthenticated by design (LiteLLM load-balancer probe),
+# so this confirms the proxy is serving without needing the master key.
+- name: Verify the LiteLLM liveness endpoint answers
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ llm_router_api_port }}/health/liveliness"
+    status_code: 200
+  register: llm_router_liveness
+  until: llm_router_liveness.status == 200
+  retries: 5
+  delay: 3

--- a/roles/llm_router/templates/config.yaml.j2
+++ b/roles/llm_router/templates/config.yaml.j2
@@ -1,0 +1,58 @@
+{{ ansible_managed | comment }}
+# LiteLLM proxy config (managed by the llm_router role). One OpenAI-compatible front
+# door for the whole fabric; consumers pick a tier by model alias. Secrets come from
+# the systemd EnvironmentFile via os.environ/ — no credential literal lives here.
+
+model_list:
+  # --- large tier: one deployment each, bearer-authed to llm-large ---
+{% for m in llm_router_large_models %}
+  - model_name: {{ m }}
+    litellm_params:
+      model: openai/{{ m }}
+      api_base: {{ llm_router_llm_large_base_url }}
+      api_key: os.environ/LLM_LARGE_BEARER_TOKEN
+{% endfor %}
+  # --- light tier: two deployments per alias (GPU llm-fast + CPU llm-light) ---
+  # Same model_name => LiteLLM load-balances the pair and cools a failed deployment
+  # down, so a GPU outage drains to the CPU standby automatically.
+{% for m in llm_router_light_models %}
+  - model_name: {{ m.alias }}
+    litellm_params:
+      model: openai/{{ m.backend }}
+      api_base: {{ llm_router_llm_fast_base_url }}
+      api_key: {{ llm_router_light_api_key }}
+{% if m.embedding | default(false) %}
+    model_info:
+      mode: embedding
+{% endif %}
+  - model_name: {{ m.alias }}
+    litellm_params:
+      model: openai/{{ m.backend }}
+      api_base: {{ llm_router_llm_light_base_url }}
+      api_key: {{ llm_router_light_api_key }}
+{% if m.embedding | default(false) %}
+    model_info:
+      mode: embedding
+{% endif %}
+{% endfor %}
+
+router_settings:
+  routing_strategy: {{ llm_router_routing_strategy }}
+  allowed_fails: {{ llm_router_allowed_fails }}
+  cooldown_time: {{ llm_router_cooldown_time }}
+  # Pre-call context-window checks so an over-long request is not routed to a model
+  # that cannot serve it (no cross-tier fallback masks the error).
+  enable_pre_call_checks: true
+
+general_settings:
+  master_key: os.environ/LLM_ROUTER_MASTER_KEY
+  # Probe drained deployments back in on their own; health_check_interval is a
+  # general_settings field (LiteLLM rejects it under router_settings).
+  background_health_checks: true
+  health_check_interval: {{ llm_router_health_check_interval }}
+
+litellm_settings:
+  # Langfuse success logging + OTLP traces to the Cribl Edge collector. Both read
+  # their endpoints/keys from the environment (the EnvironmentFile).
+  callbacks: ["langfuse", "otel"]
+  drop_params: true

--- a/roles/llm_router/templates/litellm.env.j2
+++ b/roles/llm_router/templates/litellm.env.j2
@@ -1,0 +1,12 @@
+{{ ansible_managed | comment }}
+# LiteLLM proxy secrets + observability endpoints (systemd EnvironmentFile). The
+# config.yaml references these via os.environ/. Never commit real values.
+LLM_ROUTER_MASTER_KEY={{ llm_router_master_key }}
+LLM_LARGE_BEARER_TOKEN={{ llm_router_llm_large_bearer }}
+# Langfuse success-callback credentials (empty -> the callback simply no-ops).
+LANGFUSE_PUBLIC_KEY={{ llm_router_langfuse_public_key }}
+LANGFUSE_SECRET_KEY={{ llm_router_langfuse_secret_key }}
+LANGFUSE_HOST={{ llm_router_langfuse_host }}
+# OTLP/HTTP traces to the Cribl Edge collector (otlp_http wants the full signal path).
+OTEL_EXPORTER=otlp_http
+OTEL_ENDPOINT={{ llm_router_otel_endpoint }}/v1/traces

--- a/roles/llm_router/templates/litellm.service.j2
+++ b/roles/llm_router/templates/litellm.service.j2
@@ -1,0 +1,17 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=LiteLLM proxy — the LLM fabric front door (OpenAI-compatible)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ llm_router_user }}
+Group={{ llm_router_group }}
+WorkingDirectory={{ llm_router_home }}
+EnvironmentFile={{ llm_router_env_file }}
+ExecStart={{ llm_router_venv }}/bin/litellm --config {{ llm_router_config_file }} --host 0.0.0.0 --port {{ llm_router_api_port }}
+# Restart policy is managed by the systemd_restart_policy role (99-restart-policy.conf).
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/open_webui/README.md
+++ b/roles/open_webui/README.md
@@ -22,7 +22,8 @@ Requires `OPEN_WEBUI_SECRET_KEY` in Doppler/SOPS (generate once: `openssl rand -
 - Installs Open WebUI into a venv (`/opt/open-webui/venv`) and runs it via a
   dedicated systemd unit (`open-webui serve`), data in `DATA_DIR=/var/lib/open-webui`.
 - Renders `/etc/open-webui.env` with the **reverse-proxy-correct** settings Open
-  WebUI requires behind HTTPS: `OLLAMA_BASE_URL` (→ CT 167, from inventory),
+  WebUI requires behind HTTPS: `OPENAI_API_BASE_URL` (→ the LiteLLM router at
+  `llm.<subdomain>/v1`) + `OPENAI_API_KEY` + `DEFAULT_MODELS`,
   `WEBUI_URL`/`CORS_ALLOW_ORIGIN` (= the Traefik URL, from `PROXMOX_SUBDOMAIN`),
   secure cookies, `ENABLE_WEBSOCKET_SUPPORT`, stable `WEBUI_SECRET_KEY`.
 - Restart-on-failure via the shared `systemd_restart_policy` role (`group_vars`).
@@ -32,7 +33,9 @@ Requires `OPEN_WEBUI_SECRET_KEY` in Doppler/SOPS (generate once: `openssl rand -
 | Var | Default | Purpose |
 | --- | --- | --- |
 | `open_webui_port` | `tofu_data.constants.service_ports.open_webui_web` | Listen port (no hardcode) |
-| `open_webui_ollama_base_url` | `http://<hermes-infer ip>:<ollama_api>` | Backend (from inventory) |
+| `open_webui_openai_api_base_url` | `https://llm.{{ PROXMOX_SUBDOMAIN }}/v1` | Backend (the LiteLLM router) |
+| `open_webui_openai_api_key` | `OPEN_WEBUI_OPENAI_API_KEY` (Doppler/SOPS) | Router API key |
+| `open_webui_default_model` | `gpt-oss-120b` | Default chat model (large tier) |
 | `open_webui_hostname` | `llm.{{ PROXMOX_SUBDOMAIN }}` | Public FQDN via Traefik |
 | `open_webui_data_dir` | `/var/lib/open-webui` | Persistent data |
 | `open_webui_secret_key` | `OPEN_WEBUI_SECRET_KEY` (Doppler/SOPS) | Stable JWT/encryption key |

--- a/roles/open_webui/defaults/main.yml
+++ b/roles/open_webui/defaults/main.yml
@@ -12,10 +12,16 @@ open_webui_python: "3.11"
 open_webui_uv_install_url: "https://astral.sh/uv/install.sh"
 
 open_webui_listen_host: "0.0.0.0"
-# Port + backend come from the tofu ports registry / inventory (no hardcodes).
+# Port comes from the tofu ports registry (no hardcodes).
 open_webui_port: "{{ tofu_data.constants.service_ports.open_webui_web }}"
-open_webui_ollama_base_url: >-
-  http://{{ hostvars['hermes-infer'].container_ip }}:{{ tofu_data.constants.service_ports.ollama_api }}
+
+# Backend = the LiteLLM router (the fabric front door), OpenAI-compatible, reached
+# by its neutral FQDN — never a hardcoded IP. The router routes by model alias, so
+# Open WebUI sees every tier through this one endpoint. The api key is the router
+# master key, env-sourced (SOPS/Doppler). Default the chat box to the large tier.
+open_webui_openai_api_base_url: "https://llm.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}/v1"
+open_webui_openai_api_key: "{{ lookup('env', 'OPEN_WEBUI_OPENAI_API_KEY') }}"
+open_webui_default_model: gpt-oss-120b
 
 # Public URL via Traefik — derived from the PROXMOX_SUBDOMAIN var (pve.<apex>),
 # never hardcoded. Matches the `llm` ingress entry in terraform-proxmox locals.tf.

--- a/roles/open_webui/templates/open-webui.env.j2
+++ b/roles/open_webui/templates/open-webui.env.j2
@@ -2,7 +2,9 @@
 # Open WebUI runtime config. Reverse-proxy-correct values are REQUIRED behind
 # Traefik HTTPS (sessions/websockets break without them) — per Open WebUI docs.
 DATA_DIR={{ open_webui_data_dir }}
-OLLAMA_BASE_URL={{ open_webui_ollama_base_url }}
+OPENAI_API_BASE_URL={{ open_webui_openai_api_base_url }}
+OPENAI_API_KEY={{ open_webui_openai_api_key }}
+DEFAULT_MODELS={{ open_webui_default_model }}
 WEBUI_URL={{ open_webui_url }}
 WEBUI_SECRET_KEY={{ open_webui_secret_key }}
 CORS_ALLOW_ORIGIN={{ open_webui_url }}

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1778,7 +1778,7 @@
           - "'User=llama-cpp' in _llama_unit"
         fail_msg: "llama-swap.service.j2 missing ROCm env, listen port, or user: {{ _llama_unit }}"
 
-    - name: llama_cpp template rendering PASSED
+    - name: Llama.cpp template rendering PASSED
       ansible.builtin.debug:
         msg: |
           llama_cpp assertions passed:
@@ -1922,7 +1922,7 @@
           - "'/opt/litellm-venv/bin/litellm' in _litellm_unit"
         fail_msg: "litellm.service.j2 missing env file, config, or listen port: {{ _litellm_unit }}"
 
-    - name: llm_router template rendering PASSED
+    - name: LiteLLM router template rendering PASSED
       ansible.builtin.debug:
         msg: |
           llm_router assertions passed:

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1681,3 +1681,253 @@
           - smokeping.yml.j2 renders valid YAML with the folded ping set
           - empty discovery degrades to modem + anycast
           - failed mtr (rc!=0) degrades to [] candidates without a from_json crash
+
+# =============================================================================
+# llama_cpp — llama-swap config + systemd unit (light serving tier)
+# =============================================================================
+- name: Render and verify llama_cpp templates
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    # Mirror roles/llama_cpp/defaults/main.yml (literal stand-ins for the tofu
+    # port + the gpu-derived values, so the render is offline and deterministic).
+    llama_cpp_user: llama-cpp
+    llama_cpp_group: llama-cpp
+    llama_cpp_install_dir: /opt/llama-cpp
+    llama_cpp_server_bin: /opt/llama-cpp/llama-server
+    llama_cpp_swap_bin: /usr/local/bin/llama-swap
+    llama_cpp_data_dir: /var/lib/llama-cpp
+    llama_cpp_models_dir: /var/lib/llama-cpp/models
+    llama_cpp_config_file: /etc/llama-swap/config.yaml
+    llama_cpp_gpu: true
+    llama_cpp_hsa_override_gfx_version: "10.3.0"
+    llama_cpp_ngl: "99"
+    llama_cpp_ctx_size: 8192
+    llama_cpp_api_port: 10434
+    llama_cpp_start_port: 9200
+    llama_cpp_health_check_timeout: 300
+    # Only the fields the templates consume (name/aliases/gguf/embeddings).
+    llama_cpp_models:
+      - { name: hermes-4-14b, aliases: [hermes4], gguf: "hermes.gguf", embeddings: false }
+      - { name: qwen3-4b, aliases: [], gguf: "qwen.gguf", embeddings: false }
+      - { name: embeddings, aliases: [nomic-embed-text-v1.5], gguf: "nomic.gguf", embeddings: true }
+    _template_dir: "../../roles/llama_cpp/templates"
+
+  tasks:
+    - name: Render llama-swap.yaml.j2 to /tmp
+      ansible.builtin.template:
+        src: "{{ _template_dir }}/llama-swap.yaml.j2"
+        dest: /tmp/test_llama_swap.yaml
+        mode: "0644"
+
+    - name: Parse rendered llama-swap config (must be valid YAML)
+      ansible.builtin.set_fact:
+        _llama_swap: "{{ (lookup('file', '/tmp/test_llama_swap.yaml')) | from_yaml }}"
+
+    - name: Assert llama-swap keeps all three models co-resident (group swap:false)
+      ansible.builtin.assert:
+        that:
+          - "'hermes-4-14b' in _llama_swap.models"
+          - "'qwen3-4b' in _llama_swap.models"
+          - "'embeddings' in _llama_swap.models"
+          - _llama_swap.groups.resident.swap == false
+          - _llama_swap.groups.resident.exclusive == false
+          - (_llama_swap.groups.resident.members | sort) == ['embeddings', 'hermes-4-14b', 'qwen3-4b']
+          - "'hermes4' in _llama_swap.models['hermes-4-14b'].aliases"
+        fail_msg: >-
+          llama-swap.yaml.j2 did not render the co-resident model group or the
+          hermes4 alias: {{ _llama_swap }}
+
+    - name: Assert the shared macro offloads to GPU and per-model cmd flags differ
+      ansible.builtin.assert:
+        that:
+          # -ngl lives in the shared macro (expanded by llama-swap at runtime).
+          - "'-ngl 99' in _llama_swap.macros['server-base']"
+          - "'${server-base}' in _llama_swap.models['hermes-4-14b'].cmd"
+          - "'--jinja' in _llama_swap.models['hermes-4-14b'].cmd"
+          - "'/var/lib/llama-cpp/models/hermes.gguf' in _llama_swap.models['hermes-4-14b'].cmd"
+          - "'--embeddings' in _llama_swap.models['embeddings'].cmd"
+          - "'--jinja' not in _llama_swap.models['embeddings'].cmd"
+        fail_msg: >-
+          llama-swap macro/cmd missing GPU offload / chat / embeddings flags:
+          macros={{ _llama_swap.macros }} models={{ _llama_swap.models }}
+
+    - name: Render llama-swap.service.j2 to /tmp
+      ansible.builtin.template:
+        src: "{{ _template_dir }}/llama-swap.service.j2"
+        dest: /tmp/test_llama_swap.service
+        mode: "0644"
+
+    - name: Read rendered llama-swap unit
+      ansible.builtin.slurp:
+        src: /tmp/test_llama_swap.service
+      register: _llama_unit_raw
+
+    - name: Decode llama-swap unit
+      ansible.builtin.set_fact:
+        _llama_unit: "{{ _llama_unit_raw.content | b64decode }}"
+
+    - name: Assert the unit sets ROCm env and listens on the api port
+      ansible.builtin.assert:
+        that:
+          - "'HSA_OVERRIDE_GFX_VERSION=10.3.0' in _llama_unit"
+          - "'LD_LIBRARY_PATH=/opt/llama-cpp' in _llama_unit"
+          - "'--listen 0.0.0.0:10434' in _llama_unit"
+          - "'User=llama-cpp' in _llama_unit"
+        fail_msg: "llama-swap.service.j2 missing ROCm env, listen port, or user: {{ _llama_unit }}"
+
+    - name: llama_cpp template rendering PASSED
+      ansible.builtin.debug:
+        msg: |
+          llama_cpp assertions passed:
+          - llama-swap.yaml.j2: 3 co-resident models (group swap:false), hermes4
+            alias, GPU offload + chat/embeddings flags
+          - llama-swap.service.j2: HSA override, LD_LIBRARY_PATH, listen port, user
+
+# =============================================================================
+# llm_router — LiteLLM config + env file + systemd unit (fabric front door)
+# =============================================================================
+- name: Render and verify llm_router templates
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    # Mirror roles/llm_router/defaults/main.yml (literal stand-ins for the tofu
+    # ports + env-sourced secrets; scrubbed subdomain).
+    llm_router_user: litellm
+    llm_router_group: litellm
+    llm_router_home: /var/lib/litellm
+    llm_router_venv: /opt/litellm-venv
+    llm_router_service: litellm
+    llm_router_config_file: /etc/litellm/config.yaml
+    llm_router_env_file: /etc/litellm/litellm.env
+    llm_router_api_port: 4000
+    llm_router_llm_fast_base_url: "http://llm-fast.pve.example.net:10434/v1"
+    llm_router_llm_light_base_url: "http://llm-light.pve.example.net:10434/v1"
+    llm_router_llm_large_base_url: "https://llm-large.pve.example.net:11434/v1"
+    llm_router_large_models:
+      - gpt-oss-120b
+      - qwen3-coder
+    llm_router_light_models:
+      - { alias: hermes-4-14b, backend: hermes-4-14b }
+      - { alias: hermes4, backend: hermes-4-14b }
+      - { alias: qwen3-4b, backend: qwen3-4b }
+      - { alias: embeddings, backend: embeddings, embedding: true }
+    llm_router_routing_strategy: simple-shuffle
+    llm_router_allowed_fails: 2
+    llm_router_cooldown_time: 30
+    llm_router_health_check_interval: 300
+    llm_router_light_api_key: "sk-noauth"
+    llm_router_master_key: "test-master-key-placeholder"
+    llm_router_llm_large_bearer: "test-bearer-placeholder"
+    llm_router_langfuse_public_key: "pk-test-placeholder"
+    llm_router_langfuse_secret_key: "sk-test-placeholder"
+    llm_router_langfuse_host: "https://langfuse.pve.example.net"
+    llm_router_otel_endpoint: "http://cribl-edge.pve.example.net:4318"
+    _template_dir: "../../roles/llm_router/templates"
+
+  tasks:
+    - name: Render config.yaml.j2 to /tmp
+      ansible.builtin.template:
+        src: "{{ _template_dir }}/config.yaml.j2"
+        dest: /tmp/test_litellm_config.yaml
+        mode: "0644"
+
+    - name: Parse rendered LiteLLM config (must be valid YAML)
+      ansible.builtin.set_fact:
+        _litellm: "{{ (lookup('file', '/tmp/test_litellm_config.yaml')) | from_yaml }}"
+
+    - name: Index the model_list model_names
+      ansible.builtin.set_fact:
+        _model_names: "{{ _litellm.model_list | map(attribute='model_name') | list }}"
+
+    - name: Assert large tier is bearer-authed and light tier is dual-deployment
+      ansible.builtin.assert:
+        that:
+          # Large tier: one deployment each, bearer via env.
+          - _model_names | select('equalto', 'gpt-oss-120b') | list | length == 1
+          - _model_names | select('equalto', 'qwen3-coder') | list | length == 1
+          # Light tier: two deployments per alias (GPU llm-fast + CPU llm-light).
+          - _model_names | select('equalto', 'hermes-4-14b') | list | length == 2
+          - _model_names | select('equalto', 'hermes4') | list | length == 2
+          - _model_names | select('equalto', 'qwen3-4b') | list | length == 2
+          - _model_names | select('equalto', 'embeddings') | list | length == 2
+          # Secrets referenced via os.environ, never a literal in the config.
+          - "'test-master-key-placeholder' not in (lookup('file', '/tmp/test_litellm_config.yaml'))"
+          - _litellm.general_settings.master_key == 'os.environ/LLM_ROUTER_MASTER_KEY'
+        fail_msg: "config.yaml.j2 model_list / auth wrong: {{ _litellm.model_list }}"
+
+    - name: Assert routing, health checks, and observability callbacks
+      ansible.builtin.assert:
+        that:
+          - _litellm.router_settings.routing_strategy == 'simple-shuffle'
+          - _litellm.router_settings.cooldown_time == 30
+          - _litellm.general_settings.background_health_checks == true
+          - "'langfuse' in _litellm.litellm_settings.callbacks"
+          - "'otel' in _litellm.litellm_settings.callbacks"
+          # embeddings deployments declare the embedding mode.
+          - >-
+            (_litellm.model_list | selectattr('model_name', 'equalto', 'embeddings')
+             | map(attribute='model_info.mode') | list) == ['embedding', 'embedding']
+        fail_msg: "config.yaml.j2 routing / callbacks / embedding-mode wrong: {{ _litellm }}"
+
+    - name: Render litellm.env.j2 to /tmp
+      ansible.builtin.template:
+        src: "{{ _template_dir }}/litellm.env.j2"
+        dest: /tmp/test_litellm.env
+        mode: "0644"
+
+    - name: Read rendered litellm env file
+      ansible.builtin.slurp:
+        src: /tmp/test_litellm.env
+      register: _litellm_env_raw
+
+    - name: Decode litellm env file
+      ansible.builtin.set_fact:
+        _litellm_env: "{{ _litellm_env_raw.content | b64decode }}"
+
+    - name: Assert the env file carries the secrets and full OTLP traces path
+      ansible.builtin.assert:
+        that:
+          - "'LLM_ROUTER_MASTER_KEY=test-master-key-placeholder' in _litellm_env"
+          - "'LLM_LARGE_BEARER_TOKEN=test-bearer-placeholder' in _litellm_env"
+          - "'OTEL_EXPORTER=otlp_http' in _litellm_env"
+          - "'OTEL_ENDPOINT=http://cribl-edge.pve.example.net:4318/v1/traces' in _litellm_env"
+        fail_msg: "litellm.env.j2 missing secrets or OTLP traces path: {{ _litellm_env }}"
+
+    - name: Render litellm.service.j2 to /tmp
+      ansible.builtin.template:
+        src: "{{ _template_dir }}/litellm.service.j2"
+        dest: /tmp/test_litellm.service
+        mode: "0644"
+
+    - name: Read rendered litellm unit
+      ansible.builtin.slurp:
+        src: /tmp/test_litellm.service
+      register: _litellm_unit_raw
+
+    - name: Decode litellm unit
+      ansible.builtin.set_fact:
+        _litellm_unit: "{{ _litellm_unit_raw.content | b64decode }}"
+
+    - name: Assert the unit loads the env file and serves on the api port
+      ansible.builtin.assert:
+        that:
+          - "'EnvironmentFile=/etc/litellm/litellm.env' in _litellm_unit"
+          - "'--config /etc/litellm/config.yaml' in _litellm_unit"
+          - "'--port 4000' in _litellm_unit"
+          - "'/opt/litellm-venv/bin/litellm' in _litellm_unit"
+        fail_msg: "litellm.service.j2 missing env file, config, or listen port: {{ _litellm_unit }}"
+
+    - name: llm_router template rendering PASSED
+      ansible.builtin.debug:
+        msg: |
+          llm_router assertions passed:
+          - config.yaml.j2: large tier bearer-authed (1 each), light tier dual
+            deployment (2 each, GPU+CPU), master_key via os.environ, langfuse+otel
+            callbacks, embedding mode on the embeddings group
+          - litellm.env.j2: secrets + full OTLP /v1/traces endpoint
+          - litellm.service.j2: EnvironmentFile, config, listen port


### PR DESCRIPTION
## What

The serving-fabric rework for the two-tier LLM setup: a light GPU tier, a single
OpenAI-compatible front door, and the consumer repoints so the teardown of the old
single-Ollama path can follow.

### New role: `llama_cpp` (light serving tier)
- llama.cpp (`llama-server`) behind [llama-swap](https://github.com/mostlygeek/llama-swap)
  on AMD **ROCm** (guest `llm-fast`, RX 6800 / gfx1030), one OpenAI-compatible endpoint.
- Three models kept **co-resident** in a `swap: false` llama-swap group (fit in 16 GB
  at Q4): `hermes-4-14b` (alias `hermes4`), `qwen3-4b`, `embeddings` (nomic, `--embeddings`).
- **Latest** llama.cpp + llama-swap releases resolved via the GitHub releases API by
  asset-name pattern (`ubuntu-rocm` / `linux_amd64`), so both the build tag and the
  embedded ROCm version can move with no role change — no pinned versions.
- GPU device-group resolution + `HSA_OVERRIDE_GFX_VERSION=10.3.0` cloned from
  `roles/ollama`. `llama_cpp_gpu: false` variant (skips ROCm, `-ngl 0`, smaller ctx)
  for a future CPU-only `llm-light` standby.

### New role: `llm_router` (fabric front door)
- Native venv + systemd LiteLLM proxy on guests tagged `llm-router` (×3), fronted by
  Traefik at `https://llm.<subdomain>`. Consumers pick a tier by **model alias**.
- **Large** tier: `gpt-oss-120b` / `qwen3-coder` → `llm-large` (bearer auth). **Light**
  tier: each alias registered as **two same-name deployments** (GPU `llm-fast` + CPU
  `llm-light`), so LiteLLM load-balances the pair and cools a failed deployment down —
  a GPU outage drains to CPU automatically. **No** cross-tier fallback.
- `langfuse` + `otel` callbacks (OTLP/HTTP → Cribl Edge). `/health/liveliness` is
  unauthenticated by design, so Traefik health checks need no credential.

### Wiring
- `load_tofu.yml`: `llm_fast_group` (tag `llm-fast`) + `llm_router_group` (tag
  `llm-router`) clauses; new `group_vars/` for each; two `site.yml` plays (Phase 8a3).
- **CI:** template-render coverage added for both roles' templates (llama-swap config
  + unit; LiteLLM config + env + unit).

### Consumer repoints (in this PR so it merges before the teardown apply)
The `ollama` role and its wiring are **kept** — retirement is a later phase.
- `open_webui`: `OPENAI_API_BASE_URL` → `llm.<sub>/v1` + `OPENAI_API_KEY` +
  `DEFAULT_MODELS=gpt-oss-120b`.
- `hermes_agent`: model `hermes-4-14b` via the router (api key wired through `.env`).
- `ai_orchestration_group`: both base URLs → the router + an `ai_orchestration_model_api_key` var.
- Stale `hermes-infer (Ollama)` prose in `agent_exec` corrected (its endpoints already
  resolve through the group vars).

## Deferred / dependencies
- **`openbao_secrets` role: intentionally excluded** (Phase 5, separate PR). Secrets
  are env-sourced/fail-loud for now: `LLM_ROUTER_MASTER_KEY`, `LLM_LARGE_BEARER_TOKEN`
  (mandatory), plus `OPEN_WEBUI_OPENAI_API_KEY` / `HERMES_AGENT_MODEL_API_KEY` /
  `AI_ORCHESTRATION_MODEL_API_KEY`.
- **Depends on the terraform-proxmox constants PR** adding `service_ports.llm_fast_api`
  **and** `service_ports.llm_router_api` (both hard-required — a missing constant fails loud).
- Companion `ansible-proxmox` PR renames the GPU-passthrough map key `hermes-infer` →
  `llm-fast` (must merge before the `llm-fast` converge, W6).

## Test
- `ansible-lint` (production profile): **0 failures on 224 files**.
- `yamllint`: clean.
- Template render tests (`tests/template_render/verify_templates.yml`): the two new
  plays pass (co-resident group + aliases + GPU/embeddings flags; dual-deployment light
  tier + bearer large tier + os.environ secrets + langfuse/otel callbacks + full OTLP path).
- Inventory-load verification: PASSED (new group clauses parse; `site.yml` syntax-check clean).

### Not yet live-validated (verify at converge, W6)
- The prebuilt ROCm llama.cpp binary against the container's ROCm userspace
  (`llama_cpp_rocm_packages`); `HSA_OVERRIDE_GFX_VERSION=10.3.0` on gfx1030; the GGUF
  asset filenames still resolving on HuggingFace.
- `litellm[proxy]` + the `langfuse`/`otel` callbacks importing cleanly; the `llm-large`
  runner accepting the bearer; the GPU/CPU deployment pair draining as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj