### PR TITLE
fix(llm_router): map large-tier aliases to the gate's real model ids

### DIFF
--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -61,10 +61,11 @@ llm_router_apex_domain: "{{ llm_router_subdomain | split('.', 1) | last }}"
 llm_router_llm_large_base_url: "https://llm-large.{{ llm_router_apex_domain }}:{{ llm_router_large_port }}/v1"
 
 # --- Model groups ------------------------------------------------------------
-# large: one deployment each, bearer-authed to llm-large.
+# large: exposed alias -> the backend's own model id (the serving gate lists
+# models under their full MLX repo ids). One deployment each, bearer-authed.
 llm_router_large_models:
-  - gpt-oss-120b
-  - qwen3-coder
+  - { alias: gpt-oss-120b, backend: mlx-community/gpt-oss-120b-MXFP4-Q8 }
+  - { alias: qwen3-coder, backend: mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit }
 # light: exposed aliases -> the llama-swap model_name they map to. Each becomes two
 # same-name deployments (llm-fast GPU + llm-light CPU) in the rendered config.
 # `embedding: true` marks the entry as an embeddings model_group.

--- a/roles/llm_router/templates/config.yaml.j2
+++ b/roles/llm_router/templates/config.yaml.j2
@@ -6,9 +6,9 @@
 model_list:
   # --- large tier: one deployment each, bearer-authed to llm-large ---
 {% for m in llm_router_large_models %}
-  - model_name: {{ m }}
+  - model_name: {{ m.alias }}
     litellm_params:
-      model: openai/{{ m }}
+      model: openai/{{ m.backend }}
       api_base: {{ llm_router_llm_large_base_url }}
       api_key: os.environ/LLM_LARGE_BEARER_TOKEN
 {% endfor %}

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1813,8 +1813,8 @@
     llm_router_llm_light_base_url: "http://llm-light.pve.example.net:10434/v1"
     llm_router_llm_large_base_url: "https://llm-large.example.net:11434/v1"
     llm_router_large_models:
-      - gpt-oss-120b
-      - qwen3-coder
+      - { alias: gpt-oss-120b, backend: mlx-community/gpt-oss-120b-MXFP4-Q8 }
+      - { alias: qwen3-coder, backend: mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit }
     llm_router_light_models:
       - { alias: hermes-4-14b, backend: hermes-4-14b }
       - { alias: hermes4, backend: hermes-4-14b }


### PR DESCRIPTION
## Summary
- The Studio gate lists models under their full MLX repo ids (`mlx-community/...`); the router passed the bare alias through, so every large-tier request 404'd at the backend (`no router for requested model`).
- Map alias → backend id for the large tier, the same shape the light tier already uses. Consumers keep the stable `gpt-oss-120b` / `qwen3-coder` aliases.

## Testing
- ansible-lint green; template-render test vars updated to the mapped shape.
- Live verification after merge+converge: `gpt-oss-120b` completion through the pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj