### PR TITLE
fix(llama_cpp): remove hermes-4-14b and guardrail against >=14B on llm-fast

### DIFF
--- a/roles/llama_cpp/README.md
+++ b/roles/llama_cpp/README.md
@@ -4,8 +4,13 @@ Deploys the **light serving tier**: [llama.cpp](https://github.com/ggml-org/llam
 (`llama-server`) behind [llama-swap](https://github.com/mostlygeek/llama-swap) on an
 AMD **ROCm** GPU, inside a privileged LXC (guest `llm-fast`, RX 6800 = gfx1030).
 llama-swap presents **one** OpenAI-compatible endpoint and keeps the configured
-models co-resident, so Hermes-4-14B + a small general model + an embeddings model
-all fit in 16 GB at Q4 and answer without reload churn.
+models co-resident, so a small general model + an embeddings model fit in
+16 GB at Q4 and answer without reload churn.
+
+**Absolute rule:** never serve a model with `param_billions >= 14` on this GPU.
+pve1 has hard-locked repeatedly under large-model GPU loads (VRAM eviction
+hard-hangs the host); a converge-time assert in `tasks/main.yml` enforces this,
+scoped to `llm_fast_group` only.
 
 ## Installation
 
@@ -39,12 +44,12 @@ Ordering: `terraform-proxmox` (LXC shell) → `ansible-proxmox` (GPU passthrough
 
 | model_name | aliases | kind |
 | --- | --- | --- |
-| `hermes-4-14b` | `hermes4` | chat (`--jinja`) |
 | `qwen3-4b` | — | chat (`--jinja`) |
 | `embeddings` | `nomic-embed-text-v1.5` | `--embeddings` |
 
-All three are members of the `resident` llama-swap group (`swap: false`), so they
-stay loaded together.
+Both are members of the `chat` / `embeddings` llama-swap groups (`swap: false`
+for `embeddings`), so they stay loaded together. `hermes-4-14b` (14B) was
+removed — see "Absolute rule" above.
 
 ## GPU toggle
 
@@ -59,7 +64,7 @@ with a smaller context, and drops the GPU env from the unit.
 | --- | --- | --- |
 | `llama_cpp_api_port` | `tofu_data.constants.service_ports.llm_fast_api` | llama-swap listen port (no hardcode) |
 | `llama_cpp_gpu` | `true` | ROCm GPU vs CPU-only standby |
-| `llama_cpp_models` | 3-model list | served models + GGUF sources |
+| `llama_cpp_models` | 2-model list | served models + GGUF sources (each needs `param_billions`) |
 | `llama_cpp_install_dir` | `/opt/llama-cpp` | binary + bundled ROCm `.so` files (also `LD_LIBRARY_PATH`) |
 | `llama_cpp_models_dir` | `/var/lib/llama-cpp/models` | staged GGUFs (persistent volume) |
 | `llama_cpp_rocm_packages` | `[]` | best-effort container ROCm runtime packages |

--- a/roles/llama_cpp/defaults/main.yml
+++ b/roles/llama_cpp/defaults/main.yml
@@ -2,9 +2,16 @@
 # llama_cpp role defaults — the light serving tier: llama.cpp (llama-server) behind
 # llama-swap, on an AMD ROCm GPU inside a privileged LXC (guest `llm-fast`, RX 6800
 # = gfx1030). llama-swap presents ONE OpenAI-compatible endpoint and keeps the
-# configured models co-resident (a group with swap:false), so hermes-4-14b + a
-# small general model + an embeddings model all fit in 16 GB at Q4 and answer
-# without reload churn.
+# configured models co-resident (a group with swap:false), so a small general
+# model + an embeddings model fit in 16 GB at Q4 and answer without reload churn.
+#
+# ABSOLUTE RULE: never serve a model with param_billions >= 14 on this GPU
+# (llm-fast, RX 6800, 16 GB VRAM). A single Hermes-4-14B (Q4, ~8.4 GB) load
+# hard-locked the pve1 HOST twice even alone, on top of two earlier co-resident
+# load hard-locks (see llama_cpp_service_enabled below). The `param_billions`
+# field on every llama_cpp_models entry + the converge-time assert in
+# tasks/main.yml enforce this; never add a model here without a param_billions
+# value.
 #
 # GPU device nodes (/dev/kfd, /dev/dri) are passed into the container UPSTREAM by
 # ansible-proxmox (role lxc_gpu_features); this role assumes they already exist and
@@ -43,7 +50,7 @@ llama_cpp_gpu: true
 llama_cpp_hsa_override_gfx_version: "10.3.0"
 
 # GPU-layer offload + context: full offload + full context on GPU; none + a smaller
-# context on CPU (a 14B at Q4 is slow on CPU, so keep the working set small).
+# context on CPU (a large model at Q4 is slow on CPU, so keep the working set small).
 llama_cpp_ngl: "{{ 99 if llama_cpp_gpu | bool else 0 }}"
 llama_cpp_ctx_size: "{{ 8192 if llama_cpp_gpu | bool else 2048 }}"
 
@@ -84,37 +91,41 @@ llama_cpp_api_port: "{{ tofu_data.constants.service_ports.llm_fast_api }}"
 llama_cpp_start_port: 9200
 
 # How long llama-swap waits for a model to become healthy before declaring it
-# unhealthy (a 14B cold-loads from disk into VRAM; give it headroom).
+# unhealthy (a cold model load from disk into VRAM needs headroom).
 llama_cpp_health_check_timeout: 300
 
 # --- Models (co-resident) ----------------------------------------------------
-# All three stay loaded together (see the group in the template): Hermes-4-14B Q4
-# (~8.4 GB) + a small general model + a tiny embeddings model fit in 16 GB at Q4.
-# Each entry: the served model_name, extra OpenAI aliases, the HuggingFace repo +
-# GGUF filename (the URL is composed in the task), and whether it is an embeddings
-# server. Repo/quant are role vars so a change needs no task edit.
+# Both stay loaded together (see the group in the template): a small general
+# model + a tiny embeddings model fit in 16 GB at Q4. Each entry: the served
+# model_name, extra OpenAI aliases, the HuggingFace repo + GGUF filename (the
+# URL is composed in the task), the model's approximate parameter count in
+# billions (param_billions — REQUIRED, drives the >=14B converge-time assert
+# below; extend the assert's denylist too if a model ever ships without a
+# reliable size in its name), and whether it is an embeddings server. Repo/quant
+# are role vars so a change needs no task edit.
+#
+# hermes-4-14b (NousResearch Hermes-4-14B) was removed from this list — it is a
+# 14B model and violates the ABSOLUTE >=14B rule above. Do not re-add it here.
 llama_cpp_hf_base: "https://huggingface.co"
 llama_cpp_models:
-  - name: hermes-4-14b
-    aliases: []
-    hf_repo: "bartowski/NousResearch_Hermes-4-14B-GGUF"
-    gguf: "NousResearch_Hermes-4-14B-Q4_K_M.gguf"
-    embeddings: false
   - name: qwen3-4b
     aliases: []
     hf_repo: "bartowski/Qwen_Qwen3-4B-Instruct-2507-GGUF"
     gguf: "Qwen_Qwen3-4B-Instruct-2507-Q4_K_M.gguf"
+    param_billions: 4
     embeddings: false
   - name: embeddings
     aliases: [nomic-embed-text-v1.5]
     hf_repo: "nomic-ai/nomic-embed-text-v1.5-GGUF"
     gguf: "nomic-embed-text-v1.5.Q4_K_M.gguf"
+    param_billions: 0.137
     embeddings: true
 
 # Whether llama-swap actually serves. llm-fast is FROZEN (false in host_vars):
-# four host hard-locks — two from co-resident triple loads, two from a SINGLE
-# Hermes-4-14B (8.4 GB) load with every software fix applied — put the fault at
-# the host/hardware level under large GPU allocations (qwen3-4b at 2.5 GB is
-# fine). Do NOT re-enable on llm-fast until the hardware question is settled
-# (BIOS/PSU/memtest); the light tier serves from llm-light (CPU) meanwhile.
+# four host hard-locks — two from co-resident triple loads (which included the
+# now-removed hermes-4-14b), two from a SINGLE Hermes-4-14B (8.4 GB) load with
+# every software fix applied — put the fault at the host/hardware level under
+# large GPU allocations (qwen3-4b at 2.5 GB is fine). Do NOT re-enable on
+# llm-fast until the hardware question is settled (BIOS/PSU/memtest); the light
+# tier serves from llm-light (CPU) meanwhile.
 llama_cpp_service_enabled: true

--- a/roles/llama_cpp/tasks/main.yml
+++ b/roles/llama_cpp/tasks/main.yml
@@ -29,6 +29,28 @@
     - llama_cpp_gpu | bool
     - llama_cpp_rocm_packages | length > 0
 
+# --- Absolute GPU-size guardrail ---------------------------------------------
+# pve1 (llm-fast, RX 6800, 16 GB VRAM) has hard-locked 5x under GPU load; VRAM
+# eviction of a large model is the documented hard-hang cause (see the ABSOLUTE
+# RULE comment in defaults/main.yml). Scoped to the llm_fast_group ONLY — this
+# must never block a model served elsewhere (e.g. Qwen3.6-35B-A3B on the Mac
+# Studio, a completely different host/inventory). Do not remove the group_names
+# guard even though playbooks/site.yml only ever wires this role to
+# llm_fast_group today; the guard is what keeps a future re-use of this role
+# safe.
+- name: Assert no llm-fast model is >= 14B params (ABSOLUTE pve1 GPU rule)
+  ansible.builtin.assert:
+    that:
+      - (llama_cpp_models | selectattr('param_billions', 'ge', 14) | list | length) == 0
+    fail_msg: >-
+      One or more llama_cpp_models entries has param_billions >= 14
+      ({{ llama_cpp_models | selectattr('param_billions', 'ge', 14)
+          | map(attribute='name') | list }}). pve1 (llm-fast) has hard-locked
+      repeatedly serving models this large — see defaults/main.yml. Do not add
+      a >=14B model to this GPU; serve it elsewhere.
+    success_msg: "No >=14B model configured for llm-fast — GPU guardrail OK."
+  when: "'llm_fast_group' in group_names"
+
 - name: Create the llama-cpp service group
   ansible.builtin.group:
     name: "{{ llama_cpp_group }}"

--- a/roles/llama_cpp/tasks/main.yml
+++ b/roles/llama_cpp/tasks/main.yml
@@ -38,13 +38,25 @@
 # guard even though playbooks/site.yml only ever wires this role to
 # llm_fast_group today; the guard is what keeps a future re-use of this role
 # safe.
+- name: Assert every llm-fast model declares param_billions
+  ansible.builtin.assert:
+    that:
+      - (llama_cpp_models | rejectattr('param_billions', 'defined') | list | length) == 0
+    fail_msg: >-
+      One or more llama_cpp_models entries is missing param_billions
+      ({{ llama_cpp_models | rejectattr('param_billions', 'defined')
+          | map(attribute='name') | list }}) — required so the >=14B GPU
+      guardrail below can evaluate it. Add a param_billions value.
+  when: "'llm_fast_group' in group_names"
+
 - name: Assert no llm-fast model is >= 14B params (ABSOLUTE pve1 GPU rule)
   ansible.builtin.assert:
     that:
-      - (llama_cpp_models | selectattr('param_billions', 'ge', 14) | list | length) == 0
+      - (llama_cpp_models | map(attribute='param_billions', default=0) | select('ge', 14) | list | length) == 0
     fail_msg: >-
       One or more llama_cpp_models entries has param_billions >= 14
-      ({{ llama_cpp_models | selectattr('param_billions', 'ge', 14)
+      ({{ llama_cpp_models | selectattr('param_billions', 'defined')
+          | selectattr('param_billions', 'ge', 14)
           | map(attribute='name') | list }}). pve1 (llm-fast) has hard-locked
       repeatedly serving models this large — see defaults/main.yml. Do not add
       a >=14B model to this GPU; serve it elsewhere.

--- a/roles/llama_cpp/templates/llama-swap.yaml.j2
+++ b/roles/llama_cpp/templates/llama-swap.yaml.j2
@@ -15,12 +15,14 @@ macros:
     -ngl {{ llama_cpp_ngl }}
 
 groups:
-  # VRAM discipline (learned the hard way: full co-residency of Hermes-4-14B Q4
-  # + qwen3-4b + embeddings + their KV caches exceeds the 16 GB card and the
-  # amdgpu eviction path hard-hangs the HOST — twice). Only the tiny embeddings
-  # model stays permanently resident; the chat models swap against each other,
-  # so peak pressure is one chat model + embeddings + KV. --no-mmap was also
-  # dropped from the shared invocation: mmap streaming halves the load spike.
+  # VRAM discipline (learned the hard way: full co-residency of the models
+  # + their KV caches once included a 14B chat model and exceeded the 16 GB
+  # card — the amdgpu eviction path hard-hangs the HOST. That 14B model was
+  # removed; see the ABSOLUTE >=14B rule in roles/llama_cpp/defaults/main.yml).
+  # Only the tiny embeddings model stays permanently resident; the chat models
+  # swap against each other, so peak pressure is one chat model + embeddings +
+  # KV. --no-mmap was also dropped from the shared invocation: mmap streaming
+  # halves the load spike.
   "embeddings":
     swap: false
     exclusive: false


### PR DESCRIPTION
## Summary
- Removes `hermes-4-14b` (14B) from `roles/llama_cpp/defaults/main.yml`'s `llama_cpp_models` — the last >=14B model still configured for the `llm-fast` GPU guest (pve1, RX 6800, 16 GB VRAM), which has hard-locked the host repeatedly under large-model GPU loads.
- Adds a `param_billions` field to each remaining model entry (`qwen3-4b`: 4, `embeddings`: 0.137).
- Adds a converge-time `ansible.builtin.assert` in `roles/llama_cpp/tasks/main.yml` that fails the play if any `llama_cpp_models` entry has `param_billions >= 14`, guarded by `when: "'llm_fast_group' in group_names"` so it can never affect a model served on a different host/inventory (e.g. Qwen3.6-35B-A3B on the Mac Studio).
- Updates stale comments/README references to the removed 14B model.

llama-swap is currently frozen (`llama_cpp_service_enabled: false` in `inventory/host_vars/llm-fast.yml`), so this is a config-only change with no live service impact.

## Test plan
- [x] `ansible-lint roles/llama_cpp` — production profile, 0 failures/warnings
- [x] `yamllint roles/llama_cpp` — clean
- [x] `ansible-playbook --syntax-check playbooks/site.yml` — passes
- [x] No `molecule` scenario exists for `llama_cpp` (GPU/ROCm role, not molecule-testable); instead verified the assert logic standalone with three scenarios: passes for the real post-fix model list, fails loudly if a 14B model is reintroduced, and is skipped (does not fire) for a non-`llm_fast_group` host — confirming it cannot block the Mac Studio's 35B model.