### PR TITLE
feat(dns): llm-large CNAME to the Studio gate host

### DIFF
--- a/inventory/group_vars/technitium_dns_group.yml
+++ b/inventory/group_vars/technitium_dns_group.yml
@@ -13,3 +13,10 @@ technitium_dns_retired_records:
   - claude-code-02
   - gemini-01
   - gemini-02
+
+# Neutral capability name for the heavy-tier serving gate on the Studio:
+# llm-large.<zone> -> the machine's own cert-covered hostname (verbatim FQDN
+# target; the router pool dials this name with the gate bearer).
+technitium_dns_extra_cname_records:
+  - name: llm-large
+    target: "jevans-ms.{{ lookup('env', 'PROXMOX_DOMAIN') | mandatory('PROXMOX_DOMAIN required') }}"


### PR DESCRIPTION
W7 smoke: large-tier completions fail with a litellm connection error — `llm-large.<zone>` resolves to nothing (the neutral capability CNAME was never created). Add it to `technitium_dns_extra_cname_records` (verbatim-FQDN target list) pointing at the Studio's own hostname, whose gate cert already covers it via extraHostnames (nix-darwin#1467).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj