### PR TITLE
fix(inventory-schema): accept non-apex multi-backend ingress pools

### DIFF
--- a/tests/inventory_load/tofu_inventory.json
+++ b/tests/inventory_load/tofu_inventory.json
@@ -418,6 +418,17 @@
       "insecure_tls": true,
       "sticky": true,
       "health_check": true
+    },
+    {
+      "name": "openbao",
+      "backends": [
+        "192.168.5.211",
+        "192.168.5.212"
+      ],
+      "port": 8200,
+      "sticky": true,
+      "health_check": true,
+      "health_check_path": "/v1/sys/health?standbyok=true"
     }
   ],
   "nodes": {

--- a/tests/inventory_load/tofu_inventory.schema.json
+++ b/tests/inventory_load/tofu_inventory.schema.json
@@ -91,7 +91,7 @@
       "items": {
         "type": "object",
         "additionalProperties": true,
-        "description": "Either a service route {name, ip, port} (ip is a dotted IPv4 or a hostname/FQDN for DHCP-first guests) or the Proxmox-UI apex pool {name, apex, backends, port} (a hostname pool, no single ip).",
+        "description": "Either a single-backend service route {name, ip, port} (ip is a dotted IPv4 or a hostname/FQDN for DHCP-first guests) or a multi-backend HA pool {name, backends, port} with no single ip — covering both the Proxmox-UI apex pool (apex: true) and non-apex load-balanced pools such as OpenBao and the LiteLLM router.",
         "anyOf": [
           {
             "required": [
@@ -118,7 +118,6 @@
           {
             "required": [
               "name",
-              "apex",
               "backends",
               "port"
             ],


### PR DESCRIPTION
## Summary
Unblocks the `terragrunt apply` after-hook (`sync-inventory.sh`), which was rejecting a valid inventory with **`'ip' is a required property`** on the `openbao` ingress entry.

## Root cause
The interim inventory schema's `ingress` `anyOf` had exactly two branches:
1. single-backend route — `{name, ip, port}`
2. **apex** pool — `{name, apex, backends, port}` (with `apex` **required**, `const: true`)

But the OpenBao HA ingress ([terraform-proxmox#523](https://github.com/dryvist/terraform-proxmox/pull/523)) and the LiteLLM router pool ([#540](https://github.com/dryvist/terraform-proxmox/pull/540)) emit **non-apex** load-balanced pools — `{name, backends, port, health_check, health_check_path, ...}` — no `apex`, no single `ip`. Those match **neither** branch, so validation falls back to branch 1 and reports the missing `ip`.

CI never caught it because the test fixture only exercised the single-`ip` and apex-pool shapes, and the after-hook only runs at **apply** time (not in `validate`/`plan` CI).

## Fix
- Drop `apex` from the pool branch's `required` (keep it as an optional `const: true` property). The branch now covers **both** the apex pool and non-apex HA pools (OpenBao, LiteLLM).
- Add an `openbao`-style non-apex pool entry to `tofu_inventory.json` so the data-contract CI guards this class going forward.

## Verification (with `check-jsonschema` — the exact tool the after-hook runs)
- ✅ Fixture (now incl. the openbao pool) → `ok -- validation done`.
- ✅ Negative: an entry with **neither** `ip` **nor** `backends` still fails with `'ip' is a required property` — strictness preserved, no over-loosening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)