### PR TITLE
fix(ci): add YAML document start to ai-pr-care workflow

### DIFF
--- a/.github/workflows/ai-pr-care.yml
+++ b/.github/workflows/ai-pr-care.yml
@@ -1,3 +1,4 @@
+---
 # AI PR care: dependency risk review + release highlights.
 #
 # - cc-dep-review: one AI risk-assessment comment on Renovate major/minor PRs.


### PR DESCRIPTION
One-line fix: `ansible-lint` (production profile) fails with `yaml[document-start]: Missing document start` on `.github/workflows/ai-pr-care.yml:13` — redding the merge gate on **every open PR** (first seen on #529; the violation is on `main` from the AI-caller rollout). No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qna3JuDp5y7MB2it6RqUKn