### PR TITLE
fix(openbao_secrets): disable become on localhost-delegated probe tasks

### DIFF
--- a/roles/openbao_secrets/tasks/main.yml
+++ b/roles/openbao_secrets/tasks/main.yml
@@ -28,6 +28,12 @@
 # dependency: openbao-01 down -> openbao-02 answers, ingress down -> a per-node
 # endpoint answers. If NONE answers, active_addr stays empty and the role skips
 # to env/SOPS (a total-OpenBao outage must not hard-fail every converge).
+# ansible_become: false on the delegated tasks below is REQUIRED — Ansible
+# inherits the play's become: true on delegated tasks regardless of
+# task-level become, which fails with "sudo: a password is required" on the
+# controller (same gotcha documented in roles/openbao, roles/minio,
+# roles/object_storage, roles/cribl_packs). These are unauthenticated GETs
+# and local set_facts — none need root.
 - name: Probe OpenBao endpoints for a live, unsealed one (client failover)
   ansible.builtin.uri:
     url: "{{ item }}/v1/sys/health?standbyok=true&perfstandbyok=true"
@@ -41,6 +47,10 @@
   failed_when: false
   changed_when: false
   delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
   run_once: true
   # /v1/sys/health is public + unauthenticated (no secret in URL or response), so
   # NOT no_log: keep it visible for troubleshooting DNS/TLS/connectivity failover.
@@ -55,6 +65,10 @@
           | map(attribute='item') | list | first) | default('', true) }}
   delegate_to: localhost
   delegate_facts: true
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
   run_once: true
   when: openbao_secrets_configured
 
@@ -84,13 +98,21 @@
     openbao_secrets_by_domain: {}
   delegate_to: localhost
   delegate_facts: true
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
   run_once: true
   when: openbao_secrets_active
 
 - name: Fetch each domain's secrets from OpenBao (delegated to the controller)
   when: openbao_secrets_active
   delegate_to: localhost
+  connection: local
+  become: false
   run_once: true
+  vars:
+    ansible_become: false
   block:
     - name: Fetch each configured domain's secrets from OpenBao
       ansible.builtin.include_tasks: fetch_domain.yml


### PR DESCRIPTION
## Summary

PR #640's OpenBao client-failover health probe (`roles/openbao_secrets/tasks/main.yml`)
delegates to `localhost` with `run_once`, but on this control host it inherits the
play's `become: true` (`playbooks/site.yml`) regardless of task-level `become`. The
Mac's sudo is password-gated, so the probe dies with:

```
Task failed: Premature end of stream waiting for become success.
sudo: a password is required
```

Because this is a `run_once` task at the top of `site.yml`, the failure aborts the
**entire playbook** before any app role runs — blocking every app-layer converge.

## Root cause

`ansible_become: true` is set in `group_vars/all.yml` as an inventory variable,
which overrides a plain task-level `become: false` keyword (documented gotcha,
already called out in `playbooks/site.yml:284-288`). The new probe tasks in
`openbao_secrets` didn't follow the established mitigation used by every other
localhost-delegated role in this repo (`roles/openbao`, `roles/minio`,
`roles/object_storage`, `roles/cribl_packs`): `become: false` **and**
`vars: ansible_become: false` **and** `connection: local` together.

## Fix

Added `become: false` + `vars: ansible_become: false` + `connection: local` to
all four localhost-delegated tasks in `roles/openbao_secrets/tasks/main.yml`:
the health probe, the endpoint-pin `set_fact`, the accumulator-init `set_fact`,
and the per-domain fetch block (whose child tasks in `fetch_domain.yml` inherit
delegation/become from the enclosing block, per the existing comment there).

None of these tasks need root: they're an unauthenticated GET and local
`set_fact`s.

## Test plan

- [x] `ansible-lint` (production profile): 0 failures, 0 warnings on the
      changed file.
- [x] No `molecule` scenario exists for `openbao_secrets` specifically
      (only `molecule/openbao` covers the sibling `openbao` role and doesn't
      exercise this code path).
- [x] Functional repro: wrote a throwaway playbook mirroring `site.yml`'s
      `become: true` play + a localhost-delegated unauthenticated `uri` GET.
      Without the fix it reproduces the exact reported error
      (`sudo: a password is required`); with `become: false` +
      `ansible_become: false` + `connection: local` it succeeds
      (`status=200`), proving the probe still works functionally.