### PR TITLE
feat(openbao): automated raft snapshot timer + seal/liveness alerting

### DIFF
--- a/molecule/openbao/converge.yml
+++ b/molecule/openbao/converge.yml
@@ -17,6 +17,15 @@
     # so this is an inert placeholder (not a real key).
     openbao_seal_key_id: "static-test-1"
     openbao_static_seal_key: "ZXhhbXBsZS1zdGF0aWMtc2VhbC1rZXktMzJieXRlcy0wMA=="
+    # Snapshot AppRole creds + alert targets come from tier-0 / load_tofu in
+    # production; stub them so the snapshot daemon templates render under Docker.
+    # The timer never starts here (the systemd task is guarded off under Docker),
+    # so these are inert placeholders. Literal alert URLs avoid a tofu_data
+    # dependency the container has no inventory for.
+    openbao_snapshot_role_id: "test-snapshot-role-id"
+    openbao_snapshot_secret_id: "test-snapshot-secret-id"
+    openbao_snapshot_ntfy_url: "http://ntfy.test/openbao"
+    openbao_snapshot_healthcheck_url: ""
 
   tasks:
     - name: Include openbao role

--- a/molecule/openbao/verify.yml
+++ b/molecule/openbao/verify.yml
@@ -115,3 +115,51 @@
         that:
           - bao_unit.stat.exists
         fail_msg: "openbao.service unit not installed"
+
+    # --- Automated raft snapshot daemon (rendered when snapshot creds are set;
+    # converge.yml stubs them). The timer never starts under Docker, but the
+    # script/env/service/timer templates must all render. ---
+    - name: Stat the snapshot daemon files
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      loop:
+        - /usr/local/bin/openbao-snapshot.sh
+        - /etc/openbao/openbao-snapshot.env
+        - /etc/systemd/system/openbao-snapshot.service
+        - /etc/systemd/system/openbao-snapshot.timer
+      register: bao_snap_files
+
+    - name: Assert the snapshot script, env, service, and timer all rendered
+      ansible.builtin.assert:
+        that:
+          - item.stat.exists
+        fail_msg: "snapshot daemon file missing: {{ item.item }}"
+      loop: "{{ bao_snap_files.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+
+    - name: Assert the snapshot env file is 0600 (holds the AppRole creds)
+      ansible.builtin.assert:
+        that:
+          - bao_snap_files.results[1].stat.mode == '0600'
+        fail_msg: >-
+          openbao-snapshot.env must be 0600
+          ({{ bao_snap_files.results[1].stat.mode | default('absent') }})
+
+    - name: Read the rendered snapshot script
+      ansible.builtin.slurp:
+        src: /usr/local/bin/openbao-snapshot.sh
+      register: bao_snap_script
+
+    - name: Assert the snapshot script leader-gates, verifies, and alerts
+      ansible.builtin.assert:
+        that:
+          # Leader-gated: only the active node snapshots.
+          - "'/v1/sys/leader' in (bao_snap_script.content | b64decode)"
+          - "'is_self' in (bao_snap_script.content | b64decode)"
+          # Takes + integrity-checks the snapshot.
+          - "'operator raft snapshot save' in (bao_snap_script.content | b64decode)"
+          - "'gzip -t' in (bao_snap_script.content | b64decode)"
+          # Least-privilege snapshot AppRole login, not a root token.
+          - "'auth/approle/login' in (bao_snap_script.content | b64decode)"
+        fail_msg: "openbao-snapshot.sh missing leader-gate, snapshot-save, integrity, or approle-login logic"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -493,7 +493,7 @@
 # =============================================================================
 
 - name: Deploy keystone SPOF deadman watchdog
-  hosts: technitium_dns_group:traefik_group:haproxy_group
+  hosts: technitium_dns_group:traefik_group:haproxy_group:openbao_group
   become: true
   gather_facts: false
   tags:

--- a/roles/openbao/README.md
+++ b/roles/openbao/README.md
@@ -35,12 +35,43 @@ The durability guarantee holds from this role alone:
 - The data dir (`/opt/openbao/data`) lives on a dataset covered by the host
   backup path (PBS / ZFS snapshot + offsite).
 
-A least-privilege **snapshot AppRole** (scoped to `sys/storage/raft/snapshot`)
-is provisioned so the off-box logical-snapshot shipping daemon
-([`openbao/openbao-snapshot-agent`](https://github.com/openbao/openbao-snapshot-agent)
-→ on-prem `s3` bucket `openbao-snapshots`) can authenticate. That daemon has no
-upstream release binary yet (container/source install) and is wired in a
-follow-up; the durability guarantee above does not depend on it.
+### Automated raft snapshots (on-box timer)
+
+An on-box `openbao-snapshot.timer` (every `openbao_snapshot_interval`, default
+`6h`) takes a logical raft snapshot on the **active node only** — the script
+leader-gates at runtime via `/v1/sys/leader` `is_self`, so standby nodes no-op
+and exactly one snapshot is taken per cycle regardless of who holds leadership.
+It:
+
+- authenticates with the least-privilege **`snapshot` AppRole** (scoped to
+  `sys/storage/raft/snapshot`), over the node's **own VLAN IP** (`api_addr`),
+  never the Traefik ingress VIP — OpenBao has no loopback listener, and a backup
+  must come from a known specific node;
+- integrity-checks each snapshot (`gzip -t` — raft snapshots are gzipped tar) and
+  keeps the newest `openbao_snapshot_retain` (default 14) under the data volume,
+  which sits on the ZFS/PBS-backed dataset that already replicates **off-box**;
+- pings the healthchecks deadman + ntfy on every run (OK on success, `/fail` +
+  an urgent ntfy alert on any failure), reusing the `service_deadman` stack.
+
+The daemon is deployed on **every** node (so surviving nodes keep snapshotting
+after a leadership change) and is gated on the snapshot AppRole creds being
+present — a pre-provisioning converge skips it cleanly rather than shipping an
+empty-cred EnvironmentFile. **Seal/liveness alerting** is handled by the
+`service_deadman` role's `openbao_group` check (`bao status` exits non-zero when
+a node is sealed or down → pages via the same deadman + ntfy path).
+
+**Deliberately deferred** (tracked follow-ups — the durability guarantee above
+does not depend on either):
+
+- **A second off-box copy into the RustFS `openbao-snapshots` S3 bucket** (with a
+  `HeadObject` + size/sha256 verify — never trusting the ETag, per RustFS
+  `#1458`). The OpenBao LXCs are WAN-firewalled (`outbound-internal`), and a
+  checksum-verifiable S3 client can't be delivered to them WAN-free the way the
+  `.deb` is; hand-rolling SigV4 in shell is out (repo policy). ZFS replication of
+  the data volume already carries snapshots off-box in the meantime.
+- **A full restore-to-scratch-node drill.** Needs a scratch OpenBao node that
+  does not exist yet; OpenBao 2.5.x has no `snapshot inspect` subcommand, so
+  `gzip -t` is the strongest safe on-box integrity check today.
 
 ## Apply order (important)
 

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -144,17 +144,52 @@ openbao_policies:
 openbao_approle_token_ttl: 1h
 openbao_approle_token_max_ttl: 4h
 
-# --- Raft snapshots (off-box durability) ------------------------------------
-# Automated logical raft snapshots shipped off-box to the on-prem s3 object
-# store. The snapshot IDENTITY (least-privilege policy + AppRole scoped to
-# sys/storage/raft/snapshot) is provisioned here so the shipping daemon
-# (openbao/openbao-snapshot-agent) can authenticate; the daemon itself is wired
-# in a follow-up (no upstream release binary yet — container/source install).
-# "Never lost" already holds without it: 3-node Raft (3 live copies) + recovery
-# shares (paper) + the seal key (Doppler tier-0) + the data-dir on a PBS/ZFS-
-# backed dataset.
+# --- Raft snapshots (automated, on-box timer) -------------------------------
+# An on-box systemd timer takes a raft snapshot on the ACTIVE node (leader-gated
+# at runtime via /v1/sys/leader is_self; standby nodes no-op), authenticating
+# with the least-privilege `snapshot` AppRole over the node's OWN api_addr (its
+# VLAN IP — there is no loopback listener; see openbao.hcl.j2), NOT the Traefik
+# ingress VIP. Each snapshot is integrity-checked (gzip -t, since raft snapshots
+# are gzipped tar) and written under the data volume, which sits on a ZFS/PBS-
+# backed dataset that replicates OFF-BOX; the newest N are kept. Success/failure
+# pings the healthchecks deadman + ntfy, reusing the service_deadman alert stack.
+#
+# Deliberately deferred (tracked follow-ups, see roles/openbao/README.md):
+#   * a SECOND off-box copy into the RustFS `openbao-snapshots` S3 bucket +
+#     HeadObject/size/sha256 verify — these WAN-firewalled (outbound-internal)
+#     nodes can't be handed a checksum-verifiable S3 client WAN-free the way the
+#     .deb is, and hand-rolling SigV4 is out; ZFS replication already carries
+#     snapshots off-box in the meantime.
+#   * a full restore-to-scratch-node drill (needs a scratch node that does not
+#     exist yet). gzip -t is the strongest safe on-box integrity check today.
+# "Never lost" already holds regardless: 3-node Raft (3 live copies) + recovery
+# shares (paper) + the seal key (Doppler tier-0) + the ZFS/PBS-backed data dir.
 openbao_snapshot_enabled: true
+# Reserved for the S3 follow-up above (bucket already created by object_storage).
 openbao_snapshot_s3_bucket: openbao-snapshots
+# Timer cadence (systemd OnUnitActiveSec) and how many local snapshots to keep.
+openbao_snapshot_interval: "6h"
+openbao_snapshot_retain: 14
+# Deployed paths. Staging lives under the data dir so it inherits the ZFS/PBS
+# off-box replication of the data volume.
+openbao_snapshot_dir: "{{ openbao_data_dir }}/snapshots"
+openbao_snapshot_script_path: /usr/local/bin/openbao-snapshot.sh
+openbao_snapshot_env_file: "{{ openbao_config_dir }}/openbao-snapshot.env"
+openbao_snapshot_service_name: openbao-snapshot
+# Snapshot AppRole creds the timer logs in with. Emitted by init.yml at
+# bootstrap; injected at converge from tier-0 (Doppler / break-glass file),
+# never committed. When unset the daemon is skipped so a pre-provisioning
+# converge stays green (see the include guard in tasks/main.yml).
+openbao_snapshot_role_id: "{{ lookup('env', 'OPENBAO_SNAPSHOT_ROLE_ID') | default('', true) }}"
+openbao_snapshot_secret_id: "{{ lookup('env', 'OPENBAO_SNAPSHOT_SECRET_ID') | default('', true) }}"
+# ntfy alert target (reuses the repo's ntfy LXC + notification-port convention,
+# matching service_deadman). Topic 'openbao'.
+openbao_snapshot_ntfy_url: >-
+  http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
+  tofu_data.constants.notification_ports.ntfy_http }}/openbao
+# healthchecks deadman ping URL for the snapshot job; EMPTY => ping skipped
+# (ntfy + journal alert still fire). Set per-node from the healthchecks LXC.
+openbao_snapshot_healthcheck_url: "{{ lookup('env', 'OPENBAO_SNAPSHOT_HC_URL') | default('', true) }}"
 
 # --- Break-glass / bootstrap output (controller-side, never committed) -------
 # init.yml writes recovery shares + root token, and each AppRole's creds, to

--- a/roles/openbao/handlers/main.yml
+++ b/roles/openbao/handlers/main.yml
@@ -5,3 +5,10 @@
     state: restarted
     daemon_reload: true
   when: ansible_virtualization_type | default('') != 'docker'
+
+- name: Restart openbao snapshot timer
+  ansible.builtin.systemd:
+    name: "{{ openbao_snapshot_service_name }}.timer"
+    state: restarted
+    daemon_reload: true
+  when: ansible_virtualization_type | default('') != 'docker'

--- a/roles/openbao/tasks/main.yml
+++ b/roles/openbao/tasks/main.yml
@@ -227,3 +227,16 @@
   when:
     - ansible_virtualization_type | default('') != 'docker'
     - inventory_hostname == openbao_bootstrap_host
+
+# --- Phase 10: automated raft snapshots (all nodes; script leader-gates) -----
+# Deployed on every openbao node so the surviving nodes keep snapshotting after
+# a leadership change. Gated on the snapshot AppRole creds being present: they
+# are emitted by init.yml at bootstrap and injected at converge from tier-0, so
+# a first-bootstrap converge (creds not yet minted) skips this cleanly instead
+# of rendering an empty-cred EnvironmentFile that would fail every cycle.
+- name: Deploy the automated raft snapshot timer
+  ansible.builtin.include_tasks: snapshot.yml
+  when:
+    - openbao_snapshot_enabled | bool
+    - openbao_snapshot_role_id | length > 0
+    - openbao_snapshot_secret_id | length > 0

--- a/roles/openbao/tasks/snapshot.yml
+++ b/roles/openbao/tasks/snapshot.yml
@@ -1,0 +1,61 @@
+---
+# Automated raft snapshots (on-box, timer-driven). Included from main.yml on
+# every openbao node when the snapshot daemon is enabled AND the snapshot
+# AppRole creds are present. The creds are emitted by init.yml at bootstrap and
+# injected at converge from tier-0; until they exist the include is skipped
+# (see the guard in main.yml), so a first-bootstrap converge stays green.
+# The script leader-gates at runtime, so this deploys identically on all nodes.
+
+- name: Create the OpenBao snapshot staging directory
+  ansible.builtin.file:
+    path: "{{ openbao_snapshot_dir }}"
+    state: directory
+    owner: "{{ openbao_user }}"
+    group: "{{ openbao_group }}"
+    mode: "0700"
+
+- name: Render the OpenBao snapshot AppRole EnvironmentFile
+  ansible.builtin.template:
+    src: openbao-snapshot.env.j2
+    dest: "{{ openbao_snapshot_env_file }}"
+    owner: root
+    group: "{{ openbao_group }}"
+    mode: "0600"
+  no_log: true
+  notify: Restart openbao snapshot timer
+
+- name: Deploy the OpenBao snapshot script
+  ansible.builtin.template:
+    src: openbao-snapshot.sh.j2
+    dest: "{{ openbao_snapshot_script_path }}"
+    owner: root
+    group: root
+    mode: "0755"
+  notify: Restart openbao snapshot timer
+
+- name: Deploy the OpenBao snapshot systemd service unit
+  ansible.builtin.template:
+    src: openbao-snapshot.service.j2
+    dest: "/etc/systemd/system/{{ openbao_snapshot_service_name }}.service"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart openbao snapshot timer
+
+- name: Deploy the OpenBao snapshot systemd timer unit
+  ansible.builtin.template:
+    src: openbao-snapshot.timer.j2
+    dest: "/etc/systemd/system/{{ openbao_snapshot_service_name }}.timer"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart openbao snapshot timer
+
+# Skipped under Docker (molecule) — no functional systemd init in the container.
+- name: Enable and start the OpenBao snapshot timer
+  ansible.builtin.systemd:
+    name: "{{ openbao_snapshot_service_name }}.timer"
+    state: started
+    enabled: true
+    daemon_reload: true
+  when: ansible_virtualization_type | default('') != 'docker'

--- a/roles/openbao/templates/openbao-snapshot.env.j2
+++ b/roles/openbao/templates/openbao-snapshot.env.j2
@@ -1,0 +1,7 @@
+{{ ansible_managed | comment }}
+# OpenBao snapshot daemon credentials — the least-privilege `snapshot` AppRole
+# (sys/storage/raft/snapshot read only). 0600, root:openbao. Consumed by the
+# openbao-snapshot.service systemd unit via EnvironmentFile; never inlined into
+# the script or the unit (keeps it out of `systemctl show` and `ps`).
+OPENBAO_SNAPSHOT_ROLE_ID={{ openbao_snapshot_role_id }}
+OPENBAO_SNAPSHOT_SECRET_ID={{ openbao_snapshot_secret_id }}

--- a/roles/openbao/templates/openbao-snapshot.service.j2
+++ b/roles/openbao/templates/openbao-snapshot.service.j2
@@ -1,0 +1,21 @@
+{{ ansible_managed | comment }}
+# OpenBao automated raft snapshot — one-shot, timer-driven. Rendered by the
+# openbao role. Leader-gating happens inside the script, so this unit is
+# identical on every node.
+
+[Unit]
+Description=OpenBao automated raft snapshot (leader-gated, one-shot)
+Documentation=https://github.com/JacobPEvans/ansible-proxmox-apps
+After=openbao.service
+Wants=openbao.service
+
+[Service]
+Type=oneshot
+User={{ openbao_user }}
+Group={{ openbao_group }}
+# Snapshot AppRole role_id/secret_id (0600, root:openbao).
+EnvironmentFile={{ openbao_snapshot_env_file }}
+ExecStart={{ openbao_snapshot_script_path }}
+# Snapshots are written under the openbao-owned data volume.
+ReadWritePaths={{ openbao_snapshot_dir }}
+NoNewPrivileges=yes

--- a/roles/openbao/templates/openbao-snapshot.sh.j2
+++ b/roles/openbao/templates/openbao-snapshot.sh.j2
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# {{ ansible_managed }}
+#
+# Automated OpenBao raft snapshot. Rendered by the openbao role and run on a
+# systemd timer (every {{ openbao_snapshot_interval }}). Deployed on every
+# openbao node, but only the ACTIVE node acts — standby nodes exit 0 as a no-op,
+# so exactly one snapshot is taken per cycle regardless of who holds leadership.
+#
+# It talks to THIS node's own API address ({{ openbao_api_addr }} — its VLAN IP),
+# never the Traefik ingress VIP: there is no loopback listener (see
+# openbao.hcl.j2), and a backup must come from a known specific node, not
+# whichever node the load balancer happens to pick. It authenticates with the
+# least-privilege `snapshot` AppRole (sys/storage/raft/snapshot read only).
+#
+# Each snapshot is integrity-checked (gzip -t — raft snapshots are gzipped tar)
+# and written under the data volume, which sits on a ZFS/PBS-backed dataset that
+# replicates OFF-BOX; the newest {{ openbao_snapshot_retain }} are kept locally.
+# A second off-box copy into the RustFS `openbao-snapshots` S3 bucket and a full
+# restore-to-scratch drill are tracked follow-ups (see roles/openbao/README.md):
+# these WAN-firewalled nodes cannot be handed a checksum-verifiable S3 client
+# WAN-free, and ZFS replication already carries snapshots off-box in the meantime.
+#
+# NOT `set -e`: every failure is handled explicitly so it ALERTS (ntfy +
+# healthchecks) instead of aborting silently.
+set -uo pipefail
+
+BAO_ADDR="{{ openbao_api_addr }}"
+export BAO_ADDR
+BIN="{{ openbao_install_dir }}/bao"
+SNAP_DIR="{{ openbao_snapshot_dir }}"
+RETAIN="{{ openbao_snapshot_retain }}"
+NTFY_URL="{{ openbao_snapshot_ntfy_url }}"
+HC_URL="{{ openbao_snapshot_healthcheck_url }}"
+HOST="$(hostname)"
+
+log() { logger -t openbao-snapshot "$*"; echo "openbao-snapshot: $*"; }
+
+# Ping a healthchecks endpoint if one is configured; no-op otherwise. $1 is the
+# suffix: "" for the OK ping, "/fail" to signal a breach.
+hc_ping() {
+  [ -n "${HC_URL}" ] || return 0
+  curl -fsS --max-time 8 "${HC_URL}$1" >/dev/null 2>&1 || true
+}
+
+# Alert + signal the deadman failure endpoint, then exit non-zero.
+fail() {
+  local msg="OpenBao snapshot FAILED on ${HOST}: $*"
+  log "${msg}"
+  if [ -n "${NTFY_URL}" ]; then
+    curl -fsS --max-time 8 -H "Title: openbao snapshot" -H "Priority: urgent" \
+      -H "Tags: rotating_light" -d "${msg}" "${NTFY_URL}" >/dev/null 2>&1 || true
+  fi
+  hc_ping /fail
+  exit 1
+}
+
+# 1. Leader-gate. /sys/leader is unauthenticated; is_self=true only on the
+#    active node. A standby (or an unreachable local node — the deadman watchdog
+#    covers real outages) is a clean no-op, so peers never double-ship.
+# ponytail: JSON grep instead of jq (not on these WAN-firewalled nodes); swap to
+# `jq -e .is_self` if jq ever lands in the base image.
+if ! curl -fsS --max-time 8 "${BAO_ADDR}/v1/sys/leader" | grep -q '"is_self":true'; then
+  log "not the active node — nothing to do"
+  exit 0
+fi
+
+# 2. Health-gate: never snapshot a sealed/unhealthy node (standbyok=true so an
+#    unsealed standby still reads 200; sealed=503, uninitialized=501).
+code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 8 \
+  "${BAO_ADDR}/v1/sys/health?standbyok=true")"
+[ "${code}" = "200" ] || fail "health check returned HTTP ${code} (expected 200)"
+
+# 3. Authenticate with the least-privilege snapshot AppRole (-field=token maps
+#    to .auth.client_token for auth responses — no jq needed).
+token="$("${BIN}" write -field=token auth/approle/login \
+  role_id="${OPENBAO_SNAPSHOT_ROLE_ID}" \
+  secret_id="${OPENBAO_SNAPSHOT_SECRET_ID}" 2>/dev/null)" \
+  || fail "snapshot AppRole login failed"
+[ -n "${token}" ] || fail "snapshot AppRole login returned an empty token"
+
+# 4. Take the snapshot.
+ts="$(date -u +%Y%m%dT%H%M%SZ)"
+snap="${SNAP_DIR}/openbao-${HOST}-${ts}.snap"
+BAO_TOKEN="${token}" "${BIN}" operator raft snapshot save "${snap}" \
+  || fail "raft snapshot save failed"
+
+# 5. Integrity: raft snapshots are gzipped tar — gzip -t catches a truncated or
+#    corrupt file before we trust it as a backup.
+gzip -t "${snap}" 2>/dev/null || fail "snapshot ${snap} failed gzip integrity check"
+size="$(stat -c%s "${snap}" 2>/dev/null || echo 0)"
+[ "${size}" -gt 0 ] || fail "snapshot ${snap} is empty"
+
+# 6. Prune: keep the newest ${RETAIN}, drop the rest. Bounds the local footprint;
+#    off-box durability is the ZFS/PBS replication of the data volume.
+# shellcheck disable=SC2012  # names are timestamped + controlled; ls -t is fine.
+ls -1t "${SNAP_DIR}"/openbao-*.snap 2>/dev/null | tail -n "+$((RETAIN + 1))" \
+  | while read -r old; do
+      rm -f "${old}" && log "pruned old snapshot ${old}"
+    done
+
+log "snapshot OK: ${snap} (${size} bytes)"
+hc_ping ""
+exit 0

--- a/roles/openbao/templates/openbao-snapshot.timer.j2
+++ b/roles/openbao/templates/openbao-snapshot.timer.j2
@@ -1,0 +1,18 @@
+{{ ansible_managed | comment }}
+# Fire the OpenBao snapshot every {{ openbao_snapshot_interval }}. Rendered by
+# the openbao role.
+
+[Unit]
+Description=Take an OpenBao raft snapshot every {{ openbao_snapshot_interval }}
+Documentation=https://github.com/JacobPEvans/ansible-proxmox-apps
+
+[Timer]
+# Start a few minutes after boot (let the node join + unseal first), then on a
+# fixed cadence. Persistent=true runs a missed snapshot after downtime.
+OnBootSec=300s
+OnUnitActiveSec={{ openbao_snapshot_interval }}
+AccuracySec=1m
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/roles/service_deadman/defaults/main.yml
+++ b/roles/service_deadman/defaults/main.yml
@@ -54,6 +54,18 @@ service_deadman_group_checks:
     - name: nginx-syslog-lb
       probe_command: "systemctl is-active --quiet nginx.service"
       healthcheck_url: "{{ lookup('env', 'DEADMAN_HC_URL_NGINX') | default('', true) }}"
+  openbao_group:
+    # `bao status` exits 0 only when THIS node is unsealed (2 = sealed, 1 =
+    # error/unreachable) — a direct seal+liveness probe. Hit the node's own VLAN
+    # IP: OpenBao has no loopback listener. standby-unsealed still exits 0, so
+    # every peer reports its own seal state independently, and a node that seals
+    # (e.g. lost its static seal key) or dies pages instead of failing silently.
+    - name: openbao
+      probe_command: >-
+        systemctl is-active --quiet openbao &&
+        BAO_ADDR="http://{{ container_ip | default(ansible_host) }}:8200"
+        bao status >/dev/null 2>&1
+      healthcheck_url: "{{ lookup('env', 'DEADMAN_HC_URL_OPENBAO') | default('', true) }}"
 
 # Resolved set of checks for THIS host — every group's checks the host is in.
 service_deadman_checks: >-


### PR DESCRIPTION
## Summary
Adds OpenBao's automated backup + monitoring layer (Phase 4 of the OpenBao autonomous-secrets effort). Two things ship:

1. **On-box raft-snapshot timer** (`openbao-snapshot.timer`, default every 6h) — deployed on every openbao node, but the script **leader-gates at runtime** (`/v1/sys/leader` `is_self`), so only the active node snapshots and standby nodes no-op. Exactly one snapshot per cycle regardless of who holds leadership.
2. **Seal/liveness alerting** via the existing `service_deadman` stack — a new `openbao_group` check (`bao status` exits non-zero when a node is sealed or down) that pages through the same healthchecks-deadman + ntfy path as the other keystones.

## How the snapshot works
- Authenticates with the least-privilege **`snapshot` AppRole** (`sys/storage/raft/snapshot` read only) — not a root token.
- Talks to **this node's own VLAN `api_addr`**, never the Traefik ingress VIP: OpenBao has no loopback listener (see `openbao.hcl.j2`), and a backup must come from a known specific node.
- Integrity-checks each snapshot with `gzip -t` (raft snapshots are gzipped tar), keeps the newest `openbao_snapshot_retain` (default 14) under the data volume — which sits on the **ZFS/PBS-backed dataset that already replicates off-box**.
- Pings healthchecks (OK) / healthchecks `/fail` + an urgent ntfy alert on any failure. `set -uo pipefail` (not `-e`) so every failure **alerts** rather than aborting silently.
- Gated on the snapshot AppRole creds being present, so a first-bootstrap converge (creds not yet minted) skips it cleanly instead of rendering an empty-cred EnvironmentFile that would fail every cycle.

## Deliberately deferred (documented in the role README; durability does not depend on either)
- **A second off-box copy into the RustFS `openbao-snapshots` S3 bucket** (with a `HeadObject` + size/sha256 verify, never trusting the ETag per RustFS #1458). The OpenBao LXCs are WAN-firewalled (`outbound-internal`) and a checksum-verifiable S3 client can't be delivered to them WAN-free the way the `.deb` is; hand-rolling SigV4 in shell is out (repo policy). ZFS replication already carries snapshots off-box in the meantime.
- **A full restore-to-scratch-node drill** — needs a scratch node that doesn't exist yet. OpenBao 2.5.x has **no `snapshot inspect`** subcommand ([confirmed](https://openbao.org/docs/commands/operator/raft/)), so `gzip -t` is the strongest safe on-box integrity check today.

## Files
- `roles/openbao/`: `tasks/snapshot.yml` + `openbao-snapshot.{sh,env,service,timer}.j2` templates, defaults, `main.yml` include (gated), handler, README.
- `roles/service_deadman/defaults/main.yml`: `openbao_group` seal/liveness check.
- `playbooks/site.yml`: deadman play now targets `openbao_group`.
- `molecule/openbao/`: converge stubs snapshot creds; verify asserts the script/env/service/timer render and the script leader-gates + snapshot-saves + integrity-checks + approle-logs-in.

## Verification
- [x] `shellcheck` — clean (rendered script).
- [x] `yamllint` — clean.
- [x] `ansible-lint` — production profile, **0 failures / 0 warnings on the full project (205 files)**.
- [ ] Live timer behavior (leader-gate, snapshot save, alert fire) — exercised at the credentialed apply (Phase 6); molecule can't run a live OpenBao under Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)