### PR TITLE
feat(langfuse): headless first-run provisioning via LANGFUSE_INIT_*

### DIFF
--- a/roles/langfuse_docker/defaults/main.yml
+++ b/roles/langfuse_docker/defaults/main.yml
@@ -152,3 +152,24 @@ langfuse_docker_generated_secrets:
   - { name: nextauth_secret, file: .nextauth_secret, length: 48, hex: false }
   - { name: salt, file: .salt, length: 48, hex: false }
   - { name: encryption_key, file: .encryption_key, length: 32, hex: true }
+
+# =============================================================================
+# Headless first-run provisioning (LANGFUSE_INIT_*): org, project, an admin
+# user, and the project API keypair are created on first boot, so the OTLP
+# fan-out and router callbacks have working keys with no UI onboarding.
+# Applied only on a fresh database; Langfuse ignores them once initialized.
+# =============================================================================
+langfuse_docker_init_org: homelab
+langfuse_docker_init_project: homelab
+langfuse_docker_init_user_email: >-
+  {{ lookup('env', 'LANGFUSE_INIT_USER_EMAIL')
+     | mandatory('LANGFUSE_INIT_USER_EMAIL must be set (Doppler)') }}
+langfuse_docker_init_user_password: >-
+  {{ lookup('env', 'LANGFUSE_INIT_USER_PASSWORD')
+     | mandatory('LANGFUSE_INIT_USER_PASSWORD must be set (Doppler; openssl rand -base64 24)') }}
+langfuse_docker_init_public_key: >-
+  {{ lookup('env', 'LANGFUSE_PUBLIC_KEY')
+     | mandatory('LANGFUSE_PUBLIC_KEY must be set (Doppler; pk-lf-<uuid>)') }}
+langfuse_docker_init_secret_key: >-
+  {{ lookup('env', 'LANGFUSE_SECRET_KEY')
+     | mandatory('LANGFUSE_SECRET_KEY must be set (Doppler; sk-lf-<uuid>)') }}

--- a/roles/langfuse_docker/templates/docker-compose.yml.j2
+++ b/roles/langfuse_docker/templates/docker-compose.yml.j2
@@ -71,6 +71,16 @@ services:
       {{ langfuse_docker_redis_service }}:
         condition: service_healthy
     environment: &langfuse_env
+      # Headless first-run provisioning — no-op once the DB is initialized.
+      LANGFUSE_INIT_ORG_ID: "{{ langfuse_docker_init_org }}"
+      LANGFUSE_INIT_ORG_NAME: "{{ langfuse_docker_init_org }}"
+      LANGFUSE_INIT_PROJECT_ID: "{{ langfuse_docker_init_project }}"
+      LANGFUSE_INIT_PROJECT_NAME: "{{ langfuse_docker_init_project }}"
+      LANGFUSE_INIT_PROJECT_PUBLIC_KEY: "{{ langfuse_docker_init_public_key }}"
+      LANGFUSE_INIT_PROJECT_SECRET_KEY: "{{ langfuse_docker_init_secret_key }}"
+      LANGFUSE_INIT_USER_EMAIL: "{{ langfuse_docker_init_user_email }}"
+      LANGFUSE_INIT_USER_NAME: "admin"
+      LANGFUSE_INIT_USER_PASSWORD: "{{ langfuse_docker_init_user_password }}"
       DATABASE_URL: "{{ langfuse_docker_database_url }}"
       SALT: "{{ langfuse_docker_secrets.salt }}"
       ENCRYPTION_KEY: "{{ langfuse_docker_secrets.encryption_key }}"


### PR DESCRIPTION
Langfuse traces can't flow until an org/project/API-keypair exists, which normally requires UI onboarding. Langfuse v3 supports headless init via `LANGFUSE_INIT_*` env — wire it through the role (values from Doppler, keypair pre-generated so the Cribl OTLP destination and the router's callback can reference the same keys). Ignored by Langfuse once the DB is initialized, so it's converge-idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj