### PR TITLE
fix(llm_router): dial the llm-large gate at its apex-level alias

### DIFF
--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -53,7 +53,12 @@ llm_router_large_port: "{{ tofu_data.constants.service_ports.ollama_api }}"
 # --- Backend base URLs (derived; never a hardcoded IP) -----------------------
 llm_router_llm_fast_base_url: "http://llm-fast.{{ llm_router_subdomain }}:{{ llm_router_light_port }}/v1"
 llm_router_llm_light_base_url: "http://llm-light.{{ llm_router_subdomain }}:{{ llm_router_light_port }}/v1"
-llm_router_llm_large_base_url: "https://llm-large.{{ llm_router_subdomain }}:{{ llm_router_large_port }}/v1"
+# llm-large lives one label under the APEX (the subdomain's parent), not under
+# the internal subdomain: the serving gate's ACME DNS-01 client locates the
+# hosted zone by stripping a single label, so only an apex-level alias gets a
+# cert — an llm-large.<subdomain> name fails the TLS handshake (no SNI cert).
+llm_router_apex_domain: "{{ llm_router_subdomain | split('.', 1) | last }}"
+llm_router_llm_large_base_url: "https://llm-large.{{ llm_router_apex_domain }}:{{ llm_router_large_port }}/v1"
 
 # --- Model groups ------------------------------------------------------------
 # large: one deployment each, bearer-authed to llm-large.

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1811,7 +1811,7 @@
     llm_router_llm_fast_base_url: "http://llm-fast.pve.example.net:10434/v1"
     llm_router_llm_fast_enabled: true
     llm_router_llm_light_base_url: "http://llm-light.pve.example.net:10434/v1"
-    llm_router_llm_large_base_url: "https://llm-large.pve.example.net:11434/v1"
+    llm_router_llm_large_base_url: "https://llm-large.example.net:11434/v1"
     llm_router_large_models:
       - gpt-oss-120b
       - qwen3-coder


### PR DESCRIPTION
## Summary
- The router's large-tier base URL used `llm-large.<subdomain>`, but the Studio gate can only obtain certs for apex-level names (its ACME DNS-01 client strips one label to find the hosted zone), so the handshake failed with a TLS internal error (no SNI cert).
- Derive the apex as the subdomain's parent and dial `llm-large.<apex>` — the alias the gate's cert already covers. DNS for the alias comes from dryvist/terraform-proxmox#555 (env-driven Route53 service CNAMEs).

## Merge gate
After terraform-proxmox#555 is merged **and its aws-infra apply runs** (the alias must resolve first).

## Testing
- ansible-lint green; template-render test value updated to the apex form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj