### PR TITLE
fix(llama_cpp): escape-proof asset regexes

### DIFF
--- a/roles/llama_cpp/defaults/main.yml
+++ b/roles/llama_cpp/defaults/main.yml
@@ -68,10 +68,10 @@ llama_cpp_llamacpp_releases_api: "https://api.github.com/repos/ggml-org/llama.cp
 llama_cpp_swap_releases_api: "https://api.github.com/repos/mostlygeek/llama-swap/releases/latest"
 # GPU build -> the ubuntu ROCm tarball; CPU build -> the plain ubuntu x64 tarball.
 llama_cpp_llamacpp_asset_regex: >-
-  {{ '^llama-.*-bin-ubuntu-rocm-.*-x64\\.tar\\.gz$'
+  {{ '^llama-.*-bin-ubuntu-rocm-.*-x64[.]tar[.]gz$'
      if llama_cpp_gpu | bool
-     else '^llama-.*-bin-ubuntu-x64\\.tar\\.gz$' }}
-llama_cpp_swap_asset_regex: '^llama-swap_.*_linux_amd64\\.tar\\.gz$'
+     else '^llama-.*-bin-ubuntu-x64[.]tar[.]gz$' }}
+llama_cpp_swap_asset_regex: '^llama-swap_.*_linux_amd64[.]tar[.]gz$'
 
 # --- llama-swap listener -----------------------------------------------------
 # The single OpenAI-compatible port llama-swap listens on. From the tofu ports


### PR DESCRIPTION
Run 7 reached the asset assert with assets present in the per_page=5 window and still matched nothing: the assert message shows the runtime pattern as `x64\\\\.tar\\\\.gz` — the YAML-single-quote + Jinja folded-scalar combination delivers a literal double backslash, which matches a backslash character, never a dot. Replace `\\.` with `[.]` in all three asset regexes (verified against live release asset names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj