### PR TITLE
feat(hermes_agent): repoint brain to Qwen3-Coder-30B-A3B

### DIFF
--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -36,9 +36,12 @@ hermes_agent_installer_path: "/usr/local/lib/hermes-agent-installer-{{ hermes_ag
 
 # --- Brain: the LiteLLM router (the fabric front door, OpenAI-compatible /v1) ---
 # Reached by its neutral Traefik FQDN — never a hardcoded IP. The router routes by
-# model alias, so the agent just names the model it wants (the light Hermes-4-14B
-# here). The api key is the router master key, env-sourced (SOPS/Doppler).
-hermes_agent_model: hermes-4-14b
+# model alias, so the agent just names the model it wants: Qwen3-Coder-30B-A3B
+# on the Mac Studio large tier (non-hybrid MoE, proven stable — avoids the
+# qwen3_5_moe batching crash that rules out Qwen3.6). Replaces the interim
+# hermes-4-14b light-tier brain. The api key is the router master key,
+# env-sourced (SOPS/Doppler).
+hermes_agent_model: qwen3-coder
 hermes_agent_model_base_url: "https://llm.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}/v1"
 hermes_agent_model_api_mode: chat_completions
 # The api key IS the LiteLLM router master key; source it from the canonical


### PR DESCRIPTION
## Summary
- Repoints Hermes's brain model default from the interim `hermes-4-14b` light-tier alias to `qwen3-coder`, the router alias for Qwen3-Coder-30B-A3B-Instruct-4bit served on the Mac Studio large tier.
- Non-hybrid MoE model, proven stable — dodges the qwen3_5_moe batching crash that rules out Qwen3.6 as a brain candidate.
- Verified live end-to-end: `curl .../v1/chat/completions -d '{"model":"qwen3-coder", ...}'` through the router returned a 200 completion from the Mac Studio.
- Only the model field changed; `hermes_agent_model_base_url` (router `/v1`) and the API key wiring (`LLM_ROUTER_MASTER_KEY`) are untouched.

## Test plan
- [x] Live curl through the router confirms `qwen3-coder` resolves and responds
- [ ] Converge `hermes_agent_group` and confirm the deployed `config.yaml` references the new alias
- [ ] `systemctl is-active hermes-gateway` post-converge
- [ ] A completion through the router with `qwen3-coder` returns 200 in the live gateway