### PR TITLE
fix(agent_exec): correct LangChain instrumentor import casing

### DIFF
--- a/roles/agent_exec/defaults/main.yml
+++ b/roles/agent_exec/defaults/main.yml
@@ -18,6 +18,11 @@ agent_exec_service: agent-exec
 # Installed into the venv (state: present — pinned by the ecosystem, never here).
 # crewai/crewai-tools pull deep dep trees; the opentelemetry-instrumentation-*
 # pair is the OpenLLMetry (Traceloop) auto-tracing for CrewAI + LangChain.
+#
+# opentelemetry-instrumentation-langchain is pinned: its exported class name
+# ("LangchainInstrumentor", lowercase "c") has drifted casing across releases
+# and otel_bootstrap.py.j2 aliases around it — an unpinned resolve could
+# reintroduce an ImportError crash-loop if a future release renames it again.
 agent_exec_pip_packages:
   - crewai
   - crewai-tools
@@ -26,7 +31,7 @@ agent_exec_pip_packages:
   - opentelemetry-sdk
   - opentelemetry-exporter-otlp
   - opentelemetry-instrumentation-crewai
-  - opentelemetry-instrumentation-langchain
+  - opentelemetry-instrumentation-langchain==0.62.1
 
 # Autonomy seed loop: every interval the seed runs a tiny traced crew against
 # BOTH model tiers (large = real work; light = soak path). Override

--- a/roles/agent_exec/templates/otel_bootstrap.py.j2
+++ b/roles/agent_exec/templates/otel_bootstrap.py.j2
@@ -13,7 +13,9 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from opentelemetry.instrumentation.crewai import CrewAIInstrumentor
-from opentelemetry.instrumentation.langchain import LangChainInstrumentor
+# opentelemetry-instrumentation-langchain exports "LangchainInstrumentor" (lowercase c),
+# not "LangChainInstrumentor" -- alias to match this file's usage below.
+from opentelemetry.instrumentation.langchain import LangchainInstrumentor as LangChainInstrumentor
 
 _provider = TracerProvider(
     resource=Resource.create({"service.name": "{{ agent_exec_service }}"})


### PR DESCRIPTION
## Summary
- `agent-exec` (LXC) crash-loops on `ImportError: cannot import name 'LangChainInstrumentor'` — the installed package `opentelemetry-instrumentation-langchain` exports `LangchainInstrumentor` (lowercase "c"), not `LangChainInstrumentor`.
- Fix: alias the import in `otel_bootstrap.py.j2` so the rest of the file's usage is unchanged.
- Pin `opentelemetry-instrumentation-langchain==0.62.1` (the currently-resolving version) in `roles/agent_exec/defaults/main.yml` with a comment so this can't silently recur on a future pip resolve.

## Test plan
- [x] Grepped the whole `agent_exec` role for other `LangChain`/`Langchain` casing references — none broken, remaining hits are prose (README, service description).
- [ ] No live converge/apply performed — code fix only, activation is a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)