### PR TITLE
fix(hermes_agent): use gateway run --replace instead of gateway start

### DIFF
--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -61,7 +61,7 @@ Run via `site.yml` (`--tags hermes_agent`).
 ## Not yet live-validated
 
 Verify on the first converge: (a) `install.sh` runs clean non-interactively as root
-on a minimal Debian LXC; (b) `hermes gateway start` stays up headless with no
+on a minimal Debian LXC; (b) `hermes gateway run --replace` stays up headless with no
 messaging platform; (c) Hindsight initialises from `config.yaml` alone (it may need
 its client package on first run — `memory status` check is non-fatal so it surfaces
 without failing the converge). Single-profile first; profiles + Kanban teams + a

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -62,4 +62,9 @@ hermes_agent_timezone: "UTC"
 
 # systemd ExecStart: the long-running gateway daemon. It drives the built-in cron
 # scheduler + the Kanban dispatcher even with no messaging platform configured.
-hermes_agent_gateway_cmd: "{{ hermes_agent_bin }} gateway start"
+# `gateway start` is for interactive/manual use — it shells out to manage its
+# own systemd/launchd service and requires root when no user session is
+# present ("System gateway start requires root"). `gateway run --replace` is
+# the foreground-supervised form the CLI's own --help calls out as "useful for
+# systemd" — it runs in-process under our unit instead of trying to manage one.
+hermes_agent_gateway_cmd: "{{ hermes_agent_bin }} gateway run --replace"

--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -8,9 +8,10 @@
 # 'latest' (Agy: avoids the self-update vs idempotency conflict).
 #
 # NOT YET LIVE-VALIDATED (verify on first converge): (a) install.sh running clean
-# non-interactively as root on a minimal Debian LXC; (b) `hermes gateway start`
-# staying up headless with no messaging platform; (c) Hindsight provider init from
-# config.yaml alone (it may need its client package on first run).
+# non-interactively as root on a minimal Debian LXC; (b) `hermes gateway run
+# --replace` staying up headless with no messaging platform; (c) Hindsight
+# provider init from config.yaml alone (it may need its client package on
+# first run).
 
 - name: Install role prerequisites (installer + clone)
   ansible.builtin.apt:


### PR DESCRIPTION
## Summary
- `hermes gateway start` is the interactive/manual form. It shells out to manage its own systemd/launchd service and fails headless with `System gateway start requires root` when there's no user session — exactly the case for our own systemd unit running under a dedicated non-root user.
- `hermes gateway run --replace` is the foreground, systemd-supervised form; the CLI's own `--help` for `gateway run` documents `--replace` as "useful for systemd".
- Live-validated on `hermes-agent` (pve1): converge applied clean, gateway is `active (running)` with `NRestarts=0`, and reaches the LiteLLM router (`GET /v1/models` → 200, `hermes-4-14b` present).

## Test plan
- [x] Converged `playbooks/site.yml --limit hermes_agent_group,localhost --diff` — 0 failures.
- [x] `systemctl is-active hermes-gateway` → `active`, `is-enabled` → `enabled`.
- [x] Journal shows clean startup banner, no crash loop, `NRestarts=0`.
- [x] `curl https://llm.<subdomain>/v1/models` from the guest with the router master key → HTTP 200, model list includes `hermes-4-14b`.

Assisted-by: Claude:claude-sonnet-5