### PR TITLE
fix(llama_cpp): swap chat models instead of full co-residency; drop no-mmap

### DIFF
--- a/roles/llama_cpp/templates/llama-swap.yaml.j2
+++ b/roles/llama_cpp/templates/llama-swap.yaml.j2
@@ -13,17 +13,26 @@ macros:
     {{ llama_cpp_server_bin }}
     --host 127.0.0.1 --port ${PORT}
     -ngl {{ llama_cpp_ngl }}
-    --no-mmap
 
 groups:
-  # Keep every member loaded together: 16 GB fits Hermes-4-14B Q4 + a small general
-  # model + embeddings. swap:false = do not unload a member when another is
-  # requested; exclusive:false = this group is always resident.
-  "resident":
+  # VRAM discipline (learned the hard way: full co-residency of Hermes-4-14B Q4
+  # + qwen3-4b + embeddings + their KV caches exceeds the 16 GB card and the
+  # amdgpu eviction path hard-hangs the HOST — twice). Only the tiny embeddings
+  # model stays permanently resident; the chat models swap against each other,
+  # so peak pressure is one chat model + embeddings + KV. --no-mmap was also
+  # dropped from the shared invocation: mmap streaming halves the load spike.
+  "embeddings":
     swap: false
     exclusive: false
     members:
-{% for m in llama_cpp_models %}
+{% for m in llama_cpp_models if m.embeddings %}
+      - "{{ m.name }}"
+{% endfor %}
+  "chat":
+    swap: true
+    exclusive: false
+    members:
+{% for m in llama_cpp_models if not m.embeddings %}
       - "{{ m.name }}"
 {% endfor %}
 

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1726,18 +1726,21 @@
       ansible.builtin.set_fact:
         _llama_swap: "{{ (lookup('file', '/tmp/test_llama_swap.yaml')) | from_yaml }}"
 
-    - name: Assert llama-swap keeps all three models co-resident (group swap:false)
+    - name: Assert llama-swap renders VRAM-disciplined groups (embeddings resident, chat swaps)
       ansible.builtin.assert:
         that:
           - "'hermes-4-14b' in _llama_swap.models"
           - "'qwen3-4b' in _llama_swap.models"
           - "'embeddings' in _llama_swap.models"
-          - _llama_swap.groups.resident.swap == false
-          - _llama_swap.groups.resident.exclusive == false
-          - (_llama_swap.groups.resident.members | sort) == ['embeddings', 'hermes-4-14b', 'qwen3-4b']
+          # Full co-residency exceeded the 16 GB card and hard-hung the host;
+          # only the embeddings model stays resident, chat models swap.
+          - _llama_swap.groups.embeddings.swap == false
+          - _llama_swap.groups.embeddings.members == ['embeddings']
+          - _llama_swap.groups.chat.swap == true
+          - (_llama_swap.groups.chat.members | sort) == ['hermes-4-14b', 'qwen3-4b']
           - "'hermes4' in _llama_swap.models['hermes-4-14b'].aliases"
         fail_msg: >-
-          llama-swap.yaml.j2 did not render the co-resident model group or the
+          llama-swap.yaml.j2 did not render the VRAM-disciplined groups or the
           hermes4 alias: {{ _llama_swap }}
 
     - name: Assert the shared macro offloads to GPU and per-model cmd flags differ


### PR DESCRIPTION
Supervised GPU retry produced a clean bisection: `embeddings` (~80MB) served fine, `qwen3-4b` (~2.5GB) served fine, `hermes-4-14b` (8.4GB, third co-resident model) **hard-hung the host again** — kernel hung-task warning captured on the live dmesg watch, then total lockup. The role's `resident` group (swap:false for ALL models) pushes 8.4 + 2.5 + KV caches past the 16 GB card, and the amdgpu eviction path under that pressure kills the host (256MB BAR, no ReBAR).

- embeddings-only stays resident; chat models swap against each other (peak = one chat model + embeddings + KV, comfortably inside 16 GB)
- `--no-mmap` dropped: mmap streaming avoids the GTT load spike

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj