### PR TITLE
fix(inventory-contract): vm_entry ip accepts FQDN like container_entry

### DIFF
--- a/inventory/load_tofu.yml
+++ b/inventory/load_tofu.yml
@@ -566,6 +566,13 @@
              | combine(tofu_data.splunk_vm | default({})) }}
       ansible.builtin.set_fact:
         hostname: "{{ tofu_guests[item].hostname }}"
+        # DHCP-first VMs advertise an FQDN as `ip`, exactly like containers.
+        # The containers' add_host block sets container_reserved_ip; the VM
+        # blocks predate DHCP-first VMs and don't — set it generically here so
+        # the technitium_dns A-record builder targets the reservation address
+        # for every guest kind (idempotent overwrite for containers: same
+        # inventory source value).
+        container_reserved_ip: "{{ tofu_guests[item].reserved_ip | default('', true) }}"
       delegate_to: "{{ item }}"
       delegate_facts: true
       loop: "{{ groups['all'] | reject('equalto', 'localhost') | list }}"

--- a/tests/inventory_load/tofu_inventory.schema.json
+++ b/tests/inventory_load/tofu_inventory.schema.json
@@ -251,8 +251,16 @@
           "minimum": 100
         },
         "ip": {
-          "type": "string",
-          "pattern": "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$"
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$"
+            },
+            {
+              "type": "string",
+              "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$"
+            }
+          ]
         },
         "hostname": {
           "type": "string",


### PR DESCRIPTION
## Summary

The inventory contract's `vm_entry.ip` only allowed dotted-quad IPs; `container_entry.ip` already accepts IP-or-FQDN (`anyOf`) for DHCP/DNS-first guests. The first DHCP-first **VM** (iac-platform, VM 110030, just applied) advertises `iac.jacobpevans.com` and failed the `sync-inventory.sh` schema gate on both `$.vms` and `$.docker_vms` (shared `vm_entry` $ref). This mirrors the container pattern onto `vm_entry`. `splunk_entry` deliberately stays IP-only (static-derived by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qna3JuDp5y7MB2it6RqUKn