### PR TITLE
fix(cribl): send Splunk HEC through the dedicated splunk-hec ingress

### DIFF
--- a/roles/cribl_edge/defaults/main.yml
+++ b/roles/cribl_edge/defaults/main.yml
@@ -46,13 +46,14 @@ cribl_edge_syslog_ports: "{{ cribl_edge_syslog_port_mappings.values() | list }}"
 cribl_edge_api_port: >-
   {{ hostvars['localhost']['tofu_data']['constants']['service_ports']['cribl_edge_api'] }}
 
-# Splunk HEC configuration — FQDN, never an IP. The siem VLAN address
-# changes when the host moves; the DNS record is the single source of
-# truth and resolves correctly from the pipeline VLAN (verified).
+# Splunk HEC configuration — FQDN, never an IP. HEC goes through the
+# dedicated splunk-hec Traefik ingress on 443: the splunk.<zone> alias
+# resolves to Traefik, which serves nothing on a raw 8088, so dialing
+# <alias>:8088 black-holed every HEC POST (the queue backlog in apps#588).
 cribl_edge_splunk_host: >-
-  splunk.{{ lookup('env', 'PROXMOX_SUBDOMAIN')
+  splunk-hec.{{ lookup('env', 'PROXMOX_SUBDOMAIN')
   | mandatory('PROXMOX_SUBDOMAIN environment variable is required (Doppler)') }}
-cribl_edge_hec_url: "https://{{ cribl_edge_splunk_host }}:8088"
+cribl_edge_hec_url: "https://{{ cribl_edge_splunk_host }}"
 cribl_edge_hec_token: "{{ lookup('env', 'SPLUNK_HEC_TOKEN') }}"
 
 # Per-index HEC tokens (one index = one HEC). When HEC_NAMESPACE (Doppler) is

--- a/roles/cribl_stream/defaults/main.yml
+++ b/roles/cribl_stream/defaults/main.yml
@@ -34,13 +34,13 @@ cribl_stream_netflow_port: >-
 cribl_stream_s2s_port: >-
   {{ hostvars['localhost']['tofu_data']['constants']['service_ports']['cribl_s2s'] }}
 
-# Splunk HEC output configuration — FQDN, never an IP (see cribl_edge
-# defaults for rationale).
+# Splunk HEC output configuration — FQDN, never an IP. HEC goes through
+# the dedicated splunk-hec Traefik ingress on 443: the splunk.<zone> alias
+# resolves to Traefik, which serves nothing on a raw 8088, so dialing
+# <alias>:8088 black-holed every HEC POST (apps#588).
 cribl_stream_splunk_host: >-
-  splunk.{{ lookup('env', 'PROXMOX_SUBDOMAIN')
+  splunk-hec.{{ lookup('env', 'PROXMOX_SUBDOMAIN')
   | mandatory('PROXMOX_SUBDOMAIN environment variable is required (Doppler)') }}
-cribl_stream_splunk_hec_port: >-
-  {{ hostvars['localhost']['tofu_data']['constants']['service_ports']['splunk_hec'] }}
 cribl_stream_splunk_hec_token: "{{ lookup('env', 'SPLUNK_HEC_TOKEN') }}"
 # Per-index HEC (one index = one token). When HEC_NAMESPACE (Doppler) is set,
 # single-index inputs send to a dedicated splunk_hec_<index> output whose token
@@ -54,10 +54,10 @@ cribl_stream_per_index_indexes:
 cribl_stream_splunk_hec_tls: true
 cribl_stream_splunk_hec_tls_verify: false  # Self-signed cert in lab
 # Single definition shared by the template and the drift check in tasks.
+# No port: the splunk-hec ingress serves on the standard TLS entrypoint.
 cribl_stream_splunk_hec_url: >-
   {{ 'https' if cribl_stream_splunk_hec_tls else 'http'
-  }}://{{ cribl_stream_splunk_host }}:{{ cribl_stream_splunk_hec_port
-  }}/services/collector/event
+  }}://{{ cribl_stream_splunk_host }}/services/collector/event
 
 # Persistent queue
 cribl_stream_pq_enabled: true


### PR DESCRIPTION
## Summary
- Both the **edge** and **stream** `splunk_hec` outputs dialed `splunk.<zone>:8088`. That alias resolves to Traefik, which listens on 443 only — every HEC POST black-holed (SYN-SENT sockets observed live; 284 MB queue backlog on edge-01; Splunk shows almost no fresh ingest in 24h). Tracking: #588.
- Repoint both outputs at the dedicated `splunk-hec.<zone>` Traefik ingress on the standard TLS entrypoint (dryvist/terraform-proxmox#550); drop the now-unused port composition.

## Merge gate
Land **after** terraform-proxmox#550 is merged + applied and the traefik/technitium converges run — until then `splunk-hec.<zone>` does not resolve (no worse than today's black hole, but pointless).

## Testing
- ansible-lint production green. Live verification after the ingress applies: converge stream + edges, watch the edge PQ drain, confirm per-index ingest recency in Splunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj