### PR TITLE
feat(llm_router,llama_cpp): expose Qwen 3.6 models and map Claude Code aliases

### DIFF
--- a/roles/llama_cpp/defaults/main.yml
+++ b/roles/llama_cpp/defaults/main.yml
@@ -96,7 +96,7 @@ llama_cpp_health_check_timeout: 300
 llama_cpp_hf_base: "https://huggingface.co"
 llama_cpp_models:
   - name: hermes-4-14b
-    aliases: [hermes4]
+    aliases: []
     hf_repo: "bartowski/NousResearch_Hermes-4-14B-GGUF"
     gguf: "NousResearch_Hermes-4-14B-Q4_K_M.gguf"
     embeddings: false

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -5,8 +5,9 @@
 # https://llm.<subdomain>; consumers select a tier purely by model alias.
 #
 # Two tiers, both reached through this one proxy:
-#   large — gpt-oss-120b / Qwen3-Coder-30B-A3B / Qwen3.6-35B-A3B-4bit / Qwen3.6-27B-4bit / claude-sonnet-5 on the neutral `llm-large` runner (bearer
-#           auth). One deployment each; no cross-tier fallback.
+#   large — gpt-oss-120b / Qwen3-Coder-30B-A3B / Qwen3.6-35B-A3B-4bit /
+#           Qwen3.6-27B-4bit / claude-sonnet-5 on the neutral `llm-large`
+#           runner (bearer auth). One deployment each; no cross-tier fallback.
 #   light — hermes-4-14b / qwen3-4b / embeddings / claude-haiku-4-5. TWO deployments per
 #           alias: the GPU `llm-fast` box AND the CPU `llm-light` standby, same
 #           model_name. LiteLLM load-balances the pair and cools a failed

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -5,9 +5,9 @@
 # https://llm.<subdomain>; consumers select a tier purely by model alias.
 #
 # Two tiers, both reached through this one proxy:
-#   large — gpt-oss-120b / qwen3-coder on the neutral `llm-large` runner (bearer
+#   large — gpt-oss-120b / Qwen3-Coder-30B-A3B / Qwen3.6-35B-A3B-4bit / Qwen3.6-27B-4bit / claude-sonnet-5 on the neutral `llm-large` runner (bearer
 #           auth). One deployment each; no cross-tier fallback.
-#   light — hermes-4-14b / hermes4 / qwen3-4b / embeddings. TWO deployments per
+#   light — hermes-4-14b / qwen3-4b / embeddings / claude-haiku-4-5. TWO deployments per
 #           alias: the GPU `llm-fast` box AND the CPU `llm-light` standby, same
 #           model_name. LiteLLM load-balances the pair and cools a failed
 #           deployment down, so a GPU outage drains to CPU automatically.
@@ -72,15 +72,18 @@ llm_router_llm_large_base_url: "https://llm-large.{{ llm_router_apex_domain }}:{
 # models under their full MLX repo ids). One deployment each, bearer-authed.
 llm_router_large_models:
   - { alias: gpt-oss-120b, backend: mlx-community/gpt-oss-120b-MXFP4-Q8 }
-  - { alias: qwen3-coder, backend: mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit }
+  - { alias: Qwen3-Coder-30B-A3B, backend: mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit }
+  - { alias: Qwen3.6-35B-A3B-4bit, backend: mlx-community/Qwen3.6-35B-A3B-4bit }
+  - { alias: Qwen3.6-27B-4bit, backend: mlx-community/Qwen3.6-27B-4bit }
+  - { alias: claude-sonnet-5, backend: mlx-community/Qwen3.6-35B-A3B-4bit }
 # light: exposed aliases -> the llama-swap model_name they map to. Each becomes two
 # same-name deployments (llm-fast GPU + llm-light CPU) in the rendered config.
 # `embedding: true` marks the entry as an embeddings model_group.
 llm_router_light_models:
   - { alias: hermes-4-14b, backend: hermes-4-14b }
-  - { alias: hermes4, backend: hermes-4-14b }
   - { alias: qwen3-4b, backend: qwen3-4b }
   - { alias: embeddings, backend: embeddings, embedding: true }
+  - { alias: claude-haiku-4-5, backend: hermes-4-14b }
 
 # --- Routing behaviour -------------------------------------------------------
 # Load-balance across same-name deployments; cool a failed one down so traffic

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1710,7 +1710,7 @@
     llama_cpp_health_check_timeout: 300
     # Only the fields the templates consume (name/aliases/gguf/embeddings).
     llama_cpp_models:
-      - { name: hermes-4-14b, aliases: [hermes4], gguf: "hermes.gguf", embeddings: false }
+      - { name: hermes-4-14b, aliases: [], gguf: "hermes.gguf", embeddings: false }
       - { name: qwen3-4b, aliases: [], gguf: "qwen.gguf", embeddings: false }
       - { name: embeddings, aliases: [nomic-embed-text-v1.5], gguf: "nomic.gguf", embeddings: true }
     _template_dir: "../../roles/llama_cpp/templates"
@@ -1738,10 +1738,8 @@
           - _llama_swap.groups.embeddings.members == ['embeddings']
           - _llama_swap.groups.chat.swap == true
           - (_llama_swap.groups.chat.members | sort) == ['hermes-4-14b', 'qwen3-4b']
-          - "'hermes4' in _llama_swap.models['hermes-4-14b'].aliases"
         fail_msg: >-
-          llama-swap.yaml.j2 did not render the VRAM-disciplined groups or the
-          hermes4 alias: {{ _llama_swap }}
+          llama-swap.yaml.j2 did not render the VRAM-disciplined groups: {{ _llama_swap }}
 
     - name: Assert the shared macro offloads to GPU and per-model cmd flags differ
       ansible.builtin.assert:
@@ -1814,12 +1812,15 @@
     llm_router_llm_large_base_url: "https://llm-large.example.net:11434/v1"
     llm_router_large_models:
       - { alias: gpt-oss-120b, backend: mlx-community/gpt-oss-120b-MXFP4-Q8 }
-      - { alias: qwen3-coder, backend: mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit }
+      - { alias: Qwen3-Coder-30B-A3B, backend: mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit }
+      - { alias: Qwen3.6-35B-A3B-4bit, backend: mlx-community/Qwen3.6-35B-A3B-4bit }
+      - { alias: Qwen3.6-27B-4bit, backend: mlx-community/Qwen3.6-27B-4bit }
+      - { alias: claude-sonnet-5, backend: mlx-community/Qwen3.6-35B-A3B-4bit }
     llm_router_light_models:
       - { alias: hermes-4-14b, backend: hermes-4-14b }
-      - { alias: hermes4, backend: hermes-4-14b }
       - { alias: qwen3-4b, backend: qwen3-4b }
       - { alias: embeddings, backend: embeddings, embedding: true }
+      - { alias: claude-haiku-4-5, backend: hermes-4-14b }
     llm_router_routing_strategy: simple-shuffle
     llm_router_allowed_fails: 2
     llm_router_cooldown_time: 30
@@ -1851,12 +1852,15 @@
         that:
           # Large tier: one deployment each, bearer via env.
           - _model_names | select('equalto', 'gpt-oss-120b') | list | length == 1
-          - _model_names | select('equalto', 'qwen3-coder') | list | length == 1
+          - _model_names | select('equalto', 'Qwen3-Coder-30B-A3B') | list | length == 1
+          - _model_names | select('equalto', 'Qwen3.6-35B-A3B-4bit') | list | length == 1
+          - _model_names | select('equalto', 'Qwen3.6-27B-4bit') | list | length == 1
+          - _model_names | select('equalto', 'claude-sonnet-5') | list | length == 1
           # Light tier: two deployments per alias (GPU llm-fast + CPU llm-light).
           - _model_names | select('equalto', 'hermes-4-14b') | list | length == 2
-          - _model_names | select('equalto', 'hermes4') | list | length == 2
           - _model_names | select('equalto', 'qwen3-4b') | list | length == 2
           - _model_names | select('equalto', 'embeddings') | list | length == 2
+          - _model_names | select('equalto', 'claude-haiku-4-5') | list | length == 2
           # Secrets referenced via os.environ, never a literal in the config.
           - "'test-master-key-placeholder' not in (lookup('file', '/tmp/test_litellm_config.yaml'))"
           - _litellm.general_settings.master_key == 'os.environ/LLM_ROUTER_MASTER_KEY'


### PR DESCRIPTION
Exposes Qwen 3.6 models and maps Claude Code gateway routing aliases to Qwen 3.6 and Hermes.