### PR TITLE
fix(sortarr): persist config/secret-key under the bind-mounted data dir

### DIFF
--- a/molecule/sortarr/verify.yml
+++ b/molecule/sortarr/verify.yml
@@ -5,6 +5,11 @@
 #   1. docker-compose.yml references the image, publishes 8787, mounts /data.
 #   2. The rendered compose carries the Sonarr/Radarr API keys and the basic-
 #      auth password (secrets flow through, but the file mode stays 0640).
+#   3. SORTARR_CONFIG_PATH points at the bind-mounted /data dir — upstream
+#      defaults ENV_FILE_PATH to a file next to app.py INSIDE the image when
+#      this is unset, which would silently write Sortarr's persisted config +
+#      secret key to the disposable container rootfs instead of the dataset
+#      the persistence guard below expects to be durable.
 
 - name: Verify
   hosts: all
@@ -52,6 +57,15 @@
           - sortarr_expected_radarr_key in (sortarr_compose.content | b64decode)
           - "'BASIC_AUTH_PASS' in (sortarr_compose.content | b64decode)"
         fail_msg: "docker-compose.yml did not receive the Sonarr/Radarr API keys or basic-auth password"
+
+    - name: Assert SORTARR_CONFIG_PATH points at the bind-mounted /data dir
+      ansible.builtin.assert:
+        that:
+          - "'SORTARR_CONFIG_PATH: \"/data/Sortarr.env\"' in (sortarr_compose.content | b64decode)"
+        fail_msg: >-
+          SORTARR_CONFIG_PATH is missing or not pointed at /data - Sortarr
+          would persist its config/secret-key to the container's ephemeral
+          rootfs instead of the bind-mounted host dataset.
 
 # --- persistence guard (unit-style — gated on sortarr_manage_services, --------
 # never live in this scenario since there is no running container in CI) -----

--- a/roles/sortarr/templates/docker-compose.yml.j2
+++ b/roles/sortarr/templates/docker-compose.yml.j2
@@ -10,6 +10,12 @@ services:
     ports:
       - "{{ sortarr_bind_address }}:{{ sortarr_web_port }}:8787"
     environment:
+      # Upstream defaults ENV_FILE_PATH to a file next to app.py inside the
+      # image (/app/.env) when unset — NOT the bind-mounted /data — so without
+      # this the persisted Sortarr.env/secret-key never actually lands on the
+      # host dataset the persistence guard below checks for. Matches
+      # upstream's own docker-compose.yaml example.
+      SORTARR_CONFIG_PATH: "/data/Sortarr.env"
       SONARR_URL: "http://{{ sortarr_sonarr_hostname }}:{{ sortarr_sonarr_port }}"
       SONARR_API_KEY: "{{ sortarr_sonarr_api_key }}"
       RADARR_URL: "http://{{ sortarr_radarr_hostname }}:{{ sortarr_radarr_port }}"


### PR DESCRIPTION
## Summary

- The merged Sortarr role (#602) bind-mounts a persistent host dir to the container's `/data`, and its `tasks/main.yml` fails the converge loudly if that mount isn't durable — but the compose template never told Sortarr to actually *use* `/data` for its own state.
- Upstream (`app.py`) defaults `ENV_FILE_PATH` to a file next to `app.py` **inside the image** (`/app/.env`) when `SORTARR_CONFIG_PATH`/`ENV_FILE_PATH` are unset — confirmed from the upstream source. Our compose set neither, so Sortarr's settings file and generated session secret key were silently landing on the container's ephemeral rootfs instead of the bind-mounted dataset, defeating the persistence guard's whole purpose (every container rebuild would silently reset it, and every restart would invalidate sessions).
- Upstream's own `docker-compose.yaml` example sets `SORTARR_CONFIG_PATH=/data/Sortarr.env` explicitly for exactly this reason — this PR does the same.

## Changes

- `roles/sortarr/templates/docker-compose.yml.j2`: add `SORTARR_CONFIG_PATH: "/data/Sortarr.env"` to the environment block.
- `molecule/sortarr/verify.yml`: new assertion that the rendered compose sets `SORTARR_CONFIG_PATH` to the bind-mounted path, so a regression fails CI instead of silently reintroducing the bug.

Companion: dryvist/ansible-proxmox#351 (adds the host-side `/bulk/appdata/sortarr` persistent mount this depends on).

## Test Plan

- [x] `ansible-lint` (production profile) clean — 0 failures across 12 files
- [ ] `molecule test -s sortarr` — blocked locally (missing python `docker` module for the driver on this machine, pre-existing local-only gap); relies on CI's Molecule matrix
- [ ] Live converge on the `sortarr` container — pending, alongside #351

Assisted-by: Claude:claude-sonnet-5

https://claude.ai/code/session_01KYQyqzesxqG5L46ozuVf4K