### PR TITLE
feat(cribl_edge): OTLP source + Langfuse destination for LLM fabric traces

### DIFF
--- a/roles/cribl_edge/defaults/main.yml
+++ b/roles/cribl_edge/defaults/main.yml
@@ -76,3 +76,20 @@ cribl_edge_per_index_indexes:
 # Token is optional — empty accepts unauthenticated pushes from the mgmt VLAN.
 cribl_edge_hec_input_port: "{{ cribl_hec_input_port | default(8088) }}"
 cribl_edge_hec_input_token: "{{ lookup('env', 'NETMON_HEC_TOKEN') | default('', true) }}"
+
+# =============================================================================
+# OTLP/HTTP source for the LLM fabric (LiteLLM routers + orchestration apps
+# emit OTel to this Edge) and its Langfuse destination. Port from tofu
+# constants; project keys from Doppler env (pre-provisioned via the langfuse
+# role's LANGFUSE_INIT_*). Rendering is gated on the keys being present, so a
+# host without them keeps its existing pipeline untouched. Splunk fan-out of
+# the same stream is deferred: this Cribl version cannot split one input
+# across outputs (see the in_netmon_hec note in inputs.yml.j2).
+# =============================================================================
+cribl_edge_otel_port: >-
+  {{ hostvars['localhost']['tofu_data']['constants']['service_ports']['otel_traces_http'] }}
+cribl_edge_langfuse_url: >-
+  https://langfuse.{{ lookup('env', 'PROXMOX_SUBDOMAIN')
+  | mandatory('PROXMOX_SUBDOMAIN required') }}/api/public/otel
+cribl_edge_langfuse_public_key: "{{ lookup('env', 'LANGFUSE_PUBLIC_KEY') | default('', true) }}"
+cribl_edge_langfuse_secret_key: "{{ lookup('env', 'LANGFUSE_SECRET_KEY') | default('', true) }}"

--- a/roles/cribl_edge/templates/inputs.yml.j2
+++ b/roles/cribl_edge/templates/inputs.yml.j2
@@ -67,3 +67,25 @@ inputs:
     fields:
       - name: type
         value: "'netmon'"
+{% if cribl_edge_langfuse_public_key | length > 0 %}
+
+  # OTLP/HTTP source for the LLM fabric (routers, dify/langflow/agent-exec).
+  # Single connection to the Langfuse OTLP destination — no fan-out, this
+  # Cribl version cannot split one input across outputs (see in_netmon_hec).
+  in_otel:
+    id: in_otel
+    type: open_telemetry
+    disabled: false
+    host: "0.0.0.0"
+    port: {{ cribl_edge_otel_port }}
+    protocol: http
+    extractSpans: false
+    extractMetrics: false
+    sendToRoutes: false
+    connections:
+      - output: langfuse_otlp
+    pqEnabled: true
+    fields:
+      - name: type
+        value: "'otel'"
+{% endif %}

--- a/roles/cribl_edge/templates/outputs.yml.j2
+++ b/roles/cribl_edge/templates/outputs.yml.j2
@@ -53,3 +53,24 @@ outputs:
     safeHeaders: []
 {% endfor %}
 {% endif %}
+{% if cribl_edge_langfuse_public_key | length > 0 %}
+
+  # Langfuse OTLP destination for the LLM fabric traces (basic auth with the
+  # project keypair, same keys the langfuse role provisions at first boot).
+  langfuse_otlp:
+    id: langfuse_otlp
+    type: open_telemetry
+    disabled: false
+    protocol: http
+    endpoint: "{{ cribl_edge_langfuse_url }}"
+    otlpVersion: "1.3.1"
+    authType: basic
+    username: "{{ cribl_edge_langfuse_public_key }}"
+    password: "{{ cribl_edge_langfuse_secret_key }}"
+    onBackpressure: queue
+    pqEnabled: true
+    pqPath: "$CRIBL_HOME/state/queues"
+    pqMaxFileSize: "1 GB"
+    pqMaxSize: "5 GB"
+    pqCompress: none
+{% endif %}


### PR DESCRIPTION
Phase-6 telemetry, first leg: routers + dify/langflow/agent-exec already emit OTel to `cribl-edge:<otel_traces_http>` per their roles, but the Edge has no OTLP source — every span is dropped (visible as continuous OTel export timeouts in dify's api logs).

- `in_otel` source (port from tofu constants, PQ-buffered) → `langfuse_otlp` destination (`/api/public/otel`, basic auth with the project keypair the langfuse role now provisions headlessly in #578)
- rendering gated on `LANGFUSE_PUBLIC_KEY` presence, so hosts without keys keep their pipeline untouched
- Splunk fan-out of the same stream stays deferred: this Cribl version can't split one input across outputs (same limitation documented on `in_netmon_hec`) — which also keeps ansible-splunk#294 parked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj