### PR TITLE
feat(media): source secrets from OpenBao, not Doppler

### DIFF
--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -36,18 +36,18 @@ download_vpn_wg_config_path: /etc/wireguard/wg0.conf
 # names mirror the [Interface]/[Peer] section structure of the .conf Proton
 # issues, so a fresh download maps 1:1 to env vars. NEVER hardcode key
 # material or the endpoint.
-download_vpn_wg_private_key: "{{ lookup('env', 'PROTON_WG_IFACE_PRIVATE_KEY') }}"
+download_vpn_wg_private_key: "{{ bao_media_secrets['PROTON_WG_IFACE_PRIVATE_KEY'] | default(lookup('env', 'PROTON_WG_IFACE_PRIVATE_KEY'), true) }}"
 # Tunnel interface address(es). Proton issues a dual-stack pair
 # ("10.2.0.2/32,fd00::.../128"). We keep the full value for the wg0 Address line
 # but rely on kernel IPv6 disable + nft ip6 DROP so the v6 half cannot leak.
-download_vpn_wg_address: "{{ lookup('env', 'PROTON_WG_IFACE_ADDRESS') }}"
+download_vpn_wg_address: "{{ bao_media_secrets['PROTON_WG_IFACE_ADDRESS'] | default(lookup('env', 'PROTON_WG_IFACE_ADDRESS'), true) }}"
 # Proton's WireGuard DNS resolver is a stable tunnel-side constant
 # (10.2.0.1), not a per-user secret — matches download_vpn_natpmp_gateway
 # below. Hardcoded so the .conf-derived env contract stays IFACE/PEER-only.
 download_vpn_wg_dns: "10.2.0.1"
 # Proton server public key + "host:port" endpoint.
-download_vpn_wg_peer_public_key: "{{ lookup('env', 'PROTON_WG_PEER_PUBLIC_KEY') }}"
-download_vpn_wg_endpoint: "{{ lookup('env', 'PROTON_WG_PEER_ENDPOINT') }}"
+download_vpn_wg_peer_public_key: "{{ bao_media_secrets['PROTON_WG_PEER_PUBLIC_KEY'] | default(lookup('env', 'PROTON_WG_PEER_PUBLIC_KEY'), true) }}"
+download_vpn_wg_endpoint: "{{ bao_media_secrets['PROTON_WG_PEER_ENDPOINT'] | default(lookup('env', 'PROTON_WG_PEER_ENDPOINT'), true) }}"
 # AllowedIPs deliberately routes ONLY IPv4 default via the tunnel. We do NOT
 # add ::/0 — IPv6 is killed at the kernel, so adding a v6 default route would
 # only create a path the killswitch then has to fight. IPv4 default through
@@ -62,9 +62,9 @@ download_vpn_wg_persistent_keepalive: 25
 # endpoint on the SAME wg0 — no interface/address reconfig. All three come from
 # Doppler runtime env; leave them unset to disable failover (single-endpoint
 # behaviour is preserved unchanged). NEVER hardcode key material or the endpoint.
-download_vpn_wg_backup_private_key: "{{ lookup('env', 'PROTON_WG_BACKUP_IFACE_PRIVATE_KEY') | default('', true) }}"
-download_vpn_wg_backup_peer_public_key: "{{ lookup('env', 'PROTON_WG_BACKUP_PEER_PUBLIC_KEY') | default('', true) }}"
-download_vpn_wg_backup_endpoint: "{{ lookup('env', 'PROTON_WG_BACKUP_PEER_ENDPOINT') | default('', true) }}"
+download_vpn_wg_backup_private_key: "{{ bao_media_secrets['PROTON_WG_BACKUP_IFACE_PRIVATE_KEY'] | default(lookup('env', 'PROTON_WG_BACKUP_IFACE_PRIVATE_KEY'), true) | default('', true) }}"
+download_vpn_wg_backup_peer_public_key: "{{ bao_media_secrets['PROTON_WG_BACKUP_PEER_PUBLIC_KEY'] | default(lookup('env', 'PROTON_WG_BACKUP_PEER_PUBLIC_KEY'), true) | default('', true) }}"
+download_vpn_wg_backup_endpoint: "{{ bao_media_secrets['PROTON_WG_BACKUP_PEER_ENDPOINT'] | default(lookup('env', 'PROTON_WG_BACKUP_PEER_ENDPOINT'), true) | default('', true) }}"
 # True only when a COMPLETE backup peer is configured (all three values present).
 # The killswitch permits the backup endpoint and the validator arms failover only
 # when this is true; a partial config fails loud in tasks/main.yml Phase -1.
@@ -168,7 +168,7 @@ download_vpn_qbittorrent_web_port: >-
   {{ tofu_data.constants.media_ports.qbittorrent_web }}
 # Admin password for the WebUI — from SOPS env. Still required for any client
 # OUTSIDE the auth whitelist below (defence in depth); whitelisted clients skip it.
-download_vpn_qbittorrent_admin_password: "{{ lookup('env', 'QBITTORRENT_ADMIN_PASSWORD') }}"
+download_vpn_qbittorrent_admin_password: "{{ bao_media_secrets['QBITTORRENT_ADMIN_PASSWORD'] | default(lookup('env', 'QBITTORRENT_ADMIN_PASSWORD'), true) }}"
 # WebUI auth bypass for trusted in-network clients — the qBittorrent analogue of
 # the *arr apps' AuthenticationRequired=DisabledForLocalAddresses. Clients whose
 # source IP is in this comma-separated CIDR list skip the login form (and so can

--- a/roles/openbao_secrets/defaults/main.yml
+++ b/roles/openbao_secrets/defaults/main.yml
@@ -50,7 +50,14 @@ openbao_secrets_domains:
     role_id_env: MEDIA_VAULT_ROLE_ID
     secret_id_env: MEDIA_VAULT_SECRET_ID
     paths:
-      - apps/media
+      - apps/media/plex        # PLEX_TOKEN
+      - apps/media/prowlarr    # PROWLARR_API_KEY
+      - apps/media/qbittorrent # QBITTORRENT_ADMIN_PASSWORD
+      - apps/media/radarr      # RADARR_API_KEY
+      - apps/media/seerr       # SEERR_API_KEY
+      - apps/media/sonarr      # SONARR_API_KEY
+      - apps/media/sortarr     # SORTARR_BASIC_AUTH_PASS
+      - apps/media/vpn         # PROTON_WG_*
   - name: local-llm
     role_id_env: LOCAL_LLM_VAULT_ROLE_ID
     secret_id_env: LOCAL_LLM_VAULT_SECRET_ID

--- a/roles/plex/defaults/main.yml
+++ b/roles/plex/defaults/main.yml
@@ -32,7 +32,7 @@ plex_custom_access_url: >-
 # account-scoped X-Plex-Token (NOT the ~4-min claim token), sourced from
 # SOPS/Doppler env (PLEX_TOKEN); never committed. Empty => library creation is
 # skipped and surfaced as a manual UI step (same posture as the claim flow).
-plex_account_token: "{{ lookup('env', 'PLEX_TOKEN') | default('', true) }}"
+plex_account_token: "{{ bao_media_secrets['PLEX_TOKEN'] | default(lookup('env', 'PLEX_TOKEN'), true) | default('', true) }}"
 # Library sections to ensure exist (idempotent, matched by name). Modern Plex
 # agents/scanners; type is movie | show. Paths are the scaffolded roots above.
 plex_libraries:

--- a/roles/radarr/defaults/main.yml
+++ b/roles/radarr/defaults/main.yml
@@ -26,7 +26,7 @@ radarr_manage_services: true
 # VPN). Consumers like Seerr can then authenticate against Radarr regardless of
 # VPN/ordering. servarr_wiring still owns ALL cross-app wiring; it no longer
 # touches Radarr's own key. From SOPS env; never committed.
-radarr_api_key: "{{ lookup('env', 'RADARR_API_KEY') | default('', true) }}"
+radarr_api_key: "{{ bao_media_secrets['RADARR_API_KEY'] | default(lookup('env', 'RADARR_API_KEY'), true) | default('', true) }}"
 # v4 refuses to serve the UI with AuthenticationMethod=None. "External" delegates
 # auth to the reverse proxy and "DisabledForLocalAddresses" lets LAN requests
 # through without a login prompt — matching the servarr_wiring defaults.

--- a/roles/seerr/defaults/main.yml
+++ b/roles/seerr/defaults/main.yml
@@ -24,7 +24,7 @@ seerr_web_port: "{{ tofu_data.constants.media_ports.seerr_web }}"
 # Templated into settings.json (main.apiKey) BEFORE first start so the value is
 # known to downstream wiring, not auto-generated. Sourced from SOPS env
 # (SEERR_API_KEY) — never committed. Empty => the role asserts and fails.
-seerr_api_key: "{{ lookup('env', 'SEERR_API_KEY') | default('', true) }}"
+seerr_api_key: "{{ bao_media_secrets['SEERR_API_KEY'] | default(lookup('env', 'SEERR_API_KEY'), true) | default('', true) }}"
 
 # --- Service registration (Sonarr / Radarr / Plex) ---------------------------
 # Seerr registers Sonarr + Radarr + Plex via its settings API after the
@@ -41,7 +41,7 @@ seerr_sonarr_hostname: >-
      | default(hostvars['sonarr'].container_ip)
      | default('sonarr') }}
 seerr_sonarr_port: "{{ tofu_data.constants.media_ports.sonarr_web }}"
-seerr_sonarr_api_key: "{{ lookup('env', 'SONARR_API_KEY') | default('', true) }}"
+seerr_sonarr_api_key: "{{ bao_media_secrets['SONARR_API_KEY'] | default(lookup('env', 'SONARR_API_KEY'), true) | default('', true) }}"
 seerr_sonarr_use_ssl: false
 
 # Radarr target (LAN-only PVR LXC). Same ip-first resolution as Sonarr.
@@ -50,7 +50,7 @@ seerr_radarr_hostname: >-
      | default(hostvars['radarr'].container_ip)
      | default('radarr') }}
 seerr_radarr_port: "{{ tofu_data.constants.media_ports.radarr_web }}"
-seerr_radarr_api_key: "{{ lookup('env', 'RADARR_API_KEY') | default('', true) }}"
+seerr_radarr_api_key: "{{ bao_media_secrets['RADARR_API_KEY'] | default(lookup('env', 'RADARR_API_KEY'), true) | default('', true) }}"
 seerr_radarr_use_ssl: false
 
 # Root folders inside the *arr LXCs — the TRaSH single-filesystem /data layout
@@ -75,7 +75,7 @@ seerr_radarr_quality_profile: "HD Bluray + WEB"
 # https://www.plexopedia.com/plex-media-server/general/plex-token/). PLEX_TOKEN is
 # only an optional override. When neither is available (server not claimed),
 # registration is SKIPPED and surfaced as a manual step (see role README).
-seerr_plex_token: "{{ lookup('env', 'PLEX_TOKEN') | default('', true) }}"
+seerr_plex_token: "{{ bao_media_secrets['PLEX_TOKEN'] | default(lookup('env', 'PLEX_TOKEN'), true) | default('', true) }}"
 # Where to read PlexOnlineToken from, and on which inventory host (the plex LXC).
 seerr_plex_inventory_host: plex
 seerr_plex_preferences_path: >-

--- a/roles/servarr_wiring/defaults/main.yml
+++ b/roles/servarr_wiring/defaults/main.yml
@@ -19,9 +19,9 @@
 # qBittorrent.
 
 # --- Deterministic API keys (from SOPS env; never committed) -----------------
-servarr_wiring_sonarr_api_key: "{{ lookup('env', 'SONARR_API_KEY') | default('', true) }}"
-servarr_wiring_radarr_api_key: "{{ lookup('env', 'RADARR_API_KEY') | default('', true) }}"
-servarr_wiring_prowlarr_api_key: "{{ lookup('env', 'PROWLARR_API_KEY') | default('', true) }}"
+servarr_wiring_sonarr_api_key: "{{ bao_media_secrets['SONARR_API_KEY'] | default(lookup('env', 'SONARR_API_KEY'), true) | default('', true) }}"
+servarr_wiring_radarr_api_key: "{{ bao_media_secrets['RADARR_API_KEY'] | default(lookup('env', 'RADARR_API_KEY'), true) | default('', true) }}"
+servarr_wiring_prowlarr_api_key: "{{ bao_media_secrets['PROWLARR_API_KEY'] | default(lookup('env', 'PROWLARR_API_KEY'), true) | default('', true) }}"
 
 # --- App data dirs (config.xml lives here; match the app roles' -data dirs) ---
 servarr_wiring_sonarr_data_dir: /var/lib/sonarr

--- a/roles/sonarr/defaults/main.yml
+++ b/roles/sonarr/defaults/main.yml
@@ -26,7 +26,7 @@ sonarr_manage_services: true
 # VPN). Consumers like Seerr can then authenticate against Sonarr regardless of
 # VPN/ordering. servarr_wiring still owns ALL cross-app wiring; it no longer
 # touches Sonarr's own key. From SOPS env; never committed.
-sonarr_api_key: "{{ lookup('env', 'SONARR_API_KEY') | default('', true) }}"
+sonarr_api_key: "{{ bao_media_secrets['SONARR_API_KEY'] | default(lookup('env', 'SONARR_API_KEY'), true) | default('', true) }}"
 # v4 refuses to serve the UI with AuthenticationMethod=None. "External" delegates
 # auth to the reverse proxy and "DisabledForLocalAddresses" lets LAN requests
 # through without a login prompt — matching the servarr_wiring defaults.

--- a/roles/sortarr/defaults/main.yml
+++ b/roles/sortarr/defaults/main.yml
@@ -25,14 +25,14 @@ sortarr_sonarr_hostname: >-
      | default(hostvars['sonarr'].container_ip)
      | default('sonarr') }}
 sortarr_sonarr_port: "{{ tofu_data.constants.media_ports.sonarr_web }}"
-sortarr_sonarr_api_key: "{{ lookup('env', 'SONARR_API_KEY') | default('', true) }}"
+sortarr_sonarr_api_key: "{{ bao_media_secrets['SONARR_API_KEY'] | default(lookup('env', 'SONARR_API_KEY'), true) | default('', true) }}"
 
 sortarr_radarr_hostname: >-
   {{ tofu_data.containers['radarr'].ip
      | default(hostvars['radarr'].container_ip)
      | default('radarr') }}
 sortarr_radarr_port: "{{ tofu_data.constants.media_ports.radarr_web }}"
-sortarr_radarr_api_key: "{{ lookup('env', 'RADARR_API_KEY') | default('', true) }}"
+sortarr_radarr_api_key: "{{ bao_media_secrets['RADARR_API_KEY'] | default(lookup('env', 'RADARR_API_KEY'), true) | default('', true) }}"
 
 sortarr_plex_hostname: >-
   {{ tofu_data.containers['plex'].ip
@@ -40,12 +40,12 @@ sortarr_plex_hostname: >-
      | default('plex') }}
 sortarr_plex_port: "{{ tofu_data.constants.media_ports.plex_web }}"
 # Optional: Sortarr works Arr-only with this empty (Plex overlay is additive).
-sortarr_plex_token: "{{ lookup('env', 'PLEX_TOKEN') | default('', true) }}"
+sortarr_plex_token: "{{ bao_media_secrets['PLEX_TOKEN'] | default(lookup('env', 'PLEX_TOKEN'), true) | default('', true) }}"
 
 # --- Auth (basic_local_bypass): password required from outside Traefik, -----
 # bypassed for LAN/proxy clients. See docs/Sortarr.minimal.env.example upstream.
 sortarr_basic_auth_user: "admin"
-sortarr_basic_auth_pass: "{{ lookup('env', 'SORTARR_BASIC_AUTH_PASS') | default('', true) }}"
+sortarr_basic_auth_pass: "{{ bao_media_secrets['SORTARR_BASIC_AUTH_PASS'] | default(lookup('env', 'SORTARR_BASIC_AUTH_PASS'), true) | default('', true) }}"
 sortarr_local_auth_bypass: true
 
 # DHCP-first inventory contract (same as download_vpn/seerr): container_ip


### PR DESCRIPTION
## Summary
- Repoints sonarr, radarr, plex, seerr, sortarr, download_vpn, and servarr_wiring to read `bao_media_secrets['KEY'] | default(lookup('env','KEY'), true)` first, same pattern as the merged langflow (#613) and langfuse (#611) cutovers.
- Fixes `roles/openbao_secrets/defaults/main.yml`'s media domain: it previously listed a single flat `apps/media` path, which never resolved (OpenBao actually stores each service under its own subpath: `apps/media/{plex,prowlarr,qbittorrent,radarr,seerr,sonarr,sortarr,vpn}`). Verified live against OpenBao that all 8 subpaths exist and contain the expected keys.
- `media_group` hosts (sonarr/radarr/plex/seerr/sortarr/download_vpn/immich) were already listed in `playbooks/site.yml`'s OpenBao pre-fetch play, so no site.yml change was needed.

## WIP / not done in this PR
- [ ] `immich` (`IMMICH_DB_PASSWORD`) is NOT repointed — no OpenBao path exists for it yet under the media domain. Left on env-only.
- [ ] No `--limit ...,localhost --diff` converge run yet — deliberately deferred (media is behind the Proton VPN; converging is a gated follow-on, not done in this PR per direction from the coordinating session).
- [ ] No live E2E verification against the running containers yet (unlike the langflow cutover, which was live-verified via a direct API login).
- [ ] Doppler `MEDIA_*`/`SONARR_API_KEY`/etc. keys are NOT annotated MIGRATED yet — hold until the converge + live verification above are done, so as not to mark something purge-eligible prematurely.

## Test plan
- [x] YAML syntax-validated all 8 touched files (`yaml.safe_load`).
- [x] Confirmed via direct `bao kv get`-equivalent (curl + AppRole login) that all 8 `apps/media/*` subpaths exist and their keys match what each repointed role expects.
- [ ] `ansible-playbook --limit sonarr_group,radarr_group,plex_group,seerr_group,sortarr_group,download_vpn_group,localhost --diff` converge (follow-on).
- [ ] Live service check post-converge (follow-on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYQyqzesxqG5L46ozuVf4K