### PR TITLE
fix(llama_cpp): install libgomp1 runtime dependency

### DIFF
--- a/roles/llama_cpp/tasks/main.yml
+++ b/roles/llama_cpp/tasks/main.yml
@@ -10,6 +10,9 @@
       - ca-certificates
       - tar
       - gzip
+      # OpenMP runtime: the prebuilt llama-server links libgomp.so.1, which
+      # the minimal Debian LXC template does not ship.
+      - libgomp1
     state: present
     update_cache: true
     cache_valid_time: 3600


### PR DESCRIPTION
After #556 fixed the SONAME symlinks, `llama-server --version` still fails: `libgomp.so.1: cannot open shared object file` — the prebuilt binaries link the OpenMP runtime, which the minimal Debian LXC template lacks. `ldd` shows it as the only remaining unresolved lib (with the unit's LD_LIBRARY_PATH). Add `libgomp1` to the role prerequisites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj