### PR TITLE
fix(llm_router,open_webui): return 401 not 500 on auth failure; make env API key authoritative

### DIFF
--- a/roles/llm_router/README.md
+++ b/roles/llm_router/README.md
@@ -55,6 +55,10 @@ Traefik health checks need no credential.
   hard-required — a missing constant fails loud.
 - Secrets `LLM_ROUTER_MASTER_KEY` + `LLM_LARGE_BEARER_TOKEN` are env-sourced
   (SOPS/Doppler) today; the OpenBao migration is a separate phase.
+- `prisma` is installed into the venv even though the proxy is DB-less:
+  litellm[proxy] no longer pulls it, and LiteLLM's auth-error handler
+  unconditionally imports it to classify DB outages — without it, a rejected or
+  absent API key raised `ModuleNotFoundError` and returned 500 instead of 401.
 
 ## Usage
 

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -31,6 +31,13 @@ llm_router_env_file: "{{ llm_router_config_dir }}/litellm.env"
 # arrives via the designed OTLP -> Cribl Edge fan-out path.
 llm_router_pip_packages:
   - "litellm[proxy]"
+  # LiteLLM's auth-error handler unconditionally `import prisma`s to classify
+  # whether a failed request is a DB outage, but litellm[proxy] no longer pulls
+  # prisma. On this DB-less proxy the import raised ModuleNotFoundError, turning
+  # every rejected/absent key into a 500 instead of a 401 (masking real auth
+  # failures as opaque errors). We use no database; prisma is present only so the
+  # handler's isinstance checks resolve and it returns the correct 401.
+  - prisma
   - opentelemetry-api
   - opentelemetry-sdk
   - opentelemetry-exporter-otlp

--- a/roles/open_webui/README.md
+++ b/roles/open_webui/README.md
@@ -26,6 +26,9 @@ Requires `OPEN_WEBUI_SECRET_KEY` in Doppler/SOPS (generate once: `openssl rand -
   `llm.<subdomain>/v1`) + `OPENAI_API_KEY` + `DEFAULT_MODELS`,
   `WEBUI_URL`/`CORS_ALLOW_ORIGIN` (= the Traefik URL, from `PROXMOX_SUBDOMAIN`),
   secure cookies, `ENABLE_WEBSOCKET_SUPPORT`, stable `WEBUI_SECRET_KEY`.
+- Sets `ENABLE_PERSISTENT_CONFIG=false` so env is authoritative: `OPENAI_API_KEY`
+  and the other PersistentConfig values are re-read from `/etc/open-webui.env` on
+  every start rather than being pinned to their first-boot values in the DB.
 - Restart-on-failure via the shared `systemd_restart_policy` role (`group_vars`).
 
 ## Key variables (`defaults/main.yml`)

--- a/roles/open_webui/templates/open-webui.env.j2
+++ b/roles/open_webui/templates/open-webui.env.j2
@@ -2,6 +2,12 @@
 # Open WebUI runtime config. Reverse-proxy-correct values are REQUIRED behind
 # Traefik HTTPS (sessions/websockets break without them) — per Open WebUI docs.
 DATA_DIR={{ open_webui_data_dir }}
+# Env is the single source of truth (Ansible owns this appliance). Without this,
+# OPENAI_API_KEY et al. are PersistentConfig: seeded to the DB on first boot,
+# after which the DB value wins and env changes are ignored — a connection first
+# created before the key was populated pins an empty key forever and the router
+# rejects every request. False makes env authoritative on every start.
+ENABLE_PERSISTENT_CONFIG=false
 OPENAI_API_BASE_URL={{ open_webui_openai_api_base_url }}
 OPENAI_API_KEY={{ open_webui_openai_api_key }}
 DEFAULT_MODELS={{ open_webui_default_model }}


### PR DESCRIPTION
## Incident

The chat front-end could not list models. Every request to the LiteLLM router
returned **HTTP 500** (`{"error":{"message":"Internal server error","type":"internal_server_error"}}`),
and `GET /v1/models` reproduced it. The backend and the router's own config were
healthy the whole time — a request bearing the correct master key already
returned **200** with the full model list. Two independent defects combined to
break the front-end path.

## Root cause 1 — front-end pinned an empty API key (`open_webui`)

`OPENAI_API_KEY` (and the other Open WebUI env values) are **PersistentConfig**:
seeded into the sqlite config DB on first boot, after which the DB value wins and
env changes are ignored. This connection was first created before the key was
populated, so an empty key was persisted in the DB and stayed there — the
front-end sent an **empty bearer** on every request even though the env file now
holds the correct key.

Fix: set `ENABLE_PERSISTENT_CONFIG=false` in `/etc/open-webui.env` so env is
authoritative and re-read on every start. Env already carries every value this
appliance needs; user data (accounts, chats) is unaffected.

## Root cause 2 — auth failure returned 500 instead of 401 (`llm_router`)

LiteLLM's auth-error handler unconditionally `import prisma`s to classify whether
a rejected request is a DB outage, but `litellm[proxy]` (1.90.x) no longer pulls
prisma. This is a **DB-less** proxy, so the import raised `ModuleNotFoundError`
and turned every rejected/absent key into an opaque **500** instead of a clean
**401** — which is exactly what masked defect 1.

Fix: install `prisma` into the venv. We use no database; the package is present
only so the handler's `isinstance` checks (all against `prisma.errors.*`, which
ship without `prisma generate`) resolve and it returns the correct 401.

## Verification

- Live proxy, valid master key -> `200` + full model list (`gpt-oss-120b`,
  `qwen3-coder`, `hermes-4-14b`, `hermes4`, `qwen3-4b`, `embeddings`).
- Live proxy, missing/empty key -> `500` today (the crash); becomes `401` after
  the prisma install.
- Front-end DB confirmed holding an empty key while the env file holds the
  correct one; `ENABLE_PERSISTENT_CONFIG=false` makes env win.
- End-to-end re-verify (front-end lists models) after converge of both roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYQyqzesxqG5L46ozuVf4K