### PR TITLE
fix(llama_cpp): flash-attn flag requires a value in current llama.cpp

### DIFF
--- a/roles/llama_cpp/templates/llama-swap.yaml.j2
+++ b/roles/llama_cpp/templates/llama-swap.yaml.j2
@@ -44,7 +44,7 @@ models:
       --embeddings
       --pooling mean
 {% else %}
-      --flash-attn
+      --flash-attn on
       --jinja
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
Manual spawn of the swap config's exact command shows current llama-server rejecting the bare flag: `error while handling argument \"--flash-attn\": expected value for argument` (it now takes on|off|auto). Every non-embeddings model spawn died with this, surfacing as llama-swap's 'upstream command exited prematurely'. Pass `--flash-attn on`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj