### PR TITLE
docs(hermes_agent): repoint brain comments to the LiteLLM router; stage container entry

### DIFF
--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -71,7 +71,7 @@
   no_log: true
   notify: Restart hermes-gateway
 
-- name: Deploy the Hermes config.yaml (brain -> Ollama, memory -> Hindsight, budget)
+- name: Deploy the Hermes config.yaml (brain -> LiteLLM router, memory -> Hindsight, budget)
   ansible.builtin.template:
     src: config.yaml.j2
     dest: "{{ hermes_agent_hermes_home }}/config.yaml"

--- a/roles/hermes_agent/templates/config.yaml.j2
+++ b/roles/hermes_agent/templates/config.yaml.j2
@@ -1,6 +1,7 @@
 {{ ansible_managed | comment }}
 # Hermes Agent runtime config (managed by Ansible; the daemon owns app updates).
-# Brain = the always-on homelab GPU Ollama (OpenAI-compatible). Memory = Hindsight
+# Brain = the LiteLLM router (OpenAI-compatible front door at https://llm.<sub>/v1;
+# it routes the model alias to whichever backend serves it). Memory = Hindsight
 # (best self-hostable, June 2026) alongside the always-on MEMORY.md/USER.md.
 
 model:

--- a/roles/hermes_agent/templates/hermes-gateway.service.j2
+++ b/roles/hermes_agent/templates/hermes-gateway.service.j2
@@ -12,7 +12,7 @@ WorkingDirectory={{ hermes_agent_home }}
 Environment=HERMES_HOME={{ hermes_agent_hermes_home }}
 # Load the deployed secrets so config.yaml's ${VAR} interpolation resolves. The
 # leading '-' keeps the daemon startable while .env is still empty (no messaging
-# platform wired yet); the local Ollama "custom" provider needs no API key.
+# platform wired yet) — the LiteLLM router master key still arrives via this file.
 EnvironmentFile=-{{ hermes_agent_hermes_home }}/.env
 ExecStart={{ hermes_agent_gateway_cmd }}
 # Restart policy is managed by the systemd_restart_policy role (99-restart-policy.conf).


### PR DESCRIPTION
## Summary

Finishes what can be done on the Hermes Agent (the NousResearch autonomous
agent) **without the fourth Proxmox node**, which is not yet joined to the
cluster.

The `hermes_agent` role (merged in #492) was already functionally repointed:
`hermes_agent_model_base_url` targets the LiteLLM router
(`https://llm.<subdomain>/v1`) and the API key is OpenBao-sourced
(`bao_local_llm_secrets.HERMES_AGENT_MODEL_API_KEY`, env fallback). The only
remaining references to the retired direct-Ollama brain were **comments**.
This PR aligns those comments with the code:

- `config.yaml.j2` header: "Brain = the always-on homelab GPU Ollama" -> the LiteLLM router.
- `hermes-gateway.service.j2`: the `EnvironmentFile` `-` justification no longer claims "the local Ollama custom provider needs no API key" (the router master key does arrive via that file).
- `tasks/main.yml`: the config-deploy task name (`brain -> Ollama` -> `brain -> LiteLLM router`).

No functional change. `ansible-lint` (production profile) passes: **0 failures, 0 warnings on 8 files**.

## Ready now (this PR + already-merged state)

- Role is fully repointed to the router FQDN; no `hermes-infer`/`hermes-chat` hostvar references remain.
- Secrets wired via the OpenBao `ai`-domain pattern (`bao_local_llm_secrets`), env fallback for secret-zero.
- Role is wired into `playbooks/site.yml` (Phase 8a2, `hermes_agent_group`) and the shared `systemd_restart_policy`.
- Terraform side (terraform-proxmox) is already complete and generic: `modules/firewall/hermes_agent_rules.tf` and `locals.hermes_agent_container_ids` auto-key off any container tagged `hermes-agent`. Firewall (internal access + outbound-internal + outbound-HTTPS) applies the moment the container exists.

## Blocked on the fourth node

The container cannot be created: its planned home node is not in the cluster
yet, so there is no target for VMID `517000`. Do **not** add this to
`deployment.json` until that node joins. Staged entry (ai VLAN, tagged so the
existing TF firewall + `container_ids` pick it up automatically):

```jsonc
"hermes-agent": {
  "vm_id": 517000,
  "hostname": "hermes-agent",
  "vlan": "ai",
  "tags": ["terraform", "container", "hermes-agent"],
  "dhcp": true,
  "reserved_host": 17,          // ai VLAN host octet; 6-digit VMID overflows the /24
  "cpu_cores": 4,
  "memory_dedicated": 8192,
  "root_disk": { "size": 16 },
  "mount_points": [
    { "volume": "<ai-pool>/hermes", "size": "32G", "path": "/var/lib/hermes" }
  ],
  "unprivileged": true,
  "start_on_boot": true
}
```

The mount at `/var/lib/hermes` is `HERMES_HOME` (memory, skills, profiles,
Kanban DB, sessions) — it must be a persisted, snapshotted dataset so the
agent survives rebuilds.

## Follow-ups (not blocking, noted for the deploy session)

- Brain backend availability: the default model alias (`hermes-4-14b`) routes via the LiteLLM router to the frozen GPU-serving tier. Once the fourth node is live the router should map the alias to an available backend (the large-model host is now DNS-resolvable). Verify the router answers `/v1/models` for the chosen alias before first converge.
- First-converge validation items already flagged in `tasks/main.yml` (installer running clean non-interactively; `hermes gateway start` staying up headless; Hindsight first-run init).

## Testing

- `ansible-lint roles/hermes_agent/` (production profile): 0 failures, 0 warnings on 8 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYQyqzesxqG5L46ozuVf4K