### PR TITLE
feat(dr): keepalived ingress VIP + OpenBao client failover

### DIFF
--- a/.github/workflows/_molecule.yml
+++ b/.github/workflows/_molecule.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scenario: [default, qdrant, llamaindex, download_vpn, seerr, sortarr, technitium_dns, netmon, openbao]
+        scenario: [default, qdrant, llamaindex, download_vpn, seerr, sortarr, technitium_dns, netmon, openbao, keepalived]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/_molecule.yml
+++ b/.github/workflows/_molecule.yml
@@ -18,7 +18,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scenario: [default, qdrant, llamaindex, download_vpn, seerr, sortarr, technitium_dns, netmon, openbao, keepalived]
+        scenario:
+          - default
+          - qdrant
+          - llamaindex
+          - download_vpn
+          - seerr
+          - sortarr
+          - technitium_dns
+          - netmon
+          - openbao
+          - keepalived
 
     steps:
       - name: Checkout code

--- a/molecule/keepalived/converge.yml
+++ b/molecule/keepalived/converge.yml
@@ -1,0 +1,29 @@
+---
+# Molecule converge for keepalived.
+#
+# Runs the role with keepalived_manage_services=false: it renders
+# /etc/keepalived/keepalived.conf from the tofu-derived topology but never
+# installs or starts the daemon (no privileged VRRP socket in CI). The two
+# instances exercise both roles: keepalived-1 (.101, first in ingress_hosts) ->
+# MASTER, keepalived-2 (.107) -> BACKUP.
+
+- name: Converge
+  hosts: all
+  gather_facts: false
+
+  vars:
+    keepalived_manage_services: false
+    # Stand-in for the tofu inventory load_tofu.yml provides live.
+    tofu_data:
+      ingress_vip: "192.168.5.2"
+      ingress_hosts:
+        - "192.168.5.101"
+        - "192.168.5.107"
+      constants:
+        ingress_ports:
+          keepalived_vrid: 51
+
+  tasks:
+    - name: Include keepalived role
+      ansible.builtin.include_role:
+        name: keepalived

--- a/molecule/keepalived/molecule.yml
+++ b/molecule/keepalived/molecule.yml
@@ -1,0 +1,80 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
+
+driver:
+  name: docker
+
+# Two instances exercise BOTH VRRP roles without a live cluster: keepalived-1
+# (first in the sorted ingress_hosts list) resolves to MASTER, keepalived-2 to
+# BACKUP. keepalived_manage_services=false (converge) renders the config without
+# installing/starting the daemon, so no privileged VRRP socket is needed in CI.
+platforms:
+  - name: keepalived-1-test
+    image: geerlingguy/docker-debian12-ansible:latest
+    privileged: true
+    command: ""
+    pre_build_image: true
+    tmpfs:
+      - /run
+      - /tmp
+      - /run/lock
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    groups:
+      - traefik_group
+      - lxc_containers
+  - name: keepalived-2-test
+    image: geerlingguy/docker-debian12-ansible:latest
+    privileged: true
+    command: ""
+    pre_build_image: true
+    tmpfs:
+      - /run
+      - /tmp
+      - /run/lock
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    groups:
+      - traefik_group
+      - lxc_containers
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
+  # Per-host facts normally injected by load_tofu.yml. RFC1918 placeholders only.
+  # container_ip is this instance's own ingress address; the ingress_hosts list
+  # in tofu_data (converge.yml) enrolls both, so the role derives priority/state.
+  inventory:
+    host_vars:
+      keepalived-1-test:
+        container_ip: "192.168.5.101"
+        hostname: traefik
+      keepalived-2-test:
+        container_ip: "192.168.5.107"
+        hostname: traefik-2
+
+verifier:
+  name: ansible
+
+scenario:
+  name: keepalived
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - cleanup
+    - destroy

--- a/molecule/keepalived/prepare.yml
+++ b/molecule/keepalived/prepare.yml
@@ -1,0 +1,17 @@
+---
+# Molecule preparation for keepalived — bring the test containers to a ready
+# state. The role renders config with keepalived_manage_services=false, so no
+# package install is exercised here; this just ensures the connection + facts.
+
+- name: Prepare
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Wait for container to be ready
+      ansible.builtin.wait_for_connection:
+        timeout: 30
+
+    - name: Gather facts
+      ansible.builtin.setup:

--- a/molecule/keepalived/verify.yml
+++ b/molecule/keepalived/verify.yml
@@ -1,0 +1,80 @@
+---
+# Molecule verification for keepalived (no live daemon).
+#
+# Re-runs the role with keepalived_manage_services=false to populate the derived
+# vars, then asserts the VRRP topology resolved correctly across the two-node
+# group and that the rendered config matches it:
+#   - VIP + vrid come from the tofu inventory (not hardcoded);
+#   - keepalived-1 (.101, first in sorted ingress_hosts) is MASTER (higher prio),
+#     keepalived-2 (.107) is BACKUP;
+#   - each node's unicast_peer is the OTHER instance (never itself);
+#   - the rendered keepalived.conf contains the VIP, the vrid, and the peer.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+
+  vars:
+    keepalived_manage_services: false
+    tofu_data:
+      ingress_vip: "192.168.5.2"
+      ingress_hosts:
+        - "192.168.5.101"
+        - "192.168.5.107"
+      constants:
+        ingress_ports:
+          keepalived_vrid: 51
+
+  tasks:
+    # import_role exposes the role's defaults (derived vars) to the assertions.
+    - name: Re-run keepalived role to populate derived vars
+      ansible.builtin.import_role:
+        name: keepalived
+
+    - name: Assert VIP + vrid derive from the tofu inventory
+      ansible.builtin.assert:
+        that:
+          - keepalived_vip == '192.168.5.2'
+          - keepalived_vrid | int == 51
+          - keepalived_ha_ready | bool
+        fail_msg: "VIP/vrid/HA-ready did not derive correctly on {{ inventory_hostname }}"
+
+    - name: Assert deterministic master election by position
+      ansible.builtin.assert:
+        that:
+          - >-
+            (keepalived_priority | int > keepalived_priority_base | int - 1)
+            if container_ip == '192.168.5.101'
+            else (keepalived_priority | int < keepalived_priority_base | int)
+        fail_msg: >-
+          Priority wrong on {{ inventory_hostname }} ({{ container_ip }}):
+          got {{ keepalived_priority }} (base {{ keepalived_priority_base }}).
+
+    - name: Assert unicast_peer is the OTHER instance only
+      ansible.builtin.assert:
+        that:
+          - keepalived_this_addr not in keepalived_unicast_peers
+          - keepalived_unicast_peers | length == 1
+          - >-
+            keepalived_unicast_peers[0] ==
+            ('192.168.5.107' if container_ip == '192.168.5.101' else '192.168.5.101')
+        fail_msg: >-
+          unicast_peer wrong on {{ inventory_hostname }}:
+          {{ keepalived_unicast_peers }}.
+
+    - name: Read the rendered keepalived config
+      ansible.builtin.slurp:
+        src: "{{ keepalived_config_file }}"
+      register: keepalived_rendered
+
+    - name: Assert the rendered config carries the VIP, vrid, and peer
+      ansible.builtin.assert:
+        that:
+          - "'192.168.5.2' in rendered"
+          - "'virtual_router_id 51' in rendered"
+          - >-
+            (('192.168.5.107' in rendered) if container_ip == '192.168.5.101'
+             else ('192.168.5.101' in rendered))
+        fail_msg: "rendered keepalived.conf missing VIP/vrid/peer on {{ inventory_hostname }}"
+      vars:
+        rendered: "{{ keepalived_rendered.content | b64decode }}"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -981,6 +981,10 @@
     - ingress
   roles:
     - role: traefik
+    # keepalived floats the ingress VRRP virtual IP across every Traefik
+    # instance so a node loss migrates ingress automatically (no manual DR).
+    # No-ops below 2 ingress instances / without a published VIP.
+    - role: keepalived
 
 # =============================================================================
 # Phase 9: Systemd Restart Policies

--- a/roles/keepalived/README.md
+++ b/roles/keepalived/README.md
@@ -1,0 +1,58 @@
+# keepalived
+
+Floats the ingress **VRRP virtual IP** across every Traefik instance so the
+reverse proxy has no single-node SPOF. DNS points every fronted service at the
+VIP (see the `technitium_dns` role); keepalived migrates it automatically on a
+node loss or a local Traefik failure — there is no manual DR step.
+
+## How it works
+
+- **Unicast VRRP** (no multicast, so it works across the LXC bridge) between the
+  Traefik instances. Peers, VIP, and the VRRP `virtual_router_id` are all derived
+  from the tofu inventory (`tofu_data.ingress_hosts` / `ingress_vip` /
+  `constants.ingress_ports.keepalived_vrid`) — no hardcoded IPs or ids.
+- **Deterministic master election, no manual flag.** Priority decreases with the
+  node's position in the sorted `ingress_hosts` list, so the first instance is
+  MASTER and the rest are ordered BACKUPs. keepalived preempts on priority.
+- **Health-aware.** A `track_script` (`pidof traefik`) drops this node's priority
+  when Traefik is down, so the VIP leaves even if the host itself stays up.
+- **No-op when not HA-ready.** With `< 2` ingress instances or no published VIP,
+  the role skips cleanly (single-ingress / pre-HA deployments stay green).
+
+## Requirements
+
+- Two or more LXCs tagged `ingress` (the Traefik HA pair), on different nodes.
+- terraform-proxmox publishing `ingress_vip` + `ingress_hosts` in the inventory.
+
+## Key variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `keepalived_vip` | `tofu_data.ingress_vip` | The floating VIP. |
+| `keepalived_peers_all` | `tofu_data.ingress_hosts` | All ingress instance addresses. |
+| `keepalived_vrid` | `tofu_data.constants.ingress_ports.keepalived_vrid` | VRRP router id. |
+| `keepalived_interface` | `eth0` | LXC NIC carrying the VLAN + VIP. |
+| `keepalived_auth_pass` | `env KEEPALIVED_AUTH_PASS` | Optional unicast VRRP PASS (omitted when empty). |
+| `keepalived_manage_services` | `true` | Set `false` for CI / template-render (no live service). |
+
+## Installation
+
+Included in this repo's Ansible collection; no separate install. The
+`keepalived` package is installed on the target by the role
+(`keepalived_manage_services: true`). Run from the repo root.
+
+## Usage
+
+Applied by `playbooks/site.yml` (Phase 8d) on the `traefik_group`, right after
+the `traefik` role:
+
+```bash
+ansible-playbook playbooks/site.yml --tags ingress --limit traefik_group
+```
+
+## Failover drill
+
+`scripts/ingress-failover-drill.sh` is an **automated, scriptable** drill (never a
+manual runbook): against a live ingress pair it stops Traefik on the VIP holder,
+asserts the VIP + an HTTPS probe still answer from the surviving node, then
+restores. Wire it into CI where a live pair exists.

--- a/roles/keepalived/defaults/main.yml
+++ b/roles/keepalived/defaults/main.yml
@@ -17,14 +17,14 @@
 keepalived_manage_services: true
 
 # --- Topology (all derived from the tofu inventory) --------------------------
-keepalived_vip: "{{ tofu_data.ingress_vip | default('', true) }}"
-keepalived_peers_all: "{{ tofu_data.ingress_hosts | default([]) }}"
+keepalived_vip: "{{ tofu_data['ingress_vip'] | default('', true) }}"
+keepalived_peers_all: "{{ tofu_data['ingress_hosts'] | default([]) }}"
 # This node's own ingress address (load_tofu publishes it as container_ip).
 keepalived_this_addr: "{{ container_ip | default('') }}"
 # Unicast peers = every ingress instance except this one.
 keepalived_unicast_peers: "{{ keepalived_peers_all | difference([keepalived_this_addr]) }}"
 # VRRP virtual_router_id — DRY from tofu constants, never hardcoded downstream.
-keepalived_vrid: "{{ tofu_data.constants.ingress_ports.keepalived_vrid | default(51) }}"
+keepalived_vrid: "{{ tofu_data['constants']['ingress_ports']['keepalived_vrid'] | default(51) }}"
 
 # Deterministic master election with NO per-node manual flag: priority decreases
 # with this node's position in the sorted ingress_hosts list, so the first

--- a/roles/keepalived/defaults/main.yml
+++ b/roles/keepalived/defaults/main.yml
@@ -1,0 +1,60 @@
+---
+# keepalived role — floats the ingress VRRP virtual IP across every Traefik
+# instance so the reverse proxy survives a node loss with NO manual switch. DNS
+# points every fronted service at this VIP (see the technitium_dns role), and
+# keepalived migrates it automatically when a node or its Traefik dies.
+#
+# Unicast VRRP (no multicast) so it works inside the LXC bridge. A track_script
+# watches the local Traefik: losing it drops this node's priority, so the VIP
+# leaves even when the host itself stays up (a wedged proxy is still a failure).
+#
+# EVERYTHING topology-related is DERIVED from the tofu inventory (tofu_data) — no
+# hardcoded IPs, ports, or vrid. The role NO-OPS cleanly below 2 ingress
+# instances or without a published VIP (single-ingress / pre-HA deployments).
+
+# Render always; manage the live service only on a real run. Mirrors
+# traefik_manage_services (CI / template-render sets this false).
+keepalived_manage_services: true
+
+# --- Topology (all derived from the tofu inventory) --------------------------
+keepalived_vip: "{{ tofu_data.ingress_vip | default('', true) }}"
+keepalived_peers_all: "{{ tofu_data.ingress_hosts | default([]) }}"
+# This node's own ingress address (load_tofu publishes it as container_ip).
+keepalived_this_addr: "{{ container_ip | default('') }}"
+# Unicast peers = every ingress instance except this one.
+keepalived_unicast_peers: "{{ keepalived_peers_all | difference([keepalived_this_addr]) }}"
+# VRRP virtual_router_id — DRY from tofu constants, never hardcoded downstream.
+keepalived_vrid: "{{ tofu_data.constants.ingress_ports.keepalived_vrid | default(51) }}"
+
+# Deterministic master election with NO per-node manual flag: priority decreases
+# with this node's position in the sorted ingress_hosts list, so the first
+# instance is MASTER and the rest are ordered BACKUPs. keepalived preempts on
+# priority; the track_script weight below lets a Traefik failure hand off the VIP
+# without the host going down.
+keepalived_priority_base: 200
+keepalived_priority: >-
+  {{ (keepalived_priority_base - (keepalived_peers_all | sort).index(keepalived_this_addr))
+     if keepalived_this_addr in keepalived_peers_all else 100 }}
+
+# LXC guest NIC that carries the ingress VLAN address + the floating VIP.
+keepalived_interface: eth0
+
+# VRRP unicast auth. Optional and sourced from the environment (never committed).
+# When empty the auth block is omitted — all peers omit it, so they stay
+# consistent. keepalived truncates a PASS to 8 chars.
+keepalived_auth_pass: "{{ lookup('env', 'KEEPALIVED_AUTH_PASS') | default('', true) }}"
+
+# Local Traefik liveness probe for the track_script. pidof returns non-zero when
+# Traefik is not running -> keepalived drops this node's priority -> the VIP
+# migrates. ponytail: liveness only; swap for an HTTP /ping probe if a
+# wedged-but-alive Traefik ever becomes a real failure mode.
+keepalived_track_command: "pidof traefik"
+keepalived_track_interval: 2
+keepalived_track_fall: 2
+keepalived_track_rise: 2
+keepalived_track_weight: -40
+
+# Convenience gate: the live config is only meaningful with a VIP AND >=2 peers.
+keepalived_ha_ready: "{{ (keepalived_vip | length > 0) and (keepalived_peers_all | length >= 2) }}"
+
+keepalived_config_file: /etc/keepalived/keepalived.conf

--- a/roles/keepalived/handlers/main.yml
+++ b/roles/keepalived/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart keepalived
+  ansible.builtin.systemd:
+    name: keepalived
+    state: restarted
+  when: keepalived_manage_services | bool

--- a/roles/keepalived/meta/main.yml
+++ b/roles/keepalived/meta/main.yml
@@ -1,0 +1,25 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: Float the ingress VRRP virtual IP across the Traefik instances for automatic failover
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+
+  galaxy_tags:
+    - keepalived
+    - vrrp
+    - ingress
+    - ha
+    - failover
+
+dependencies: []

--- a/roles/keepalived/tasks/main.yml
+++ b/roles/keepalived/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+# Install + configure keepalived so the ingress VRRP virtual IP fails over
+# automatically across the Traefik instances. Skips cleanly when the deployment
+# is not HA-ready (no VIP or a single ingress instance) so a partial / pre-HA
+# converge stays green.
+
+- name: Report ingress HA not ready — skipping keepalived
+  ansible.builtin.debug:
+    msg: >-
+      keepalived skipped on {{ inventory_hostname }}: ingress HA needs a published
+      VIP (tofu_data.ingress_vip) AND >= 2 ingress instances
+      (tofu_data.ingress_hosts). Have vip='{{ keepalived_vip }}',
+      peers={{ keepalived_peers_all }}. Add a second ingress-tagged Traefik LXC
+      in deployment.json to enable the floating VIP.
+  when: not (keepalived_ha_ready | bool)
+
+- name: Configure ingress VRRP failover
+  when: keepalived_ha_ready | bool
+  block:
+    - name: Assert this node is enrolled in the ingress peer set
+      ansible.builtin.assert:
+        that:
+          - keepalived_this_addr | length > 0
+          - keepalived_this_addr in keepalived_peers_all
+        fail_msg: >-
+          {{ inventory_hostname }} runs Traefik but its address
+          '{{ keepalived_this_addr }}' is not in the tofu ingress_hosts set
+          {{ keepalived_peers_all }} — the inventory (container_ip vs ingress_hosts)
+          is inconsistent; keepalived cannot pick a deterministic priority.
+        quiet: true
+
+    - name: Install keepalived
+      ansible.builtin.apt:
+        name: keepalived
+        state: present
+        update_cache: true
+        cache_valid_time: 3600
+      when: keepalived_manage_services | bool
+
+    - name: Ensure keepalived config directory exists
+      ansible.builtin.file:
+        path: "{{ keepalived_config_file | dirname }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Render keepalived configuration
+      ansible.builtin.template:
+        src: keepalived.conf.j2
+        dest: "{{ keepalived_config_file }}"
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Restart keepalived
+
+    - name: Enable + start keepalived
+      ansible.builtin.systemd:
+        name: keepalived
+        enabled: true
+        state: started
+      when: keepalived_manage_services | bool

--- a/roles/keepalived/templates/keepalived.conf.j2
+++ b/roles/keepalived/templates/keepalived.conf.j2
@@ -39,7 +39,9 @@ vrrp_instance ingress {
 
     authentication {
         auth_type PASS
-        auth_pass {{ keepalived_auth_pass }}
+        # keepalived truncates auth_pass to 8 chars internally; do it explicitly
+        # so every peer renders the SAME value (a mismatch drops VRRP adverts).
+        auth_pass {{ keepalived_auth_pass[:8] }}
     }
 {% endif %}
 

--- a/roles/keepalived/templates/keepalived.conf.j2
+++ b/roles/keepalived/templates/keepalived.conf.j2
@@ -1,0 +1,53 @@
+{{ ansible_managed | comment }}
+# keepalived — ingress VRRP virtual IP ({{ keepalived_vip }}) failover.
+# Rendered by the keepalived role from the tofu inventory. Unicast VRRP between
+# the Traefik instances; master election by priority; a Traefik outage on this
+# node drops its priority (track_script) so the VIP migrates automatically.
+
+global_defs {
+    enable_script_security
+    script_user root
+}
+
+# Local Traefik liveness — a non-zero exit drops this node's effective priority
+# by {{ keepalived_track_weight }}, handing the VIP to a healthy peer.
+vrrp_script chk_traefik {
+    script "{{ keepalived_track_command }}"
+    interval {{ keepalived_track_interval }}
+    fall {{ keepalived_track_fall }}
+    rise {{ keepalived_track_rise }}
+    weight {{ keepalived_track_weight }}
+}
+
+vrrp_instance ingress {
+    # Highest-priority reachable instance owns the VIP; preemption lets a
+    # recovered higher-priority node reclaim it.
+    state {{ 'MASTER' if keepalived_priority | int >= keepalived_priority_base else 'BACKUP' }}
+    interface {{ keepalived_interface }}
+    virtual_router_id {{ keepalived_vrid }}
+    priority {{ keepalived_priority }}
+    advert_int 1
+
+    # Unicast VRRP (no multicast — works across the LXC bridge).
+    unicast_src_ip {{ keepalived_this_addr }}
+    unicast_peer {
+{% for peer in keepalived_unicast_peers %}
+        {{ peer }}
+{% endfor %}
+    }
+{% if keepalived_auth_pass | length > 0 %}
+
+    authentication {
+        auth_type PASS
+        auth_pass {{ keepalived_auth_pass }}
+    }
+{% endif %}
+
+    virtual_ipaddress {
+        {{ keepalived_vip }}
+    }
+
+    track_script {
+        chk_traefik
+    }
+}

--- a/roles/openbao_secrets/README.md
+++ b/roles/openbao_secrets/README.md
@@ -61,6 +61,18 @@ Any domain whose credentials aren't set simply falls back to env/SOPS for its
 consumer roles — see [Wiring](#wiring) for how the pre-fetch play publishes
 each domain's fact.
 
+## Client failover
+
+Before fetching, the controller probes an ordered list of endpoints and pins the
+first that answers a health check unsealed (standbyok, since a standby forwards
+to the active peer so any node can serve the read). It tries `BAO_ADDR` (the
+Traefik ingress VIP name, made HA by the `keepalived` role) first, then each
+`openbao`-tagged container's own per-node endpoint derived from the tofu
+inventory (no literal address), so failover holds even if both ingress instances
+are unreachable. If none answers, the role skips to the env/SOPS fallback for
+this run rather than hard-failing every converge. This is client failover only;
+server-side quorum HA needs a fourth node and is out of scope.
+
 ## Domains fetched (`openbao_secrets_domains`)
 
 | Domain | AppRole env vars | KV paths | Consumers |

--- a/roles/openbao_secrets/defaults/main.yml
+++ b/roles/openbao_secrets/defaults/main.yml
@@ -23,13 +23,12 @@ openbao_secrets_validate_certs: true
 openbao_secrets_kv_mount: secret
 # Client failover across the OpenBao nodes: probe an ordered candidate list and
 # use the first reachable endpoint. See README for the full ordering + rationale.
-openbao_secrets_openbao_api_port: "{{ tofu_data.constants.service_ports.openbao_api | default(8200) }}"
+openbao_secrets_openbao_api_port: "{{ tofu_data['constants']['service_ports']['openbao_api'] | default(8200) }}"
 openbao_secrets_node_addrs: >-
-  {{ tofu_data.containers | default({}) | dict2items
+  {{ tofu_data['containers'] | default({}) | dict2items
      | selectattr('value.tags', 'defined')
      | selectattr('value.tags', 'contains', 'openbao')
-     | map(attribute='value.ip')
-     | select('string') | reject('equalto', '')
+     | map(attribute='value.ip', default='') | reject('equalto', '')
      | map('regex_replace', '^(.+)$', 'http://\1:' ~ (openbao_secrets_openbao_api_port | string))
      | list }}
 openbao_secrets_bao_addr_candidates: >-

--- a/roles/openbao_secrets/defaults/main.yml
+++ b/roles/openbao_secrets/defaults/main.yml
@@ -21,6 +21,20 @@ openbao_secrets_bao_addr: "{{ lookup('env', 'BAO_ADDR') | default('', true) }}"
 # default; override only for a direct-to-node http bootstrap endpoint.
 openbao_secrets_validate_certs: true
 openbao_secrets_kv_mount: secret
+# Client failover across the OpenBao nodes: probe an ordered candidate list and
+# use the first reachable endpoint. See README for the full ordering + rationale.
+openbao_secrets_openbao_api_port: "{{ tofu_data.constants.service_ports.openbao_api | default(8200) }}"
+openbao_secrets_node_addrs: >-
+  {{ tofu_data.containers | default({}) | dict2items
+     | selectattr('value.tags', 'defined')
+     | selectattr('value.tags', 'contains', 'openbao')
+     | map(attribute='value.ip')
+     | select('string') | reject('equalto', '')
+     | map('regex_replace', '^(.+)$', 'http://\1:' ~ (openbao_secrets_openbao_api_port | string))
+     | list }}
+openbao_secrets_bao_addr_candidates: >-
+  {{ (([openbao_secrets_bao_addr] if openbao_secrets_bao_addr | length > 0 else [])
+      + openbao_secrets_node_addrs) | unique }}
 
 # One entry per resource-domain identity this Ansible converge fetches for.
 # Each domain's role_id/secret_id come from its own env vars — sourced from

--- a/roles/openbao_secrets/tasks/fetch_domain.yml
+++ b/roles/openbao_secrets/tasks/fetch_domain.yml
@@ -38,7 +38,7 @@
 
     - name: Log in with the AppRole for {{ openbao_domain.name }}
       community.hashi_vault.vault_login:
-        url: "{{ openbao_secrets_bao_addr }}"
+        url: "{{ hostvars['localhost'].openbao_secrets_active_addr | default(openbao_secrets_bao_addr, true) }}"
         auth_method: approle
         role_id: "{{ openbao_secrets_domain_role_id }}"
         secret_id: "{{ openbao_secrets_domain_secret_id }}"
@@ -47,7 +47,7 @@
 
     - name: Read each KV path, tolerating not-yet-seeded ones, for {{ openbao_domain.name }}
       community.hashi_vault.vault_kv2_get:
-        url: "{{ openbao_secrets_bao_addr }}"
+        url: "{{ hostvars['localhost'].openbao_secrets_active_addr | default(openbao_secrets_bao_addr, true) }}"
         auth_method: token
         token: "{{ openbao_secrets_domain_login.login.auth.client_token }}"
         engine_mount_point: "{{ openbao_secrets_kv_mount }}"

--- a/roles/openbao_secrets/tasks/main.yml
+++ b/roles/openbao_secrets/tasks/main.yml
@@ -10,17 +10,68 @@
 
 - name: Decide whether OpenBao is configured at all
   ansible.builtin.set_fact:
-    openbao_secrets_active: "{{ openbao_secrets_bao_addr | length > 0 }}"
+    openbao_secrets_configured: "{{ openbao_secrets_bao_addr_candidates | length > 0 }}"
 
 - name: Report that OpenBao is not configured (env/SOPS fallback in effect)
   ansible.builtin.debug:
     msg: >-
-      BAO_ADDR is unset — openbao_secrets is skipping entirely; every domain
-      falls back to env/SOPS secrets. Set BAO_ADDR plus each domain's
-      <DOMAIN>_VAULT_ROLE_ID / <DOMAIN>_VAULT_SECRET_ID to source that
-      domain's secrets from OpenBao.
+      No OpenBao endpoint (BAO_ADDR unset and no openbao-tagged nodes in the tofu
+      inventory) — openbao_secrets is skipping entirely; every domain falls back
+      to env/SOPS secrets. Set BAO_ADDR plus each domain's role_id/secret_id
+      envs to source that domain's secrets from OpenBao.
   run_once: true
-  when: not openbao_secrets_active
+  when: not openbao_secrets_configured
+
+# Client failover: probe the ordered candidate endpoints ONCE on the controller
+# and pin the first that is reachable + unsealed (health 200, standbyok — a
+# standby forwards to the active peer). This is what removes the single-node
+# dependency: openbao-01 down -> openbao-02 answers, ingress down -> a per-node
+# endpoint answers. If NONE answers, active_addr stays empty and the role skips
+# to env/SOPS (a total-OpenBao outage must not hard-fail every converge).
+- name: Probe OpenBao endpoints for a live, unsealed one (client failover)
+  ansible.builtin.uri:
+    url: "{{ item }}/v1/sys/health?standbyok=true&perfstandbyok=true"
+    method: GET
+    validate_certs: "{{ openbao_secrets_validate_certs }}"
+    timeout: 5
+  loop: "{{ openbao_secrets_bao_addr_candidates }}"
+  loop_control:
+    label: "{{ item }}"
+  register: openbao_secrets_health
+  failed_when: false
+  changed_when: false
+  delegate_to: localhost
+  run_once: true
+  no_log: true
+  when: openbao_secrets_configured
+
+- name: Pin the first reachable OpenBao endpoint for this run
+  ansible.builtin.set_fact:
+    openbao_secrets_active_addr: >-
+      {{ (openbao_secrets_health.results
+          | selectattr('status', 'defined')
+          | selectattr('status', 'equalto', 200)
+          | map(attribute='item') | list | first) | default('', true) }}
+  delegate_to: localhost
+  delegate_facts: true
+  run_once: true
+  when: openbao_secrets_configured
+
+- name: Decide whether a usable OpenBao endpoint was found
+  ansible.builtin.set_fact:
+    openbao_secrets_active: "{{ (hostvars['localhost'].openbao_secrets_active_addr | default('', true)) | length > 0 }}"
+
+- name: Report no OpenBao endpoint answered (env/SOPS fallback in effect)
+  ansible.builtin.debug:
+    msg: >-
+      OpenBao is configured but none of {{ openbao_secrets_bao_addr_candidates }}
+      answered /v1/sys/health unsealed — skipping OpenBao for this run; every
+      domain falls back to env/SOPS secrets. This is the DR degrade path, not a
+      hard failure.
+  run_once: true
+  when:
+    - openbao_secrets_configured
+    - not openbao_secrets_active
 
 # delegate_facts is REQUIRED, not optional: set_fact + delegate_to + run_once
 # WITHOUT delegate_facts writes the fact to the play's hosts, NOT to localhost,

--- a/roles/openbao_secrets/tasks/main.yml
+++ b/roles/openbao_secrets/tasks/main.yml
@@ -42,7 +42,8 @@
   changed_when: false
   delegate_to: localhost
   run_once: true
-  no_log: true
+  # /v1/sys/health is public + unauthenticated (no secret in URL or response), so
+  # NOT no_log: keep it visible for troubleshooting DNS/TLS/connectivity failover.
   when: openbao_secrets_configured
 
 - name: Pin the first reachable OpenBao endpoint for this run

--- a/roles/technitium_dns/defaults/main.yml
+++ b/roles/technitium_dns/defaults/main.yml
@@ -74,6 +74,15 @@ technitium_dns_extra_cname_records: []
 # own name points at Traefik, not the host — safe because all internal
 # service-to-service traffic uses container IPs, not these DNS names).
 technitium_dns_ingress_host: traefik
+# Ingress HA: fronted-service aliases resolve to the keepalived VRRP virtual IP
+# (tofu_data.ingress_vip) so a Traefik node loss never breaks name resolution —
+# the VIP floats to a surviving instance. Falls back to the single Traefik LXC's
+# own IP when no VIP is published (single-ingress / pre-HA deployments),
+# preserving the prior behavior exactly.
+technitium_dns_ingress_target_ip: >-
+  {{ (tofu_data.ingress_vip | default('', true))
+     if (tofu_data.ingress_vip | default('', true)) | length > 0
+     else (hostvars[technitium_dns_ingress_host].container_ip | default('')) }}
 # Apex ingress rows (the Proxmox cluster UI fronted at the bare subdomain) are
 # EXCLUDED here — they resolve at the zone root, not as <name>.<subdomain> — and
 # are handled by technitium_dns_ingress_apex below instead.

--- a/roles/technitium_dns/defaults/main.yml
+++ b/roles/technitium_dns/defaults/main.yml
@@ -80,8 +80,8 @@ technitium_dns_ingress_host: traefik
 # own IP when no VIP is published (single-ingress / pre-HA deployments),
 # preserving the prior behavior exactly.
 technitium_dns_ingress_target_ip: >-
-  {{ (tofu_data.ingress_vip | default('', true))
-     if (tofu_data.ingress_vip | default('', true)) | length > 0
+  {{ (tofu_data['ingress_vip'] | default('', true))
+     if (tofu_data['ingress_vip'] | default('', true)) | length > 0
      else (hostvars[technitium_dns_ingress_host].container_ip | default('')) }}
 # Apex ingress rows (the Proxmox cluster UI fronted at the bare subdomain) are
 # EXCLUDED here — they resolve at the zone root, not as <name>.<subdomain> — and

--- a/roles/technitium_dns/tasks/main.yml
+++ b/roles/technitium_dns/tasks/main.yml
@@ -464,14 +464,14 @@
       domain: "{{ item }}.{{ technitium_dns_ingress_domain }}"
       zone: "{{ technitium_dns_zone }}"
       type: A
-      ipAddress: "{{ hostvars[technitium_dns_ingress_host].container_ip }}"
+      ipAddress: "{{ technitium_dns_ingress_target_ip }}"
       ttl: "{{ technitium_dns_zone_ttl }}"
       overwrite: "true"
     return_content: true
     timeout: "{{ technitium_dns_api_timeout }}"
   loop: "{{ technitium_dns_ingress_aliases | default([]) }}"
   loop_control:
-    label: "{{ item }} -> {{ technitium_dns_ingress_host }}"
+    label: "{{ item }} -> {{ technitium_dns_ingress_target_ip }}"
   register: technitium_dns_ingress_result
   changed_when: technitium_dns_ingress_result.json.status == "ok"
   failed_when:
@@ -481,8 +481,8 @@
   when:
     - technitium_dns_role == 'primary'
     - technitium_dns_apply | bool
-    - technitium_dns_ingress_host in hostvars
-    - hostvars[technitium_dns_ingress_host].container_ip is defined
+    # Points at the ingress VIP when published, else the single Traefik LXC's IP.
+    - technitium_dns_ingress_target_ip | length > 0
 
 # The Proxmox API/UI apex (the subdomain zone root itself) resolves directly to
 # the Proxmox node endpoint IPs when PROXMOX_IP_ADDRESSES is set. Delete the old
@@ -555,7 +555,7 @@
       domain: "{{ technitium_dns_zone }}"
       zone: "{{ technitium_dns_zone }}"
       type: A
-      ipAddress: "{{ hostvars[technitium_dns_ingress_host].container_ip }}"
+      ipAddress: "{{ technitium_dns_ingress_target_ip }}"
       ttl: "{{ technitium_dns_zone_ttl }}"
       overwrite: "true"
     return_content: true
@@ -571,8 +571,8 @@
     - technitium_dns_proxmox_endpoint_a_records | default([]) | length == 0
     - technitium_dns_role == 'primary'
     - technitium_dns_apply | bool
-    - technitium_dns_ingress_host in hostvars
-    - hostvars[technitium_dns_ingress_host].container_ip is defined
+    # Points at the ingress VIP when published, else the single Traefik LXC's IP.
+    - technitium_dns_ingress_target_ip | length > 0
 
 # Authorize the secondaries to pull the zone via AXFR. UseSpecifiedNetworkACL
 # restricts transfer to exactly the secondary IPs (default-deny otherwise).

--- a/scripts/ingress-failover-drill.sh
+++ b/scripts/ingress-failover-drill.sh
@@ -85,11 +85,12 @@ if [[ -n "${probe_host:-}" ]]; then
     die "HTTPS via VIP failed for ${probe_host} after failover"
   fi
 else
-  # No service name given: at least confirm the VIP accepts TCP :443.
-  if on "$new_holder" "curl -fsS -o /dev/null -k https://127.0.0.1:443/ || true; timeout 3 bash -c '</dev/tcp/${VIP}/443'"; then
-    ok "VIP $VIP accepts TCP :443 from the surviving node"
+  # No service name given: confirm the VIP terminates TLS + answers HTTP from the
+  # surviving node (no -f: a Traefik 404 on / is still a served response).
+  if on "$new_holder" "curl -sS -o /dev/null -k https://${VIP}/"; then
+    ok "VIP $VIP accepts HTTPS connections on the surviving node"
   else
-    die "VIP $VIP not serving :443 after failover"
+    die "VIP $VIP not serving HTTPS after failover"
   fi
 fi
 

--- a/scripts/ingress-failover-drill.sh
+++ b/scripts/ingress-failover-drill.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Automated ingress-failover drill (NOT a manual runbook).
+#
+# Proves the keepalived VRRP virtual IP actually fails over: it finds the node
+# currently holding the VIP, stops Traefik there, and asserts that (a) the VIP
+# migrates to the surviving ingress node and (b) an HTTPS probe through the VIP
+# still answers. Then it restores Traefik and re-asserts the VIP is back to a
+# healthy 2-node state. Everything is derived from the tofu inventory — no
+# hardcoded IPs. Safe by construction: an EXIT trap always restarts Traefik on
+# every ingress node, so a failed assertion never leaves the proxy down.
+#
+# Intended to run in CI (or by an operator) where a LIVE ingress pair exists;
+# it cannot run headless without one, which is exactly why it is a script and
+# not a documented "click here to test failover" step.
+#
+# Usage:
+#   ./scripts/ingress-failover-drill.sh [--probe-host NAME.SUBDOMAIN]
+# Env:
+#   INVENTORY_FILE   tofu inventory (default inventory/tofu_inventory.json)
+#   SSH_USER         user for ssh to the ingress nodes (default root)
+#   PROBE_PATH       HTTPS path to probe through the VIP (default /)
+set -euo pipefail
+
+INVENTORY_FILE="${INVENTORY_FILE:-inventory/tofu_inventory.json}"
+SSH_USER="${SSH_USER:-root}"
+PROBE_PATH="${PROBE_PATH:-/}"
+SSH_OPTS=(-o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new -o BatchMode=yes)
+
+log()  { printf '\033[0;36m[drill]\033[0m %s\n' "$*"; }
+ok()   { printf '\033[0;32m[ pass]\033[0m %s\n' "$*"; }
+die()  { printf '\033[0;31m[FAIL]\033[0m %s\n' "$*" >&2; exit 1; }
+
+command -v jq >/dev/null || die "jq is required"
+[[ -f "$INVENTORY_FILE" ]] || die "inventory not found: $INVENTORY_FILE"
+
+VIP="$(jq -r '.ingress_vip // empty' "$INVENTORY_FILE")"
+mapfile -t HOSTS < <(jq -r '.ingress_hosts[]? // empty' "$INVENTORY_FILE")
+
+[[ -n "$VIP" ]] || die "inventory has no ingress_vip — ingress HA not deployed"
+(( ${#HOSTS[@]} >= 2 )) || die "need >= 2 ingress_hosts for a failover drill, have ${#HOSTS[@]}"
+
+log "VIP=$VIP  ingress nodes=${HOSTS[*]}"
+
+on() { ssh "${SSH_OPTS[@]}" "${SSH_USER}@${1}" "${@:2}"; }
+
+# Which node currently holds the VIP?
+holder=""
+for h in "${HOSTS[@]}"; do
+  if on "$h" "ip -4 addr show | grep -qw '$VIP'"; then holder="$h"; break; fi
+done
+[[ -n "$holder" ]] || die "no ingress node currently holds $VIP — keepalived not converged"
+log "current VIP holder: $holder"
+
+# Always restore Traefik everywhere on exit, regardless of outcome.
+restore() {
+  log "restoring Traefik on all ingress nodes"
+  for h in "${HOSTS[@]}"; do on "$h" "systemctl start traefik" || true; done
+}
+trap restore EXIT
+
+# --- Induce failure on the holder ------------------------------------------
+log "stopping Traefik on $holder to force VRRP failover"
+on "$holder" "systemctl stop traefik"
+
+# --- Assert the VIP migrated to a surviving node ---------------------------
+new_holder=""
+for _ in $(seq 1 15); do
+  for h in "${HOSTS[@]}"; do
+    [[ "$h" == "$holder" ]] && continue
+    if on "$h" "ip -4 addr show | grep -qw '$VIP'"; then new_holder="$h"; break 2; fi
+  done
+  sleep 1
+done
+[[ -n "$new_holder" ]] || die "VIP $VIP did not migrate off $holder within 15s"
+ok "VIP migrated $holder -> $new_holder"
+
+# --- Assert HTTPS through the VIP still answers ----------------------------
+probe_target="${1:-}"
+if [[ "$probe_target" == "--probe-host" ]]; then probe_host="$2"; else probe_host="${PROBE_HOST:-}"; fi
+if [[ -n "${probe_host:-}" ]]; then
+  # Resolve the service name to the VIP so we exercise real SNI + routing.
+  if curl -fsS -o /dev/null --resolve "${probe_host}:443:${VIP}" "https://${probe_host}${PROBE_PATH}"; then
+    ok "HTTPS via VIP answered for ${probe_host}"
+  else
+    die "HTTPS via VIP failed for ${probe_host} after failover"
+  fi
+else
+  # No service name given: at least confirm the VIP accepts TCP :443.
+  if on "$new_holder" "curl -fsS -o /dev/null -k https://127.0.0.1:443/ || true; timeout 3 bash -c '</dev/tcp/${VIP}/443'"; then
+    ok "VIP $VIP accepts TCP :443 from the surviving node"
+  else
+    die "VIP $VIP not serving :443 after failover"
+  fi
+fi
+
+# --- Restore + re-assert healthy 2-node state ------------------------------
+log "restoring Traefik on $holder"
+on "$holder" "systemctl start traefik"
+trap - EXIT
+
+sleep 3
+back=""
+for h in "${HOSTS[@]}"; do
+  if on "$h" "ip -4 addr show | grep -qw '$VIP'"; then back="$h"; break; fi
+done
+[[ -n "$back" ]] || die "after restore, no node holds $VIP"
+ok "ingress healthy again (VIP on $back)"
+log "DRILL PASSED"


### PR DESCRIPTION
Consumer side of the fully-autonomous DR/HA mandate. Pairs with terraform-proxmox #570 (ingress_vip / ingress_hosts / constants + deployment.json fetch failover). No manual outage-detection or node-switch steps anywhere.

## W1 — Ingress HA (keepalived VRRP)
- **New `keepalived` role** floats one VRRP virtual IP across every Traefik instance (unicast, works inside the LXC bridge). VIP, unicast peers, and the VRRP vrid are **derived from the tofu inventory** (`ingress_vip` / `ingress_hosts` / `constants.ingress_ports.keepalived_vrid`) — no hardcoded IPs. **Deterministic master election** by position in the sorted `ingress_hosts` list (no per-node manual flag); a `chk_traefik` track_script drops priority when local Traefik dies, so the VIP migrates even without full host loss. **No-ops** below 2 ingress instances / without a VIP.
- **`playbooks/site.yml`** Phase 8d runs it on `traefik_group` after the `traefik` role.
- **`technitium_dns`** repoints every ingress alias + apex A record at the VIP when published; **falls back** to the single Traefik IP for pre-HA / single-ingress deployments (backward compatible).
- **`scripts/ingress-failover-drill.sh`** — an **automated, scriptable** failover drill (never a manual runbook): finds the VIP holder, stops Traefik there, asserts the VIP migrates + an HTTPS probe still answers from the survivor, then restores. For CI / operator where a live pair exists.
- **`molecule/keepalived`** scenario (2 instances → MASTER/BACKUP) asserts the derived topology + rendered config.

## W3 — OpenBao client failover
`openbao_secrets` now probes an **ordered endpoint list** and pins the first reachable + unsealed one: `BAO_ADDR` (the ingress VIP name, HA via keepalived) first, then each `openbao`-tagged node's own endpoint derived from the inventory. `openbao-01` down → `openbao-02` answers; ingress down → a direct node answers; none → graceful env/SOPS fallback (not a hard fail). **Client failover only** — server-side 3-voter Raft HA is **pve4-gated / out of scope**.

## Validation
- **ansible-lint (production profile): passes on all 223 files, 0 failures.**
- keepalived + openbao_secrets Jinja derivations **runtime-checked on localhost**: `unicast_peers=['…101']`, priority `200` (master) / `199` (backup), per-node endpoints `http://<ip>:8200`.
- Molecule (`keepalived`, `technitium_dns`) runs in CI (docker).

## Applied vs disabled
- keepalived role, site.yml wiring, technitium VIP repoint, openbao failover: **active on converge.**
- Nothing shipped-disabled here.

## Residue / caveats
- **Live 2-node VRRP failover needs the scriptable drill against a real pair** (`scripts/ingress-failover-drill.sh`) — cannot run headless in CI without a live ingress pair. This is the mandated scriptable check, not a manual step. keepalived adding the VIP inside an unprivileged LXC is expected to work (namespaced CAP_NET_ADMIN + unicast avoids multicast filtering); the drill is the confirmation.
- pve4-gated: OpenBao server 3-voter Raft HA (out of scope).
- Depends on terraform-proxmox #570 publishing `ingress_vip`/`ingress_hosts` and the private `deployment.json` gaining the second `ingress`-tagged Traefik LXC.

Cross-ref: dryvist/terraform-proxmox#570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)