### PR TITLE
fix(openbao): upgrade to 2.5.5 (security fixes)

### DIFF
--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -12,7 +12,7 @@
 # pinning convention (Renovate keeps the .deb/checksums pin fresh; see
 # renovate.json and AGENTS.md "Version management"). Do NOT scatter the
 # version across multiple files — change it here only.
-openbao_version: "2.5.4"
+openbao_version: "2.5.5"
 
 # --- Download (checksum-verified .deb from GitHub releases) ------------------
 # The controller stages the .deb + the release checksums file, verifies the


### PR DESCRIPTION
## Summary
- Bumps `openbao_version` 2.5.4 → 2.5.5 in `roles/openbao/defaults/main.yml`. The `.deb`/checksums pin is fetched dynamically from the GitHub release at converge time, so this one-line change is the entire fix.
- v2.5.5 (2026-06-17) fixes 4 CVE-tracked issues: LDAP bind-DN injection (GHSA-6mwx-4547-5vc9), a Transit RSA derived-key mutex crash (GHSA-8w8f-r2xv-4q4j), unauthorized cross-namespace lease revocation (GHSA-c36x-h252-g9x2), and namespace path canonicalization (GHSA-mwr2-wmgp-crj6).
- Confirmed via grep that this cluster's config touches none of the affected paths (no LDAP auth, no Transit engine, single root namespace) — this is a proactive patch, not an active-exploit fix.
- Phase 0 of a larger OpenBao RBAC-separation + autonomous-secrets effort; done first so subsequent policy/AppRole changes land on the patched binary.

## Test plan
- [x] `ansible-lint` (production profile) passes clean on `roles/openbao/`.
- [x] Verified both v2.5.5 release assets exist (`openbao_2.5.5_linux_amd64.deb`, `checksums-linux.txt`).
- [x] Grepped the role + consumer role for `ldap|transit|namespace` — no matches.
- [ ] CI's molecule matrix (local molecule is a known-broken toolchain mismatch here, tracked separately — CI is the real gate).
- [ ] Live rolling upgrade on the 2-node cluster (openbao-01/-02), one node at a time, confirming `bao operator raft autopilot state` healthy between each — part of the credentialed apply session, not this PR.