### PR TITLE
fix(site): converge llamaindex after the LiteLLM router

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -575,27 +575,6 @@
     - role: idrac_kvm_docker
 
 # =============================================================================
-# Phase 8: LlamaIndex RAG Engine
-# CPU-only embeddings via Ollama + LlamaIndex orchestration
-# =============================================================================
-
-- name: Configure LlamaIndex RAG engine
-  hosts: llamaindex_group
-  become: true
-  gather_facts: true
-  tags:
-    - llamaindex
-    - rag
-    - ai
-  vars:
-    _vdb_ports: >-
-      {{ hostvars['localhost']['tofu_data']['constants']['vector_db_ports'] }}
-    llamaindex_qdrant_host: "{{ hostvars['qdrant']['container_ip'] }}"
-    llamaindex_qdrant_port: "{{ _vdb_ports.qdrant_http }}"
-  roles:
-    - role: llamaindex
-
-# =============================================================================
 # Phase 8a: Local LLM — Ollama inference (AMD ROCm) + Open WebUI chat
 # Ollama (CT 167, RX 6800) serves Hermes 4 14B; Open WebUI (CT 168) is the chat
 # front-end. Open WebUI is fronted by Traefik at https://llm.<subdomain>
@@ -669,6 +648,28 @@
     - ai
   roles:
     - role: llm_router
+
+# =============================================================================
+# Phase 8a-post: LlamaIndex RAG Engine
+# Embeddings via the fabric router (llm-fast) — must converge AFTER the
+# router play; its health check queries https://llm.<subdomain>/v1/models.
+# =============================================================================
+
+- name: Configure LlamaIndex RAG engine
+  hosts: llamaindex_group
+  become: true
+  gather_facts: true
+  tags:
+    - llamaindex
+    - rag
+    - ai
+  vars:
+    _vdb_ports: >-
+      {{ hostvars['localhost']['tofu_data']['constants']['vector_db_ports'] }}
+    llamaindex_qdrant_host: "{{ hostvars['qdrant']['container_ip'] }}"
+    llamaindex_qdrant_port: "{{ _vdb_ports.qdrant_http }}"
+  roles:
+    - role: llamaindex
 
 # =============================================================================
 # Phase 8a-bis: AI Orchestration Layer


### PR DESCRIPTION
Follow-up to #541: the llamaindex role's health check queries the router's `/v1/models` for the `embeddings` model, but the llamaindex play sat before the llama_cpp/llm_router plays in site order — a first full-site converge could never pass it. Move the play to directly after the router play (its other dependency, qdrant, converges even earlier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj