### PR TITLE
fix(llamaindex): embeddings via the fabric router, retire local Ollama

### DIFF
--- a/molecule/llamaindex/converge.yml
+++ b/molecule/llamaindex/converge.yml
@@ -11,6 +11,11 @@
     # Provide variables normally injected from tofu_data.constants at playbook level
     llamaindex_qdrant_host: "192.168.0.165"
     llamaindex_qdrant_port: 6333
+    # No env / live router in molecule: pin the env-lookup defaults and skip
+    # the router health check.
+    llamaindex_router_base_url: "https://llm.example.test/v1"
+    llamaindex_router_api_key: "molecule-test-key"
+    llamaindex_verify_router: false
 
   tasks:
     - name: Include llamaindex role

--- a/molecule/llamaindex/verify.yml
+++ b/molecule/llamaindex/verify.yml
@@ -9,7 +9,6 @@
 
   vars:
     llamaindex_data_dir: /opt/llamaindex
-    llamaindex_ollama_model: "nomic-embed-text"
 
   tasks:
     - name: Check LlamaIndex data directory exists
@@ -67,43 +66,17 @@
     - name: Assert config.yaml has expected content
       ansible.builtin.assert:
         that:
-          - "'nomic-embed-text' in (config_content.content | b64decode)"
+          - "'embeddings' in (config_content.content | b64decode)"
           - "'qdrant' in (config_content.content | b64decode)"
         fail_msg: "config.yaml does not contain expected LlamaIndex configuration"
 
-    - name: Check Ollama binary exists
+    - name: Check the legacy Ollama binary is gone
       ansible.builtin.stat:
         path: /usr/local/bin/ollama
       register: ollama_binary
 
-    - name: Assert Ollama binary exists
+    - name: Assert the legacy Ollama binary is gone
       ansible.builtin.assert:
         that:
-          - ollama_binary.stat.exists
-        fail_msg: "Ollama binary not found at /usr/local/bin/ollama"
-
-    - name: Check Ollama service is active
-      ansible.builtin.systemd:
-        name: ollama
-      register: ollama_status
-      failed_when: false
-
-    - name: Assert Ollama service is active
-      ansible.builtin.assert:
-        that:
-          - ollama_status.status.ActiveState == 'active'
-        fail_msg: >-
-          Ollama service is not running
-          (ActiveState: {{ ollama_status.status.ActiveState | default('unknown') }})
-
-    - name: Check embedding model is present
-      ansible.builtin.command:
-        cmd: ollama list
-      register: ollama_list
-      changed_when: false
-
-    - name: Assert embedding model is loaded
-      ansible.builtin.assert:
-        that:
-          - "llamaindex_ollama_model in ollama_list.stdout"
-        fail_msg: "Embedding model {{ llamaindex_ollama_model }} not found in ollama list"
+          - not ollama_binary.stat.exists
+        fail_msg: "Legacy Ollama binary still present at /usr/local/bin/ollama"

--- a/roles/llamaindex/defaults/main.yml
+++ b/roles/llamaindex/defaults/main.yml
@@ -1,6 +1,14 @@
 ---
 llamaindex_data_dir: /opt/llamaindex
-llamaindex_ollama_model: "nomic-embed-text"
+# Embeddings come from the fabric router (llm-fast serves the `embeddings`
+# model, OpenAI-compatible); the local Ollama sidecar is retired.
+llamaindex_embed_model: "embeddings"
+llamaindex_router_base_url: >-
+  https://llm.{{ lookup('env', 'PROXMOX_SUBDOMAIN')
+  | mandatory('PROXMOX_SUBDOMAIN required') }}/v1
+llamaindex_router_api_key: >-
+  {{ lookup('env', 'LLM_ROUTER_MASTER_KEY')
+  | mandatory('LLM_ROUTER_MASTER_KEY required') }}
 llamaindex_qdrant_api_key: "{{ lookup('env', 'QDRANT_API_KEY') }}"
 # llamaindex_qdrant_host is injected from hostvars (inventory) and
 # llamaindex_qdrant_port from tofu_data.constants at the playbook

--- a/roles/llamaindex/handlers/main.yml
+++ b/roles/llamaindex/handlers/main.yml
@@ -1,5 +1,0 @@
----
-- name: Restart ollama
-  ansible.builtin.systemd:
-    name: ollama
-    state: restarted

--- a/roles/llamaindex/tasks/main.yml
+++ b/roles/llamaindex/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # LlamaIndex RAG Engine Deployment Tasks
-# Deploys Ollama (CPU-only embeddings) + LlamaIndex orchestration
+# Python venv + config pointing embeddings at the fabric router (llm-fast).
 
 # =============================================================================
 # System Dependencies
@@ -17,39 +17,24 @@
     update_cache: true
 
 # =============================================================================
-# Ollama Installation
+# Retire the legacy local-Ollama embeddings sidecar (no-op on fresh guests;
+# cleans up pre-fabric installs on converge)
 # =============================================================================
 
-- name: Download Ollama install script
-  ansible.builtin.get_url:
-    url: https://ollama.com/install.sh
-    dest: /tmp/ollama-install.sh
-    mode: "0755"
-
-- name: Install Ollama
-  ansible.builtin.command:
-    cmd: /tmp/ollama-install.sh
-    creates: /usr/local/bin/ollama
-
-- name: Enable and start Ollama systemd service
+- name: Remove legacy Ollama systemd service
   ansible.builtin.systemd:
     name: ollama
-    state: started
-    enabled: true
-    daemon_reload: true
+    state: stopped
+    enabled: false
+  failed_when: false
 
-- name: Check if embedding model is already present
-  ansible.builtin.command:
-    cmd: "ollama list"
-  register: llamaindex_ollama_list
-  changed_when: false
-
-- name: Pull embedding model
-  ansible.builtin.command:
-    cmd: "ollama pull {{ llamaindex_ollama_model }}"
-  register: llamaindex_ollama_pull
-  changed_when: true
-  when: llamaindex_ollama_model not in llamaindex_ollama_list.stdout
+- name: Remove legacy Ollama binary and install script
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /usr/local/bin/ollama
+    - /tmp/ollama-install.sh
 
 # =============================================================================
 # LlamaIndex Application Directory
@@ -73,7 +58,7 @@
     name:
       - llama-index-core
       - llama-index-vector-stores-qdrant
-      - llama-index-embeddings-ollama
+      - llama-index-embeddings-openai
     state: present
     virtualenv: "{{ llamaindex_data_dir }}/venv"
 
@@ -93,15 +78,16 @@
 # Health Checks
 # =============================================================================
 
-- name: Verify Ollama service is running
-  ansible.builtin.systemd:
-    name: ollama
-  register: llamaindex_ollama_service
-  failed_when: llamaindex_ollama_service.status.ActiveState != 'active'
-
-- name: Verify embedding model is loaded
-  ansible.builtin.command:
-    cmd: "ollama list"
-  register: llamaindex_model_check
-  changed_when: false
-  failed_when: "llamaindex_ollama_model not in llamaindex_model_check.stdout"
+- name: Verify the router serves the embeddings model
+  ansible.builtin.uri:
+    url: "{{ llamaindex_router_base_url }}/models"
+    headers:
+      Authorization: "Bearer {{ llamaindex_router_api_key }}"
+    return_content: true
+  register: llamaindex_router_models
+  # The router pool may still be converging on a first full-site run.
+  retries: 3
+  delay: 10
+  until: llamaindex_router_models is not failed
+  failed_when: "llamaindex_embed_model not in llamaindex_router_models.content"
+  no_log: true

--- a/roles/llamaindex/tasks/main.yml
+++ b/roles/llamaindex/tasks/main.yml
@@ -85,9 +85,13 @@
       Authorization: "Bearer {{ llamaindex_router_api_key }}"
     return_content: true
   register: llamaindex_router_models
-  # The router pool may still be converging on a first full-site run.
+  # The router pool may still be converging on a first full-site run, and a
+  # reachable router can answer before the embeddings deployment registers —
+  # retry on the content, not just the connection.
   retries: 3
   delay: 10
-  until: llamaindex_router_models is not failed
-  failed_when: "llamaindex_embed_model not in llamaindex_router_models.content"
+  until: llamaindex_embed_model in (llamaindex_router_models.content | default(''))
+  failed_when: llamaindex_embed_model not in (llamaindex_router_models.content | default(''))
   no_log: true
+  # Molecule has no live router; the scenario disables this check.
+  when: llamaindex_verify_router | default(true)

--- a/roles/llamaindex/templates/llamaindex-config.yaml.j2
+++ b/roles/llamaindex/templates/llamaindex-config.yaml.j2
@@ -4,8 +4,9 @@ qdrant:
   port: {{ llamaindex_qdrant_port }}
   api_key: "{{ llamaindex_qdrant_api_key }}"
 
-ollama:
-  model: "{{ llamaindex_ollama_model }}"
-  base_url: "http://localhost:11434"
+embeddings:
+  model: "{{ llamaindex_embed_model }}"
+  base_url: "{{ llamaindex_router_base_url }}"
+  api_key: "{{ llamaindex_router_api_key }}"
 
 data_dir: "{{ llamaindex_data_dir }}"


### PR DESCRIPTION
First converge of the rebuilt llamaindex guest failed at `Install Ollama` — the role predates the fabric and still deploys a local Ollama sidecar for embeddings, which this campaign retires everywhere.

- pip: `llama-index-embeddings-ollama` → `llama-index-embeddings-openai`
- config: `ollama:` block → `embeddings:` block pointing at `https://llm.<subdomain>/v1` (model `embeddings`, served by llm-fast, master key from env)
- converge now removes any legacy Ollama service/binary (idempotent no-op on fresh guests)
- health check queries the router's `/v1/models` for the embeddings model instead of the local service

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj