### PR TITLE
fix(ntp+hermes): chrony container guard, router key, native pinned Hermes install

### DIFF
--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -11,18 +11,37 @@ VLAN.
 ## What it does
 
 - Installs Hermes Agent system-wide via the official installer (bundles Python/uv +
-  Node), once, behind a `creates` guard. The Hermes daemon owns subsequent updates
+  Node), once, behind a `creates` guard. The installer is fetched from the pinned
+  release tag's raw URL and **sha256-verified before it runs** — never
+  `curl <url> | bash` of a moving remote script — and `--branch <tag>` pins the
+  app checkout to the same release. The Hermes daemon owns subsequent updates
   (`hermes update`) — Ansible owns only the platform, so converge stays idempotent.
 - Runs the `hermes gateway` daemon under a dedicated non-root `hermes` user via
   systemd. The gateway drives the built-in **cron** scheduler and the **Kanban**
   dispatcher (autonomy) even with no messaging platform configured.
 - `HERMES_HOME` (`/var/lib/hermes/.hermes`) lives on a dedicated ZFS data volume —
   memory, skills, profiles, the Kanban DB, sessions and logs — so it is snapshotted
-  + replicated pve→pve3 (the agent's accumulated knowledge is irreplaceable).
+  and replicated pve→pve3 (the agent's accumulated knowledge is irreplaceable).
 - Points the model backend at the LiteLLM router (`hermes-4-14b` via
   `llm.<subdomain>/v1`, OpenAI-compatible); sets memory provider to **Hindsight** (best self-hostable
   June 2026) alongside the always-on `MEMORY.md`/`USER.md`; caps `agent.max_turns`
   so a runaway loop can't pin the GPU overnight.
+
+## Installation
+
+This role ships in the `ansible-proxmox-apps` repository — no separate
+installation. The role itself fetches and sha256-verifies the pinned Hermes
+installer on the target, so the LXC only needs base connectivity and apt.
+
+## Usage
+
+Run the role against its inventory group:
+
+```bash
+doppler run -- uv run ansible-playbook \
+  -i inventory/hosts.yml playbooks/site.yml \
+  --tags hermes_agent
+```
 
 ## Key variables
 

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -13,7 +13,26 @@ hermes_agent_user: hermes
 hermes_agent_home: /var/lib/hermes
 hermes_agent_hermes_home: "{{ hermes_agent_home }}/.hermes" # $HERMES_HOME
 hermes_agent_bin: /usr/local/bin/hermes                     # system-wide install
-hermes_agent_install_url: "https://hermes-agent.nousresearch.com/install.sh"
+
+# --- Pinned, checksum-verified installer (NO curl|bash of a moving remote script) ---
+# Hermes ships as a Python app built from a git checkout (uv venv + editable pip),
+# not a released binary — so there is no binary artifact to checksum. What we CAN
+# pin is (a) the installer script, fetched from the tag's immutable raw URL and
+# sha256-verified, and (b) the app checkout, via the installer's --branch <tag>.
+#
+# Ansible pins the PLATFORM version for the ONE-TIME install (creates guard on the
+# binary); the Hermes daemon self-updates the app thereafter (`hermes update`).
+# To move the pinned floor: bump hermes_agent_version AND refresh the sha256
+# (curl the URL below, `sha256sum`). A stale checksum fails the converge loudly —
+# by design, that is the tamper/rug-pull guard.
+hermes_agent_version: "v2026.7.1"
+hermes_agent_installer_url: >-
+  https://raw.githubusercontent.com/NousResearch/hermes-agent/{{
+  hermes_agent_version }}/scripts/install.sh
+hermes_agent_installer_sha256: "a93c65b01ea392e179cf872e182bd01a2b65c0c15f17833e9f9569033ef10e07"
+# Version-stamped so a version bump downloads (and re-verifies) a fresh copy
+# instead of reusing a stale cached file.
+hermes_agent_installer_path: "/usr/local/lib/hermes-agent-installer-{{ hermes_agent_version }}.sh"
 
 # --- Brain: the LiteLLM router (the fabric front door, OpenAI-compatible /v1) ---
 # Reached by its neutral Traefik FQDN — never a hardcoded IP. The router routes by

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -22,7 +22,12 @@ hermes_agent_install_url: "https://hermes-agent.nousresearch.com/install.sh"
 hermes_agent_model: hermes-4-14b
 hermes_agent_model_base_url: "https://llm.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}/v1"
 hermes_agent_model_api_mode: chat_completions
-hermes_agent_model_api_key: "{{ lookup('env', 'HERMES_AGENT_MODEL_API_KEY') }}"
+# The api key IS the LiteLLM router master key; source it from the canonical
+# LLM_ROUTER_MASTER_KEY env (same as the llm_router role) so no per-run mapping
+# is needed. HERMES_AGENT_MODEL_API_KEY still overrides if explicitly set.
+hermes_agent_model_api_key: >-
+  {{ lookup('env', 'HERMES_AGENT_MODEL_API_KEY')
+     | default(lookup('env', 'LLM_ROUTER_MASTER_KEY'), true) }}
 
 # --- Memory: best self-hostable as of June 2026 (Agy-validated) ---
 # Hindsight: local knowledge-graph + multi-strategy retrieval. Runs alongside the

--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -26,9 +26,15 @@
 # Run as root (play become: true) -> system-wide install: binary /usr/local/bin/hermes,
 # code /usr/local/lib/hermes-agent. The installer handles its own Python/Node/
 # ripgrep/ffmpeg deps. `creates` guard installs once; the daemon self-updates after.
+# --skip-setup: the installer's final step is an INTERACTIVE `hermes setup` wizard
+# that reads /dev/tty and hangs forever under Ansible (no controlling TTY). We skip
+# it and configure declaratively via the config.yaml/.env templates below;
+# --non-interactive defaults any remaining prompt instead of blocking.
 - name: Install Hermes Agent system-wide (once; daemon self-updates thereafter)
   ansible.builtin.shell:
-    cmd: "set -o pipefail && curl -fsSL {{ hermes_agent_install_url }} | bash"
+    cmd: >-
+      set -o pipefail && curl -fsSL {{ hermes_agent_install_url }}
+      | bash -s -- --skip-setup --non-interactive
     creates: "{{ hermes_agent_bin }}"
   args:
     executable: /bin/bash

--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -23,21 +23,36 @@
     update_cache: true
     cache_valid_time: 3600
 
-# Run as root (play become: true) -> system-wide install: binary /usr/local/bin/hermes,
-# code /usr/local/lib/hermes-agent. The installer handles its own Python/Node/
-# ripgrep/ffmpeg deps. `creates` guard installs once; the daemon self-updates after.
+# Fetch the installer from the pinned release tag's immutable raw URL and verify
+# its sha256 BEFORE running it — no `curl <url> | bash` of a moving remote script.
+# A checksum mismatch (upstream changed the tag, MITM, rug-pull) fails here, loud.
+- name: Fetch the pinned Hermes installer (checksum-verified)
+  ansible.builtin.get_url:
+    url: "{{ hermes_agent_installer_url }}"
+    dest: "{{ hermes_agent_installer_path }}"
+    checksum: "sha256:{{ hermes_agent_installer_sha256 }}"
+    owner: root
+    group: root
+    mode: "0644"
+
+# Run the VERIFIED local installer (root + play become: true) -> system-wide FHS
+# layout: binary /usr/local/bin/hermes, code /usr/local/lib/hermes-agent. Do NOT
+# pass --dir: an explicit dir disables the root-FHS auto-layout and drops the
+# launcher in /root/.local/bin instead of /usr/local/bin (breaks hermes_agent_bin).
+# --branch {{ version }}: the installer git-clones the app at this release TAG
+# (`git clone --depth 1 --branch <tag>`), pinning the app checkout too. The
+# installer handles its own Python/uv/venv/Node/ripgrep/ffmpeg deps.
+# `creates` guard installs once; the Hermes daemon self-updates the app after.
 # --skip-setup: the installer's final step is an INTERACTIVE `hermes setup` wizard
 # that reads /dev/tty and hangs forever under Ansible (no controlling TTY). We skip
 # it and configure declaratively via the config.yaml/.env templates below;
 # --non-interactive defaults any remaining prompt instead of blocking.
 - name: Install Hermes Agent system-wide (once; daemon self-updates thereafter)
-  ansible.builtin.shell:
+  ansible.builtin.command:
     cmd: >-
-      set -o pipefail && curl -fsSL {{ hermes_agent_install_url }}
-      | bash -s -- --skip-setup --non-interactive
+      bash {{ hermes_agent_installer_path }}
+      --branch {{ hermes_agent_version }} --skip-setup --non-interactive
     creates: "{{ hermes_agent_bin }}"
-  args:
-    executable: /bin/bash
 
 - name: Create the hermes runtime user (HERMES_HOME on the data volume)
   ansible.builtin.user:

--- a/roles/ntp/handlers/main.yml
+++ b/roles/ntp/handlers/main.yml
@@ -1,9 +1,12 @@
 ---
 # NTP role handlers
 
+# Skip in system containers: the Proxmox host owns the LXC clock and chrony
+# can't start there (no CAP_SYS_TIME) — same guard the enable/start task uses.
+# Default 0 (assume container) so an undefined fact fails safe = no restart.
 - name: Restart chrony
   ansible.builtin.systemd:
     name: chrony
     state: restarted
-  when: ansible_virtualization_type | default('') != 'docker'
+  when: _ntp_virt_container.rc | default(0) != 0
   listen: Restart chrony


### PR DESCRIPTION
Three fixes in the `hermes_agent` bring-up path plus the chrony container guard.

## Commits
- `cb353bf` fix(ntp): skip the chrony restart handler in system containers.
- `1b34f38` fix(hermes_agent): source the model API key from `LLM_ROUTER_MASTER_KEY`.
- `c9c0881` fix(hermes_agent): **native pinned + checksummed install — drop `curl | bash`.**

## Native pinned Hermes install (replaces `curl -fsSL <url> | bash`)

The previous task piped a **moving remote script** straight into a shell — no
pinning, no checksum, arbitrary remote code executed on every fresh install.
Replaced with a two-step native Ansible flow:

1. `ansible.builtin.get_url` fetches the installer from the **pinned release
   tag's immutable raw URL** (`scripts/install.sh` @ `v2026.7.1`) and
   **sha256-verifies** it (`a93c65b0…f10e07`) *before* it runs.
2. `ansible.builtin.command` runs the verified local script with
   `--branch v2026.7.1`, so the app git checkout is pinned to the **same
   release** (`git clone --depth 1 --branch <tag>`).

### Why a script + tag, not a binary + checksum

Hermes ships as a **Python app built from a git checkout** (uv venv + editable
`pip install -e '.[all]'`). Releases are **git tags** (latest `v2026.7.1`);
there is **no released binary artifact** to `get_url`+checksum. So the
pinnable/verifiable units are the installer **script** (sha256) and the app
**tag** (`--branch`). This matches the locked design: Ansible pins the
**platform** version for the one-time install (`creates` guard on the binary);
the Hermes daemon self-updates the **app** thereafter (`hermes update`). Bump
`hermes_agent_version` + refresh the sha256 to move the floor.

### Security posture
- No unpinned remote code execution. A changed tag / MITM / rug-pull fails the
  checksum **loudly** instead of silently running new code.
- Installer runs from a local, verified file — no pipe-to-shell.

Declarative config was already in place (`config.yaml.j2`, `.env`, systemd
unit); the interactive `hermes setup` wizard is still skipped (`--skip-setup`),
so nothing reads `/dev/tty`.

## Verification
- `ansible-lint roles/hermes_agent/` → passes (production profile).
- Not molecule-tested (no `hermes_agent` scenario exists).
- **Not yet live-converged** on a Debian LXC — first converge still needs to
  confirm the installer runs clean non-interactively as root and the gateway
  stays up headless.