### PR TITLE
fix(technitium_dns): stop the zone self-destruct and repoint the cribl-edge alias

### DIFF
--- a/inventory/group_vars/technitium_dns_group.yml
+++ b/inventory/group_vars/technitium_dns_group.yml
@@ -16,7 +16,12 @@ technitium_dns_retired_records:
 
 # Neutral capability name for the heavy-tier serving gate on the Studio:
 # llm-large.<zone> -> the machine's own cert-covered hostname (verbatim FQDN
-# target; the router pool dials this name with the gate bearer).
+# target; the router pool dials this name with the gate bearer). The Studio's
+# name lives at the APEX (parent of the guest zone), so derive it from
+# PROXMOX_SUBDOMAIN — PROXMOX_DOMAIN holds the guest zone in this environment.
 technitium_dns_extra_cname_records:
   - name: llm-large
-    target: "jevans-ms.{{ lookup('env', 'PROXMOX_DOMAIN') | mandatory('PROXMOX_DOMAIN required') }}"
+    target: >-
+      jevans-ms.{{ lookup('env', 'PROXMOX_SUBDOMAIN')
+      | mandatory('PROXMOX_SUBDOMAIN required')
+      | split('.', 1) | last }}

--- a/roles/technitium_dns/defaults/main.yml
+++ b/roles/technitium_dns/defaults/main.yml
@@ -44,8 +44,11 @@ technitium_dns_retired_records: []
 # CNAME aliases for services
 # Maps service name to canonical hostname
 technitium_dns_cname_records:
+  # Cribl Edge moved from the docker host to the cribl-edge-01/02 LXCs; the
+  # alias is the stable OTLP/collector entry point for routers and apps.
+  # ponytail: single-edge target; repoint to an LB when edge HA matters.
   - name: cribl-edge
-    target: docker
+    target: cribl-edge-01
   - name: cribl-stream
     target: docker
   # Stable syslog entry point - always points to HAProxy load balancer.

--- a/roles/technitium_dns/defaults/main.yml
+++ b/roles/technitium_dns/defaults/main.yml
@@ -20,8 +20,11 @@ technitium_dns_api_token: "{{ lookup('env', 'TECHNITIUM_DNS_API_TOKEN') }}"
 technitium_dns_zone: "{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
 # Apex domain — referenced ONLY to remove a stale apex Primary zone if a
 # pre-existing server still owns one (so non-subdomain names forward, not
-# NXDOMAIN). Never created/served here.
-technitium_dns_apex_domain: "{{ lookup('env', 'PROXMOX_DOMAIN') }}"
+# NXDOMAIN). Never created/served here. Derived as the PARENT of the managed
+# zone, never from env: PROXMOX_DOMAIN's meaning varies by repo (elsewhere it
+# holds the guest zone itself), and an apex equal to the zone made this task
+# delete the zone the role had just created — a live outage.
+technitium_dns_apex_domain: "{{ technitium_dns_zone.split('.', 1) | last }}"
 
 # DNS zone configuration
 technitium_dns_zone_type: "Primary"

--- a/roles/technitium_dns/tasks/main.yml
+++ b/roles/technitium_dns/tasks/main.yml
@@ -212,29 +212,13 @@
   when: technitium_dns_apply | bool
   no_log: true
 
-- name: Create authoritative subdomain DNS zone (primary)
-  ansible.builtin.uri:
-    url: "{{ technitium_dns_api_url }}/api/zones/create?token={{ technitium_dns_api_token }}"
-    method: POST
-    body_format: form-urlencoded
-    body:
-      zone: "{{ technitium_dns_zone }}"
-      type: "{{ technitium_dns_zone_type }}"
-    return_content: true
-    timeout: "{{ technitium_dns_api_timeout }}"
-    status_code: [200, 400]
-  register: technitium_dns_zone_create
-  changed_when: technitium_dns_zone_create.json.status == "ok"
-  when:
-    - technitium_dns_role == 'primary'
-    - technitium_dns_apply | bool
-    - technitium_dns_zone not in technitium_dns_existing_zones
-  no_log: true
-
 # Remove a stale apex Primary zone so non-subdomain names FORWARD upstream
 # instead of resolving NXDOMAIN here. Destructive but guarded: only fires if a
 # pre-existing server still owns the apex zone (a no-op on a freshly built node,
 # which never had it). Idempotent via the existing-zones membership check.
+# MUST run BEFORE the subdomain zone create: while the apex zone exists, the
+# subzone create 400s (conflict), and a swallowed 400 here once left the server
+# with the apex deleted and NO replacement zone — a live outage.
 - name: Remove stale apex Primary zone (primary)
   ansible.builtin.uri:
     url: "{{ technitium_dns_api_url }}/api/zones/delete?token={{ technitium_dns_api_token }}"
@@ -251,6 +235,28 @@
     - technitium_dns_role == 'primary'
     - technitium_dns_apply | bool
     - technitium_dns_apex_domain in technitium_dns_existing_zones
+  no_log: true
+
+- name: Create authoritative subdomain DNS zone (primary)
+  ansible.builtin.uri:
+    url: "{{ technitium_dns_api_url }}/api/zones/create?token={{ technitium_dns_api_token }}"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      zone: "{{ technitium_dns_zone }}"
+      type: "{{ technitium_dns_zone_type }}"
+    return_content: true
+    timeout: "{{ technitium_dns_api_timeout }}"
+    status_code: [200, 400]
+  register: technitium_dns_zone_create
+  changed_when: technitium_dns_zone_create.json.status == "ok"
+  failed_when:
+    - technitium_dns_zone_create.json.status | default('') != "ok"
+    - "'already exists' not in (technitium_dns_zone_create.json.errorMessage | default(''))"
+  when:
+    - technitium_dns_role == 'primary'
+    - technitium_dns_apply | bool
+    - technitium_dns_zone not in technitium_dns_existing_zones
   no_log: true
 
 # Secondaries replicate the zone from the primary via native AXFR/IXFR zone

--- a/roles/technitium_dns/tasks/main.yml
+++ b/roles/technitium_dns/tasks/main.yml
@@ -235,6 +235,10 @@
     - technitium_dns_role == 'primary'
     - technitium_dns_apply | bool
     - technitium_dns_apex_domain in technitium_dns_existing_zones
+    # Hard guard: never delete the zone this role manages, even if the apex
+    # derivation ever degenerates to the zone itself (e.g. a single-label
+    # PROXMOX_SUBDOMAIN) — deleting it here once caused a live outage.
+    - technitium_dns_apex_domain != technitium_dns_zone
   no_log: true
 
 - name: Create authoritative subdomain DNS zone (primary)


### PR DESCRIPTION
## Summary
Three fixes found while restoring internal DNS after a converge outage:

- **Apex derived, never from env**: `PROXMOX_DOMAIN` holds the guest zone itself in this environment (other repos depend on that meaning), so the apex-cleanup task resolved to the managed zone and **deleted it on every converge**. The apex is now derived as the zone's parent; the Studio `llm-large` CNAME target derives the same way (`jevans-ms.<apex>`).
- **Delete-before-create + fail-loud**: while the apex zone exists, the subdomain zone create 400s (conflict) and the accepted status_code list swallowed it — the apex delete then ran anyway, leaving the server with no authoritative zone. Reordered, and zone-create errors now fail loud.
- **cribl-edge alias repointed**: it still targeted the docker host from the pre-LXC era, black-holing every OTLP trace the routers and apps export.

## Testing
- ansible-lint green; converged live — zone rebuilt with all A/CNAME/ingress records, verified via the Technitium API and in-fabric resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj