### PR TITLE
feat(langflow): source secrets from OpenBao, not Doppler

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -21,7 +21,7 @@
 - name: Pre-fetch resource-domain secrets from OpenBao
   hosts: >-
     qdrant_group:open_webui_group:hermes_agent_group:llm_router_group:ai_orchestration_group:
-    langfuse_group:
+    langfuse_group:langflow_group:
     cribl_stream_group:cribl_edge:
     object_storage_group:
     netmon_group:prometheus_group:unifi_metrics_group:

--- a/roles/langflow_docker/defaults/main.yml
+++ b/roles/langflow_docker/defaults/main.yml
@@ -62,19 +62,20 @@ langflow_docker_database_url: >-
   langflow_docker_db_service }}:{{ langflow_docker_postgres_port }}/{{
   langflow_docker_db_name }}
 
-# Secrets — sourced from the runtime env (Doppler / SOPS injected). Same
-# precedent as roles/infisical_docker + roles/mssql_docker: lookup('env')
-# + mandatory so a missing secret fails loud at template time rather than
-# silently shipping an insecure default.
+# Secrets — sourced bao-first (secret/ai/langflow via the local-llm domain
+# AppRole), env fallback for pre-migration/dev use.
 langflow_docker_superuser: >-
-  {{ lookup('env', 'LANGFLOW_SUPERUSER')
-     | mandatory('LANGFLOW_SUPERUSER must be set (Doppler/SOPS env)') }}
+  {{ bao_local_llm_secrets['LANGFLOW_SUPERUSER']
+     | default(lookup('env', 'LANGFLOW_SUPERUSER'), true)
+     | mandatory('LANGFLOW_SUPERUSER unset (OpenBao ai/langflow, or Doppler)') }}
 langflow_docker_superuser_password: >-
-  {{ lookup('env', 'LANGFLOW_SUPERUSER_PASSWORD')
-     | mandatory('LANGFLOW_SUPERUSER_PASSWORD must be set (Doppler/SOPS env)') }}
+  {{ bao_local_llm_secrets['LANGFLOW_SUPERUSER_PASSWORD']
+     | default(lookup('env', 'LANGFLOW_SUPERUSER_PASSWORD'), true)
+     | mandatory('LANGFLOW_SUPERUSER_PASSWORD unset (OpenBao ai/langflow, or Doppler)') }}
 langflow_docker_db_password: >-
-  {{ lookup('env', 'LANGFLOW_DB_PASSWORD')
-     | mandatory('LANGFLOW_DB_PASSWORD must be set (Doppler/SOPS env)') }}
+  {{ bao_local_llm_secrets['LANGFLOW_DB_PASSWORD']
+     | default(lookup('env', 'LANGFLOW_DB_PASSWORD'), true)
+     | mandatory('LANGFLOW_DB_PASSWORD unset (OpenBao ai/langflow, or Doppler)') }}
 
 # LANGFLOW_SECRET_KEY (Fernet key for stored credentials) — generated once on
 # the LXC and persisted to {{ langflow_docker_data_dir }}/.secret_key

--- a/roles/openbao_secrets/defaults/main.yml
+++ b/roles/openbao_secrets/defaults/main.yml
@@ -63,3 +63,4 @@ openbao_secrets_domains:
       - ai/langfuse    # LANGFUSE_{POSTGRES_PASSWORD,CLICKHOUSE_PASSWORD,REDIS_AUTH,
                        #   S3_ACCESS_KEY_ID,S3_SECRET_ACCESS_KEY,PUBLIC_KEY,SECRET_KEY,
                        #   INIT_USER_EMAIL,INIT_USER_PASSWORD} — fully seeded 2026-07-05
+      - ai/langflow    # LANGFLOW_{SUPERUSER,SUPERUSER_PASSWORD,DB_PASSWORD}


### PR DESCRIPTION
## Summary
- Repoints `LANGFLOW_SUPERUSER` / `LANGFLOW_SUPERUSER_PASSWORD` / `LANGFLOW_DB_PASSWORD` to `secret/ai/langflow` via the `local-llm` OpenBao domain AppRole, with an env-var fallback retained for pre-migration/dev use.
- Adds `ai/langflow` to the `local-llm` domain's path list in `openbao_secrets`.
- Adds `langflow_group` to the "Pre-fetch resource-domain secrets from OpenBao" play's host pattern in `site.yml`.

Mirrors the Langfuse cutover in #611.

## Test plan
- [x] `tofu`/ansible-lint via CI
- [ ] Molecule matrix green
- [ ] Post-merge: converge `langflow_group`, confirm OpenBao resolves non-empty (fallback unreachable), live authenticated API check

Assisted-by: Claude:claude-sonnet-5
https://claude.ai/code/session_01KYQyqzesxqG5L46ozuVf4K