### PR TITLE
fix(llama_cpp): tolerate asset-less latest release; CPU standby host_vars

### DIFF
--- a/inventory/host_vars/llm-light.yml
+++ b/inventory/host_vars/llm-light.yml
@@ -1,0 +1,4 @@
+---
+# llm-light is the CPU-only cold standby of the light tier (DR-sleep node):
+# plain ubuntu-x64 llama.cpp build, no GPU device assertions or ROCm path.
+llama_cpp_gpu: false

--- a/roles/llama_cpp/defaults/main.yml
+++ b/roles/llama_cpp/defaults/main.yml
@@ -64,7 +64,7 @@ llama_cpp_rocm_packages: []
 # --- Release resolution (never pin a version — resolve latest at converge) ----
 # Query the GitHub "latest release" and pick the asset by NAME pattern, so both the
 # build tag AND the embedded ROCm version can move without a role change.
-llama_cpp_llamacpp_releases_api: "https://api.github.com/repos/ggml-org/llama.cpp/releases/latest"
+llama_cpp_llamacpp_releases_api: "https://api.github.com/repos/ggml-org/llama.cpp/releases?per_page=5"
 llama_cpp_swap_releases_api: "https://api.github.com/repos/mostlygeek/llama-swap/releases/latest"
 # GPU build -> the ubuntu ROCm tarball; CPU build -> the plain ubuntu x64 tarball.
 llama_cpp_llamacpp_asset_regex: >-

--- a/roles/llama_cpp/tasks/main.yml
+++ b/roles/llama_cpp/tasks/main.yml
@@ -97,7 +97,7 @@
 - name: Install the llama.cpp release binary
   when: not llama_cpp_server_stat.stat.exists
   block:
-    - name: Resolve the latest llama.cpp release metadata
+    - name: Resolve recent llama.cpp release metadata
       ansible.builtin.uri:
         url: "{{ llama_cpp_llamacpp_releases_api }}"
         return_content: true
@@ -105,17 +105,22 @@
           Accept: application/vnd.github+json
       register: llama_cpp_llamacpp_release
 
+    # llama.cpp cuts a release every few hours and CI uploads assets minutes
+    # later, so the newest release is routinely asset-less. Scan newest-first
+    # across the last few releases and take the first matching asset.
     - name: Select the llama.cpp release asset by name pattern
       ansible.builtin.set_fact:
         llama_cpp_llamacpp_asset_url: >-
-          {{ llama_cpp_llamacpp_release.json.assets
+          {{ llama_cpp_llamacpp_release.json
+             | map(attribute='assets') | flatten
              | selectattr('name', 'match', llama_cpp_llamacpp_asset_regex)
-             | map(attribute='browser_download_url') | list | first }}
+             | map(attribute='browser_download_url') | list
+             | first | default('') }}
 
     - name: Assert a matching llama.cpp asset was found
       ansible.builtin.assert:
         that:
-          - llama_cpp_llamacpp_asset_url | default('') | length > 0
+          - llama_cpp_llamacpp_asset_url | length > 0
         fail_msg: >-
           No llama.cpp release asset matched {{ llama_cpp_llamacpp_asset_regex }}
           in {{ llama_cpp_llamacpp_releases_api }} — the asset naming may have changed.
@@ -185,7 +190,8 @@
         llama_cpp_swap_asset_url: >-
           {{ llama_cpp_swap_release.json.assets
              | selectattr('name', 'match', llama_cpp_swap_asset_regex)
-             | map(attribute='browser_download_url') | list | first }}
+             | map(attribute='browser_download_url') | list
+             | first | default('') }}
 
     - name: Assert a matching llama-swap asset was found
       ansible.builtin.assert:

--- a/roles/llama_cpp/tasks/main.yml
+++ b/roles/llama_cpp/tasks/main.yml
@@ -196,7 +196,7 @@
     - name: Assert a matching llama-swap asset was found
       ansible.builtin.assert:
         that:
-          - llama_cpp_swap_asset_url | default('') | length > 0
+          - llama_cpp_swap_asset_url | length > 0
         fail_msg: >-
           No llama-swap release asset matched {{ llama_cpp_swap_asset_regex }}
           in {{ llama_cpp_swap_releases_api }} — the asset naming may have changed.


### PR DESCRIPTION
First llama_cpp converge hit two failures:

1. **llm-fast**: `releases/latest` returned b9871 with **zero assets** (llama.cpp cuts a release every few hours; CI uploads lag minutes behind), so the asset `| first` blew up with 'sequence was empty'. Resolve `releases?per_page=5` newest-first and take the first matching asset; guard both `first` selections with `default('')` so the existing assert message fires instead of a template error.
2. **llm-light**: nothing wired `llama_cpp_gpu: false` for the CPU standby, so it tripped the GPU device-node assertion. Added `inventory/host_vars/llm-light.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj