### PR TITLE
fix(llm_router): passive health recovery by default

### DIFF
--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -73,7 +73,13 @@ llm_router_light_models:
 llm_router_routing_strategy: simple-shuffle
 llm_router_allowed_fails: 2
 llm_router_cooldown_time: 30
-# Background health checks so a drained deployment is probed back in on its own.
+# Background health checks send REAL test requests to every deployment — on the
+# llama-swap fast tier each probe spawns the target model, and with 3 routers
+# probing every model this both churns VRAM constantly and (pre swap-groups)
+# triple-loaded the 16 GB card and hard-hung the GPU host. Passive recovery
+# (allowed_fails + cooldown_time) already re-admits drained deployments, so
+# active probing stays OFF by default.
+llm_router_background_health_checks: false
 llm_router_health_check_interval: 300
 
 # --- Secrets (env-sourced; OpenBao migration is a later phase) ----------------

--- a/roles/llm_router/templates/config.yaml.j2
+++ b/roles/llm_router/templates/config.yaml.j2
@@ -46,10 +46,13 @@ router_settings:
 
 general_settings:
   master_key: os.environ/LLM_ROUTER_MASTER_KEY
-  # Probe drained deployments back in on their own; health_check_interval is a
-  # general_settings field (LiteLLM rejects it under router_settings).
-  background_health_checks: true
+  # Active probes spawn models on the llama-swap tier (see defaults) — passive
+  # recovery via allowed_fails/cooldown_time is the default; health_check_interval
+  # is a general_settings field (LiteLLM rejects it under router_settings).
+  background_health_checks: {{ llm_router_background_health_checks | to_json }}
+{% if llm_router_background_health_checks %}
   health_check_interval: {{ llm_router_health_check_interval }}
+{% endif %}
 
 litellm_settings:
   # Langfuse success logging + OTLP traces to the Cribl Edge collector. Both read

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1823,6 +1823,7 @@
     llm_router_allowed_fails: 2
     llm_router_cooldown_time: 30
     llm_router_health_check_interval: 300
+    llm_router_background_health_checks: false
     llm_router_light_api_key: "sk-noauth"
     llm_router_master_key: "test-master-key-placeholder"
     llm_router_llm_large_bearer: "test-bearer-placeholder"

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1868,7 +1868,8 @@
         that:
           - _litellm.router_settings.routing_strategy == 'simple-shuffle'
           - _litellm.router_settings.cooldown_time == 30
-          - _litellm.general_settings.background_health_checks == true
+          # Active probes spawn models on the swap tier — passive by default.
+          - _litellm.general_settings.background_health_checks == false
           - "'langfuse' in _litellm.litellm_settings.callbacks"
           - "'otel' in _litellm.litellm_settings.callbacks"
           # embeddings deployments declare the embedding mode.


### PR DESCRIPTION
Crash #3 root cause: `background_health_checks: true` makes every router send real test requests to every deployment each interval — on the llama-swap fast tier a probe **spawns the model**, and against the pre-#577 co-resident group one probe triple-loaded the 16 GB card and hard-hung pve1. This made the crash loop self-sustaining on every boot (routers on other nodes probe llm-fast the moment it comes up).

Passive recovery (`allowed_fails` + `cooldown_time`) already re-admits drained deployments; active probing is now off by default behind `llm_router_background_health_checks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj