### PR TITLE
feat(langfuse): source secrets from OpenBao, not Doppler

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -21,6 +21,7 @@
 - name: Pre-fetch resource-domain secrets from OpenBao
   hosts: >-
     qdrant_group:open_webui_group:hermes_agent_group:llm_router_group:ai_orchestration_group:
+    langfuse_group:
     cribl_stream_group:cribl_edge:
     object_storage_group:
     netmon_group:prometheus_group:unifi_metrics_group:

--- a/roles/langfuse_docker/defaults/main.yml
+++ b/roles/langfuse_docker/defaults/main.yml
@@ -126,11 +126,11 @@ langfuse_docker_s3_region: us-east-1
 langfuse_docker_s3_event_prefix: "events/"
 langfuse_docker_s3_media_prefix: "media/"
 langfuse_docker_s3_access_key_id: >-
-  {{ bao_local_llm_secrets.LANGFUSE_S3_ACCESS_KEY_ID
+  {{ bao_local_llm_secrets['LANGFUSE_S3_ACCESS_KEY_ID']
      | default(lookup('env', 'LANGFUSE_S3_ACCESS_KEY_ID'), true)
      | mandatory('LANGFUSE_S3_ACCESS_KEY_ID unset (OpenBao ai/langfuse, or Doppler)') }}
 langfuse_docker_s3_secret_access_key: >-
-  {{ bao_local_llm_secrets.LANGFUSE_S3_SECRET_ACCESS_KEY
+  {{ bao_local_llm_secrets['LANGFUSE_S3_SECRET_ACCESS_KEY']
      | default(lookup('env', 'LANGFUSE_S3_SECRET_ACCESS_KEY'), true)
      | mandatory('LANGFUSE_S3_SECRET_ACCESS_KEY unset (OpenBao ai/langfuse, or Doppler)') }}
 
@@ -141,15 +141,15 @@ langfuse_docker_s3_secret_access_key: >-
 # existing data.
 # =============================================================================
 langfuse_docker_postgres_password: >-
-  {{ bao_local_llm_secrets.LANGFUSE_POSTGRES_PASSWORD
+  {{ bao_local_llm_secrets['LANGFUSE_POSTGRES_PASSWORD']
      | default(lookup('env', 'LANGFUSE_POSTGRES_PASSWORD'), true)
      | mandatory('LANGFUSE_POSTGRES_PASSWORD unset (OpenBao ai/langfuse, or Doppler)') }}
 langfuse_docker_clickhouse_password: >-
-  {{ bao_local_llm_secrets.LANGFUSE_CLICKHOUSE_PASSWORD
+  {{ bao_local_llm_secrets['LANGFUSE_CLICKHOUSE_PASSWORD']
      | default(lookup('env', 'LANGFUSE_CLICKHOUSE_PASSWORD'), true)
      | mandatory('LANGFUSE_CLICKHOUSE_PASSWORD unset (OpenBao ai/langfuse, or Doppler)') }}
 langfuse_docker_redis_auth: >-
-  {{ bao_local_llm_secrets.LANGFUSE_REDIS_AUTH
+  {{ bao_local_llm_secrets['LANGFUSE_REDIS_AUTH']
      | default(lookup('env', 'LANGFUSE_REDIS_AUTH'), true)
      | mandatory('LANGFUSE_REDIS_AUTH unset (OpenBao ai/langfuse, or Doppler)') }}
 
@@ -174,18 +174,18 @@ langfuse_docker_generated_secrets:
 langfuse_docker_init_org: homelab
 langfuse_docker_init_project: homelab
 langfuse_docker_init_user_email: >-
-  {{ bao_local_llm_secrets.LANGFUSE_INIT_USER_EMAIL
+  {{ bao_local_llm_secrets['LANGFUSE_INIT_USER_EMAIL']
      | default(lookup('env', 'LANGFUSE_INIT_USER_EMAIL'), true)
      | mandatory('LANGFUSE_INIT_USER_EMAIL unset (OpenBao ai/langfuse, or Doppler)') }}
 langfuse_docker_init_user_password: >-
-  {{ bao_local_llm_secrets.LANGFUSE_INIT_USER_PASSWORD
+  {{ bao_local_llm_secrets['LANGFUSE_INIT_USER_PASSWORD']
      | default(lookup('env', 'LANGFUSE_INIT_USER_PASSWORD'), true)
      | mandatory('LANGFUSE_INIT_USER_PASSWORD unset (OpenBao ai/langfuse, or Doppler)') }}
 langfuse_docker_init_public_key: >-
-  {{ bao_local_llm_secrets.LANGFUSE_PUBLIC_KEY
+  {{ bao_local_llm_secrets['LANGFUSE_PUBLIC_KEY']
      | default(lookup('env', 'LANGFUSE_PUBLIC_KEY'), true)
      | mandatory('LANGFUSE_PUBLIC_KEY unset (OpenBao ai/langfuse, or Doppler)') }}
 langfuse_docker_init_secret_key: >-
-  {{ bao_local_llm_secrets.LANGFUSE_SECRET_KEY
+  {{ bao_local_llm_secrets['LANGFUSE_SECRET_KEY']
      | default(lookup('env', 'LANGFUSE_SECRET_KEY'), true)
      | mandatory('LANGFUSE_SECRET_KEY unset (OpenBao ai/langfuse, or Doppler)') }}

--- a/roles/langfuse_docker/defaults/main.yml
+++ b/roles/langfuse_docker/defaults/main.yml
@@ -113,8 +113,9 @@ langfuse_docker_clickhouse_migration_url: >-
 # =============================================================================
 # External blob storage — homelab RustFS S3 (replaces the bundled MinIO).
 # Endpoint is a group_var contract (ai_orchestration_s3_endpoint); credentials
-# come from Doppler env. Event and media uploads are configured independently
-# but share one bucket + credential pair.
+# sourced bao-first (secret/ai/langfuse via the local-llm domain AppRole),
+# env fallback for pre-migration/dev use. Event and media uploads are
+# configured independently but share one bucket + credential pair.
 # =============================================================================
 langfuse_docker_s3_endpoint: >-
   {{ ai_orchestration_s3_endpoint
@@ -125,25 +126,32 @@ langfuse_docker_s3_region: us-east-1
 langfuse_docker_s3_event_prefix: "events/"
 langfuse_docker_s3_media_prefix: "media/"
 langfuse_docker_s3_access_key_id: >-
-  {{ lookup('env', 'LANGFUSE_S3_ACCESS_KEY_ID')
-     | mandatory('LANGFUSE_S3_ACCESS_KEY_ID must be set (Doppler; RustFS access key for the langfuse bucket)') }}
+  {{ bao_local_llm_secrets.LANGFUSE_S3_ACCESS_KEY_ID
+     | default(lookup('env', 'LANGFUSE_S3_ACCESS_KEY_ID'), true)
+     | mandatory('LANGFUSE_S3_ACCESS_KEY_ID unset (OpenBao ai/langfuse, or Doppler)') }}
 langfuse_docker_s3_secret_access_key: >-
-  {{ lookup('env', 'LANGFUSE_S3_SECRET_ACCESS_KEY')
-     | mandatory('LANGFUSE_S3_SECRET_ACCESS_KEY must be set (Doppler; RustFS secret key for the langfuse bucket)') }}
+  {{ bao_local_llm_secrets.LANGFUSE_S3_SECRET_ACCESS_KEY
+     | default(lookup('env', 'LANGFUSE_S3_SECRET_ACCESS_KEY'), true)
+     | mandatory('LANGFUSE_S3_SECRET_ACCESS_KEY unset (OpenBao ai/langfuse, or Doppler)') }}
 
 # =============================================================================
-# Datastore passwords — sourced from Doppler env (never generated, so the same
-# value is reused across runs without invalidating existing data).
+# Datastore passwords — sourced bao-first (secret/ai/langfuse via the
+# local-llm domain AppRole), env fallback for pre-migration/dev use. Never
+# generated, so the same value is reused across runs without invalidating
+# existing data.
 # =============================================================================
 langfuse_docker_postgres_password: >-
-  {{ lookup('env', 'LANGFUSE_POSTGRES_PASSWORD')
-     | mandatory('LANGFUSE_POSTGRES_PASSWORD must be set (Doppler; openssl rand -base64 24)') }}
+  {{ bao_local_llm_secrets.LANGFUSE_POSTGRES_PASSWORD
+     | default(lookup('env', 'LANGFUSE_POSTGRES_PASSWORD'), true)
+     | mandatory('LANGFUSE_POSTGRES_PASSWORD unset (OpenBao ai/langfuse, or Doppler)') }}
 langfuse_docker_clickhouse_password: >-
-  {{ lookup('env', 'LANGFUSE_CLICKHOUSE_PASSWORD')
-     | mandatory('LANGFUSE_CLICKHOUSE_PASSWORD must be set (Doppler; openssl rand -base64 24)') }}
+  {{ bao_local_llm_secrets.LANGFUSE_CLICKHOUSE_PASSWORD
+     | default(lookup('env', 'LANGFUSE_CLICKHOUSE_PASSWORD'), true)
+     | mandatory('LANGFUSE_CLICKHOUSE_PASSWORD unset (OpenBao ai/langfuse, or Doppler)') }}
 langfuse_docker_redis_auth: >-
-  {{ lookup('env', 'LANGFUSE_REDIS_AUTH')
-     | mandatory('LANGFUSE_REDIS_AUTH must be set (Doppler; openssl rand -base64 24, no whitespace)') }}
+  {{ bao_local_llm_secrets.LANGFUSE_REDIS_AUTH
+     | default(lookup('env', 'LANGFUSE_REDIS_AUTH'), true)
+     | mandatory('LANGFUSE_REDIS_AUTH unset (OpenBao ai/langfuse, or Doppler)') }}
 
 # =============================================================================
 # Application secrets — generated once on the LXC and persisted under the data
@@ -161,18 +169,23 @@ langfuse_docker_generated_secrets:
 # user, and the project API keypair are created on first boot, so the OTLP
 # fan-out and router callbacks have working keys with no UI onboarding.
 # Applied only on a fresh database; Langfuse ignores them once initialized.
+# Sourced bao-first (secret/ai/langfuse), env fallback for pre-migration/dev use.
 # =============================================================================
 langfuse_docker_init_org: homelab
 langfuse_docker_init_project: homelab
 langfuse_docker_init_user_email: >-
-  {{ lookup('env', 'LANGFUSE_INIT_USER_EMAIL')
-     | mandatory('LANGFUSE_INIT_USER_EMAIL must be set (Doppler)') }}
+  {{ bao_local_llm_secrets.LANGFUSE_INIT_USER_EMAIL
+     | default(lookup('env', 'LANGFUSE_INIT_USER_EMAIL'), true)
+     | mandatory('LANGFUSE_INIT_USER_EMAIL unset (OpenBao ai/langfuse, or Doppler)') }}
 langfuse_docker_init_user_password: >-
-  {{ lookup('env', 'LANGFUSE_INIT_USER_PASSWORD')
-     | mandatory('LANGFUSE_INIT_USER_PASSWORD must be set (Doppler; openssl rand -base64 24)') }}
+  {{ bao_local_llm_secrets.LANGFUSE_INIT_USER_PASSWORD
+     | default(lookup('env', 'LANGFUSE_INIT_USER_PASSWORD'), true)
+     | mandatory('LANGFUSE_INIT_USER_PASSWORD unset (OpenBao ai/langfuse, or Doppler)') }}
 langfuse_docker_init_public_key: >-
-  {{ lookup('env', 'LANGFUSE_PUBLIC_KEY')
-     | mandatory('LANGFUSE_PUBLIC_KEY must be set (Doppler; pk-lf-<uuid>)') }}
+  {{ bao_local_llm_secrets.LANGFUSE_PUBLIC_KEY
+     | default(lookup('env', 'LANGFUSE_PUBLIC_KEY'), true)
+     | mandatory('LANGFUSE_PUBLIC_KEY unset (OpenBao ai/langfuse, or Doppler)') }}
 langfuse_docker_init_secret_key: >-
-  {{ lookup('env', 'LANGFUSE_SECRET_KEY')
-     | mandatory('LANGFUSE_SECRET_KEY must be set (Doppler; sk-lf-<uuid>)') }}
+  {{ bao_local_llm_secrets.LANGFUSE_SECRET_KEY
+     | default(lookup('env', 'LANGFUSE_SECRET_KEY'), true)
+     | mandatory('LANGFUSE_SECRET_KEY unset (OpenBao ai/langfuse, or Doppler)') }}

--- a/roles/openbao_secrets/defaults/main.yml
+++ b/roles/openbao_secrets/defaults/main.yml
@@ -55,8 +55,11 @@ openbao_secrets_domains:
     role_id_env: LOCAL_LLM_VAULT_ROLE_ID
     secret_id_env: LOCAL_LLM_VAULT_SECRET_ID
     paths:
-      - ai/router      # LLM_ROUTER_MASTER_KEY (+ LANGFUSE_* project keys)
+      - ai/router      # LLM_ROUTER_MASTER_KEY
       - ai/llm-large   # LLM_LARGE_BEARER_TOKEN
       - ai/qdrant      # QDRANT_API_KEY
       - ai/open-webui  # OPEN_WEBUI_SECRET_KEY, OPEN_WEBUI_OPENAI_API_KEY
       - ai/hermes      # HERMES_AGENT_MODEL_API_KEY
+      - ai/langfuse    # LANGFUSE_{POSTGRES_PASSWORD,CLICKHOUSE_PASSWORD,REDIS_AUTH,
+                       #   S3_ACCESS_KEY_ID,S3_SECRET_ACCESS_KEY,PUBLIC_KEY,SECRET_KEY,
+                       #   INIT_USER_EMAIL,INIT_USER_PASSWORD} — fully seeded 2026-07-05


### PR DESCRIPTION
## Summary
- Repoints the `langfuse_docker` role's 9 `LANGFUSE_*` secrets (postgres/clickhouse/redis passwords, S3 access/secret key, init user email/password, public/secret project keypair) to read `bao_local_llm_secrets.X` first, falling back to the existing `lookup('env', 'X')` — the same bao-first/env-fallback pattern already used by `qdrant_docker` and `open_webui` in this same `local-llm` domain.
- Adds `ai/langfuse` to the `local-llm` domain's KV path list in `roles/openbao_secrets/defaults/main.yml`. `secret/ai/langfuse` is fully seeded (all 9 keys present, verified directly against OpenBao) and the domain's AppRole policy already grants `secret/data/ai/*` (wildcard), so no new OpenBao policy work was needed.
- Adds `langfuse_group` to the "Pre-fetch resource-domain secrets from OpenBao" play's host list in `playbooks/site.yml`. Langfuse has its own dedicated inventory group (distinct from `ai_orchestration_group`) and was not previously included in that play — without this, `bao_local_llm_secrets` would be entirely undefined on Langfuse hosts and the new lookups would hard-fail rather than gracefully falling back to Doppler.

This is stage (b) of the Doppler → OpenBao cutover (Langfuse first, per the consumer-inventory recommendation — it's the only one of the seeded AI apps with all its keys already fully present in OpenBao).

## Test plan
- [x] `ansible-lint` (production profile) clean on all three changed files.
- [x] `ansible-playbook playbooks/site.yml --syntax-check` passes (unmatched host-pattern warnings are expected in a static check — those groups come from the dynamic tofu inventory).
- [ ] Live converge + E2E verification against the running langfuse_group host (next step after merge, per the dual-source-proof cutover ordering: repoint → quarantine Doppler copies → converge/restart → verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYQyqzesxqG5L46ozuVf4K