### PR TITLE
feat(media): sticky failover to a backup VPN tunnel endpoint

### DIFF
--- a/molecule/download_vpn/molecule.yml
+++ b/molecule/download_vpn/molecule.yml
@@ -42,6 +42,12 @@ provisioner:
     PROTON_WG_IFACE_ADDRESS: "${PROTON_WG_IFACE_ADDRESS:-10.2.0.2/32}"
     PROTON_WG_PEER_ENDPOINT: "${PROTON_WG_PEER_ENDPOINT:-192.168.0.7:51820}"
     PROTON_WG_PEER_PUBLIC_KEY: "${PROTON_WG_PEER_PUBLIC_KEY:-cGVlclRFU1RwdWJsaWNrZXlOT1RyZWFsa2V5MDA=}"
+    # Backup Proton peer (second server) — arms sticky failover in CI so the
+    # dual-endpoint killswitch + validator failover paths are exercised. The
+    # endpoint stays in the committed 192.168.* range; keys are fake base64.
+    PROTON_WG_BACKUP_IFACE_PRIVATE_KEY: "${PROTON_WG_BACKUP_IFACE_PRIVATE_KEY:-Ymt1cFByaXZGYWtla2V5}"
+    PROTON_WG_BACKUP_PEER_PUBLIC_KEY: "${PROTON_WG_BACKUP_PEER_PUBLIC_KEY:-Ymt1cFB1YkZha2VrZXkw}"
+    PROTON_WG_BACKUP_PEER_ENDPOINT: "${PROTON_WG_BACKUP_PEER_ENDPOINT:-192.168.0.8:51820}"
     QBITTORRENT_ADMIN_PASSWORD: "${QBITTORRENT_ADMIN_PASSWORD:-molecule-test-pass}"
 
 verifier:

--- a/molecule/download_vpn/verify.yml
+++ b/molecule/download_vpn/verify.yml
@@ -18,6 +18,15 @@
   vars:
     download_vpn_wg_interface: wg0
     download_vpn_nft_ruleset_path: /etc/nftables.d/download-vpn-killswitch.nft
+    download_vpn_wg_backup_key_path: /etc/wireguard/wg0-backup.key
+    # Endpoint hosts to expect in the killswitch — from the (placeholder) env the
+    # molecule scenario injects; 192.168.* fallbacks keep this committed-safe.
+    _primary_ep_host: >-
+      {{ (lookup('env', 'PROTON_WG_PEER_ENDPOINT')
+          | default('192.168.0.7:51820', true)).split(':')[0] }}
+    _backup_ep_host: >-
+      {{ (lookup('env', 'PROTON_WG_BACKUP_PEER_ENDPOINT')
+          | default('192.168.0.8:51820', true)).split(':')[0] }}
     # Matches the role default: download_vpn_data_dir (/data) is not overridden
     # by converge.yml, so the --profile tree lands at this fixed, deterministic
     # path (see defaults/main.yml: download_vpn_qbittorrent_{profile,config}_dir).
@@ -55,6 +64,31 @@
           - "'ip6 daddr ::/0 accept' not in ks"
           - "'accept comment \"any\"' not in ks"
         fail_msg: "Killswitch ruleset has unexpected or missing rules."
+
+    - name: Assert BOTH Proton endpoints (primary + backup) are permitted
+      # Failover to the backup would be blocked fail-closed unless the killswitch
+      # pre-permits its endpoint too.
+      ansible.builtin.assert:
+        that:
+          - _primary_ep_host in ks
+          - _backup_ep_host in ks
+        fail_msg: >-
+          Killswitch does not permit both Proton endpoints (primary
+          {{ _primary_ep_host }} + backup {{ _backup_ep_host }}).
+
+    - name: Stat the backup WireGuard key
+      ansible.builtin.stat:
+        path: "{{ download_vpn_wg_backup_key_path }}"
+      register: _backup_key
+
+    - name: Assert the backup WireGuard key is deployed root-only (0600)
+      ansible.builtin.assert:
+        that:
+          - _backup_key.stat.exists
+          - _backup_key.stat.mode == '0600'
+        fail_msg: >-
+          Backup WireGuard key {{ download_vpn_wg_backup_key_path }} is missing
+          or not root-only (0600).
 
     - name: Load the killswitch ruleset into the kernel
       ansible.builtin.command:
@@ -186,7 +220,12 @@
           - "'--interface eth0' not in (validator.content | b64decode)"
           - "'ip -6 route show default' in (validator.content | b64decode)"
           - "'systemctl stop qbittorrent-nox.service' in (validator.content | b64decode)"
-        fail_msg: "Runtime validator does not cover both address families or does not fail closed."
+          # Sticky failover: on sustained tunnel-down the validator switches wg0
+          # to the backup peer (and never on a leak-type breach).
+          - "'FAILOVER_STATE_FILE=' in (validator.content | b64decode)"
+          - "'peer \"${BACKUP_PEER}\" endpoint' in (validator.content | b64decode)"
+          - "'peer \"${PRIMARY_PEER}\" remove' in (validator.content | b64decode)"
+        fail_msg: "Runtime validator does not cover both address families, fail closed, or sticky failover."
 
     - name: Clean up the loaded killswitch table
       ansible.builtin.command:

--- a/roles/download_vpn/README.md
+++ b/roles/download_vpn/README.md
@@ -126,6 +126,11 @@ sops exec-env secrets.enc.yaml 'doppler run -- ansible-playbook \
   `PROTON_WG_IFACE_ADDRESS`, `PROTON_WG_PEER_PUBLIC_KEY`,
   `PROTON_WG_PEER_ENDPOINT`. Proton's tunnel DNS resolver `10.2.0.1` is a
   stable constant and is hardcoded in `defaults/main.yml` (not a secret).
+  Optionally set `PROTON_WG_BACKUP_IFACE_PRIVATE_KEY`,
+  `PROTON_WG_BACKUP_PEER_PUBLIC_KEY`, and `PROTON_WG_BACKUP_PEER_ENDPOINT`
+  (a second Proton server) to arm sticky auto-failover: after a sustained
+  primary outage the runtime validator switches `wg0` to the backup peer and
+  stays there until the next converge re-lays the primary. All three or none.
   `QBITTORRENT_ADMIN_PASSWORD` is delivered via SOPS.
 - The single `bulk/data` dataset bind-mounted at `/data` (TRaSH
   single-filesystem layout). qBittorrent saves to `/data/torrents` (per-category

--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -55,6 +55,36 @@ download_vpn_wg_endpoint: "{{ lookup('env', 'PROTON_WG_PEER_ENDPOINT') }}"
 download_vpn_wg_allowed_ips: "0.0.0.0/0"
 download_vpn_wg_persistent_keepalive: 25
 
+# --- WireGuard failover (backup Proton peer) --------------------------------
+# Optional second Proton server for sticky auto-failover. Proton issues a full
+# per-server keypair, but the tunnel Address (10.2.0.2, point-to-point) is shared
+# with the primary, so failover swaps only the client private key + peer key +
+# endpoint on the SAME wg0 — no interface/address reconfig. All three come from
+# Doppler runtime env; leave them unset to disable failover (single-endpoint
+# behaviour is preserved unchanged). NEVER hardcode key material or the endpoint.
+download_vpn_wg_backup_private_key: "{{ lookup('env', 'PROTON_WG_BACKUP_IFACE_PRIVATE_KEY') | default('', true) }}"
+download_vpn_wg_backup_peer_public_key: "{{ lookup('env', 'PROTON_WG_BACKUP_PEER_PUBLIC_KEY') | default('', true) }}"
+download_vpn_wg_backup_endpoint: "{{ lookup('env', 'PROTON_WG_BACKUP_PEER_ENDPOINT') | default('', true) }}"
+# True only when a COMPLETE backup peer is configured (all three values present).
+# The killswitch permits the backup endpoint and the validator arms failover only
+# when this is true; a partial config fails loud in tasks/main.yml Phase -1.
+download_vpn_wg_failover_enabled: >-
+  {{ (download_vpn_wg_backup_private_key | length > 0)
+     and (download_vpn_wg_backup_peer_public_key | length > 0)
+     and (download_vpn_wg_backup_endpoint | length > 0) }}
+# Consecutive tunnel-down validator cycles before switching to the backup peer.
+# At the 2min validator cadence, 3 => ~6min of a dead primary before failover.
+download_vpn_failover_cycles: 3
+# Sticky failover: once switched to the backup the validator STAYS there (no auto
+# flip-back — avoids flapping between two unhealthy servers). Failback happens on
+# the next converge, which re-lays wg0 on the primary and clears these markers.
+# Both live on tmpfs (/run) so a reboot also resets to the primary.
+download_vpn_failover_state_file: /run/download-vpn-active-endpoint
+download_vpn_failover_counter_file: /run/download-vpn-down-count
+# Root-only on-disk copy of the backup private key, read by the validator's
+# `wg set private-key` on failover. Rendered only when failover is enabled.
+download_vpn_wg_backup_key_path: /etc/wireguard/wg0-backup.key
+
 # --- LAN reachability --------------------------------------------------------
 # LAN subnet that may reach the web UIs and that *arr/qBit/Prowlarr use to talk
 # to each other. Derived from the container's own /24 (tofu-owned IP) so

--- a/roles/download_vpn/tasks/main.yml
+++ b/roles/download_vpn/tasks/main.yml
@@ -27,6 +27,25 @@
     quiet: true
   when: download_vpn_manage_services | bool
 
+# The backup peer is optional, but a PARTIAL config (some backup secrets set,
+# others empty) would silently disable failover while looking configured. Fail
+# loud: all three backup values, or none.
+- name: Assert the backup Proton secrets are all-or-nothing (fail loud on partial)
+  ansible.builtin.assert:
+    that:
+      - >-
+        ((download_vpn_wg_backup_private_key | length > 0)
+         == (download_vpn_wg_backup_peer_public_key | length > 0))
+        and ((download_vpn_wg_backup_private_key | length > 0)
+             == (download_vpn_wg_backup_endpoint | length > 0))
+    fail_msg: >-
+      Partial backup Proton config. Set ALL of
+      PROTON_WG_BACKUP_IFACE_PRIVATE_KEY / PROTON_WG_BACKUP_PEER_PUBLIC_KEY /
+      PROTON_WG_BACKUP_PEER_ENDPOINT to enable sticky failover, or none to
+      disable it.
+    quiet: true
+  when: download_vpn_manage_services | bool
+
 # --- Phase 0: resolve endpoint family (v4 vs v6) ----------------------------
 - name: Resolve Proton endpoint host/port
   ansible.builtin.set_fact:
@@ -36,6 +55,23 @@
 - name: Classify Proton endpoint address family
   ansible.builtin.set_fact:
     download_vpn_endpoint_is_ipv4: "{{ download_vpn_endpoint_host is ansible.utils.ipv4 }}"
+
+# Every Proton endpoint the killswitch must PERMIT — primary plus the backup when
+# failover is configured. The fail-closed ruleset has to allow the backup
+# handshake too, or a failover would be blocked by its own killswitch. Built from
+# the endpoint vars — NO hardcoded IPs. host/port split mirrors the primary above.
+- name: Resolve every Proton endpoint (primary + backup) for the killswitch
+  ansible.builtin.set_fact:
+    download_vpn_endpoints_resolved: "{{ download_vpn_endpoints_resolved | default([]) + [_ep] }}"
+  vars:
+    _ep:
+      host: "{{ item.split(':')[0] }}"
+      port: "{{ item.split(':')[1] }}"
+      is_ipv4: "{{ item.split(':')[0] is ansible.utils.ipv4 }}"
+  loop: >-
+    {{ [download_vpn_wg_endpoint]
+       + ([download_vpn_wg_backup_endpoint]
+          if (download_vpn_wg_failover_enabled | bool) else []) }}
 
 - name: Derive the IPv4-only tunnel address (drop any v6 half Proton issues)
   # Proton's Address is dual-stack ("10.2.0.2/32,fd00::.../128"); keep only the
@@ -307,6 +343,25 @@
   no_log: true
   notify: Restart wg tunnel
 
+- name: Deploy the backup WireGuard private key (root-only, for validator failover)
+  # Written to a root-only file (NOT wg0.conf, which stays PRIMARY) so the
+  # validator can `wg set wg0 private-key <file>` on failover. Absent when no
+  # backup is configured, so a disabled-failover container carries no stray key.
+  ansible.builtin.copy:
+    content: "{{ download_vpn_wg_backup_private_key }}\n"
+    dest: "{{ download_vpn_wg_backup_key_path }}"
+    owner: root
+    group: root
+    mode: "0600"
+  no_log: true
+  when: download_vpn_wg_failover_enabled | bool
+
+- name: Remove the backup WireGuard key when failover is disabled
+  ansible.builtin.file:
+    path: "{{ download_vpn_wg_backup_key_path }}"
+    state: absent
+  when: not (download_vpn_wg_failover_enabled | bool)
+
 - name: Deploy WireGuard systemd unit
   ansible.builtin.template:
     src: download-vpn-wg.service.j2
@@ -323,6 +378,38 @@
     enabled: true
     daemon_reload: true
   when: download_vpn_manage_services
+
+# Sticky-failover failback. The validator may have switched wg0 to the BACKUP
+# peer at runtime (recorded in the state marker). wg0.conf on disk is always the
+# PRIMARY, so a converge is the deliberate reset point: if we are currently on the
+# backup, restart the tunnel (reloads the primary from wg0.conf) and clear the
+# runtime markers. No-op on a container that never failed over.
+- name: Read the current failover state marker
+  ansible.builtin.slurp:
+    src: "{{ download_vpn_failover_state_file }}"
+  register: download_vpn_failover_state
+  failed_when: false
+  when: download_vpn_manage_services
+
+- name: Fail back to the primary Proton peer if currently on the backup
+  ansible.builtin.systemd:
+    name: download-vpn-wg.service
+    state: restarted
+    daemon_reload: true
+  when:
+    - download_vpn_manage_services
+    - "'backup' in (download_vpn_failover_state.content | default('') | b64decode)"
+
+- name: Clear the runtime failover markers after failback
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ download_vpn_failover_state_file }}"
+    - "{{ download_vpn_failover_counter_file }}"
+  when:
+    - download_vpn_manage_services
+    - "'backup' in (download_vpn_failover_state.content | default('') | b64decode)"
 
 # --- Phase 5b: LAN-reply policy routing (cross-subnet web UI reachability) ---
 # Lets cross-subnet clients (Traefik on the management VLAN) reach the

--- a/roles/download_vpn/tasks/validate.yml
+++ b/roles/download_vpn/tasks/validate.yml
@@ -42,6 +42,20 @@
           - "'counter packets' in download_vpn_nft_output.stdout or 'drop' in download_vpn_nft_output.stdout"
         fail_msg: "Killswitch ruleset is missing one of the required allow rules."
 
+    - name: Assert every configured Proton endpoint is permitted (failover-ready)
+      # Each primary+backup endpoint must have an accept rule; otherwise a
+      # failover to that endpoint would be blocked fail-closed by the killswitch.
+      ansible.builtin.assert:
+        that:
+          - item.host in download_vpn_nft_output.stdout
+        fail_msg: >-
+          Killswitch does not permit Proton endpoint {{ item.host }} — a failover
+          to it would be blocked fail-closed.
+        quiet: true
+      loop: "{{ download_vpn_endpoints_resolved }}"
+      loop_control:
+        label: "{{ item.host }}"
+
     # --- B. internet-bound IPv4 traffic egresses via wg0 (Table=auto) ------
     # wg-quick `Table = auto` installs the tunnel default in a SEPARATE fwmark
     # routing table (51820), not the main table — so the main-table default stays

--- a/roles/download_vpn/templates/killswitch-validate.sh.j2
+++ b/roles/download_vpn/templates/killswitch-validate.sh.j2
@@ -32,16 +32,32 @@ NTFY_URL="{{ download_vpn_ntfy_url }}"
 HC_URL="{{ download_vpn_healthcheck_url }}"
 IP_PROBE="{{ download_vpn_ip_probe_url }}"
 IP_PROBE6="{{ download_vpn_ip_probe_url_v6 }}"
+{% if download_vpn_wg_failover_enabled | bool %}
+# --- sticky failover config (rendered only when a backup Proton peer is set) --
+FAILOVER_CYCLES={{ download_vpn_failover_cycles }}
+FAILOVER_STATE_FILE="{{ download_vpn_failover_state_file }}"
+FAILOVER_COUNTER_FILE="{{ download_vpn_failover_counter_file }}"
+PRIMARY_PEER="{{ download_vpn_wg_peer_public_key }}"
+BACKUP_PEER="{{ download_vpn_wg_backup_peer_public_key }}"
+BACKUP_ENDPOINT="{{ download_vpn_wg_backup_endpoint }}"
+BACKUP_KEY_FILE="{{ download_vpn_wg_backup_key_path }}"
+WG_ALLOWED_IPS="{{ download_vpn_wg_allowed_ips }}"
+WG_KEEPALIVE="{{ download_vpn_wg_persistent_keepalive }}"
+{% endif %}
 
 breaches=()
+# Failure classification: a DOWN tunnel (recoverable by failover) vs a LEAK — a
+# security breach that must hard-stop and NEVER trigger a peer switch.
+tunnel_down=0
+leak=0
 
 # --- A. killswitch present + default drop -----------------------------------
 if ! nft list table inet killswitch >/dev/null 2>&1; then
-  breaches+=("nftables 'inet killswitch' table is MISSING")
+  breaches+=("nftables 'inet killswitch' table is MISSING"); leak=1
 else
   policy="$(nft -a list chain inet killswitch output 2>/dev/null \
     | awk '/policy/ {gsub(/;/,"",$NF); print $NF; exit}')"
-  [[ "${policy}" == "drop" ]] || breaches+=("killswitch output policy is '${policy:-unknown}', expected 'drop'")
+  [[ "${policy}" == "drop" ]] || { breaches+=("killswitch output policy is '${policy:-unknown}', expected 'drop'"); leak=1; }
 fi
 
 # --- B. internet-bound IPv4 traffic routes via wg0 (Table=auto) -------------
@@ -51,15 +67,15 @@ fi
 # resolves out wg0 via the policy rule instead of reading the main default.
 route_egress="$(ip -4 route get "${ROUTE_PROBE_IP}" 2>/dev/null)"
 if [[ -z "${route_egress}" ]]; then
-  breaches+=("could not resolve an IPv4 route to ${ROUTE_PROBE_IP} (routing broken / VPN down)")
+  breaches+=("could not resolve an IPv4 route to ${ROUTE_PROBE_IP} (routing broken / VPN down)"); tunnel_down=1
 elif ! grep -q "dev ${WG_IF}" <<<"${route_egress}"; then
-  breaches+=("internet-bound IPv4 traffic does NOT route via ${WG_IF}: ${route_egress}")
+  breaches+=("internet-bound IPv4 traffic does NOT route via ${WG_IF}: ${route_egress}"); tunnel_down=1
 fi
 
 # --- C. no IPv6 default route -----------------------------------------------
 v6_defaults="$(ip -6 route show default 2>/dev/null)"
 if [[ -n "${v6_defaults}" ]]; then
-  breaches+=("IPv6 default route present (must be none): ${v6_defaults}")
+  breaches+=("IPv6 default route present (must be none): ${v6_defaults}"); leak=1
 fi
 
 # --- D. qBittorrent bound to wg0 --------------------------------------------
@@ -72,7 +88,7 @@ if curl -fsS -c "${cookie}" \
     "http://127.0.0.1:{{ download_vpn_qbittorrent_web_port }}/api/v2/app/preferences" 2>/dev/null \
     | grep -o '"current_network_interface":"[^"]*"' | cut -d'"' -f4)"
   if [[ -n "${iface}" && "${iface}" != "${WG_IF}" ]]; then
-    breaches+=("qBittorrent network interface is '${iface}', expected '${WG_IF}'")
+    breaches+=("qBittorrent network interface is '${iface}', expected '${WG_IF}'"); leak=1
   fi
 fi
 rm -f "${cookie}"
@@ -81,18 +97,18 @@ rm -f "${cookie}"
 # E: egress via the tunnel must succeed (we are connected to the VPN).
 vpn_ip="$(curl -fsS --max-time 10 --interface "${WG_IF}" "${IP_PROBE}" 2>/dev/null || true)"
 if [[ -z "${vpn_ip}" ]]; then
-  breaches+=("no IPv4 egress via ${WG_IF} (VPN exit unreachable)")
+  breaches+=("no IPv4 egress via ${WG_IF} (VPN exit unreachable)"); tunnel_down=1
 fi
 # F: forced egress bound to the LAN interface must be REFUSED by the killswitch.
 leak_ip="$(curl -fsS --max-time 8 --interface "${LAN_IF}" "${IP_PROBE}" 2>/dev/null || true)"
 if [[ -n "${leak_ip}" ]]; then
-  breaches+=("LEAK: non-VPN IPv4 egress via ${LAN_IF} succeeded (got ${leak_ip})")
+  breaches+=("LEAK: non-VPN IPv4 egress via ${LAN_IF} succeeded (got ${leak_ip})"); leak=1
 fi
 
 # --- G. IPv6 egress must be refused -----------------------------------------
 v6_ip="$(curl -fsS -6 --max-time 8 "${IP_PROBE6}" 2>/dev/null || true)"
 if [[ -n "${v6_ip}" ]]; then
-  breaches+=("LEAK: IPv6 egress succeeded (got ${v6_ip})")
+  breaches+=("LEAK: IPv6 egress succeeded (got ${v6_ip})"); leak=1
 fi
 
 # --- H. marked-path leak surface --------------------------------------------
@@ -102,7 +118,7 @@ fi
 # dev ${LAN_IF}. Catches a regression that re-introduces a clearnet LAN default.
 marked_route="$(ip -4 route get "${ROUTE_PROBE_IP}" mark {{ download_vpn_lanroute_mark }} 2>/dev/null || true)"
 if grep -q "dev ${LAN_IF}" <<<"${marked_route}"; then
-  breaches+=("LEAK SURFACE: marked packet to ${ROUTE_PROBE_IP} egresses ${LAN_IF}: ${marked_route}")
+  breaches+=("LEAK SURFACE: marked packet to ${ROUTE_PROBE_IP} egresses ${LAN_IF}: ${marked_route}"); leak=1
 fi
 
 # --- verdict ----------------------------------------------------------------
@@ -111,6 +127,35 @@ if [[ "{% raw %}${#breaches[@]}{% endraw %}" -gt 0 ]]; then
   logger -t killswitch-validate "${msg}"
   # 1. Stop the apps that could leak FIRST.
   systemctl stop qbittorrent-nox.service download-vpn-natpmp.service || true
+{% if download_vpn_wg_failover_enabled | bool %}
+  # 1b. Sticky failover. If the ONLY problem is a DOWN tunnel (no leak), count
+  # consecutive down-cycles and switch wg0 to the backup Proton peer after
+  # FAILOVER_CYCLES. A leak-type breach NEVER triggers a switch (hard stop only).
+  # Once on the backup we STAY there; the next converge resets to the primary.
+  if [[ "${leak}" -eq 0 && "${tunnel_down}" -eq 1 ]]; then
+    active="$(cat "${FAILOVER_STATE_FILE}" 2>/dev/null || echo primary)"
+    if [[ "${active}" == "primary" ]]; then
+      count="$(cat "${FAILOVER_COUNTER_FILE}" 2>/dev/null || echo 0)"
+      count=$(( count + 1 )); echo "${count}" > "${FAILOVER_COUNTER_FILE}"
+      if [[ "${count}" -ge "${FAILOVER_CYCLES}" ]]; then
+        logger -t killswitch-validate "download-vpn: primary down ${count} cycles — switching wg0 to BACKUP Proton peer"
+        # The nftables default-drop killswitch stays in force throughout the
+        # swap (both endpoints are pre-permitted), so there is no leak window.
+        if wg set "${WG_IF}" private-key "${BACKUP_KEY_FILE}" \
+           && wg set "${WG_IF}" peer "${BACKUP_PEER}" endpoint "${BACKUP_ENDPOINT}" allowed-ips "${WG_ALLOWED_IPS}" persistent-keepalive "${WG_KEEPALIVE}" \
+           && wg set "${WG_IF}" peer "${PRIMARY_PEER}" remove; then
+          echo backup > "${FAILOVER_STATE_FILE}"; echo 0 > "${FAILOVER_COUNTER_FILE}"
+          curl -fsS --max-time 8 -H "Title: download-vpn VPN failover" \
+            -H "Priority: high" -H "Tags: arrows_counterclockwise" \
+            -d "download-vpn: primary Proton endpoint down ${count} cycles — switched wg0 to BACKUP peer (sticky; a converge resets to primary)." \
+            "${NTFY_URL}" >/dev/null 2>&1 || true
+        else
+          logger -t killswitch-validate "download-vpn: FAILOVER 'wg set' FAILED — staying fail-closed (dropped)"
+        fi
+      fi
+    fi
+  fi
+{% endif %}
   # 2. Alert ntfy.
   curl -fsS --max-time 8 -H "Title: download-vpn killswitch breach" \
     -H "Priority: urgent" -H "Tags: rotating_light" \
@@ -122,6 +167,12 @@ if [[ "{% raw %}${#breaches[@]}{% endraw %}" -gt 0 ]]; then
   exit 1
 fi
 
+{% if download_vpn_wg_failover_enabled | bool %}
+# Clean cycle → reset the consecutive-down counter (failover triggers on
+# CONSECUTIVE down-cycles only). Sticky: we do NOT flip back to the primary here
+# — that happens on the next converge.
+echo 0 > "{{ download_vpn_failover_counter_file }}" 2>/dev/null || true
+{% endif %}
 # Self-heal: on a clean (no-breach) cycle the VPN/killswitch is intact, so it is
 # safe to (re)start the services if a prior transient breach stopped them and the
 # VPN has since recovered (the validator otherwise only ever stops, never starts).

--- a/roles/download_vpn/templates/killswitch.nft.j2
+++ b/roles/download_vpn/templates/killswitch.nft.j2
@@ -16,8 +16,6 @@
   belt to that suspenders: even if v6 were re-enabled, only loopback, LAN and
   wg0 could egress, never the public internet.
 -#}
-{% set _endpoint_host = download_vpn_wg_endpoint.split(':')[0] %}
-{% set _endpoint_port = download_vpn_wg_endpoint.split(':')[1] %}
 table inet killswitch {
   chain input {
     type filter hook input priority 0; policy accept;
@@ -39,13 +37,16 @@ table inet killswitch {
 
     # 3. LAN subnet (web UIs + *arr <-> qBittorrent/Prowlarr coordination).
     ip daddr {{ download_vpn_lan_subnet }} accept
-{% if download_vpn_endpoint_is_ipv4 %}
-    # 4. WireGuard handshake to the Proton endpoint (UDP). v4 endpoint.
-    ip daddr {{ _endpoint_host }} udp dport {{ _endpoint_port }} accept
+    # 4. WireGuard handshake to each permitted Proton endpoint (UDP). Primary +
+    #    backup (when failover is configured) — the fail-closed ruleset must
+    #    allow the backup handshake too, or a failover would block itself.
+{% for _ep in download_vpn_endpoints_resolved %}
+{% if _ep.is_ipv4 %}
+    ip daddr {{ _ep.host }} udp dport {{ _ep.port }} accept
 {% else %}
-    # 4. WireGuard handshake to the Proton endpoint (UDP). v6 endpoint.
-    ip6 daddr {{ _endpoint_host }} udp dport {{ _endpoint_port }} accept
+    ip6 daddr {{ _ep.host }} udp dport {{ _ep.port }} accept
 {% endif %}
+{% endfor %}
 
     # 5. Anything via the VPN tunnel.
     oifname "{{ download_vpn_wg_interface }}" accept


### PR DESCRIPTION
## What

Add an optional **second VPN tunnel endpoint** with **sticky automatic
failover** for the media stack's VPN-locked egress path, so a single upstream
endpoint outage no longer takes egress down until someone intervenes.

## How

- **Killswitch**: now permits every configured endpoint (primary + backup),
  built from a parameterized list — no hardcoded IPs — so a failover can't be
  blocked by its own fail-closed ruleset.
- **Validator**: classifies each breach as *tunnel-down* (failover-eligible) vs
  *leak* (hard-stop, never switched). After K consecutive tunnel-down cycles it
  switches the interface to the backup peer via native `wg set` (private-key +
  peer + endpoint swap on the same interface — the tunnel address is shared),
  then **stays** there.
- **Failback is deliberate, not automatic**: a converge re-lays the primary and
  clears the runtime markers (also reset on reboot — markers live on tmpfs).
  This avoids flapping between two unhealthy endpoints.
- **Secrets**: the backup peer is runtime-only and env-sourced, all-or-nothing
  (a partial config fails loud at preflight).
- **Tests**: molecule arms failover and asserts the dual-endpoint ruleset, the
  root-only backup key file, and the validator's failover logic.

## Safety

Fail-closed invariants hold throughout the swap: both endpoints are
pre-permitted, the tunnel interface stays the only egress, and a leak-type
breach never triggers a switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhigfmGU3XSV1dCNF8XqZu
