### PR TITLE
feat(ui): headless admin provisioning for Open WebUI and Dify + dify data-dir ownership fixes

### DIFF
--- a/roles/dify_docker/defaults/main.yml
+++ b/roles/dify_docker/defaults/main.yml
@@ -121,3 +121,12 @@ dify_docker_inner_api_key: >-
 dify_docker_public_url: >-
   https://dify.{{ lookup('env', 'PROXMOX_SUBDOMAIN')
   | mandatory('PROXMOX_SUBDOMAIN required') }}
+
+# Headless first-run setup (POST /console/api/setup creates the admin and
+# finishes installation), so the UI never shows the /install wizard.
+dify_docker_admin_email: >-
+  {{ lookup('env', 'DIFY_ADMIN_EMAIL')
+     | mandatory('DIFY_ADMIN_EMAIL must be set (Doppler)') }}
+dify_docker_admin_password: >-
+  {{ lookup('env', 'DIFY_ADMIN_PASSWORD')
+     | mandatory('DIFY_ADMIN_PASSWORD must be set (Doppler; openssl rand -base64 24)') }}

--- a/roles/dify_docker/tasks/main.yml
+++ b/roles/dify_docker/tasks/main.yml
@@ -112,7 +112,6 @@
   loop:
     - "{{ dify_docker_data_dir }}"
     - "{{ dify_docker_data_dir }}/postgres"
-    - "{{ dify_docker_data_dir }}/redis"
     - "{{ dify_docker_data_dir }}/weaviate"
     - "{{ dify_docker_data_dir }}/plugin_daemon"
     - "{{ dify_docker_data_dir }}/postgres-init"
@@ -128,6 +127,16 @@
     state: directory
     owner: "1001"
     group: "1001"
+    mode: "0755"
+
+# redis-server runs as the image's redis user (uid 999); a root-owned /data
+# makes every RDB save fail (MISCONF) and redis then refuses writes entirely.
+- name: Create Dify redis data directory (redis runs as uid 999)
+  ansible.builtin.file:
+    path: "{{ dify_docker_data_dir }}/redis"
+    state: directory
+    owner: "999"
+    group: "999"
     mode: "0755"
 
 # =============================================================================

--- a/roles/dify_docker/tasks/main.yml
+++ b/roles/dify_docker/tasks/main.yml
@@ -114,12 +114,21 @@
     - "{{ dify_docker_data_dir }}/postgres"
     - "{{ dify_docker_data_dir }}/redis"
     - "{{ dify_docker_data_dir }}/weaviate"
-    - "{{ dify_docker_data_dir }}/storage"
     - "{{ dify_docker_data_dir }}/plugin_daemon"
     - "{{ dify_docker_data_dir }}/postgres-init"
     - "{{ dify_docker_data_dir }}/sandbox/dependencies"
     - "{{ dify_docker_data_dir }}/ssrf_proxy"
     - "{{ dify_docker_data_dir }}/nginx"
+
+# The api/worker images run as uid 1001 ("dify"), not root, and write privkeys/
+# uploads into this bind mount — it must be writable by that uid.
+- name: Create Dify app storage directory (api/worker run as uid 1001)
+  ansible.builtin.file:
+    path: "{{ dify_docker_data_dir }}/storage"
+    state: directory
+    owner: "1001"
+    group: "1001"
+    mode: "0755"
 
 # =============================================================================
 # SECRET_KEY (generate-once, persist on disk)

--- a/roles/dify_docker/tasks/main.yml
+++ b/roles/dify_docker/tasks/main.yml
@@ -305,6 +305,8 @@
       name: "admin"
       password: "{{ dify_docker_admin_password }}"
     status_code: [200, 201]
-  when: dify_docker_setup_state.json.step | default('') == 'not_started'
+  # json is absent when the endpoint returns non-JSON (proxy error page);
+  # guard it so the check degrades to "skip" instead of a templating error.
+  when: (dify_docker_setup_state.json | default({})).step | default('') == 'not_started'
   changed_when: true
   no_log: true

--- a/roles/dify_docker/tasks/main.yml
+++ b/roles/dify_docker/tasks/main.yml
@@ -266,3 +266,27 @@
   delay: 10
   until: dify_docker_health.status == 200
   changed_when: false
+
+# --- Headless first-run provisioning ------------------------------------------
+# GET /console/api/setup reports {"step":"not_started"} until installation is
+# finished; the POST creates the admin workspace and completes setup so the UI
+# never shows /install. Skipped on every converge after the first.
+- name: Check whether Dify setup is finished
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ dify_docker_web_port }}/console/api/setup"
+    return_content: true
+  register: dify_docker_setup_state
+
+- name: Complete Dify setup (create admin)
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ dify_docker_web_port }}/console/api/setup"
+    method: POST
+    body_format: json
+    body:
+      email: "{{ dify_docker_admin_email }}"
+      name: "admin"
+      password: "{{ dify_docker_admin_password }}"
+    status_code: [200, 201]
+  when: dify_docker_setup_state.json.step | default('') == 'not_started'
+  changed_when: true
+  no_log: true

--- a/roles/open_webui/defaults/main.yml
+++ b/roles/open_webui/defaults/main.yml
@@ -26,7 +26,7 @@ open_webui_default_model: gpt-oss-120b
 
 # Public URL via Traefik — derived from the PROXMOX_SUBDOMAIN var (pve.<apex>),
 # never hardcoded. Matches the `llm` ingress entry in terraform-proxmox locals.tf.
-open_webui_hostname: "llm.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
+open_webui_hostname: "chat.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
 open_webui_url: "https://{{ open_webui_hostname }}"
 
 # Stable secret key for JWT/data encryption — generate once (openssl rand -hex 32),
@@ -34,3 +34,12 @@ open_webui_url: "https://{{ open_webui_hostname }}"
 # runs or sessions invalidate.
 open_webui_secret_key: >-
   {{ bao_local_llm_secrets.OPEN_WEBUI_SECRET_KEY | default(lookup('env', 'OPEN_WEBUI_SECRET_KEY'), true) }}
+
+# Headless first-run admin (the first signup becomes the admin account), so
+# the UI never shows the "Create Admin Account" wizard.
+open_webui_admin_email: >-
+  {{ lookup('env', 'OPEN_WEBUI_ADMIN_EMAIL')
+     | mandatory('OPEN_WEBUI_ADMIN_EMAIL must be set (Doppler)') }}
+open_webui_admin_password: >-
+  {{ lookup('env', 'OPEN_WEBUI_ADMIN_PASSWORD')
+     | mandatory('OPEN_WEBUI_ADMIN_PASSWORD must be set (Doppler; openssl rand -base64 24)') }}

--- a/roles/open_webui/tasks/main.yml
+++ b/roles/open_webui/tasks/main.yml
@@ -96,3 +96,27 @@
   retries: 30
   delay: 5
   until: open_webui_health.status == 200
+
+# --- Headless first-run provisioning ------------------------------------------
+# Open WebUI reports onboarding=true until a first user exists; the first
+# signup becomes the admin. Provision it here so the UI never shows the
+# wizard. Skipped on every converge after the first.
+- name: Check whether Open WebUI is onboarded
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ open_webui_port }}/api/config"
+    return_content: true
+  register: open_webui_cfg
+
+- name: Create the admin account (first signup)
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ open_webui_port }}/api/v1/auths/signup"
+    method: POST
+    body_format: json
+    body:
+      name: admin
+      email: "{{ open_webui_admin_email }}"
+      password: "{{ open_webui_admin_password }}"
+    status_code: 200
+  when: open_webui_cfg.json.onboarding | default(false)
+  changed_when: true
+  no_log: true

--- a/roles/open_webui/tasks/main.yml
+++ b/roles/open_webui/tasks/main.yml
@@ -117,6 +117,8 @@
       email: "{{ open_webui_admin_email }}"
       password: "{{ open_webui_admin_password }}"
     status_code: 200
-  when: open_webui_cfg.json.onboarding | default(false)
+  # json is absent when the endpoint returns non-JSON (proxy error page);
+  # guard it so the check degrades to "skip" instead of a templating error.
+  when: (open_webui_cfg.json | default({})).onboarding | default(false)
   changed_when: true
   no_log: true


### PR DESCRIPTION
## Summary
- **open_webui**: fix the ingress hostname (llm.→chat.), provision the admin account headlessly (first-signup-is-admin via `POST /api/v1/auths/signup`, gated on `/api/config` onboarding), then signup stays closed. No Create-Admin wizard.
- **dify_docker**: drive `POST /console/api/setup` to `finished` headlessly (gated on `GET step == not_started`).
- **dify_docker**: two upstream-image UID fixes — the api/worker containers run as uid 1001 (`dify`) and write privkeys/uploads into the storage bind mount (root-owned = setup 500s with PermissionDenied), and redis runs as uid 999 (root-owned /data = every RDB save fails with MISCONF and redis refuses writes).

## Testing
- Live converges green. `chat.<zone>/api/config` reports onboarding complete + signup disabled; `dify.<zone>/console/api/setup` returns `finished`; dify redis background saves now succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj