### PR TITLE
chore(deps): bump langfuse + qdrant to latest stable

### DIFF
--- a/roles/langfuse_docker/defaults/main.yml
+++ b/roles/langfuse_docker/defaults/main.yml
@@ -13,8 +13,8 @@
 # Container images — pinned. Bump via Renovate or manual review.
 # web and worker MUST share the same Langfuse version.
 # =============================================================================
-langfuse_docker_web_image: "langfuse/langfuse:3.201.1"
-langfuse_docker_worker_image: "langfuse/langfuse-worker:3.201.1"
+langfuse_docker_web_image: "langfuse/langfuse:3.205.1"
+langfuse_docker_worker_image: "langfuse/langfuse-worker:3.205.1"
 langfuse_docker_postgres_image: "postgres:17"
 # ClickHouse 24.8 is an upstream LTS line and satisfies Langfuse v3's minimum.
 langfuse_docker_clickhouse_image: "clickhouse/clickhouse-server:24.8"

--- a/roles/qdrant_docker/defaults/main.yml
+++ b/roles/qdrant_docker/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-qdrant_docker_image: "qdrant/qdrant:v1.17.0"
+qdrant_docker_image: "qdrant/qdrant:v1.18.2"
 qdrant_docker_container_name: qdrant
 qdrant_docker_data_dir: /opt/qdrant
 qdrant_docker_api_key: >-


### PR DESCRIPTION
Sweep of every pinned LLM/media image against latest stable (2026-07-05). Only two pinned application images were behind:

| image | from | to |
| --- | --- | --- |
| `langfuse/langfuse` (web) | 3.201.1 | 3.205.1 |
| `langfuse/langfuse-worker` | 3.201.1 | 3.205.1 |
| `qdrant/qdrant` | v1.17.0 | v1.18.2 |

langfuse web + worker move in lockstep (required). All minor bumps, no major jumps.

**Held deliberately (bundled datastores):** postgres (→18), redis (→8), clickhouse (24.8 LTS→26). A tag-only major bump does not migrate the on-disk data directory (postgres 18 will not start on a v15/16/17 datadir), and clickhouse 24.8 is the LTS the app validates against. Their `<major>-alpine` tags already roll to the newest minor within-major on each converge, so they stay patched without a breaking major swap.

**Not pinned (update on converge):** the remaining LLM and media components install latest at converge time (native/rolling tags), so they reach current without a code change — a re-converge deploys them.