### PR TITLE
feat(technitium_dns): prune retired guest A records

### DIFF
--- a/inventory/group_vars/technitium_dns_group.yml
+++ b/inventory/group_vars/technitium_dns_group.yml
@@ -1,0 +1,15 @@
+---
+# Technitium DNS overrides for the technitium_dns_group.
+
+# Guest hostnames retired for good: their A records are deleted from the zone so
+# they stop resolving to addresses no longer in service. The record-add path is
+# add/overwrite-only and never removes a name, so a name only stops resolving
+# once it is listed here. Bare hostnames only. A name being rebuilt under the
+# SAME hostname is refreshed by the overwrite path and must NOT be listed here.
+technitium_dns_retired_records:
+  - hermes-infer
+  - hermes-chat
+  - claude-code-01
+  - claude-code-02
+  - gemini-01
+  - gemini-02

--- a/roles/technitium_dns/defaults/main.yml
+++ b/roles/technitium_dns/defaults/main.yml
@@ -32,6 +32,15 @@ technitium_dns_zone_ttl: 3600
 # These are populated dynamically from hostvars in tasks
 technitium_dns_a_records: []
 
+# Bare hostnames whose A records are DELETED from the zone when present. The
+# record-add tasks are add/overwrite-only and never remove a name, so a hostname
+# that is gone for good keeps resolving until it is listed here. This list is
+# EXPLICIT and never inferred: it is the only way to retire a guest name without
+# touching unrelated or static records (node A records, for example, are static
+# entries the role must never prune). Each name is looked up and its A record
+# removed if found; an absent name is a no-op. Bare hostnames only, no zone suffix.
+technitium_dns_retired_records: []
+
 # CNAME aliases for services
 # Maps service name to canonical hostname
 technitium_dns_cname_records:

--- a/roles/technitium_dns/tasks/main.yml
+++ b/roles/technitium_dns/tasks/main.yml
@@ -296,6 +296,72 @@
     - technitium_dns_apply | bool
   no_log: true
 
+# --- Prune retired guest A records -------------------------------------------
+# The record-add tasks above are add/overwrite-only, so a hostname that is gone
+# for good would keep resolving unless its A record is deleted here.
+# technitium_dns_retired_records lists the bare hostnames to remove (explicit,
+# never inferred — static entries such as node A records must never be pruned).
+# The delete API needs the record's ipAddress, so each name is looked up first
+# and only the A rdata actually present is deleted. A name with no record yields
+# an empty lookup, no delete is issued, and the run reports no change — the prune
+# is idempotent by construction.
+- name: Look up retired guest A records
+  ansible.builtin.uri:
+    url: >-
+      {{ technitium_dns_api_url }}/api/zones/records/get?token={{
+      technitium_dns_api_token }}&domain={{
+      (item ~ '.' ~ technitium_dns_zone) | urlencode }}&zone={{
+      technitium_dns_zone | urlencode }}
+    method: GET
+    return_content: true
+    timeout: "{{ technitium_dns_api_timeout }}"
+  loop: "{{ technitium_dns_retired_records }}"
+  loop_control:
+    label: "{{ item }}"
+  register: technitium_dns_retired_lookup
+  changed_when: false
+  when:
+    - technitium_dns_role == 'primary'
+    - technitium_dns_apply | bool
+  no_log: true
+
+# Flatten the per-name lookups into the concrete A records to delete. Each record
+# carries its own fully-qualified `name` and `rData.ipAddress` — the two values
+# the delete API needs. An empty result means every retired name was already
+# absent, so the delete task below loops zero times.
+- name: Build retired A-record deletion list
+  ansible.builtin.set_fact:
+    technitium_dns_retired_deletions: >-
+      {{ technitium_dns_retired_lookup.results | default([])
+         | map(attribute='json.response.records', default=[])
+         | flatten | selectattr('type', 'equalto', 'A') | list }}
+  when:
+    - technitium_dns_role == 'primary'
+    - technitium_dns_apply | bool
+
+- name: Delete retired guest A records
+  ansible.builtin.uri:
+    url: "{{ technitium_dns_api_url }}/api/zones/records/delete?token={{ technitium_dns_api_token }}"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      domain: "{{ item.name }}"
+      zone: "{{ technitium_dns_zone }}"
+      type: A
+      ipAddress: "{{ item.rData.ipAddress }}"
+    return_content: true
+    timeout: "{{ technitium_dns_api_timeout }}"
+  loop: "{{ technitium_dns_retired_deletions | default([]) }}"
+  loop_control:
+    label: "{{ item.name }} -> {{ item.rData.ipAddress }}"
+  register: technitium_dns_retired_delete_result
+  changed_when: technitium_dns_retired_delete_result.json.status == "ok"
+  failed_when: technitium_dns_retired_delete_result.json.status | default('') != "ok"
+  when:
+    - technitium_dns_role == 'primary'
+    - technitium_dns_apply | bool
+  no_log: true
+
 - name: Create CNAME records for service aliases
   ansible.builtin.uri:
     url: "{{ technitium_dns_api_url }}/api/zones/records/add?token={{ technitium_dns_api_token }}"


### PR DESCRIPTION
## What

`roles/technitium_dns` adds/overwrites A records but never deletes them, so an A record for a permanently-retired guest hostname lingers in the zone forever and keeps resolving to an address no longer in service.

This adds a declarative prune:

- **`technitium_dns_retired_records`** (new role default, `[]`) — a list of bare hostnames whose A records are deleted from the zone when present. Explicit and never inferred, so static entries (node A records, etc.) are never touched.
- **Task block** after the A-record adds: for each retired name, GET its records, flatten to the A rdata actually present, then DELETE each. The Technitium `records/delete` API requires the record's `ipAddress` for A records, so a lookup-first pass is mandatory — and it makes the prune idempotent by construction: a name with no record yields an empty lookup, no delete is issued, and the run reports no change.
- **`group_vars/technitium_dns_group.yml`** — sets the six retired names.

## How the delete works

`GET /api/zones/records/get?domain=<name>.<zone>&zone=<zone>` returns each record with its own FQDN `name` and `rData.ipAddress`. Those two values feed `POST /api/zones/records/delete` (`domain`, `zone`, `type=A`, `ipAddress`). Only records returned by the live lookup are deleted, so re-running deletes nothing.

## Verification

- `yamllint` clean; `ansible-lint` production profile: 0 failures / 0 warnings.
- `ansible-playbook --syntax-check` on the site playbook passes.
- Unit-tested the deletion-list build expression against a realistic `records/get` register (present A record, already-absent name, mixed A+non-A, skipped loop item): selects exactly the present A records, filters non-A, safe on absent/skipped.
- All new API tasks are gated on `technitium_dns_apply | bool`, so molecule (`apply=false`) is unaffected.

Code-only; nothing converged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj