### PR TITLE
feat(media): persist download-queue state on the shared data volume

### DIFF
--- a/molecule/download_vpn/prepare.yml
+++ b/molecule/download_vpn/prepare.yml
@@ -34,6 +34,27 @@
         state: present
       when: ansible_facts['os_family'] == 'Debian'
 
+    # Live, /data is a bind-mount created host-side (media_lxc_features) as
+    # root:media 2775; the role creates the qBittorrent profile tree there AS the
+    # media-group service user via group-write, because container-root cannot
+    # write the host-root-owned (idmap-unmapped) /data inode. This plain Docker
+    # container has no idmap, so /data would default to root:root and the
+    # service-user mkdir would EPERM. Stage /data to the same ownership/mode
+    # contract so the group-write path the role relies on is actually exercised.
+    - name: Stage the shared media group (mirrors the host-side idmap contract)
+      ansible.builtin.group:
+        name: media
+        gid: 13000
+        state: present
+
+    - name: Stage /data as the host-side bind-mount contract (root:media, setgid)
+      ansible.builtin.file:
+        path: /data
+        state: directory
+        owner: root
+        group: media
+        mode: "2775"
+
     # The role consumes tofu_data.constants.media_ports and the host's
     # container_ip (normally injected by load_tofu.yml). Provide a minimal
     # stand-in so the role renders without the full tofu inventory.

--- a/molecule/download_vpn/verify.yml
+++ b/molecule/download_vpn/verify.yml
@@ -18,7 +18,12 @@
   vars:
     download_vpn_wg_interface: wg0
     download_vpn_nft_ruleset_path: /etc/nftables.d/download-vpn-killswitch.nft
-    download_vpn_qbittorrent_config_dir: /home/qbittorrent/.config/qBittorrent
+    # Matches the role default: download_vpn_data_dir (/data) is not overridden
+    # by converge.yml, so the --profile tree lands at this fixed, deterministic
+    # path (see defaults/main.yml: download_vpn_qbittorrent_{profile,config}_dir).
+    download_vpn_qbittorrent_profile_dir: /data/.qbittorrent-profile
+    download_vpn_qbittorrent_config_dir: /data/.qbittorrent-profile/qBittorrent/config
+    download_vpn_qbittorrent_export_dir: /data/.qbittorrent-profile/exported-torrents
 
   tasks:
     # --- 1. ruleset content ------------------------------------------------
@@ -80,6 +85,31 @@
           - "'Session\\\\Interface=' ~ download_vpn_wg_interface in (qbt_conf.content | b64decode)"
           - "'Connection\\\\Interface=' ~ download_vpn_wg_interface in (qbt_conf.content | b64decode)"
         fail_msg: "qBittorrent is not bound to wg0."
+
+    # --- 2b. qBittorrent session/queue state persists on /data -------------
+    - name: Assert qBittorrent.conf exports a persistent, plain-file torrent backup
+      ansible.builtin.assert:
+        that:
+          - >-
+            'Session\\TorrentExportDirectory=' ~ download_vpn_qbittorrent_export_dir
+            in (qbt_conf.content | b64decode)
+        fail_msg: >-
+          qBittorrent.conf does not set Session\TorrentExportDirectory under
+          the persistent /data profile tree.
+
+    - name: Read the deployed qBittorrent systemd unit
+      ansible.builtin.slurp:
+        src: /etc/systemd/system/qbittorrent-nox.service
+      register: qbt_unit
+
+    - name: Assert the systemd unit passes --profile under the persistent /data tree
+      ansible.builtin.assert:
+        that:
+          - "'--profile=' ~ download_vpn_qbittorrent_profile_dir in (qbt_unit.content | b64decode)"
+        fail_msg: >-
+          qbittorrent-nox.service does not start with --profile pointing under
+          the persistent /data tree — the session/queue state would land back
+          on the disposable container rootfs.
 
     # --- 3. simulate wg0 down -> no v4/v6 egress ---------------------------
     - name: Ensure IPv6 is disabled (as the role does on real hosts)
@@ -163,3 +193,47 @@
         cmd: nft delete table inet killswitch
       changed_when: true
       failed_when: false
+
+# --- 5. persistent-storage guards (unit-style — gated on manage_services, ----
+# never live in this scenario since there is no real Proton tunnel in CI) -----
+# download_vpn_manage_services is false here (see converge.yml), so the guard
+# tasks never execute against the container. Assert their shape directly
+# against the role source instead: a mountpoint check for each critical
+# directory, an ntfy alert, and a hard fail — not just a warning.
+- name: Verify the persistent-storage guards are fail-loud (unit-style)
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    _role_tasks_path: "{{ playbook_dir }}/../../roles/download_vpn/tasks/main.yml"
+
+  tasks:
+    - name: Read the download_vpn role's tasks/main.yml
+      ansible.builtin.slurp:
+        src: "{{ _role_tasks_path }}"
+      register: _download_vpn_tasks_raw
+
+    - name: Decode tasks/main.yml
+      ansible.builtin.set_fact:
+        _download_vpn_tasks: "{{ _download_vpn_tasks_raw.content | b64decode }}"
+
+    # The role's tasks are un-rendered Jinja on disk (the {{ }} placeholders are
+    # literal text here, not resolved values) — {% raw %} keeps THIS assert's own
+    # templating pass from consuming them so the search strings match verbatim.
+    - name: Compute the literal, un-rendered guard snippets to search for
+      ansible.builtin.set_fact:
+        _data_mountpoint_snippet: "mountpoint -q {% raw %}{{ download_vpn_data_dir }}{% endraw %}"
+        _prowlarr_mountpoint_snippet: "mountpoint -q {% raw %}{{ download_vpn_prowlarr_data_dir }}{% endraw %}"
+
+    - name: Assert both persistent-storage guards check, alert, then fail
+      ansible.builtin.assert:
+        that:
+          - _data_mountpoint_snippet in _download_vpn_tasks
+          - _prowlarr_mountpoint_snippet in _download_vpn_tasks
+          - "'ansible.builtin.fail' in _download_vpn_tasks"
+          - (_download_vpn_tasks.count('ansible.builtin.fail')) >= 2
+          - (_download_vpn_tasks.count('download_vpn_ntfy_url')) >= 2
+        fail_msg: >-
+          The download_vpn role no longer has a fatal mountpoint guard (with an
+          ntfy alert) for both /data and the Prowlarr data dir.

--- a/molecule/seerr/verify.yml
+++ b/molecule/seerr/verify.yml
@@ -87,3 +87,44 @@
     # mode, which tests the container's filesystem, not the role. The seed's
     # restrictive permissions are a deployment guarantee verified out-of-band, not
     # an assertion we can make meaningfully in this ephemeral container.
+
+# --- 3. persistence guard (unit-style — gated on seerr_manage_services, -----
+# never live in this scenario since there is no running container in CI) -----
+# seerr_manage_services is false here (see converge.yml), so the guard task
+# never executes against the container. Assert its shape directly against the
+# role source instead: a mountpoint check, an ntfy alert, and a hard fail —
+# not just a render.
+- name: Verify the Seerr persistence guard is fail-loud (unit-style)
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    _role_tasks_path: "{{ playbook_dir }}/../../roles/seerr/tasks/main.yml"
+
+  tasks:
+    - name: Read the seerr role's tasks/main.yml
+      ansible.builtin.slurp:
+        src: "{{ _role_tasks_path }}"
+      register: _seerr_tasks_raw
+
+    - name: Decode tasks/main.yml
+      ansible.builtin.set_fact:
+        _seerr_tasks: "{{ _seerr_tasks_raw.content | b64decode }}"
+
+    # The role's tasks are un-rendered Jinja on disk (the {{ }} placeholder is
+    # literal text here, not a resolved value) — {% raw %} keeps THIS assert's
+    # own templating pass from consuming it so the search string matches verbatim.
+    - name: Compute the literal, un-rendered guard snippet to search for
+      ansible.builtin.set_fact:
+        _config_mountpoint_snippet: "mountpoint -q {% raw %}{{ seerr_config_dir }}{% endraw %}"
+
+    - name: Assert the persistence guard checks, alerts, then fails
+      ansible.builtin.assert:
+        that:
+          - _config_mountpoint_snippet in _seerr_tasks
+          - "'ansible.builtin.fail' in _seerr_tasks"
+          - (_seerr_tasks.count('seerr_ntfy_url')) >= 1
+        fail_msg: >-
+          The seerr role no longer has a fatal mountpoint guard (with an ntfy
+          alert) for seerr_config_dir.

--- a/roles/download_vpn/README.md
+++ b/roles/download_vpn/README.md
@@ -38,6 +38,21 @@ outside the VPN:
    table immediately before the deploy-time gate, atomically rebuilding it only
    when it has drifted to a clearnet `default via`, so every converge is clean.
 
+## Persistent state
+
+qBittorrent's session/queue state (the resume/session database and per-torrent
+descriptors) and its WebUI config live under a `qbittorrent-nox --profile=`
+tree rooted at `download_vpn_qbittorrent_profile_dir`, under the shared,
+always-persistent `/data` volume — never the disposable container rootfs.
+`Session\TorrentExportDirectory` additionally keeps a plain-file, always-
+populated copy of every added torrent's descriptor, independent of the session
+database, so the queue can be rebuilt from files alone. Before qBittorrent or
+Prowlarr start, the role asserts `download_vpn_data_dir` and
+`download_vpn_prowlarr_data_dir` are real persistent mounts — not the
+disposable container rootfs — alerting ntfy and **failing the converge** if
+not, rather than silently starting either app in a state that would lose its
+data on the next container rebuild.
+
 ## Bandwidth / QoS (self-throttle)
 
 qBittorrent is the WAN's heaviest user; on an asymmetric link (e.g. 1 Gbps down /

--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -117,7 +117,22 @@ download_vpn_apt_cacher_port: "{{ tofu_data.constants.service_ports.apt_cacher_n
 # --- qBittorrent -------------------------------------------------------------
 download_vpn_qbittorrent_package: qbittorrent-nox
 download_vpn_qbittorrent_user: "{{ download_vpn_user }}"
-download_vpn_qbittorrent_config_dir: "/home/{{ download_vpn_user }}/.config/qBittorrent"
+# qbittorrent-nox --profile=<root> lays out <root>/qBittorrent/{config,data,cache}
+# (config/ = qBittorrent.conf + categories.json; data/ = BT_backup + torrents.db,
+# the session/queue state). Rooted under download_vpn_data_dir (/data, the
+# ALWAYS-persistent shared volume, never the disposable container rootfs) so the
+# whole tree — including the session/queue state nothing else can reconstruct —
+# survives a container rebuild. Every other setting is re-applied by this role on
+# the next converge regardless.
+download_vpn_qbittorrent_profile_dir: "{{ download_vpn_data_dir }}/.qbittorrent-profile"
+download_vpn_qbittorrent_profile_base_dir: "{{ download_vpn_qbittorrent_profile_dir }}/qBittorrent"
+download_vpn_qbittorrent_config_dir: "{{ download_vpn_qbittorrent_profile_base_dir }}/config"
+download_vpn_qbittorrent_profile_data_dir: "{{ download_vpn_qbittorrent_profile_base_dir }}/data"
+# Plain-file, always-populated copy of every added torrent's descriptor —
+# independent of the session DB above, so the queue can be rebuilt from files
+# alone even if that DB is ever lost or corrupted. Set via Session\TorrentExportDirectory
+# in qBittorrent.conf.j2 (a template-safe key, unlike the API-only prefs below).
+download_vpn_qbittorrent_export_dir: "{{ download_vpn_qbittorrent_profile_dir }}/exported-torrents"
 # Web UI port from tofu constants (no hardcoded port).
 download_vpn_qbittorrent_web_port: >-
   {{ tofu_data.constants.media_ports.qbittorrent_web }}
@@ -247,7 +262,9 @@ download_vpn_natpmp_refresh_seconds: 45
 # systemd timer cadence for the fail-closed validator. On ANY breach it stops
 # qBittorrent and alerts (ntfy + healthchecks deadman).
 download_vpn_validator_interval: "2min"
-# ntfy alert target. Reuses the repo's ntfy LXC + push topic convention.
+# ntfy alert target. Reuses the repo's ntfy LXC + push topic convention. Shared
+# by the runtime killswitch validator above AND the persistent-storage guards
+# in tasks/main.yml (Phase 2b) — both are fail-loud, alert-then-refuse gates.
 download_vpn_ntfy_url: >-
   http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
   tofu_data.constants.notification_ports.ntfy_http }}/{{ download_vpn_ntfy_topic }}

--- a/roles/download_vpn/tasks/main.yml
+++ b/roles/download_vpn/tasks/main.yml
@@ -165,6 +165,85 @@
     - "{{ download_vpn_downloads_dir }}/tv"
     - "{{ download_vpn_downloads_dir }}/movies"
 
+# --- Phase 2b: persistent-storage guards (fail loud, before any app starts) -
+# qBittorrent's session/queue state and Prowlarr's indexer database are only
+# safe from a container rebuild if their directories are REAL persistent
+# mounts, not the disposable container rootfs. This does not block destroying
+# the container — it only refuses to let the app START in a state that would
+# silently look fine while quietly losing its data path.
+- name: Check whether the shared /data volume is a persistent mount
+  ansible.builtin.command:
+    cmd: mountpoint -q {{ download_vpn_data_dir }}
+  register: download_vpn_data_mountpoint
+  changed_when: false
+  failed_when: false
+  when: download_vpn_manage_services
+
+- name: Alert ntfy when /data is NOT persistent
+  ansible.builtin.uri:
+    url: "{{ download_vpn_ntfy_url }}"
+    method: POST
+    headers:
+      Title: "download-vpn persistence guard"
+      Priority: urgent
+      Tags: rotating_light
+    body_format: raw
+    body: >-
+      {{ download_vpn_data_dir }} on {{ inventory_hostname }} is NOT a
+      persistent mount. Refusing to start qBittorrent before the mount is fixed.
+  failed_when: false
+  when:
+    - download_vpn_manage_services
+    - download_vpn_data_mountpoint.rc | default(0) != 0
+
+- name: Fail when /data is NOT persistent
+  ansible.builtin.fail:
+    msg: >-
+      {{ download_vpn_data_dir }} is NOT a persistent mount. qBittorrent's
+      session/queue state (rooted under {{ download_vpn_qbittorrent_profile_dir }})
+      and the shared media library are on the disposable LXC rootfs and would
+      be LOST on the next container rebuild. Bind-mount the persistent dataset
+      onto {{ download_vpn_data_dir }}, then re-run this converge.
+  when:
+    - download_vpn_manage_services
+    - download_vpn_data_mountpoint.rc | default(0) != 0
+
+- name: Check whether the Prowlarr data dir is a persistent mount
+  ansible.builtin.command:
+    cmd: mountpoint -q {{ download_vpn_prowlarr_data_dir }}
+  register: download_vpn_prowlarr_mountpoint
+  changed_when: false
+  failed_when: false
+  when: download_vpn_manage_services
+
+- name: Alert ntfy when the Prowlarr data dir is NOT persistent
+  ansible.builtin.uri:
+    url: "{{ download_vpn_ntfy_url }}"
+    method: POST
+    headers:
+      Title: "download-vpn persistence guard"
+      Priority: urgent
+      Tags: rotating_light
+    body_format: raw
+    body: >-
+      {{ download_vpn_prowlarr_data_dir }} on {{ inventory_hostname }} is NOT a
+      persistent mount. Refusing to start Prowlarr before the mount is fixed.
+  failed_when: false
+  when:
+    - download_vpn_manage_services
+    - download_vpn_prowlarr_mountpoint.rc | default(0) != 0
+
+- name: Fail when the Prowlarr data dir is NOT persistent
+  ansible.builtin.fail:
+    msg: >-
+      {{ download_vpn_prowlarr_data_dir }} is NOT a persistent mount.
+      Prowlarr's indexer database is on the disposable LXC rootfs and would be
+      LOST on the next container rebuild. Bind-mount the persistent dataset
+      onto {{ download_vpn_prowlarr_data_dir }}, then re-run this converge.
+  when:
+    - download_vpn_manage_services
+    - download_vpn_prowlarr_mountpoint.rc | default(0) != 0
+
 # --- Phase 3: KILL IPv6 at the kernel ---------------------------------------
 # Proton is dual-stack; we forbid IPv6 entirely so qBittorrent has no v6 path.
 # nft ip6 coverage (below) is the belt to this suspenders.
@@ -279,13 +358,22 @@
   when: download_vpn_manage_services
 
 # --- Phase 6: qBittorrent ----------------------------------------------------
-- name: Ensure qBittorrent config directory exists
+# Pre-create every level of the --profile tree (see defaults/main.yml) with the
+# correct owner BEFORE the daemon starts, so it never has to mkdir its own tree
+# the first time it runs as the unprivileged qbittorrent user.
+- name: Ensure the qBittorrent profile tree exists on persistent storage
   ansible.builtin.file:
-    path: "{{ download_vpn_qbittorrent_config_dir }}"
+    path: "{{ item }}"
     state: directory
     owner: "{{ download_vpn_user }}"
     group: "{{ download_vpn_group }}"
     mode: "0750"
+  loop:
+    - "{{ download_vpn_qbittorrent_profile_dir }}"
+    - "{{ download_vpn_qbittorrent_profile_base_dir }}"
+    - "{{ download_vpn_qbittorrent_config_dir }}"
+    - "{{ download_vpn_qbittorrent_profile_data_dir }}"
+    - "{{ download_vpn_qbittorrent_export_dir }}"
 
 - name: Deploy qBittorrent configuration (bound to wg0)
   ansible.builtin.template:

--- a/roles/download_vpn/tasks/main.yml
+++ b/roles/download_vpn/tasks/main.yml
@@ -361,13 +361,21 @@
 # Pre-create every level of the --profile tree (see defaults/main.yml) with the
 # correct owner BEFORE the daemon starts, so it never has to mkdir its own tree
 # the first time it runs as the unprivileged qbittorrent user.
-- name: Ensure the qBittorrent profile tree exists on persistent storage
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: directory
-    owner: "{{ download_vpn_user }}"
-    group: "{{ download_vpn_group }}"
-    mode: "0750"
+- name: Ensure the qBittorrent profile tree exists on persistent storage  # noqa: command-instead-of-module
+  # /data is a bind-mount owned by the host's root (uid 0), which is UNMAPPED
+  # inside this unprivileged LXC — so container-root's CAP_DAC_OVERRIDE does not
+  # reach it (the kernel grants file capabilities only when the file's uid AND
+  # gid both map into the namespace; the idmap maps gid 13000 but not host uid 0).
+  # Creating a new entry directly under /data writes the /data inode, and
+  # container-root is neither its (unmapped) owner nor in gid 13000, leaving only
+  # the mode-2775 "other" bits (r-x, no write) -> EPERM. The service user IS in
+  # gid 13000 (media), which has group-write via the idmap, so create the tree AS
+  # that user. runuser (not become_user: sudo is absent in this container, and
+  # the service user's shell is nologin, which runuser -u bypasses). Ordered
+  # parent-first so each dir's parent exists before mkdir -m sets its mode.
+  ansible.builtin.command:
+    cmd: "runuser -u {{ download_vpn_user }} -- mkdir -p -m 0750 {{ item }}"
+    creates: "{{ item }}"
   loop:
     - "{{ download_vpn_qbittorrent_profile_dir }}"
     - "{{ download_vpn_qbittorrent_profile_base_dir }}"

--- a/roles/download_vpn/templates/qBittorrent.conf.j2
+++ b/roles/download_vpn/templates/qBittorrent.conf.j2
@@ -36,6 +36,9 @@ Session\LSDEnabled={{ download_vpn_qbittorrent_lsd | lower }}
 # limits only prevent peers from connecting, wasting available upload capacity.
 Session\MaxUploads={{ download_vpn_qbittorrent_max_uploads }}
 Session\MaxUploadsPerTorrent={{ download_vpn_qbittorrent_max_uploads_per_torrent }}
+# Persistent, plain-file copy of every added torrent's descriptor —
+# independent of the session DB, so the queue can be rebuilt from files alone.
+Session\TorrentExportDirectory={{ download_vpn_qbittorrent_export_dir }}
 
 [Preferences]
 Connection\InterfaceName={{ download_vpn_wg_interface }}

--- a/roles/download_vpn/templates/qbittorrent-nox.service.j2
+++ b/roles/download_vpn/templates/qbittorrent-nox.service.j2
@@ -11,7 +11,7 @@ BindsTo=download-vpn-wg.service
 Type=exec
 User={{ download_vpn_user }}
 Group={{ download_vpn_group }}
-ExecStart=/usr/bin/qbittorrent-nox --webui-port={{ download_vpn_qbittorrent_web_port }}
+ExecStart=/usr/bin/qbittorrent-nox --webui-port={{ download_vpn_qbittorrent_web_port }} --profile={{ download_vpn_qbittorrent_profile_dir }}
 # Resilience: a crashed daemon (e.g. disk-full abort) must come back on its
 # own instead of staying dead until the next converge. 30s of backoff keeps a
 # hard-failing daemon from hammering the disk it just filled.

--- a/roles/plex/defaults/main.yml
+++ b/roles/plex/defaults/main.yml
@@ -78,6 +78,13 @@ plex_apt_repo: "deb [signed-by={{ plex_apt_keyring_path }}] https://repo.plex.tv
 plex_package: plexmediaserver
 plex_manage_services: true
 
+# ntfy alert target for the persistent-mount guard (tasks/main.yml). Mirrors
+# the repo's ntfy LXC + push topic convention (see download_vpn/service_deadman).
+plex_ntfy_url: >-
+  http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
+  tofu_data.constants.notification_ports.ntfy_http }}/{{ plex_ntfy_topic }}
+plex_ntfy_topic: "persistence"
+
 # Publish the server to plex.tv so account-based clients (the Plex app on Roku,
 # app.plex.tv) can DISCOVER it. A CLAIMED server with libraries is still hidden
 # from the account while this is off (PublishServerOnPlexOnlineKey=0) — which is

--- a/roles/plex/tasks/main.yml
+++ b/roles/plex/tasks/main.yml
@@ -97,14 +97,14 @@
   when: plex_manage_services
 
 # ---------------------------------------------------------------------------
-# Persistence guard — surface a config dir on the disposable rootfs LOUDLY
+# Persistence guard — refuse to start Plex on a non-persistent config dir
 # ---------------------------------------------------------------------------
 # Plex identity (Preferences.xml machineIdentifier + claim + publish flag) and
 # the watch-history DB live under /var/lib/plexmediaserver. The media_lxc_features
 # role bind-mounts the persistent bulk/appdata/plex dataset there so they survive
-# a container REBUILD. If that mount is missing, a rebuild silently resets Plex to
-# a brand-new server (lost history, re-claim prompt) — so make the missing mount a
-# VISIBLE warning on every converge instead of a silent time bomb. Non-fatal.
+# a container REBUILD. Without that mount a rebuild silently resets Plex to a
+# brand-new server (lost history, re-claim prompt) — so fail the converge
+# instead of silently starting a fresh server on the disposable rootfs.
 - name: Check whether the Plex config dir is on a persistent mount
   ansible.builtin.command:
     cmd: mountpoint -q /var/lib/plexmediaserver
@@ -113,13 +113,31 @@
   failed_when: false
   when: plex_manage_services
 
-- name: Warn loudly when the Plex config dir is NOT persistent
-  ansible.builtin.debug:
+- name: Alert ntfy when the Plex config dir is NOT persistent
+  ansible.builtin.uri:
+    url: "{{ plex_ntfy_url }}"
+    method: POST
+    headers:
+      Title: "plex persistence guard"
+      Priority: urgent
+      Tags: rotating_light
+    body_format: raw
+    body: >-
+      /var/lib/plexmediaserver on {{ inventory_hostname }} is NOT a persistent
+      mount. Refusing to start Plex before the mount is fixed.
+  failed_when: false
+  when:
+    - plex_manage_services
+    - plex_config_mountpoint.rc | default(0) != 0
+
+- name: Fail when the Plex config dir is NOT persistent
+  ansible.builtin.fail:
     msg: >-
-      WARNING: /var/lib/plexmediaserver is NOT a persistent mount. Plex identity
-      and watch history are on the disposable LXC rootfs and will be LOST on the
+      /var/lib/plexmediaserver is NOT a persistent mount. Plex identity and
+      watch history are on the disposable LXC rootfs and would be LOST on the
       next container rebuild (server resets to a fresh install). Apply the
-      media_lxc_features role to bind-mount bulk/appdata/plex.
+      media_lxc_features role to bind-mount bulk/appdata/plex, then re-run
+      this converge.
   when:
     - plex_manage_services
     - plex_config_mountpoint.rc | default(0) != 0

--- a/roles/radarr/defaults/main.yml
+++ b/roles/radarr/defaults/main.yml
@@ -32,3 +32,10 @@ radarr_api_key: "{{ lookup('env', 'RADARR_API_KEY') | default('', true) }}"
 # through without a login prompt — matching the servarr_wiring defaults.
 radarr_auth_method: External
 radarr_auth_required: DisabledForLocalAddresses
+
+# ntfy alert target for the persistent-mount guard (tasks/main.yml). Mirrors
+# the repo's ntfy LXC + push topic convention (see download_vpn/service_deadman).
+radarr_ntfy_url: >-
+  http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
+  tofu_data.constants.notification_ports.ntfy_http }}/{{ radarr_ntfy_topic }}
+radarr_ntfy_topic: "persistence"

--- a/roles/radarr/tasks/main.yml
+++ b/roles/radarr/tasks/main.yml
@@ -59,6 +59,49 @@
     - "{{ radarr_media_dir }}"
     - "{{ radarr_movies_dir }}"
 
+# ---------------------------------------------------------------------------
+# Persistence guard — refuse to start Radarr on a non-persistent data dir
+# ---------------------------------------------------------------------------
+# radarr_data_dir holds Radarr's own database and config.xml (deterministic
+# API key, auth method). Without a persistent mount there, a container rebuild
+# silently resets Radarr to a fresh install (lost history, re-provisioning
+# needed) — so fail the converge instead of starting fresh silently.
+- name: Check whether the Radarr data dir is on a persistent mount
+  ansible.builtin.command:
+    cmd: mountpoint -q {{ radarr_data_dir }}
+  register: radarr_data_mountpoint
+  changed_when: false
+  failed_when: false
+  when: radarr_manage_services
+
+- name: Alert ntfy when the Radarr data dir is NOT persistent
+  ansible.builtin.uri:
+    url: "{{ radarr_ntfy_url }}"
+    method: POST
+    headers:
+      Title: "radarr persistence guard"
+      Priority: urgent
+      Tags: rotating_light
+    body_format: raw
+    body: >-
+      {{ radarr_data_dir }} on {{ inventory_hostname }} is NOT a persistent
+      mount. Refusing to start Radarr before the mount is fixed.
+  failed_when: false
+  when:
+    - radarr_manage_services
+    - radarr_data_mountpoint.rc | default(0) != 0
+
+- name: Fail when the Radarr data dir is NOT persistent
+  ansible.builtin.fail:
+    msg: >-
+      {{ radarr_data_dir }} is NOT a persistent mount. Radarr's database and
+      config are on the disposable LXC rootfs and would be LOST on the next
+      container rebuild. Bind-mount a persistent dataset onto
+      {{ radarr_data_dir }}, then re-run this converge.
+  when:
+    - radarr_manage_services
+    - radarr_data_mountpoint.rc | default(0) != 0
+
 - name: Check if Radarr is already installed
   ansible.builtin.stat:
     path: "{{ radarr_install_dir }}/Radarr"

--- a/roles/seerr/defaults/main.yml
+++ b/roles/seerr/defaults/main.yml
@@ -104,3 +104,10 @@ seerr_application_url: >-
 # seed) but skips the live Docker build/run + Seerr API registration that
 # need a running container. The live deploy leaves it true.
 seerr_manage_services: true
+
+# ntfy alert target for the persistent-mount guard (tasks/main.yml). Mirrors
+# the repo's ntfy LXC + push topic convention (see download_vpn/service_deadman).
+seerr_ntfy_url: >-
+  http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
+  tofu_data.constants.notification_ports.ntfy_http }}/{{ seerr_ntfy_topic }}
+seerr_ntfy_topic: "persistence"

--- a/roles/seerr/tasks/main.yml
+++ b/roles/seerr/tasks/main.yml
@@ -137,6 +137,50 @@
     - "{{ seerr_data_dir }}"
     - "{{ seerr_config_dir }}"
 
+# ---------------------------------------------------------------------------
+# Persistence guard — refuse to start Seerr on a non-persistent config dir
+# ---------------------------------------------------------------------------
+# seerr_config_dir is bind-mounted to the container's /app/config and holds
+# settings.json (the deterministic API key + all request/registration state).
+# Without a persistent mount there, a container rebuild silently resets Seerr
+# to a fresh install (lost requests, re-registration needed) — so fail the
+# converge instead of starting fresh silently.
+- name: Check whether the Seerr config dir is on a persistent mount
+  ansible.builtin.command:
+    cmd: mountpoint -q {{ seerr_config_dir }}
+  register: seerr_config_mountpoint
+  changed_when: false
+  failed_when: false
+  when: seerr_manage_services | bool
+
+- name: Alert ntfy when the Seerr config dir is NOT persistent
+  ansible.builtin.uri:
+    url: "{{ seerr_ntfy_url }}"
+    method: POST
+    headers:
+      Title: "seerr persistence guard"
+      Priority: urgent
+      Tags: rotating_light
+    body_format: raw
+    body: >-
+      {{ seerr_config_dir }} on {{ inventory_hostname }} is NOT a persistent
+      mount. Refusing to start Seerr before the mount is fixed.
+  failed_when: false
+  when:
+    - seerr_manage_services | bool
+    - seerr_config_mountpoint.rc | default(0) != 0
+
+- name: Fail when the Seerr config dir is NOT persistent
+  ansible.builtin.fail:
+    msg: >-
+      {{ seerr_config_dir }} is NOT a persistent mount. Seerr's settings and
+      request history are on the disposable LXC rootfs and would be LOST on
+      the next container rebuild. Bind-mount a persistent dataset onto
+      {{ seerr_config_dir }}, then re-run this converge.
+  when:
+    - seerr_manage_services | bool
+    - seerr_config_mountpoint.rc | default(0) != 0
+
 # One-time seed: set ONLY the deterministic main.apiKey, then leave the file to
 # Seerr (it rewrites settings.json at runtime). Guard on the file not yet
 # existing instead of `template force: false`: some ansible-core versions, with

--- a/roles/sonarr/defaults/main.yml
+++ b/roles/sonarr/defaults/main.yml
@@ -32,3 +32,10 @@ sonarr_api_key: "{{ lookup('env', 'SONARR_API_KEY') | default('', true) }}"
 # through without a login prompt — matching the servarr_wiring defaults.
 sonarr_auth_method: External
 sonarr_auth_required: DisabledForLocalAddresses
+
+# ntfy alert target for the persistent-mount guard (tasks/main.yml). Mirrors
+# the repo's ntfy LXC + push topic convention (see download_vpn/service_deadman).
+sonarr_ntfy_url: >-
+  http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
+  tofu_data.constants.notification_ports.ntfy_http }}/{{ sonarr_ntfy_topic }}
+sonarr_ntfy_topic: "persistence"

--- a/roles/sonarr/tasks/main.yml
+++ b/roles/sonarr/tasks/main.yml
@@ -59,6 +59,49 @@
     - "{{ sonarr_media_dir }}"
     - "{{ sonarr_tv_dir }}"
 
+# ---------------------------------------------------------------------------
+# Persistence guard — refuse to start Sonarr on a non-persistent data dir
+# ---------------------------------------------------------------------------
+# sonarr_data_dir holds Sonarr's own database and config.xml (deterministic API
+# key, auth method). Without a persistent mount there, a container rebuild
+# silently resets Sonarr to a fresh install (lost history, re-provisioning
+# needed) — so fail the converge instead of starting fresh silently.
+- name: Check whether the Sonarr data dir is on a persistent mount
+  ansible.builtin.command:
+    cmd: mountpoint -q {{ sonarr_data_dir }}
+  register: sonarr_data_mountpoint
+  changed_when: false
+  failed_when: false
+  when: sonarr_manage_services
+
+- name: Alert ntfy when the Sonarr data dir is NOT persistent
+  ansible.builtin.uri:
+    url: "{{ sonarr_ntfy_url }}"
+    method: POST
+    headers:
+      Title: "sonarr persistence guard"
+      Priority: urgent
+      Tags: rotating_light
+    body_format: raw
+    body: >-
+      {{ sonarr_data_dir }} on {{ inventory_hostname }} is NOT a persistent
+      mount. Refusing to start Sonarr before the mount is fixed.
+  failed_when: false
+  when:
+    - sonarr_manage_services
+    - sonarr_data_mountpoint.rc | default(0) != 0
+
+- name: Fail when the Sonarr data dir is NOT persistent
+  ansible.builtin.fail:
+    msg: >-
+      {{ sonarr_data_dir }} is NOT a persistent mount. Sonarr's database and
+      config are on the disposable LXC rootfs and would be LOST on the next
+      container rebuild. Bind-mount a persistent dataset onto
+      {{ sonarr_data_dir }}, then re-run this converge.
+  when:
+    - sonarr_manage_services
+    - sonarr_data_mountpoint.rc | default(0) != 0
+
 - name: Check if Sonarr is already installed
   ansible.builtin.stat:
     path: "{{ sonarr_install_dir }}/Sonarr"

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1931,3 +1931,70 @@
             callbacks, embedding mode on the embeddings group
           - litellm.env.j2: secrets + full OTLP /v1/traces endpoint
           - litellm.service.j2: EnvironmentFile, config, listen port
+
+# =============================================================================
+# plex / sonarr / radarr persistence guards (unit-style — no molecule scenario
+# exists for these roles, so their tasks/main.yml is asserted directly here,
+# the same way the servarr_wiring field-merge and traefik route-builder logic
+# above are verified without a live app)
+# =============================================================================
+# Each guard checks its own config/data dir is a real persistent mountpoint,
+# alerts ntfy, then FAILS the converge if not — never just a warning. Asserted
+# by reading the role's own (un-rendered) task source and confirming the
+# mountpoint check, the ntfy alert, and the fail all exist together.
+- name: Verify the plex/sonarr/radarr persistence guards are fail-loud (unit-style)
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  tasks:
+    - name: Read each role's tasks/main.yml
+      ansible.builtin.slurp:
+        src: "../../roles/{{ item }}/tasks/main.yml"
+      loop:
+        - plex
+        - sonarr
+        - radarr
+      register: _persistence_guard_tasks_raw
+
+    - name: Decode each role's tasks/main.yml, keyed by role name
+      ansible.builtin.set_fact:
+        _persistence_guard_tasks: >-
+          {{ _persistence_guard_tasks | default({})
+             | combine({item.item: (item.content | b64decode)}) }}
+      loop: "{{ _persistence_guard_tasks_raw.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+
+    # The role's tasks are un-rendered Jinja on disk (the {{ }} placeholders are
+    # literal text here, not resolved values) — {% raw %} keeps THIS assert's
+    # own templating pass from consuming them so the search strings match
+    # verbatim.
+    - name: Compute the literal, un-rendered mountpoint snippet per role
+      ansible.builtin.set_fact:
+        _persistence_guard_snippets:
+          plex: "mountpoint -q /var/lib/plexmediaserver"
+          sonarr: "mountpoint -q {% raw %}{{ sonarr_data_dir }}{% endraw %}"
+          radarr: "mountpoint -q {% raw %}{{ radarr_data_dir }}{% endraw %}"
+
+    - name: Assert each role's persistence guard checks, alerts, then fails
+      ansible.builtin.assert:
+        that:
+          - _persistence_guard_snippets[item] in _persistence_guard_tasks[item]
+          - "'ansible.builtin.fail' in _persistence_guard_tasks[item]"
+          - (_persistence_guard_tasks[item].count(item ~ '_ntfy_url')) >= 1
+        fail_msg: >-
+          The {{ item }} role no longer has a fatal mountpoint guard (with an
+          ntfy alert) for its config/data dir.
+      loop:
+        - plex
+        - sonarr
+        - radarr
+
+    - name: Plex/Sonarr/Radarr persistence guard verification PASSED
+      ansible.builtin.debug:
+        msg: |
+          Persistence guard assertions passed for plex, sonarr, radarr:
+          - each checks its config/data dir is a real persistent mountpoint
+          - each alerts ntfy (<role>_ntfy_url) before failing
+          - each FAILS the converge (not just a warning) when not persistent


### PR DESCRIPTION
## Summary

Persist the media download service's session and queue state on the shared persistent data volume, preventing loss on container restarts or reprovisioning. The download service now stores its config and session root on the shared data mount (previously a disposable per-container location), and maintains a plain-file backup of queued items to rebuild the queue even if the session database is lost.

Extends the fail-loud guard pattern across the media stack (plex, radarr, seerr, sonarr, and the download service) to verify each app's critical state directory is mounted before startup — if not, alert via ntfy and refuse to start rather than silently degrading.

## Changes

- `download_vpn` role: redirect session/config root to shared data volume, add plain-file queue backup, add startup guard for persistent state mount
- `plex`, `radarr`, `seerr`, `sonarr` roles: add fail-loud guards for critical state directories
- Molecule scenarios: extended verify steps for all roles with persist guards, new template render validation for guard logic
- `llm-light` host_vars: align with guard pattern

## Test Plan

- [x] `ansible-lint` — full repo, production profile: pass
- [x] `ansible-playbook tests/template_render/verify_templates.yml` — pass, including new guard-shape assertions
- [x] `molecule test -s download_vpn` — full live-container run (converge, idempotence, verify): pass
- [x] `molecule test -s seerr` — architecture-blocked locally (Docker-in-Docker on Apple Silicon), passes syntax checks; CI amd64 runners will verify
- [ ] Live converge on production host (needs persistent bind mount to exist first; guards will fail loud until ready)