### PR TITLE
fix(ci): add YAML document-start to two issue-automation workflows

### DIFF
--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -1,3 +1,4 @@
+---
 name: Issue Auto-Resolve
 
 on:

--- a/.github/workflows/issue-backlog-sweep.yml
+++ b/.github/workflows/issue-backlog-sweep.yml
@@ -14,7 +14,7 @@
 # context in a reusable-call `with:` while a `schedule` trigger is present makes
 # GitHub startup-fail every run (`inputs` is undefined for scheduled events). The
 # reusable's default (5) is used for both the weekly run and manual dispatches.
-
+---
 name: Issue Backlog Sweep
 
 on:


### PR DESCRIPTION
## Summary
Unblocks `ci / Ansible Lint` → `Merge Gate` on **every** open PR (#540, #542, #563) and every future PR.

## Root cause
The floating `ansible/ansible-lint@v26` action tag rolled to **26.6.0**, which now enforces `yaml[document-start]` as **fatal** under the repo's `production` profile, repo-wide. Two hand-authored workflow files were missing the `---` marker:

- `.github/workflows/issue-auto-resolve.yml:1`
- `.github/workflows/issue-backlog-sweep.yml:18`

This is an **environmental break on `main`**, not a defect in any single PR — it surfaced simultaneously on all open PRs the moment their Ansible Lint job re-ran against the newer linter.

## Fix
Add the missing `---`:
- `issue-auto-resolve.yml` — at line 1 (no header comment).
- `issue-backlog-sweep.yml` — after the existing explanatory comment header, before the first content key. yamllint permits leading comments before `---` (it reported the violation at the first *content* line, line 18, not line 1).

Every other non-generated workflow in the repo already leads with `---`; this just matches that convention.

## Verification
`ansible-lint` (production profile) passes both files — 0 failures. The fix is linter-version-agnostic (a present `---` satisfies the rule on any version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)