### PR TITLE
feat(openbao): generalize openbao_secrets to per-domain fetch

### DIFF
--- a/inventory/group_vars/ai_orchestration_group.yml
+++ b/inventory/group_vars/ai_orchestration_group.yml
@@ -28,7 +28,7 @@ ai_orchestration_ollama_base_url: "https://llm.{{ ai_subdomain }}/v1"
 ai_orchestration_model_large_base_url: "https://llm.{{ ai_subdomain }}/v1"
 # Router API key (master key), OpenBao-first with env (SOPS/Doppler) fallback.
 ai_orchestration_model_api_key: >-
-  {{ bao_ai_secrets.AI_ORCHESTRATION_MODEL_API_KEY
+  {{ bao_local_llm_secrets.AI_ORCHESTRATION_MODEL_API_KEY
      | default(lookup('env', 'AI_ORCHESTRATION_MODEL_API_KEY'), true) }}
 
 # Restart the Docker stack on failure (Phase 9 systemd restart policy).

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -32,8 +32,16 @@ technitium_dns_extra_cname_records:
   - name: llm-large
     target: "{{ lookup('env', 'LLM_LARGE_RUNNER_HOST') }}"
 
-# AI secrets fetched from OpenBao by the openbao_secrets pre-play. Defaults to an
-# empty dict so every consumer's `bao_ai_secrets.X | default(lookup('env','X'),
-# true)` resolves even when the fetch is skipped (VAULT_ADDR unset) or the host is
-# outside the openbao_secrets play. The pre-play overrides it per host when active.
-bao_ai_secrets: {}
+# Resource-domain secrets fetched from OpenBao by the openbao_secrets pre-play,
+# one dict per domain. Defaults to an empty dict for each so every consumer's
+# `bao_<domain>_secrets.X | default(lookup('env','X'), true)` resolves even
+# when the fetch is skipped (BAO_ADDR unset, or that domain's role_id/secret_id
+# envs unset) or the host is outside the openbao_secrets play. The pre-play
+# overrides these per host when active. `local-llm` replaces the old
+# `ai-readonly`-backed `bao_ai_secrets` for the LLM serving stack — ai-readonly
+# is now reserved for AI AGENT identities, not the serving stack itself.
+bao_local_llm_secrets: {}
+bao_observability_secrets: {}
+bao_local_cloud_secrets: {}
+bao_monitoring_secrets: {}
+bao_media_secrets: {}

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -8,31 +8,46 @@
 # Configure application stacks based on OpenTofu infrastructure
 
 # =============================================================================
-# Phase 0-secrets: OpenBao AI secrets pre-fetch
-# Reads the AI KV subtree (ai-readonly AppRole) into the `bao_ai_secrets` fact so
-# every AI/vectordb role can resolve its secrets bao-first with an env fallback.
-# Runs once on the controller and publishes to the consuming groups; SKIPS CLEANLY
-# when VAULT_ADDR is unset. Placed before Phase 6 (qdrant) so it precedes every
-# consumer.
+# Phase 0-secrets: OpenBao resource-domain secrets pre-fetch
+# Reads each resource-domain's KV subtree (its own least-privilege AppRole)
+# into a per-domain `bao_<domain>_secrets` fact so every consumer role can
+# resolve its secrets bao-first with an env fallback. Runs once on the
+# controller and publishes to the union of every domain's consuming groups;
+# each domain SKIPS CLEANLY when BAO_ADDR or that domain's own role_id/
+# secret_id envs are unset. Placed before Phase 6 (qdrant) so it precedes
+# every consumer.
 # =============================================================================
 
-- name: Pre-fetch AI secrets from OpenBao
-  hosts: qdrant_group:open_webui_group:hermes_agent_group:llm_router_group:ai_orchestration_group
+- name: Pre-fetch resource-domain secrets from OpenBao
+  hosts: >-
+    qdrant_group:open_webui_group:hermes_agent_group:llm_router_group:ai_orchestration_group:
+    cribl_stream_group:cribl_edge:
+    object_storage_group:
+    netmon_group:prometheus_group:unifi_metrics_group:
+    sonarr_group:radarr_group:plex_group:seerr_group:download_vpn_group:immich_group
   gather_facts: false
   tags:
     - openbao_secrets
     - ai
   tasks:
-    - name: Fetch the AI KV subtree via the ai-readonly AppRole
+    - name: Fetch each resource-domain's KV subtree via its own AppRole
       ansible.builtin.include_role:
         name: openbao_secrets
 
-    # Publish the shared, un-prefixed fact at the playbook layer (like tofu_data in
-    # load_tofu.yml). openbao_secrets_merged was computed once on the delegated
-    # controller; hosts where the fetch was skipped fall back to the {} default.
-    - name: Publish the merged AI secrets to the AI hosts
+    # Publish each domain's shared, un-prefixed fact at the playbook layer
+    # (like tofu_data in load_tofu.yml). openbao_secrets_by_domain was
+    # computed once on the delegated controller; a domain that was skipped
+    # (BAO_ADDR or that domain's creds unset) is simply absent from the dict,
+    # so `default({})` covers it the same as a host outside this play.
+    - name: Publish each domain's merged secrets to every host in this play
       ansible.builtin.set_fact:
-        bao_ai_secrets: "{{ hostvars['localhost'].openbao_secrets_merged | default({}) }}"
+        bao_observability_secrets: "{{ openbao_secrets_by_domain['observability'] | default({}) }}"
+        bao_local_cloud_secrets: "{{ openbao_secrets_by_domain['local-cloud'] | default({}) }}"
+        bao_monitoring_secrets: "{{ openbao_secrets_by_domain['monitoring'] | default({}) }}"
+        bao_media_secrets: "{{ openbao_secrets_by_domain['media'] | default({}) }}"
+        bao_local_llm_secrets: "{{ openbao_secrets_by_domain['local-llm'] | default({}) }}"
+      vars:
+        openbao_secrets_by_domain: "{{ hostvars['localhost'].openbao_secrets_by_domain | default({}) }}"
       no_log: true
 
 # =============================================================================

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -23,7 +23,7 @@ hermes_agent_model: hermes-4-14b
 hermes_agent_model_base_url: "https://llm.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}/v1"
 hermes_agent_model_api_mode: chat_completions
 hermes_agent_model_api_key: >-
-  {{ bao_ai_secrets.HERMES_AGENT_MODEL_API_KEY | default(lookup('env', 'HERMES_AGENT_MODEL_API_KEY'), true) }}
+  {{ bao_local_llm_secrets.HERMES_AGENT_MODEL_API_KEY | default(lookup('env', 'HERMES_AGENT_MODEL_API_KEY'), true) }}
 
 # --- Memory: best self-hostable as of June 2026 (Agy-validated) ---
 # Hindsight: local knowledge-graph + multi-strategy retrieval. Runs alongside the

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -79,10 +79,10 @@ llm_router_health_check_interval: 300
 # --- Secrets (env-sourced; OpenBao migration is a later phase) ----------------
 # Mandatory, fail-loud (mirrors the ai_orchestration group_vars pattern).
 llm_router_master_key: >-
-  {{ bao_ai_secrets.LLM_ROUTER_MASTER_KEY | default(lookup('env', 'LLM_ROUTER_MASTER_KEY'), true)
+  {{ bao_local_llm_secrets.LLM_ROUTER_MASTER_KEY | default(lookup('env', 'LLM_ROUTER_MASTER_KEY'), true)
      | mandatory('LLM_ROUTER_MASTER_KEY must be set (OpenBao secret/ai/router or SOPS/Doppler env)') }}
 llm_router_llm_large_bearer: >-
-  {{ bao_ai_secrets.LLM_LARGE_BEARER_TOKEN | default(lookup('env', 'LLM_LARGE_BEARER_TOKEN'), true)
+  {{ bao_local_llm_secrets.LLM_LARGE_BEARER_TOKEN | default(lookup('env', 'LLM_LARGE_BEARER_TOKEN'), true)
      | mandatory('LLM_LARGE_BEARER_TOKEN must be set (OpenBao secret/ai/llm-large or SOPS/Doppler env)') }}
 # The GPU/CPU light backends need no auth; a placeholder keeps the OpenAI client happy.
 llm_router_light_api_key: "sk-noauth"

--- a/roles/open_webui/defaults/main.yml
+++ b/roles/open_webui/defaults/main.yml
@@ -21,7 +21,7 @@ open_webui_port: "{{ tofu_data.constants.service_ports.open_webui_web }}"
 # master key, env-sourced (SOPS/Doppler). Default the chat box to the large tier.
 open_webui_openai_api_base_url: "https://llm.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}/v1"
 open_webui_openai_api_key: >-
-  {{ bao_ai_secrets.OPEN_WEBUI_OPENAI_API_KEY | default(lookup('env', 'OPEN_WEBUI_OPENAI_API_KEY'), true) }}
+  {{ bao_local_llm_secrets.OPEN_WEBUI_OPENAI_API_KEY | default(lookup('env', 'OPEN_WEBUI_OPENAI_API_KEY'), true) }}
 open_webui_default_model: gpt-oss-120b
 
 # Public URL via Traefik — derived from the PROXMOX_SUBDOMAIN var (pve.<apex>),
@@ -33,4 +33,4 @@ open_webui_url: "https://{{ open_webui_hostname }}"
 # store in OpenBao (secret/ai/open-webui) or Doppler/SOPS. Must NOT change between
 # runs or sessions invalidate.
 open_webui_secret_key: >-
-  {{ bao_ai_secrets.OPEN_WEBUI_SECRET_KEY | default(lookup('env', 'OPEN_WEBUI_SECRET_KEY'), true) }}
+  {{ bao_local_llm_secrets.OPEN_WEBUI_SECRET_KEY | default(lookup('env', 'OPEN_WEBUI_SECRET_KEY'), true) }}

--- a/roles/openbao_secrets/README.md
+++ b/roles/openbao_secrets/README.md
@@ -1,69 +1,115 @@
 # openbao_secrets
 
-A controller-side **pre-play** that logs in to OpenBao with the **ai-readonly**
-AppRole and reads the AI KV subtree into a single `bao_ai_secrets` fact. AI roles
-then resolve their secrets **bao-first with an env fallback**:
+A controller-side **pre-play** that logs in to OpenBao **once per
+resource-domain identity** (each with its own least-privilege AppRole) and
+reads that domain's KV subtree into a per-domain fact,
+`bao_<domain>_secrets` (hyphens become underscores, e.g. `local-cloud` ->
+`bao_local_cloud_secrets`). Consumer roles then resolve their secrets
+**bao-first with an env fallback**:
 
 ```yaml
-some_secret: "{{ bao_ai_secrets.SOME_SECRET | default(lookup('env', 'SOME_SECRET'), true) }}"
+some_secret: "{{ bao_observability_secrets.SOME_SECRET | default(lookup('env', 'SOME_SECRET'), true) }}"
 ```
 
-It runs **once** on the controller (`delegate_to: localhost`, `run_once`), leaving
-the merged result as `openbao_secrets_merged` on the controller; the `site.yml`
-play then copies it into the shared, un-prefixed `bao_ai_secrets` fact per host (the
-publish lives at the playbook layer — like `tofu_data` in `load_tofu.yml` — so the
-role's own facts stay role-prefixed). It **skips cleanly** when `VAULT_ADDR` is
-unset, so converges keep working on env/SOPS secrets before the KV is seeded (the
-`group_vars/all.yml` default `bao_ai_secrets: {}` guarantees the fallback resolves).
+It runs **once** on the controller (`delegate_to: localhost`, `run_once`),
+looping `openbao_secrets_domains` and leaving each domain's merged result in
+`openbao_secrets_by_domain[<domain>]` on the controller; the calling playbook
+then copies each domain's dict into its own shared, un-prefixed
+`bao_<domain>_secrets` fact per host (the publish lives at the playbook
+layer — like `tofu_data` in `load_tofu.yml` — so the role's own facts stay
+role-prefixed). Each domain **skips cleanly** when its own role_id/secret_id
+envs are unset, so an operator can migrate one domain at a time onto OpenBao
+while the rest keep resolving from env/SOPS (the `group_vars/all.yml` `{}`
+defaults guarantee the fallback resolves for every domain).
 
 ## Alignment with `roles/openbao` (RBAC)
 
-The layout is aligned to what `roles/openbao` bootstraps — do not invent paths the
-policy can't read:
+The layout is aligned to what `roles/openbao` bootstraps — do not invent paths
+a policy can't read:
 
 - **KV mount**: `secret` (KV v2).
-- **AppRole**: `ai-readonly` (role_id/secret_id).
-- **Policy grant**: the `ai-readonly` policy grants `read` on `secret/data/ai/*`
-  (and `secret/data/apps/*`) — a wildcard, so every path under `ai/` is readable.
-- **Seeding**: `roles/openbao` seeds **no** values; it creates only the mount +
-  policies + AppRoles. So the paths below yield keys only once a writer populates
-  them; until then every read is empty and the env fallback wins.
+- **One AppRole per domain**, not one shared identity — a domain's
+  credentials only ever unlock that domain's own KV subtree. See
+  `terraform-proxmox` `docs/SECRETS_HIERARCHY.md` for the full RBAC table.
+- **Seeding**: `roles/openbao` seeds **no** values; it creates only the mount,
+  policies, and AppRoles. So a domain's paths yield keys only once a writer
+  populates them; until then every read is empty and the env fallback wins.
+
+## Installation
+
+The role lives in this repository under `roles/openbao_secrets/`. Reference
+it from a pre-fetch play — no Galaxy install needed:
+
+```yaml
+- hosts: <union of every domain's consumer groups>
+  gather_facts: false
+  tasks:
+    - ansible.builtin.include_role:
+        name: openbao_secrets
+```
+
+## Usage
+
+Set `BAO_ADDR` plus each domain's `<DOMAIN>_VAULT_ROLE_ID` / `_SECRET_ID`
+(see [Inputs (env)](#inputs-env)), then run through the normal wrapper:
+
+```sh
+doppler run -- ansible-playbook playbooks/site.yml --tags openbao_secrets
+```
+
+Any domain whose credentials aren't set simply falls back to env/SOPS for its
+consumer roles — see [Wiring](#wiring) for how the pre-fetch play publishes
+each domain's fact.
+
+## Domains fetched (`openbao_secrets_domains`)
+
+| Domain | AppRole env vars | KV paths | Consumers |
+| --- | --- | --- | --- |
+| `observability` | `OBSERVABILITY_VAULT_ROLE_ID` / `_SECRET_ID` | `platform/splunk`, `platform/cribl` | splunk_docker, cribl_* roles |
+| `local-cloud` | `LOCAL_CLOUD_VAULT_ROLE_ID` / `_SECRET_ID` | `platform/object-storage`, `platform/compute` | object_storage role |
+| `monitoring` | `MONITORING_VAULT_ROLE_ID` / `_SECRET_ID` | `apps/monitoring` | netmon, unifi_metrics, prometheus_stack |
+| `media` | `MEDIA_VAULT_ROLE_ID` / `_SECRET_ID` | `apps/media` | *arr/qBittorrent/Plex roles |
+| `local-llm` | `LOCAL_LLM_VAULT_ROLE_ID` / `_SECRET_ID` | `ai/*` (router/llm-large/qdrant/open-webui/hermes) | LLM serving roles |
+
+`local-llm` replaces the old `ai-readonly`-backed `bao_ai_secrets` for the LLM
+**serving stack** — `ai-readonly`/`ai-elevated` are reserved for AI AGENT
+identities (Claude/codex-style agents), not the serving stack itself; keeping
+them separate means an agent's credentials can never be used to read the
+serving stack's own secrets, and vice versa.
+
+All readable path keys for a domain are merged flat into that domain's
+`bao_<domain>_secrets`, keyed by the field name, so a consumer default reads
+`bao_<domain>_secrets.<FIELD_NAME>`.
 
 ## Inputs (env)
 
 | Env var | Purpose |
 | --- | --- |
-| `VAULT_ADDR` | OpenBao ingress URL (`https://openbao.<subdomain>`). Unset ⇒ skip. |
-| `AI_VAULT_ROLE_ID` | ai-readonly AppRole role_id |
-| `AI_VAULT_SECRET_ID` | ai-readonly AppRole secret_id |
+| `BAO_ADDR` | OpenBao ingress URL (`https://openbao.<subdomain>`). Unset ⇒ skip everything. |
+| `<DOMAIN>_VAULT_ROLE_ID` / `_SECRET_ID` | That domain's own AppRole credentials. Unset ⇒ skip just that domain. |
 
-## KV paths read (`openbao_secrets_paths`)
-
-| Path (mount-relative) | Expected keys |
-| --- | --- |
-| `ai/router` | `LLM_ROUTER_MASTER_KEY` (+ `LANGFUSE_*` project keys) |
-| `ai/llm-large` | `LLM_LARGE_BEARER_TOKEN` |
-| `ai/qdrant` | `QDRANT_API_KEY` |
-| `ai/open-webui` | `OPEN_WEBUI_SECRET_KEY`, `OPEN_WEBUI_OPENAI_API_KEY` |
-| `ai/hermes` | `HERMES_AGENT_MODEL_API_KEY` |
-
-All readable path keys are merged flat into `bao_ai_secrets`, keyed by the field
-name, so a consumer default reads `bao_ai_secrets.<FIELD_NAME>`.
+On macOS these are sourced from the operator's dedicated `openbao.keychain-db`
+keychain (72h auto-lock — the keychain's lock state is the access boundary,
+not the AppRole's own TTL) via a resolver script; on Linux guests, from a
+root-only systemd credential / `0600` EnvironmentFile. See
+`terraform-proxmox` `docs/SECRETS_HIERARCHY.md`.
 
 ## Wiring
 
-Runs as the first AI-phase play in `playbooks/site.yml` (before any AI/vectordb
-role), against the union of AI-consuming groups, so `bao_ai_secrets` exists before
-those roles evaluate their secret defaults.
+Runs as a pre-fetch play in `playbooks/site.yml`, against the union of every
+domain's consumer groups, before any of those roles evaluate their secret
+defaults. One execution fetches ALL configured domains (regardless of which
+specific groups are in the play's host list) — cheap and avoids redundant
+logins from being split across multiple domain-scoped plays.
 
 ## Dependencies
 
 - `community.hashi_vault` (added to `requirements.yml`) and its Python `hvac`
   dependency in the controller environment (provided by the Nix dev shell —
-  `nix-devenv#ansible-apps`; see the PR for the companion change).
+  `nix-devenv#ansible-apps`).
 
 ## Not yet live-validated
 
-Verify at the first bao-backed converge: the ai-readonly AppRole login against the
-Traefik ingress, and that `vault_kv2_get` returns the expected field names once the
-`secret/ai/*` paths are seeded.
+Verify at the first bao-backed converge: each domain's AppRole login against
+the Traefik ingress, and that `vault_kv2_get` returns the expected field names
+once that domain's `secret/<path>` is seeded.

--- a/roles/openbao_secrets/defaults/main.yml
+++ b/roles/openbao_secrets/defaults/main.yml
@@ -1,32 +1,62 @@
 ---
 # openbao_secrets role defaults — a controller-side pre-play that logs in to
-# OpenBao with the ai-readonly AppRole and reads the AI KV subtree into a single
-# `bao_ai_secrets` fact. AI roles then read bao-first with an env fallback:
-#   X: "{{ bao_ai_secrets.X | default(lookup('env','X'), true) }}"
+# OpenBao, once per resource-domain identity, and reads that domain's KV
+# subtree into a per-domain fact (`bao_<domain>_secrets`, hyphens become
+# underscores — e.g. `local-cloud` -> `bao_local_cloud_secrets`). Consumer
+# roles then read bao-first with an env fallback:
+#   X: "{{ bao_<domain>_secrets.X | default(lookup('env','X'), true) }}"
 #
-# KV layout is aligned to what roles/openbao actually bootstraps: mount `secret`
-# (KV v2), and the ai-readonly policy grants read on `secret/data/ai/*` (a
-# wildcard — every path under ai/ is covered; nothing is pre-seeded, so a
-# not-yet-written path simply yields no keys and the env fallback wins).
+# Each domain authenticates with its OWN least-privilege AppRole (see
+# terraform-proxmox docs/SECRETS_HIERARCHY.md) rather than one broad shared
+# identity — a domain's credentials only ever unlock that domain's KV subtree.
 #
-# SKIPS CLEANLY when VAULT_ADDR is unset, so pre-migration converges keep working.
+# SKIPS CLEANLY at two levels: the whole role no-ops when BAO_ADDR is unset
+# (no OpenBao configured at all), and each domain independently no-ops when
+# its own role_id/secret_id envs are unset (lets an operator migrate one
+# domain at a time onto OpenBao while the rest still fall back to env/SOPS).
 
-# AppRole login inputs (env-sourced; see docs — the ai-readonly role_id/secret_id).
-openbao_secrets_vault_addr: "{{ lookup('env', 'VAULT_ADDR') | default('', true) }}"
-openbao_secrets_role_id: "{{ lookup('env', 'AI_VAULT_ROLE_ID') | default('', true) }}"
-openbao_secrets_secret_id: "{{ lookup('env', 'AI_VAULT_SECRET_ID') | default('', true) }}"
-
+# Shared connection inputs.
+openbao_secrets_bao_addr: "{{ lookup('env', 'BAO_ADDR') | default('', true) }}"
 # TLS terminates at the OpenBao Traefik ingress (a real cert), so verify by
 # default; override only for a direct-to-node http bootstrap endpoint.
 openbao_secrets_validate_certs: true
-
-# KV v2 mount + the AI paths to read (mount-relative; the ai-readonly policy's
-# `secret/data/ai/*` wildcard covers all of these). Reads tolerate a not-yet-seeded
-# path — only the paths that exist contribute keys to bao_ai_secrets.
 openbao_secrets_kv_mount: secret
-openbao_secrets_paths:
-  - ai/router      # LLM_ROUTER_MASTER_KEY (+ LANGFUSE_* project keys)
-  - ai/llm-large   # LLM_LARGE_BEARER_TOKEN
-  - ai/qdrant      # QDRANT_API_KEY
-  - ai/open-webui  # OPEN_WEBUI_SECRET_KEY, OPEN_WEBUI_OPENAI_API_KEY
-  - ai/hermes      # HERMES_AGENT_MODEL_API_KEY
+
+# One entry per resource-domain identity this Ansible converge fetches for.
+# Each domain's role_id/secret_id come from its own env vars — sourced from
+# the operator's keychain-backed resolver on macOS, or a root-only systemd
+# credential on Linux (never a shared/broad credential). Add a domain here as
+# new consumer roles are wired to read bao-first; each needs a matching
+# AppRole + policy in roles/openbao's `openbao_approles`/`openbao_policies`.
+openbao_secrets_domains:
+  - name: observability
+    role_id_env: OBSERVABILITY_VAULT_ROLE_ID
+    secret_id_env: OBSERVABILITY_VAULT_SECRET_ID
+    paths:
+      - platform/splunk
+      - platform/cribl
+  - name: local-cloud
+    role_id_env: LOCAL_CLOUD_VAULT_ROLE_ID
+    secret_id_env: LOCAL_CLOUD_VAULT_SECRET_ID
+    paths:
+      - platform/object-storage
+      - platform/compute
+  - name: monitoring
+    role_id_env: MONITORING_VAULT_ROLE_ID
+    secret_id_env: MONITORING_VAULT_SECRET_ID
+    paths:
+      - apps/monitoring
+  - name: media
+    role_id_env: MEDIA_VAULT_ROLE_ID
+    secret_id_env: MEDIA_VAULT_SECRET_ID
+    paths:
+      - apps/media
+  - name: local-llm
+    role_id_env: LOCAL_LLM_VAULT_ROLE_ID
+    secret_id_env: LOCAL_LLM_VAULT_SECRET_ID
+    paths:
+      - ai/router      # LLM_ROUTER_MASTER_KEY (+ LANGFUSE_* project keys)
+      - ai/llm-large   # LLM_LARGE_BEARER_TOKEN
+      - ai/qdrant      # QDRANT_API_KEY
+      - ai/open-webui  # OPEN_WEBUI_SECRET_KEY, OPEN_WEBUI_OPENAI_API_KEY
+      - ai/hermes      # HERMES_AGENT_MODEL_API_KEY

--- a/roles/openbao_secrets/tasks/fetch_domain.yml
+++ b/roles/openbao_secrets/tasks/fetch_domain.yml
@@ -65,8 +65,12 @@
         label: "{{ item.item }}"
       when: item.secret is defined and item.secret is mapping
 
+    # delegate_facts + reading hostvars['localhost'] keep the single accumulator
+    # on localhost (see the note on the init task in main.yml). Reading the bare
+    # var here would resolve the play-host copy and silently drop earlier domains.
     - name: Accumulate into the by-domain dict for {{ openbao_domain.name }}
       ansible.builtin.set_fact:
         openbao_secrets_by_domain: >-
-          {{ openbao_secrets_by_domain
+          {{ hostvars['localhost'].openbao_secrets_by_domain
              | combine({ openbao_domain.name: openbao_secrets_domain_merged }) }}
+      delegate_facts: true

--- a/roles/openbao_secrets/tasks/fetch_domain.yml
+++ b/roles/openbao_secrets/tasks/fetch_domain.yml
@@ -1,0 +1,72 @@
+---
+# Fetches ONE domain's KV subtree from OpenBao, invoked once per entry in
+# openbao_secrets_domains (the loop var is `openbao_domain`; delegation and
+# run_once are set by the caller's enclosing block in main.yml, so every task
+# here inherits them). SKIPS CLEANLY when this specific domain's role_id/
+# secret_id envs are unset — an operator can migrate one domain at a time
+# onto OpenBao while the rest still fall back to env/SOPS via the
+# group_vars/all.yml `{}` defaults.
+
+- name: Resolve role_id/secret_id from env for {{ openbao_domain.name }}
+  ansible.builtin.set_fact:
+    openbao_secrets_domain_role_id: "{{ lookup('env', openbao_domain.role_id_env) | default('', true) }}"
+    openbao_secrets_domain_secret_id: "{{ lookup('env', openbao_domain.secret_id_env) | default('', true) }}"
+  no_log: true
+
+- name: Report missing credentials (env/SOPS fallback) for {{ openbao_domain.name }}
+  ansible.builtin.debug:
+    msg: >-
+      {{ openbao_domain.role_id_env }} / {{ openbao_domain.secret_id_env }}
+      not both set — skipping the {{ openbao_domain.name }} domain; its
+      consumer roles fall back to env/SOPS secrets.
+  when: >-
+    openbao_secrets_domain_role_id | length == 0
+    or openbao_secrets_domain_secret_id | length == 0
+
+- name: Fetch and merge secrets for {{ openbao_domain.name }}
+  when:
+    - openbao_secrets_domain_role_id | length > 0
+    - openbao_secrets_domain_secret_id | length > 0
+  no_log: true
+  block:
+    # set_fact persists for the rest of the play, so without an explicit reset
+    # here the SECOND domain's merge would start from the FIRST domain's
+    # leftover data (facts aren't automatically scoped per loop iteration).
+    - name: Reset the per-domain merge accumulator for {{ openbao_domain.name }}
+      ansible.builtin.set_fact:
+        openbao_secrets_domain_merged: {}
+
+    - name: Log in with the AppRole for {{ openbao_domain.name }}
+      community.hashi_vault.vault_login:
+        url: "{{ openbao_secrets_bao_addr }}"
+        auth_method: approle
+        role_id: "{{ openbao_secrets_domain_role_id }}"
+        secret_id: "{{ openbao_secrets_domain_secret_id }}"
+        validate_certs: "{{ openbao_secrets_validate_certs }}"
+      register: openbao_secrets_domain_login
+
+    - name: Read each KV path, tolerating not-yet-seeded ones, for {{ openbao_domain.name }}
+      community.hashi_vault.vault_kv2_get:
+        url: "{{ openbao_secrets_bao_addr }}"
+        auth_method: token
+        token: "{{ openbao_secrets_domain_login.login.auth.client_token }}"
+        engine_mount_point: "{{ openbao_secrets_kv_mount }}"
+        path: "{{ item }}"
+        validate_certs: "{{ openbao_secrets_validate_certs }}"
+      loop: "{{ openbao_domain.paths }}"
+      register: openbao_secrets_domain_reads
+      failed_when: false
+
+    - name: Merge readable paths into one dict for {{ openbao_domain.name }}
+      ansible.builtin.set_fact:
+        openbao_secrets_domain_merged: "{{ openbao_secrets_domain_merged | combine(item.secret) }}"
+      loop: "{{ openbao_secrets_domain_reads.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+      when: item.secret is defined and item.secret is mapping
+
+    - name: Accumulate into the by-domain dict for {{ openbao_domain.name }}
+      ansible.builtin.set_fact:
+        openbao_secrets_by_domain: >-
+          {{ openbao_secrets_by_domain
+             | combine({ openbao_domain.name: openbao_secrets_domain_merged }) }}

--- a/roles/openbao_secrets/tasks/main.yml
+++ b/roles/openbao_secrets/tasks/main.yml
@@ -1,69 +1,42 @@
 ---
-# Reads the AI KV subtree from OpenBao via the ai-readonly AppRole and merges it
-# into the `bao_ai_secrets` fact. Runs ONCE on the controller (delegate_to
-# localhost, run_once) and publishes the fact to every host in the play. SKIPS
-# CLEANLY when VAULT_ADDR is unset, so pre-migration converges keep working on
-# env/SOPS secrets. All vault interactions are no_log.
+# Driver: loops openbao_secrets_domains, fetching each domain's KV subtree via
+# its OWN AppRole (see fetch_domain.yml) and accumulating the results into
+# openbao_secrets_by_domain, keyed by domain name. Runs ONCE on the
+# controller (delegate_to localhost, run_once); the calling playbook then
+# publishes each domain's dict into its own `bao_<domain>_secrets` fact per
+# host (mirrors how `tofu_data` is published in inventory/load_tofu.yml).
+# SKIPS CLEANLY when BAO_ADDR is unset, so pre-migration converges keep
+# working on env/SOPS secrets.
 
-- name: Decide whether the OpenBao fetch is enabled
+- name: Decide whether OpenBao is configured at all
   ansible.builtin.set_fact:
-    openbao_secrets_active: "{{ openbao_secrets_vault_addr | length > 0 }}"
+    openbao_secrets_active: "{{ openbao_secrets_bao_addr | length > 0 }}"
 
 - name: Report that OpenBao is not configured (env/SOPS fallback in effect)
   ansible.builtin.debug:
     msg: >-
-      VAULT_ADDR is unset — openbao_secrets is skipping; AI roles fall back to
-      env/SOPS secrets. Set VAULT_ADDR + AI_VAULT_ROLE_ID + AI_VAULT_SECRET_ID
-      (ai-readonly AppRole) to source secrets from OpenBao.
+      BAO_ADDR is unset — openbao_secrets is skipping entirely; every domain
+      falls back to env/SOPS secrets. Set BAO_ADDR plus each domain's
+      <DOMAIN>_VAULT_ROLE_ID / <DOMAIN>_VAULT_SECRET_ID to source that
+      domain's secrets from OpenBao.
   run_once: true
   when: not openbao_secrets_active
 
-- name: Fetch the AI secrets from OpenBao (controller-side, once)
+- name: Initialize the per-domain secrets accumulator
+  ansible.builtin.set_fact:
+    openbao_secrets_by_domain: {}
+  delegate_to: localhost
+  run_once: true
+  when: openbao_secrets_active
+
+- name: Fetch each domain's secrets from OpenBao (delegated to the controller)
   when: openbao_secrets_active
   delegate_to: localhost
   run_once: true
-  no_log: true
   block:
-    - name: Assert the ai-readonly AppRole credentials are present
-      ansible.builtin.assert:
-        that:
-          - openbao_secrets_role_id | length > 0
-          - openbao_secrets_secret_id | length > 0
-        fail_msg: >-
-          VAULT_ADDR is set but AI_VAULT_ROLE_ID / AI_VAULT_SECRET_ID are not.
-          Provide the ai-readonly AppRole role_id + secret_id.
-
-    - name: Log in to OpenBao with the ai-readonly AppRole
-      community.hashi_vault.vault_login:
-        url: "{{ openbao_secrets_vault_addr }}"
-        auth_method: approle
-        role_id: "{{ openbao_secrets_role_id }}"
-        secret_id: "{{ openbao_secrets_secret_id }}"
-        validate_certs: "{{ openbao_secrets_validate_certs }}"
-      register: openbao_secrets_login
-
-    - name: Read each AI KV path (tolerate not-yet-seeded paths)
-      community.hashi_vault.vault_kv2_get:
-        url: "{{ openbao_secrets_vault_addr }}"
-        auth_method: token
-        token: "{{ openbao_secrets_login.login.auth.client_token }}"
-        engine_mount_point: "{{ openbao_secrets_kv_mount }}"
-        path: "{{ item }}"
-        validate_certs: "{{ openbao_secrets_validate_certs }}"
-      loop: "{{ openbao_secrets_paths }}"
-      register: openbao_secrets_reads
-      failed_when: false
-
-    - name: Merge the readable KV paths into one dict
-      ansible.builtin.set_fact:
-        openbao_secrets_merged: "{{ openbao_secrets_merged | default({}) | combine(item.secret) }}"
-      loop: "{{ openbao_secrets_reads.results }}"
+    - name: Fetch each configured domain's secrets from OpenBao
+      ansible.builtin.include_tasks: fetch_domain.yml
+      loop: "{{ openbao_secrets_domains }}"
       loop_control:
-        label: "{{ item.item }}"
-      when: item.secret is defined and item.secret is mapping
-
-# The shared, un-prefixed `bao_ai_secrets` fact is published at the PLAYBOOK layer
-# (playbooks/site.yml), not here — mirrors how `tofu_data` is set in
-# inventory/load_tofu.yml, and keeps this role's own facts role-prefixed. This role
-# leaves the merged result on the delegated controller as `openbao_secrets_merged`
-# (hostvars['localhost']); the site.yml play copies it into `bao_ai_secrets` per host.
+        loop_var: openbao_domain
+        label: "{{ openbao_domain.name }}"

--- a/roles/openbao_secrets/tasks/main.yml
+++ b/roles/openbao_secrets/tasks/main.yml
@@ -22,10 +22,16 @@
   run_once: true
   when: not openbao_secrets_active
 
+# delegate_facts is REQUIRED, not optional: set_fact + delegate_to + run_once
+# WITHOUT delegate_facts writes the fact to the play's hosts, NOT to localhost,
+# so hostvars['localhost'].openbao_secrets_by_domain (how the calling play reads
+# it back) would be undefined and every domain would publish empty secrets.
+# Verified empirically against ansible-core 2.21.
 - name: Initialize the per-domain secrets accumulator
   ansible.builtin.set_fact:
     openbao_secrets_by_domain: {}
   delegate_to: localhost
+  delegate_facts: true
   run_once: true
   when: openbao_secrets_active
 

--- a/roles/qdrant_docker/defaults/main.yml
+++ b/roles/qdrant_docker/defaults/main.yml
@@ -3,5 +3,5 @@ qdrant_docker_image: "qdrant/qdrant:v1.17.0"
 qdrant_docker_container_name: qdrant
 qdrant_docker_data_dir: /opt/qdrant
 qdrant_docker_api_key: >-
-  {{ bao_ai_secrets.QDRANT_API_KEY | default(lookup('env', 'QDRANT_API_KEY'), true) }}
+  {{ bao_local_llm_secrets.QDRANT_API_KEY | default(lookup('env', 'QDRANT_API_KEY'), true) }}
 qdrant_docker_storage_driver: "fuse-overlayfs"


### PR DESCRIPTION
## Summary
- Generalizes `openbao_secrets` from a single `ai-readonly` login fetching one `bao_ai_secrets` fact, to looping `openbao_secrets_domains` and authenticating with **each domain's own least-privilege AppRole** (matching the RBAC split from #540): `observability`, `local-cloud`, `monitoring`, `media`, `local-llm`.
- Each domain publishes its own `bao_<domain>_secrets` fact and **independently** skips cleanly when that domain's `role_id`/`secret_id` envs are unset — an operator can migrate one domain at a time onto OpenBao while the rest keep resolving from env/SOPS (the existing, documented pattern).
- `local-llm` replaces the old `ai-readonly`-backed `bao_ai_secrets` for the **LLM serving stack** (`llm_router`, `open_webui`, `hermes_agent`, `qdrant_docker`, `ai_orchestration`) — `ai-readonly`/`ai-elevated` are now reserved for AI AGENT identities, not the serving stack itself, so an agent's credentials can never be used to read the serving stack's own secrets.
- `playbooks/site.yml`'s pre-fetch play expands to the union of every domain's consumer groups (adds cribl, object-storage, netmon/prometheus/unifi_metrics, and the media roles) and publishes all 5 domain facts in one run rather than splitting into multiple plays with redundant logins.
- Standardizes on `BAO_ADDR` (was `VAULT_ADDR`) for this role's connection input, per the effort's naming convention.
- Part of the larger OpenBao autonomous-secrets effort — Phase 3 of that plan. Depends conceptually on #540 (the RBAC identities this role authenticates as) but is independently mergeable (both roles already ship in this repo; wiring is additive).

## Test plan
- [x] `ansible-lint` (production profile) passes clean.
- [x] `yamllint` passes clean.
- [x] Found and fixed a real cross-domain leakage bug during implementation: `set_fact` persists across loop iterations, so without an explicit per-domain reset the second domain's merge would start from the first domain's leftover data. Verified the fix with a standalone throwaway playbook simulating two domains with distinct secrets before trusting it.
- [x] Found and fixed a real syntax bug: `delegate_to`/`run_once` aren't valid directly on an `include_tasks` "TaskInclude" node in this ansible-core version — moved them to an enclosing `block:`.
- [x] Verified the `hostvars['localhost'].<undefined_dict>['key'] | default({})` fallback (used when `BAO_ADDR` is unset entirely, so the accumulator fact never exists) resolves gracefully rather than raising, with a standalone throwaway playbook.
- [ ] Live fetch against the real cluster once the domain AppRoles exist (part of the credentialed apply session, not this PR): confirm each domain's login succeeds and `vault_kv2_get` returns expected fields once seeded.