### PR TITLE
fix(dify): web SSR needs absolute API URLs

### DIFF
--- a/roles/dify_docker/defaults/main.yml
+++ b/roles/dify_docker/defaults/main.yml
@@ -114,3 +114,10 @@ dify_docker_plugin_daemon_key: >-
 dify_docker_inner_api_key: >-
   {{ lookup('env', 'DIFY_INNER_API_KEY')
      | mandatory('DIFY_INNER_API_KEY must be set (openssl rand -base64 24; store in SOPS)') }}
+
+# Public fronted URL (Traefik). The web container's SSR needs absolute API
+# URLs — the current dify-web image no longer treats blank as same-origin
+# (server-side fetches fall back to localhost inside the container).
+dify_docker_public_url: >-
+  https://dify.{{ lookup('env', 'PROXMOX_SUBDOMAIN')
+  | mandatory('PROXMOX_SUBDOMAIN required') }}

--- a/roles/dify_docker/templates/docker-compose.yml.j2
+++ b/roles/dify_docker/templates/docker-compose.yml.j2
@@ -115,8 +115,8 @@ services:
     image: {{ dify_docker_web_image }}
     restart: {{ dify_docker_restart_policy }}
     environment:
-      CONSOLE_API_URL: ""
-      APP_API_URL: ""
+      CONSOLE_API_URL: "{{ dify_docker_public_url }}"
+      APP_API_URL: "{{ dify_docker_public_url }}"
       NEXT_TELEMETRY_DISABLED: "1"
 
   db:


### PR DESCRIPTION
With all containers healthy (post-secrets), dify still 500s on every page: `docker logs dify-web-1` shows ECONNREFUSED from the web container's server-side fetches — the current dify-web image no longer treats blank `CONSOLE_API_URL`/`APP_API_URL` as same-origin and falls back to localhost inside its own container. Set both to the Traefik-fronted `https://dify.<subdomain>` (these URLs are also browser-visible, so the public FQDN is the correct value, not an internal address).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj