### PR TITLE
test(qdrant): sync molecule verify fixture to v1.18.2

### DIFF
--- a/molecule/qdrant/verify.yml
+++ b/molecule/qdrant/verify.yml
@@ -9,7 +9,7 @@
 
   vars:
     qdrant_docker_data_dir: /opt/qdrant
-    qdrant_docker_image: "qdrant/qdrant:v1.17.0"
+    qdrant_docker_image: "qdrant/qdrant:v1.18.2"
     qdrant_docker_container_name: qdrant
     qdrant_docker_http_port: 6333
 


### PR DESCRIPTION
Follow-up to #589. The qdrant molecule `verify.yml` hardcodes the expected image (`qdrant/qdrant:v1.17.0`) and asserts the rendered compose references it. #589 bumped the role default to `v1.18.2` but not this fixture, so the compose-image assertion now fails on `main` (deployment itself is fine — health endpoint + compose render pass). This syncs the fixture to `v1.18.2`.