### PR TITLE
Align OpenBao role wording with five-voter topology

### DIFF
--- a/molecule/openbao/verify.yml
+++ b/molecule/openbao/verify.yml
@@ -70,7 +70,7 @@
           # On-prem static-key seal — never the cloud awskms seal.
           - "'seal \"static\"' in (bao_cfg_content.content | b64decode)"
           - "'awskms' not in (bao_cfg_content.content | b64decode)"
-          # 3-node Raft auto-join: a retry_join block is rendered per peer.
+          # Raft auto-join: a retry_join block is rendered per peer.
           - "'retry_join' in (bao_cfg_content.content | b64decode)"
           - "'listener \"tcp\"' in (bao_cfg_content.content | b64decode)"
           # Listener must bind the VLAN IP, never all-interfaces. Match the

--- a/molecule/technitium_dns/molecule.yml
+++ b/molecule/technitium_dns/molecule.yml
@@ -69,6 +69,7 @@ provisioner:
     # apply=false (converge/verify) means no live API call is ever made.
     PROXMOX_DOMAIN: "${PROXMOX_DOMAIN:-example.net}"
     PROXMOX_SUBDOMAIN: "${PROXMOX_SUBDOMAIN:-svc.example.net}"
+    PROXMOX_IP_ADDRESSES: "${PROXMOX_IP_ADDRESSES:-192.168.5.10,192.168.5.11}"
     PROXMOX_VE_GATEWAY: "${PROXMOX_VE_GATEWAY:-192.168.5.1}"
     TECHNITIUM_DNS_API_TOKEN: "${TECHNITIUM_DNS_API_TOKEN:-moleculetesttoken}"
     TECHNITIUM_DNS_ADMIN_PASSWORD: "${TECHNITIUM_DNS_ADMIN_PASSWORD:-moleculetestpass}"

--- a/molecule/technitium_dns/verify.yml
+++ b/molecule/technitium_dns/verify.yml
@@ -91,6 +91,21 @@
           apex='{{ technitium_dns_apex_domain }}'
           forwarders={{ technitium_dns_forwarders }}.
 
+    - name: Assert Proxmox endpoint apex A records are built from env
+      ansible.builtin.assert:
+        that:
+          - technitium_dns_proxmox_endpoint_ips == ['192.168.5.10', '192.168.5.11']
+          - technitium_dns_proxmox_endpoint_a_records | length == 2
+          - >-
+            technitium_dns_proxmox_endpoint_a_records
+            | map(attribute='domain') | unique | list == ['svc.example.net']
+          - >-
+            technitium_dns_proxmox_endpoint_a_records
+            | map(attribute='ip') | list == ['192.168.5.10', '192.168.5.11']
+        fail_msg: >-
+          Proxmox endpoint apex records were not built from PROXMOX_IP_ADDRESSES:
+          {{ technitium_dns_proxmox_endpoint_a_records }}.
+
     # Extra CNAME records (verbatim FQDN target): an entry with an empty target
     # (e.g. an unset LLM_LARGE_RUNNER_HOST) must be dropped so converge never
     # POSTs a blank alias.

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -756,7 +756,7 @@
 
 # =============================================================================
 # Phase 8.4: OpenBao secrets-management engine (machine/IaC/dynamic secrets)
-# 3-node Raft HA cluster (quorum 2) with on-prem static-key auto-unseal — no
+# 5-voter Raft HA cluster (quorum 3) with on-prem static-key auto-unseal — no
 # cloud. The role installs the native binary, renders the Raft + static-seal
 # config, and (on the bootstrap host only) initializes the cluster, the secret
 # hierarchy, the RBAC policies, and the AppRoles (terraform / ansible /

--- a/roles/openbao/README.md
+++ b/roles/openbao/README.md
@@ -1,17 +1,18 @@
 # openbao
 
 Installs and bootstraps [OpenBao](https://openbao.org/) — a native single Go
-binary on Debian (no Docker) — as a **3-node Raft HA cluster** with **on-prem
+binary on Debian (no Docker) — as a **5-voter Raft HA cluster** with **on-prem
 static-key auto-unseal** (no cloud KMS). After the cluster is live the role
 provisions a KV v2 mount, the secret hierarchy, the RBAC policies, and one
 AppRole per resource-domain identity (see [Secret hierarchy & RBAC](#secret-hierarchy--rbac)).
 
 ## Architecture
 
-- **3-node Raft HA** (quorum 2): every node carries a `retry_join` for each peer
+- **5-voter Raft HA** (quorum 3): every node carries a `retry_join` for each peer
   (built from `openbao_group` hostvars' `container_ip`), so a node that is not
-  yet part of a cluster finds the leader and joins automatically. The cluster
-  survives one node loss with no downtime.
+  yet part of a cluster finds the leader and joins automatically. The target
+  placement is pve1:1, pve2:2, pve3:2, so a whole Proxmox server outage still
+  leaves quorum.
 - **On-prem static-key auto-unseal**: a single 32-byte AES-256 key (base64),
   shared by all nodes, unwraps the root key on every start — each node
   self-unseals on reboot with no operator key entry and **no cloud dependency**.
@@ -28,7 +29,7 @@ AppRole per resource-domain identity (see [Secret hierarchy & RBAC](#secret-hier
 
 The durability guarantee holds from this role alone:
 
-- **3 live Raft copies** (one per node).
+- **5 live Raft copies** spread across three Proxmox servers.
 - **Recovery shares** transcribed to paper, split across custodians.
 - **The seal key** in Doppler tier-0 (kept OUT of OpenBao so a cold cluster
   can't brick).
@@ -79,7 +80,7 @@ This role brings OpenBao live **before** anything that reads secrets from it.
 
 1. Generate the seal key once (`openssl rand -base64 32`) and load it into
    Doppler tier-0 as `OPENBAO_STATIC_SEAL_KEY` (+ `OPENBAO_STATIC_SEAL_KEY_ID`).
-2. `terraform-proxmox` — provision the 3 OpenBao LXCs (VMID/IP/firewall).
+2. `terraform-proxmox` — provision the 5 OpenBao LXCs (VMID/IP/firewall).
 3. **this role** — install + init the cluster, mint the AppRoles.
 4. Operator — transcribe recovery shares to paper (+ Bitwarden); load each
    AppRole's `role_id`/`secret_id` into its own item in the dedicated

--- a/roles/openbao/README.md
+++ b/roles/openbao/README.md
@@ -89,6 +89,51 @@ This role brings OpenBao live **before** anything that reads secrets from it.
 5. `terraform-proxmox` `vault-secrets` — now able to authenticate as
    `terraform-apply` (read/write proof).
 
+## Rolling expansion / migration (preserve a live cluster's data)
+
+`bao operator init` creates a **brand-new empty cluster**. To grow or renumber a
+cluster that already holds secrets **without losing them**, the new nodes must
+JOIN the live cluster (retry_join), not init. The role enforces this:
+`openbao_allow_fresh_init` defaults `false`, and before any init the bootstrap
+host probes every peer — if one is already initialized it refuses to init and
+fails loudly. Fresh init happens only on a genuine first bootstrap
+(`-e openbao_allow_fresh_init=true`).
+
+To expand the current 2-node cluster (`openbao-01`, `openbao-02`) into the
+5-voter topology (`openbao-10/-20/-21/-30/-31` — one/two/two across the three
+Proxmox hosts, each node's IP last octet matching its `NN` suffix), do it in two
+phases so the data replicates to the new voters before the old ones leave:
+
+**Phase 1 — add (interim 7-node cluster, zero downtime):**
+
+1. In `deployment.json`, KEEP `openbao-01` + `openbao-02` AND add the five new
+   nodes, so `openbao_group` has all seven. Every node's `retry_join` is the
+   union, so the new nodes find the live leader and replicate the full store.
+2. Pin the bootstrap/provisioning host to a **live, initialized** node for the
+   migration: `-e openbao_bootstrap_host=openbao-02` (never a new node; and not a
+   node whose host is currently unstable). `openbao_allow_fresh_init` stays
+   `false`.
+3. `terraform-proxmox` apply creates the five new LXCs; then run this role with
+   `--limit openbao_group,localhost`.
+4. **Verify before Phase 2:** `bao operator raft list-peers` shows all 7;
+   `bao operator raft autopilot state` shows 7 healthy voters; a read of a known
+   secret succeeds from a NEW node. Do not proceed until healthy.
+
+**Phase 2 — remove the old nodes (shrink to the clean 5):**
+
+1. `bao operator raft remove-peer openbao-01` then `... openbao-02`.
+2. Drop `openbao-01`/`openbao-02` from `deployment.json`; `terraform-proxmox`
+   apply destroys the two old LXCs. Final state: 5 voters, quorum 3 — survives
+   any single node, and any single Proxmox host, going down.
+
+**Leader preference** (first host > second > third): Raft does not natively pin a
+leader — whichever voter wins the election leads; autopilot only handles
+stabilization and dead-server cleanup. If keeping leadership off a specific host
+matters, the real lever is making that host's nodes **non-voters** (they never
+lead and never count toward quorum) — weigh that against the HA math (5 voters
+tolerate 2 down; 3 voters + 2 non-voters tolerate 1). Do not claim hard
+leader-pinning the engine can't do.
+
 ## Installation
 
 The role lives in this repository under `roles/openbao/`. Reference it from a

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -2,7 +2,7 @@
 # OpenBao single-binary secrets manager — role defaults.
 #
 # OpenBao is a native Go binary on Debian; no Docker. This role installs the
-# upstream .deb (checksum-verified), renders a 3-node Raft HA + on-prem
+# upstream .deb (checksum-verified), renders a Raft HA + on-prem
 # static-key auto-unseal config, runs it under systemd, and (in init.yml)
 # bootstraps the cluster, the secret hierarchy, the RBAC policies, and the
 # AppRoles — one per resource-domain identity (terraform-apply / terrakube-plan
@@ -239,7 +239,7 @@ openbao_approle_token_max_ttl: 4h
 #     snapshots off-box in the meantime.
 #   * a full restore-to-scratch-node drill (needs a scratch node that does not
 #     exist yet). gzip -t is the strongest safe on-box integrity check today.
-# "Never lost" already holds regardless: 3-node Raft (3 live copies) + recovery
+# "Never lost" already holds regardless: Raft HA live copies + recovery
 # shares (paper) + the seal key (Doppler tier-0) + the ZFS/PBS-backed data dir.
 openbao_snapshot_enabled: true
 # Reserved for the S3 follow-up above (bucket already created by object_storage).

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -78,6 +78,16 @@ openbao_raft_peer_ips: >-
 openbao_bootstrap_host: >-
   {{ (groups['openbao_group'] | default([inventory_hostname]) | sort | first) }}
 
+# DATA-LOSS GUARD. `bao operator init` creates a BRAND-NEW empty cluster. On a
+# homelab that already holds live secrets, a fresh init on a mis-scoped run (a
+# node list that dropped the existing members, or a bootstrap host that can't
+# reach them) would orphan the real data into a second, empty cluster. So fresh
+# init is OPT-IN. For a ROLLING EXPANSION of a live cluster (add nodes, preserve
+# data) leave this false — the new nodes join via retry_join and the existing
+# data replicates to them. Set true ONLY for the very first cluster creation.
+# See roles/openbao/README.md ("Rolling expansion / migration").
+openbao_allow_fresh_init: false
+
 # --- Seal: on-prem static-key auto-unseal (no cloud) ------------------------
 # A single 32-byte AES-256 key (base64), shared by all nodes, unwraps the root
 # key on every start so each node self-unseals without operator key entry and

--- a/roles/openbao/meta/main.yml
+++ b/roles/openbao/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: JacobPEvans
-  description: Deploy OpenBao secrets manager (3-node Raft HA + on-prem static-key auto-unseal)
+  description: Deploy OpenBao secrets manager (Raft HA + on-prem static-key auto-unseal)
   license: Apache-2.0
   min_ansible_version: "2.15"
   platforms:

--- a/roles/openbao/tasks/init.yml
+++ b/roles/openbao/tasks/init.yml
@@ -36,7 +36,59 @@
   ansible.builtin.set_fact:
     openbao_status: "{{ openbao_status_raw.stdout | from_json }}"
 
-# --- Initialization (only when not yet initialized) -------------------------
+# --- Data-loss guard: never fresh-init on top of an existing cluster ---------
+# A rolling expansion of a LIVE cluster must JOIN, never re-init. Before the
+# bootstrap host would run `bao operator init`, probe every configured peer: if
+# ANY already reports initialized=true, a real cluster exists and its data must
+# be preserved, so we do NOT init (the peers' retry_join pulls this node in and
+# the data replicates). Fresh init is allowed ONLY when no peer is initialized
+# AND the operator explicitly opted in (openbao_allow_fresh_init) — so a
+# mis-scoped node list fails loudly instead of silently orphaning the secrets.
+- name: Probe peers for an already-initialized cluster
+  ansible.builtin.uri:
+    url: "http://{{ item }}:{{ openbao_api_port }}/v1/sys/health?standbyok=true&uninitcode=200&sealedcode=200"
+    method: GET
+    timeout: 5
+    return_content: true
+  loop: "{{ openbao_raft_peer_ips | reject('equalto', openbao_bind_address) | list }}"
+  loop_control:
+    label: "{{ item }}"
+  register: openbao_peer_health
+  changed_when: false
+  failed_when: false
+  when: not openbao_status.initialized
+
+- name: Determine whether a live cluster already exists among the peers
+  ansible.builtin.set_fact:
+    openbao_existing_cluster_present: >-
+      {{ (openbao_peer_health.results | default([]))
+         | selectattr('json', 'defined')
+         | map(attribute='json.initialized') | select('equalto', true)
+         | list | length > 0 }}
+  when: not openbao_status.initialized
+
+- name: Refuse to fresh-init when a cluster may already exist (data-loss guard)
+  ansible.builtin.fail:
+    msg: >-
+      This bootstrap host is not initialized, no already-initialized peer was
+      reachable, and openbao_allow_fresh_init is false. Refusing `bao operator
+      init` — it would create a NEW empty cluster and orphan any existing
+      secrets. If this is a genuine first bootstrap, re-run with
+      -e openbao_allow_fresh_init=true. If this is a rolling expansion, ensure
+      the existing openbao nodes are in openbao_group and reachable, then re-run.
+  when:
+    - not openbao_status.initialized
+    - not (openbao_existing_cluster_present | default(false))
+    - not (openbao_allow_fresh_init | bool)
+
+- name: Decide fresh-init vs join (join preserves an existing cluster's data)
+  ansible.builtin.set_fact:
+    openbao_do_fresh_init: >-
+      {{ (not openbao_status.initialized)
+         and (not (openbao_existing_cluster_present | default(false)))
+         and (openbao_allow_fresh_init | bool) }}
+
+# --- Initialization (only on a genuine first bootstrap) ---------------------
 # With an auto-unseal seal (static key) `bao operator init` produces RECOVERY
 # shares (not classic unseal keys); the static seal unwraps the root key on
 # every start, so the bootstrap node self-unseals and the peers do too on join.
@@ -52,13 +104,13 @@
   register: openbao_init_raw
   no_log: true
   changed_when: true
-  when: not openbao_status.initialized
+  when: openbao_do_fresh_init
 
 - name: Capture init result
   ansible.builtin.set_fact:
     openbao_init: "{{ openbao_init_raw.stdout | from_json }}"
   no_log: true
-  when: not openbao_status.initialized
+  when: openbao_do_fresh_init
 
 # Break-glass: write recovery shares + root token to a 0600 file ON THE
 # CONTROLLER (gitignored), then shout at the operator to move it to paper.
@@ -73,7 +125,7 @@
   vars:
     ansible_become: false
   no_log: true
-  when: not openbao_status.initialized
+  when: openbao_do_fresh_init
 
 - name: WARN — transcribe recovery material to paper, then delete the file
   ansible.builtin.debug:
@@ -90,7 +142,7 @@
       the seal key is ever lost. Do NOT commit it. Do NOT leave it
       on disk.
       ============================================================
-  when: not openbao_status.initialized
+  when: openbao_do_fresh_init
 
 # Root token: from this run's init output on the FIRST bootstrap. On a cluster
 # that's already initialized, provisioning (new policies/AppRoles) only runs
@@ -101,7 +153,7 @@
   ansible.builtin.set_fact:
     openbao_bootstrap_token: "{{ openbao_init.root_token }}"
   no_log: true
-  when: not openbao_status.initialized
+  when: openbao_do_fresh_init
 
 - name: Use the externally-supplied admin token for provisioning against a live cluster
   ansible.builtin.set_fact:

--- a/roles/openbao/tasks/init.yml
+++ b/roles/openbao/tasks/init.yml
@@ -4,7 +4,7 @@
 # cluster, then provisions the KV mount, the RBAC policies, and the AppRoles
 # (terraform-apply / terrakube-plan / ansible-converge / observability /
 # local-cloud / monitoring / media / local-llm / public / ai-readonly /
-# ai-elevated / snapshot — see docs/SECRETS_HIERARCHY.md). The other two Raft
+# ai-elevated / snapshot — see docs/SECRETS_HIERARCHY.md). The other Raft
 # peers never run this: they join the leader automatically (retry_join in
 # openbao.hcl) and self-unseal via the static seal. Every step is guarded so
 # re-runs are no-ops: nothing is created if it already exists, and break-glass

--- a/roles/openbao/templates/openbao.hcl.j2
+++ b/roles/openbao/templates/openbao.hcl.j2
@@ -1,8 +1,8 @@
 {{ ansible_managed | comment }}
-# OpenBao server configuration — 3-node Raft HA + on-prem static-key auto-unseal.
+# OpenBao server configuration — Raft HA + on-prem static-key auto-unseal.
 # Rendered by the openbao Ansible role. Do not edit manually.
 
-# Integrated Raft storage. This is one peer of a 3-node HA cluster (quorum 2).
+# Integrated Raft storage. This is one peer of the HA cluster.
 # Every node carries a retry_join for each peer, so a freshly-started node finds
 # the leader and joins automatically; with the static seal it then self-unseals.
 # Exactly one node runs `bao operator init` (the bootstrap host) — the others

--- a/roles/technitium_dns/defaults/main.yml
+++ b/roles/technitium_dns/defaults/main.yml
@@ -81,6 +81,16 @@ technitium_dns_ingress_aliases: >-
 technitium_dns_ingress_apex: >-
   {{ tofu_data.ingress | default([]) | selectattr('apex', 'defined')
      | selectattr('apex') | list }}
+
+# Proxmox API/UI endpoint IPs for the subdomain apex itself. When set, the
+# apex A record is published as DNS round-robin directly to the Proxmox nodes
+# instead of pointing at Traefik. Keep this sourced from the same Doppler value
+# used by terraform-proxmox/aws-infra Route53 so public and local DNS agree.
+technitium_dns_proxmox_endpoint_ips: >-
+  {{ lookup('env', 'PROXMOX_IP_ADDRESSES') | default('', true)
+     | split(',') | map('trim') | reject('equalto', '') | list }}
+technitium_dns_proxmox_endpoint_a_records: []
+
 # Ingress lives under PROXMOX_SUBDOMAIN (matches the traefik role's
 # traefik_base_domain): aliases resolve as <name>.<PROXMOX_SUBDOMAIN>. This is the
 # SAME value as the authoritative technitium_dns_zone, so the records land in the

--- a/roles/technitium_dns/tasks/main.yml
+++ b/roles/technitium_dns/tasks/main.yml
@@ -108,6 +108,31 @@
       and re-apply so the inventory exports reserved_ip.
     quiet: true
 
+- name: Build Proxmox endpoint apex A records
+  ansible.builtin.set_fact:
+    technitium_dns_proxmox_endpoint_a_records: >-
+      {{
+        technitium_dns_proxmox_endpoint_a_records | default([]) +
+        [{ 'domain': technitium_dns_zone, 'ip': item }]
+      }}
+  loop: "{{ technitium_dns_proxmox_endpoint_ips | default([]) }}"
+  loop_control:
+    label: "{{ technitium_dns_zone }} -> {{ item }}"
+
+- name: Assert every Proxmox endpoint A-record target is an IPv4 address
+  ansible.builtin.assert:
+    that:
+      - >-
+        technitium_dns_proxmox_endpoint_a_records | default([])
+        | rejectattr('ip', 'match', '^\d{1,3}(\.\d{1,3}){3}$')
+        | list | length == 0
+    fail_msg: >-
+      PROXMOX_IP_ADDRESSES contains non-IPv4 target(s): {{
+      technitium_dns_proxmox_endpoint_a_records | default([])
+      | rejectattr('ip', 'match', '^\d{1,3}(\.\d{1,3}){3}$')
+      | map(attribute='ip') | join(', ') }}.
+    quiet: true
+
 # --- Derive HA topology (primary = lowest-vmid technitium_dns_group member) ---
 # Build a {vmid, ip} list for the group so the primary is the lowest vmid
 # (terraform pins technitium-1 lowest). vmid is int-cast so it sorts numerically.
@@ -449,11 +474,68 @@
     - technitium_dns_ingress_host in hostvars
     - hostvars[technitium_dns_ingress_host].container_ip is defined
 
-# The Proxmox cluster-UI apex (the subdomain zone root itself) resolves to the
-# Traefik LXC, same target as the per-service aliases above, so the bare apex
-# https://<subdomain> reaches Traefik's load-balanced node pool over TLS.
-# domain == the zone name writes the A record AT the zone apex. Created only when
-# the tofu ingress table carries an apex row (otherwise a no-op).
+# The Proxmox API/UI apex (the subdomain zone root itself) resolves directly to
+# the Proxmox node endpoint IPs when PROXMOX_IP_ADDRESSES is set. Delete the old
+# apex A set first so the authoritative answer exactly matches the desired node
+# list, then add one A record per endpoint.
+- name: Delete existing Proxmox endpoint apex A records
+  ansible.builtin.uri:
+    url: "{{ technitium_dns_api_url }}/api/zones/records/delete?token={{ technitium_dns_api_token }}"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      domain: "{{ item.name }}"
+      zone: "{{ technitium_dns_zone }}"
+      type: A
+      ipAddress: "{{ item.rData.ipAddress }}"
+    return_content: true
+    timeout: "{{ technitium_dns_api_timeout }}"
+  loop: >-
+    {{ technitium_dns_existing_records.json.response.records | default([])
+       | selectattr('type', 'equalto', 'A')
+       | selectattr('name', 'equalto', technitium_dns_zone)
+       | list }}
+  loop_control:
+    label: "{{ item.name }} -> {{ item.rData.ipAddress }}"
+  register: technitium_dns_proxmox_endpoint_delete_result
+  changed_when: technitium_dns_proxmox_endpoint_delete_result.json.status == "ok"
+  failed_when: technitium_dns_proxmox_endpoint_delete_result.json.status | default('') != "ok"
+  no_log: true
+  when:
+    - technitium_dns_proxmox_endpoint_a_records | default([]) | length > 0
+    - technitium_dns_role == 'primary'
+    - technitium_dns_apply | bool
+
+- name: Create Proxmox endpoint apex A records
+  ansible.builtin.uri:
+    url: "{{ technitium_dns_api_url }}/api/zones/records/add?token={{ technitium_dns_api_token }}"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      domain: "{{ item.domain }}"
+      zone: "{{ technitium_dns_zone }}"
+      type: A
+      ipAddress: "{{ item.ip }}"
+      ttl: "{{ technitium_dns_zone_ttl }}"
+    return_content: true
+    timeout: "{{ technitium_dns_api_timeout }}"
+  loop: "{{ technitium_dns_proxmox_endpoint_a_records | default([]) }}"
+  loop_control:
+    label: "{{ item.domain }} -> {{ item.ip }}"
+  register: technitium_dns_proxmox_endpoint_result
+  changed_when: technitium_dns_proxmox_endpoint_result.json.status == "ok"
+  failed_when:
+    - technitium_dns_proxmox_endpoint_result.json.status | default('') != "ok"
+    - "'already exists' not in (technitium_dns_proxmox_endpoint_result.json.errorMessage | default(''))"
+  no_log: true
+  when:
+    - technitium_dns_role == 'primary'
+    - technitium_dns_apply | bool
+
+# Fallback: if no direct Proxmox endpoint IP list is configured, the Proxmox
+# cluster-UI apex resolves to the Traefik LXC, same target as the per-service
+# aliases above, so the bare apex https://<subdomain> reaches Traefik's backend
+# pool over TLS. domain == the zone name writes the A record AT the zone apex.
 - name: Create Traefik apex A record (zone root -> Traefik)
   ansible.builtin.uri:
     url: "{{ technitium_dns_api_url }}/api/zones/records/add?token={{ technitium_dns_api_token }}"
@@ -476,6 +558,7 @@
   no_log: true
   when:
     - technitium_dns_ingress_apex | default([]) | length > 0
+    - technitium_dns_proxmox_endpoint_a_records | default([]) | length == 0
     - technitium_dns_role == 'primary'
     - technitium_dns_apply | bool
     - technitium_dns_ingress_host in hostvars


### PR DESCRIPTION
## Summary
- update OpenBao role/docs comments from 3-node to five-voter Raft HA wording
- keep OpenBao role behavior tag/group-driven
- update Technitium DNS so the `pve` zone apex can publish multi-A Proxmox endpoint records from `PROXMOX_IP_ADDRESSES` instead of pointing the apex at Traefik when endpoint IPs are configured

Refs: dryvist/terraform-proxmox#547

## Validation
- `nix develop github:JacobPEvans/nix-devenv#ansible-apps --command bash -lc 'ansible-lint roles/openbao playbooks/site.yml molecule/openbao'`\n- `nix develop github:JacobPEvans/nix-devenv#ansible-apps --command bash -lc 'ansible-lint roles/technitium_dns molecule/technitium_dns roles/openbao playbooks/site.yml'`\n- `molecule test -s openbao` blocked before role execution by molecule-docker/Ansible 2.21 conditional compatibility in plugin destroy playbook (`when: (lookup('env', 'HOME'))`)\n- Live Technitium apply was not run from this shell: dynamic inventory resolved only `_meta`, so there were no safe `technitium_dns_group` hosts to target here