### PR TITLE
feat(openbao): openbao_secrets role + bao-first AI secret migration

### DIFF
--- a/inventory/group_vars/ai_orchestration_group.yml
+++ b/inventory/group_vars/ai_orchestration_group.yml
@@ -26,9 +26,10 @@ ai_orchestration_otel_endpoint: "http://cribl-edge.{{ ai_subdomain }}:{{ ai_otel
 # so downstream app/systemd configs that read them don't churn.
 ai_orchestration_ollama_base_url: "https://llm.{{ ai_subdomain }}/v1"
 ai_orchestration_model_large_base_url: "https://llm.{{ ai_subdomain }}/v1"
-# Router API key (master key), env-sourced (SOPS/Doppler) like its siblings.
+# Router API key (master key), OpenBao-first with env (SOPS/Doppler) fallback.
 ai_orchestration_model_api_key: >-
-  {{ lookup('env', 'AI_ORCHESTRATION_MODEL_API_KEY') | default('', true) }}
+  {{ bao_ai_secrets.AI_ORCHESTRATION_MODEL_API_KEY
+     | default(lookup('env', 'AI_ORCHESTRATION_MODEL_API_KEY'), true) }}
 
 # Restart the Docker stack on failure (Phase 9 systemd restart policy).
 systemd_restart_policy_services:

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -31,3 +31,9 @@ cribl_hec_input_port: >-
 technitium_dns_extra_cname_records:
   - name: llm-large
     target: "{{ lookup('env', 'LLM_LARGE_RUNNER_HOST') }}"
+
+# AI secrets fetched from OpenBao by the openbao_secrets pre-play. Defaults to an
+# empty dict so every consumer's `bao_ai_secrets.X | default(lookup('env','X'),
+# true)` resolves even when the fetch is skipped (VAULT_ADDR unset) or the host is
+# outside the openbao_secrets play. The pre-play overrides it per host when active.
+bao_ai_secrets: {}

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -8,6 +8,34 @@
 # Configure application stacks based on OpenTofu infrastructure
 
 # =============================================================================
+# Phase 0-secrets: OpenBao AI secrets pre-fetch
+# Reads the AI KV subtree (ai-readonly AppRole) into the `bao_ai_secrets` fact so
+# every AI/vectordb role can resolve its secrets bao-first with an env fallback.
+# Runs once on the controller and publishes to the consuming groups; SKIPS CLEANLY
+# when VAULT_ADDR is unset. Placed before Phase 6 (qdrant) so it precedes every
+# consumer.
+# =============================================================================
+
+- name: Pre-fetch AI secrets from OpenBao
+  hosts: qdrant_group:open_webui_group:hermes_agent_group:llm_router_group:ai_orchestration_group
+  gather_facts: false
+  tags:
+    - openbao_secrets
+    - ai
+  tasks:
+    - name: Fetch the AI KV subtree via the ai-readonly AppRole
+      ansible.builtin.include_role:
+        name: openbao_secrets
+
+    # Publish the shared, un-prefixed fact at the playbook layer (like tofu_data in
+    # load_tofu.yml). openbao_secrets_merged was computed once on the delegated
+    # controller; hosts where the fetch was skipped fall back to the {} default.
+    - name: Publish the merged AI secrets to the AI hosts
+      ansible.builtin.set_fact:
+        bao_ai_secrets: "{{ hostvars['localhost'].openbao_secrets_merged | default({}) }}"
+      no_log: true
+
+# =============================================================================
 # Phase 0: APT Cache Infrastructure
 # apt-cacher-ng must be deployed BEFORE any roles that install apt packages
 # =============================================================================

--- a/requirements.yml
+++ b/requirements.yml
@@ -19,3 +19,6 @@ collections:
 
   - name: community.docker
     version: ">=3.6.0"  # docker_compose_v2 module added in 3.6.0
+
+  - name: community.hashi_vault
+    version: ">=6.0.0"  # openbao_secrets role: vault_login (approle) + vault_kv2_get (needs python hvac)

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -22,7 +22,8 @@ hermes_agent_install_url: "https://hermes-agent.nousresearch.com/install.sh"
 hermes_agent_model: hermes-4-14b
 hermes_agent_model_base_url: "https://llm.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}/v1"
 hermes_agent_model_api_mode: chat_completions
-hermes_agent_model_api_key: "{{ lookup('env', 'HERMES_AGENT_MODEL_API_KEY') | default('', true) }}"
+hermes_agent_model_api_key: >-
+  {{ bao_ai_secrets.HERMES_AGENT_MODEL_API_KEY | default(lookup('env', 'HERMES_AGENT_MODEL_API_KEY'), true) }}
 
 # --- Memory: best self-hostable as of June 2026 (Agy-validated) ---
 # Hindsight: local knowledge-graph + multi-strategy retrieval. Runs alongside the

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -79,11 +79,11 @@ llm_router_health_check_interval: 300
 # --- Secrets (env-sourced; OpenBao migration is a later phase) ----------------
 # Mandatory, fail-loud (mirrors the ai_orchestration group_vars pattern).
 llm_router_master_key: >-
-  {{ lookup('env', 'LLM_ROUTER_MASTER_KEY')
-     | mandatory('LLM_ROUTER_MASTER_KEY must be set (SOPS/Doppler; the LiteLLM master key)') }}
+  {{ bao_ai_secrets.LLM_ROUTER_MASTER_KEY | default(lookup('env', 'LLM_ROUTER_MASTER_KEY'), true)
+     | mandatory('LLM_ROUTER_MASTER_KEY must be set (OpenBao secret/ai/router or SOPS/Doppler env)') }}
 llm_router_llm_large_bearer: >-
-  {{ lookup('env', 'LLM_LARGE_BEARER_TOKEN')
-     | mandatory('LLM_LARGE_BEARER_TOKEN must be set (SOPS/Doppler; bearer for the llm-large runner)') }}
+  {{ bao_ai_secrets.LLM_LARGE_BEARER_TOKEN | default(lookup('env', 'LLM_LARGE_BEARER_TOKEN'), true)
+     | mandatory('LLM_LARGE_BEARER_TOKEN must be set (OpenBao secret/ai/llm-large or SOPS/Doppler env)') }}
 # The GPU/CPU light backends need no auth; a placeholder keeps the OpenAI client happy.
 llm_router_light_api_key: "sk-noauth"
 

--- a/roles/open_webui/defaults/main.yml
+++ b/roles/open_webui/defaults/main.yml
@@ -20,7 +20,8 @@ open_webui_port: "{{ tofu_data.constants.service_ports.open_webui_web }}"
 # Open WebUI sees every tier through this one endpoint. The api key is the router
 # master key, env-sourced (SOPS/Doppler). Default the chat box to the large tier.
 open_webui_openai_api_base_url: "https://llm.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}/v1"
-open_webui_openai_api_key: "{{ lookup('env', 'OPEN_WEBUI_OPENAI_API_KEY') }}"
+open_webui_openai_api_key: >-
+  {{ bao_ai_secrets.OPEN_WEBUI_OPENAI_API_KEY | default(lookup('env', 'OPEN_WEBUI_OPENAI_API_KEY'), true) }}
 open_webui_default_model: gpt-oss-120b
 
 # Public URL via Traefik — derived from the PROXMOX_SUBDOMAIN var (pve.<apex>),
@@ -29,5 +30,7 @@ open_webui_hostname: "llm.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
 open_webui_url: "https://{{ open_webui_hostname }}"
 
 # Stable secret key for JWT/data encryption — generate once (openssl rand -hex 32),
-# store in Doppler/SOPS. Must NOT change between runs or sessions invalidate.
-open_webui_secret_key: "{{ lookup('env', 'OPEN_WEBUI_SECRET_KEY') }}"
+# store in OpenBao (secret/ai/open-webui) or Doppler/SOPS. Must NOT change between
+# runs or sessions invalidate.
+open_webui_secret_key: >-
+  {{ bao_ai_secrets.OPEN_WEBUI_SECRET_KEY | default(lookup('env', 'OPEN_WEBUI_SECRET_KEY'), true) }}

--- a/roles/openbao_secrets/README.md
+++ b/roles/openbao_secrets/README.md
@@ -1,0 +1,69 @@
+# openbao_secrets
+
+A controller-side **pre-play** that logs in to OpenBao with the **ai-readonly**
+AppRole and reads the AI KV subtree into a single `bao_ai_secrets` fact. AI roles
+then resolve their secrets **bao-first with an env fallback**:
+
+```yaml
+some_secret: "{{ bao_ai_secrets.SOME_SECRET | default(lookup('env', 'SOME_SECRET'), true) }}"
+```
+
+It runs **once** on the controller (`delegate_to: localhost`, `run_once`), leaving
+the merged result as `openbao_secrets_merged` on the controller; the `site.yml`
+play then copies it into the shared, un-prefixed `bao_ai_secrets` fact per host (the
+publish lives at the playbook layer — like `tofu_data` in `load_tofu.yml` — so the
+role's own facts stay role-prefixed). It **skips cleanly** when `VAULT_ADDR` is
+unset, so converges keep working on env/SOPS secrets before the KV is seeded (the
+`group_vars/all.yml` default `bao_ai_secrets: {}` guarantees the fallback resolves).
+
+## Alignment with `roles/openbao` (RBAC)
+
+The layout is aligned to what `roles/openbao` bootstraps — do not invent paths the
+policy can't read:
+
+- **KV mount**: `secret` (KV v2).
+- **AppRole**: `ai-readonly` (role_id/secret_id).
+- **Policy grant**: the `ai-readonly` policy grants `read` on `secret/data/ai/*`
+  (and `secret/data/apps/*`) — a wildcard, so every path under `ai/` is readable.
+- **Seeding**: `roles/openbao` seeds **no** values; it creates only the mount +
+  policies + AppRoles. So the paths below yield keys only once a writer populates
+  them; until then every read is empty and the env fallback wins.
+
+## Inputs (env)
+
+| Env var | Purpose |
+| --- | --- |
+| `VAULT_ADDR` | OpenBao ingress URL (`https://openbao.<subdomain>`). Unset ⇒ skip. |
+| `AI_VAULT_ROLE_ID` | ai-readonly AppRole role_id |
+| `AI_VAULT_SECRET_ID` | ai-readonly AppRole secret_id |
+
+## KV paths read (`openbao_secrets_paths`)
+
+| Path (mount-relative) | Expected keys |
+| --- | --- |
+| `ai/router` | `LLM_ROUTER_MASTER_KEY` (+ `LANGFUSE_*` project keys) |
+| `ai/llm-large` | `LLM_LARGE_BEARER_TOKEN` |
+| `ai/qdrant` | `QDRANT_API_KEY` |
+| `ai/open-webui` | `OPEN_WEBUI_SECRET_KEY`, `OPEN_WEBUI_OPENAI_API_KEY` |
+| `ai/hermes` | `HERMES_AGENT_MODEL_API_KEY` |
+
+All readable path keys are merged flat into `bao_ai_secrets`, keyed by the field
+name, so a consumer default reads `bao_ai_secrets.<FIELD_NAME>`.
+
+## Wiring
+
+Runs as the first AI-phase play in `playbooks/site.yml` (before any AI/vectordb
+role), against the union of AI-consuming groups, so `bao_ai_secrets` exists before
+those roles evaluate their secret defaults.
+
+## Dependencies
+
+- `community.hashi_vault` (added to `requirements.yml`) and its Python `hvac`
+  dependency in the controller environment (provided by the Nix dev shell —
+  `nix-devenv#ansible-apps`; see the PR for the companion change).
+
+## Not yet live-validated
+
+Verify at the first bao-backed converge: the ai-readonly AppRole login against the
+Traefik ingress, and that `vault_kv2_get` returns the expected field names once the
+`secret/ai/*` paths are seeded.

--- a/roles/openbao_secrets/defaults/main.yml
+++ b/roles/openbao_secrets/defaults/main.yml
@@ -1,0 +1,32 @@
+---
+# openbao_secrets role defaults — a controller-side pre-play that logs in to
+# OpenBao with the ai-readonly AppRole and reads the AI KV subtree into a single
+# `bao_ai_secrets` fact. AI roles then read bao-first with an env fallback:
+#   X: "{{ bao_ai_secrets.X | default(lookup('env','X'), true) }}"
+#
+# KV layout is aligned to what roles/openbao actually bootstraps: mount `secret`
+# (KV v2), and the ai-readonly policy grants read on `secret/data/ai/*` (a
+# wildcard — every path under ai/ is covered; nothing is pre-seeded, so a
+# not-yet-written path simply yields no keys and the env fallback wins).
+#
+# SKIPS CLEANLY when VAULT_ADDR is unset, so pre-migration converges keep working.
+
+# AppRole login inputs (env-sourced; see docs — the ai-readonly role_id/secret_id).
+openbao_secrets_vault_addr: "{{ lookup('env', 'VAULT_ADDR') | default('', true) }}"
+openbao_secrets_role_id: "{{ lookup('env', 'AI_VAULT_ROLE_ID') | default('', true) }}"
+openbao_secrets_secret_id: "{{ lookup('env', 'AI_VAULT_SECRET_ID') | default('', true) }}"
+
+# TLS terminates at the OpenBao Traefik ingress (a real cert), so verify by
+# default; override only for a direct-to-node http bootstrap endpoint.
+openbao_secrets_validate_certs: true
+
+# KV v2 mount + the AI paths to read (mount-relative; the ai-readonly policy's
+# `secret/data/ai/*` wildcard covers all of these). Reads tolerate a not-yet-seeded
+# path — only the paths that exist contribute keys to bao_ai_secrets.
+openbao_secrets_kv_mount: secret
+openbao_secrets_paths:
+  - ai/router      # LLM_ROUTER_MASTER_KEY (+ LANGFUSE_* project keys)
+  - ai/llm-large   # LLM_LARGE_BEARER_TOKEN
+  - ai/qdrant      # QDRANT_API_KEY
+  - ai/open-webui  # OPEN_WEBUI_SECRET_KEY, OPEN_WEBUI_OPENAI_API_KEY
+  - ai/hermes      # HERMES_AGENT_MODEL_API_KEY

--- a/roles/openbao_secrets/tasks/main.yml
+++ b/roles/openbao_secrets/tasks/main.yml
@@ -1,0 +1,69 @@
+---
+# Reads the AI KV subtree from OpenBao via the ai-readonly AppRole and merges it
+# into the `bao_ai_secrets` fact. Runs ONCE on the controller (delegate_to
+# localhost, run_once) and publishes the fact to every host in the play. SKIPS
+# CLEANLY when VAULT_ADDR is unset, so pre-migration converges keep working on
+# env/SOPS secrets. All vault interactions are no_log.
+
+- name: Decide whether the OpenBao fetch is enabled
+  ansible.builtin.set_fact:
+    openbao_secrets_active: "{{ openbao_secrets_vault_addr | length > 0 }}"
+
+- name: Report that OpenBao is not configured (env/SOPS fallback in effect)
+  ansible.builtin.debug:
+    msg: >-
+      VAULT_ADDR is unset — openbao_secrets is skipping; AI roles fall back to
+      env/SOPS secrets. Set VAULT_ADDR + AI_VAULT_ROLE_ID + AI_VAULT_SECRET_ID
+      (ai-readonly AppRole) to source secrets from OpenBao.
+  run_once: true
+  when: not openbao_secrets_active
+
+- name: Fetch the AI secrets from OpenBao (controller-side, once)
+  when: openbao_secrets_active
+  delegate_to: localhost
+  run_once: true
+  no_log: true
+  block:
+    - name: Assert the ai-readonly AppRole credentials are present
+      ansible.builtin.assert:
+        that:
+          - openbao_secrets_role_id | length > 0
+          - openbao_secrets_secret_id | length > 0
+        fail_msg: >-
+          VAULT_ADDR is set but AI_VAULT_ROLE_ID / AI_VAULT_SECRET_ID are not.
+          Provide the ai-readonly AppRole role_id + secret_id.
+
+    - name: Log in to OpenBao with the ai-readonly AppRole
+      community.hashi_vault.vault_login:
+        url: "{{ openbao_secrets_vault_addr }}"
+        auth_method: approle
+        role_id: "{{ openbao_secrets_role_id }}"
+        secret_id: "{{ openbao_secrets_secret_id }}"
+        validate_certs: "{{ openbao_secrets_validate_certs }}"
+      register: openbao_secrets_login
+
+    - name: Read each AI KV path (tolerate not-yet-seeded paths)
+      community.hashi_vault.vault_kv2_get:
+        url: "{{ openbao_secrets_vault_addr }}"
+        auth_method: token
+        token: "{{ openbao_secrets_login.login.auth.client_token }}"
+        engine_mount_point: "{{ openbao_secrets_kv_mount }}"
+        path: "{{ item }}"
+        validate_certs: "{{ openbao_secrets_validate_certs }}"
+      loop: "{{ openbao_secrets_paths }}"
+      register: openbao_secrets_reads
+      failed_when: false
+
+    - name: Merge the readable KV paths into one dict
+      ansible.builtin.set_fact:
+        openbao_secrets_merged: "{{ openbao_secrets_merged | default({}) | combine(item.secret) }}"
+      loop: "{{ openbao_secrets_reads.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+      when: item.secret is defined and item.secret is mapping
+
+# The shared, un-prefixed `bao_ai_secrets` fact is published at the PLAYBOOK layer
+# (playbooks/site.yml), not here — mirrors how `tofu_data` is set in
+# inventory/load_tofu.yml, and keeps this role's own facts role-prefixed. This role
+# leaves the merged result on the delegated controller as `openbao_secrets_merged`
+# (hostvars['localhost']); the site.yml play copies it into `bao_ai_secrets` per host.

--- a/roles/qdrant_docker/defaults/main.yml
+++ b/roles/qdrant_docker/defaults/main.yml
@@ -2,5 +2,6 @@
 qdrant_docker_image: "qdrant/qdrant:v1.17.0"
 qdrant_docker_container_name: qdrant
 qdrant_docker_data_dir: /opt/qdrant
-qdrant_docker_api_key: "{{ lookup('env', 'QDRANT_API_KEY') }}"
+qdrant_docker_api_key: >-
+  {{ bao_ai_secrets.QDRANT_API_KEY | default(lookup('env', 'QDRANT_API_KEY'), true) }}
 qdrant_docker_storage_driver: "fuse-overlayfs"


### PR DESCRIPTION
## What

Phase 5 of the LLM re-arch: introduce the `openbao_secrets` role and migrate the AI
roles to resolve secrets **OpenBao-first with an env fallback**, keeping the
existing fail-loud asserts as the final gate.

### New role `openbao_secrets` (pre-play)
- Logs in with the **ai-readonly** AppRole (`VAULT_ADDR` + `AI_VAULT_ROLE_ID` +
  `AI_VAULT_SECRET_ID`, fail-loud asserts) and reads the AI KV subtree via
  `community.hashi_vault` (`vault_login` + `vault_kv2_get`), `no_log`, `run_once`,
  `delegate_to: localhost`.
- Merges the readable paths into `openbao_secrets_merged`; the shared, un-prefixed
  `bao_ai_secrets` fact is published at the **playbook layer** (`site.yml`, the same
  place `tofu_data` is set) so the role's own facts stay role-prefixed (satisfies
  `var-naming[no-role-prefix]` with no lint bypass).
- **Skips cleanly** when `VAULT_ADDR` is unset — `group_vars/all.yml` seeds
  `bao_ai_secrets: {}`, so `bao_ai_secrets.X | default(lookup('env','X'), true)`
  always resolves. Pre-migration converges keep working on env/SOPS.
- Wired as the first AI-phase play, before Phase 6 (qdrant), so `bao_ai_secrets`
  exists before any consumer evaluates its defaults.

### RBAC-policy alignment finding (checked `roles/openbao` first)
Aligned exactly to what `roles/openbao` bootstraps — **did not invent paths the
policy can't read**:
- **KV mount** `secret` (v2); **AppRole** `ai-readonly`.
- The `ai-readonly` policy grants `read` on `secret/data/ai/*` (+ `secret/data/apps/*`)
  — a **wildcard**, so every `ai/<name>` path is covered. There is no per-path
  declaration to match.
- `roles/openbao` **seeds no values** (mount + policies + AppRoles only). So the
  paths read here (`ai/router`, `ai/llm-large`, `ai/qdrant`, `ai/open-webui`,
  `ai/hermes`) yield keys only once a writer populates them; until then every read is
  empty and the env fallback wins. A future seeding step (or the Vault UI) must
  create them.
- Login endpoint: `VAULT_ADDR=https://openbao.<subdomain>` (the Traefik ingress; the
  role's own bootstrap uses `BAO_*`/http:8200 internally). No `VAULT_SKIP_VERIFY`.

### Migrated defaults (bao-first, env fallback, asserts kept)
`llm_router` (LLM_ROUTER_MASTER_KEY, LLM_LARGE_BEARER_TOKEN), `open_webui`
(OPEN_WEBUI_SECRET_KEY, OPEN_WEBUI_OPENAI_API_KEY), `hermes_agent`
(HERMES_AGENT_MODEL_API_KEY), `ai_orchestration_group`
(AI_ORCHESTRATION_MODEL_API_KEY), `qdrant_docker` (QDRANT_API_KEY).

## Dependencies / deferred
- `requirements.yml` adds `community.hashi_vault`. Its python `hvac` dep is added to
  the **nix-devenv `ansible-apps`** shell in companion PR dryvist/nix-devenv#60 (the
  repo-native way this repo gets Python libs — no in-repo pip/venv mechanism exists).
- **SOPS-sourced `DIFY_*` / `LANGFLOW_*` / `LANGFUSE_*` left untouched** this PR —
  full migration needs the seeded KV first (follow-up).
- No template-render CI addition: the role has **no templates** (tasks only).

## Test
- `ansible-lint` (production profile): **0 failures on 567 files**.
- `yamllint`: clean.
- `ansible-playbook --syntax-check` on `site.yml`: passes (exit 0).
- Inventory-load verification: PASSED.

### Not yet live-validated (verify at the first bao-backed converge)
The ai-readonly AppRole login against the Traefik ingress and that `vault_kv2_get`
returns the expected field names once `secret/ai/*` is seeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj