### PR TITLE
fix(llm_router,hermes_agent): advertise Qwen3-Coder context window; fix Hermes alias

### DIFF
--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -47,7 +47,12 @@ hermes_agent_installer_path: "/usr/local/lib/hermes-agent-installer-{{ hermes_ag
 # qwen3_5_moe batching crash that rules out Qwen3.6). Replaces the interim
 # hermes-4-14b light-tier brain. The api key is the router master key,
 # env-sourced (SOPS/Doppler).
-hermes_agent_model: qwen3-coder
+# Must match llm_router_large_models' alias exactly (llm_router role,
+# roles/llm_router/defaults/main.yml) — PR #624 renamed the router's alias
+# from the lowercase `qwen3-coder` to the model-id-cased `Qwen3-Coder-30B-A3B`
+# without updating this consumer; the live router hadn't been reconverged
+# since, so both sides still matched by accident until this fix.
+hermes_agent_model: Qwen3-Coder-30B-A3B
 hermes_agent_model_base_url: "https://llm.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}/v1"
 hermes_agent_model_api_mode: chat_completions
 # The api key IS the LiteLLM router master key; source it from the canonical

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -73,7 +73,12 @@ llm_router_llm_large_base_url: "https://llm-large.{{ llm_router_apex_domain }}:{
 # models under their full MLX repo ids). One deployment each, bearer-authed.
 llm_router_large_models:
   - { alias: gpt-oss-120b, backend: mlx-community/gpt-oss-120b-MXFP4-Q8 }
-  - { alias: Qwen3-Coder-30B-A3B, backend: mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit }
+  # context_window = Qwen3-Coder-30B-A3B-Instruct's real native context
+  # (262,144 tokens / 256K, per the Qwen3-Coder model card) — LiteLLM has no
+  # built-in entry for this mlx-community backend id, so leaving it unset
+  # resolves max_input_tokens to null (see config.yaml.j2 for the failure
+  # mode this caused).
+  - { alias: Qwen3-Coder-30B-A3B, backend: mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit, context_window: 262144 }
   - { alias: Qwen3.6-35B-A3B-4bit, backend: mlx-community/Qwen3.6-35B-A3B-4bit }
   - { alias: Qwen3.6-27B-4bit, backend: mlx-community/Qwen3.6-27B-4bit }
   - { alias: claude-sonnet-5, backend: mlx-community/Qwen3.6-35B-A3B-4bit }

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -71,17 +71,20 @@ llm_router_llm_large_base_url: "https://llm-large.{{ llm_router_apex_domain }}:{
 # --- Model groups ------------------------------------------------------------
 # large: exposed alias -> the backend's own model id (the serving gate lists
 # models under their full MLX repo ids). One deployment each, bearer-authed.
+# context_window on EVERY entry = the backend's real native context
+# (max_position_embeddings from each mlx-community repo's config.json).
+# LiteLLM has no built-in entry for these mlx-community backend ids, so an
+# unset context_window resolves max_input_tokens to null — clients that read
+# that (e.g. Hermes, OpenWebUI) fall back to a near-zero context guess and
+# compress every request to death (see config.yaml.j2 for the failure mode).
 llm_router_large_models:
-  - { alias: gpt-oss-120b, backend: mlx-community/gpt-oss-120b-MXFP4-Q8 }
-  # context_window = Qwen3-Coder-30B-A3B-Instruct's real native context
-  # (262,144 tokens / 256K, per the Qwen3-Coder model card) — LiteLLM has no
-  # built-in entry for this mlx-community backend id, so leaving it unset
-  # resolves max_input_tokens to null (see config.yaml.j2 for the failure
-  # mode this caused).
+  - { alias: gpt-oss-120b, backend: mlx-community/gpt-oss-120b-MXFP4-Q8, context_window: 131072 }
   - { alias: Qwen3-Coder-30B-A3B, backend: mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit, context_window: 262144 }
-  - { alias: Qwen3.6-35B-A3B-4bit, backend: mlx-community/Qwen3.6-35B-A3B-4bit }
-  - { alias: Qwen3.6-27B-4bit, backend: mlx-community/Qwen3.6-27B-4bit }
-  - { alias: claude-sonnet-5, backend: mlx-community/Qwen3.6-35B-A3B-4bit }
+  - { alias: Qwen3.6-35B-A3B-4bit, backend: mlx-community/Qwen3.6-35B-A3B-4bit, context_window: 262144 }
+  - { alias: Qwen3.6-27B-4bit, backend: mlx-community/Qwen3.6-27B-4bit, context_window: 262144 }
+  # claude-sonnet-5 is a Claude Code alias deliberately mapped to a local Qwen3.6
+  # backend (PR #624) — not a mis-map; it inherits that backend's 262144 context.
+  - { alias: claude-sonnet-5, backend: mlx-community/Qwen3.6-35B-A3B-4bit, context_window: 262144 }
 # light: exposed aliases -> the llama-swap model_name they map to. Each becomes two
 # same-name deployments (llm-fast GPU + llm-light CPU) in the rendered config.
 # `embedding: true` marks the entry as an embeddings model_group.

--- a/roles/llm_router/templates/config.yaml.j2
+++ b/roles/llm_router/templates/config.yaml.j2
@@ -11,6 +11,17 @@ model_list:
       model: openai/{{ m.backend }}
       api_base: {{ llm_router_llm_large_base_url }}
       api_key: os.environ/LLM_LARGE_BEARER_TOKEN
+{% if m.context_window is defined %}
+    model_info:
+      # These mlx-community backend ids are unknown to LiteLLM's built-in
+      # model cost/context map, so without an explicit value here
+      # max_input_tokens resolves to null — enable_pre_call_checks then has
+      # nothing to check against and callers seeing that null (e.g. Hermes)
+      # fall back to a near-zero context guess and compress a request to
+      # death. Value = the model's real served context length.
+      max_input_tokens: {{ m.context_window }}
+      max_tokens: {{ m.context_window }}
+{% endif %}
 {% endfor %}
   # --- light tier: two deployments per alias (GPU llm-fast + CPU llm-light) ---
   # Same model_name => LiteLLM load-balances the pair and cools a failed deployment

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1812,7 +1812,7 @@
     llm_router_llm_large_base_url: "https://llm-large.example.net:11434/v1"
     llm_router_large_models:
       - { alias: gpt-oss-120b, backend: mlx-community/gpt-oss-120b-MXFP4-Q8 }
-      - { alias: Qwen3-Coder-30B-A3B, backend: mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit }
+      - { alias: Qwen3-Coder-30B-A3B, backend: mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit, context_window: 262144 }
       - { alias: Qwen3.6-35B-A3B-4bit, backend: mlx-community/Qwen3.6-35B-A3B-4bit }
       - { alias: Qwen3.6-27B-4bit, backend: mlx-community/Qwen3.6-27B-4bit }
       - { alias: claude-sonnet-5, backend: mlx-community/Qwen3.6-35B-A3B-4bit }
@@ -1865,6 +1865,17 @@
           - "'test-master-key-placeholder' not in (lookup('file', '/tmp/test_litellm_config.yaml'))"
           - _litellm.general_settings.master_key == 'os.environ/LLM_ROUTER_MASTER_KEY'
         fail_msg: "config.yaml.j2 model_list / auth wrong: {{ _litellm.model_list }}"
+
+    - name: Assert explicit context_window models get a real max_input_tokens
+      ansible.builtin.assert:
+        that:
+          # Without an explicit context_window, this mlx-community backend id is
+          # unknown to LiteLLM's cost map and max_input_tokens silently resolves to
+          # null, which is the actual root cause of the Hermes context-collapse bug
+          # this fixes — assert the rendered config carries the real value through.
+          - (_litellm.model_list | selectattr('model_name', 'equalto', 'Qwen3-Coder-30B-A3B') | first).model_info.max_input_tokens == 262144
+          - (_litellm.model_list | selectattr('model_name', 'equalto', 'Qwen3-Coder-30B-A3B') | first).model_info.max_tokens == 262144
+        fail_msg: "config.yaml.j2 did not render model_info.max_input_tokens for Qwen3-Coder-30B-A3B: {{ _litellm.model_list }}"
 
     - name: Assert routing, health checks, and observability callbacks
       ansible.builtin.assert:

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1811,11 +1811,11 @@
     llm_router_llm_light_base_url: "http://llm-light.pve.example.net:10434/v1"
     llm_router_llm_large_base_url: "https://llm-large.example.net:11434/v1"
     llm_router_large_models:
-      - { alias: gpt-oss-120b, backend: mlx-community/gpt-oss-120b-MXFP4-Q8 }
+      - { alias: gpt-oss-120b, backend: mlx-community/gpt-oss-120b-MXFP4-Q8, context_window: 131072 }
       - { alias: Qwen3-Coder-30B-A3B, backend: mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit, context_window: 262144 }
-      - { alias: Qwen3.6-35B-A3B-4bit, backend: mlx-community/Qwen3.6-35B-A3B-4bit }
-      - { alias: Qwen3.6-27B-4bit, backend: mlx-community/Qwen3.6-27B-4bit }
-      - { alias: claude-sonnet-5, backend: mlx-community/Qwen3.6-35B-A3B-4bit }
+      - { alias: Qwen3.6-35B-A3B-4bit, backend: mlx-community/Qwen3.6-35B-A3B-4bit, context_window: 262144 }
+      - { alias: Qwen3.6-27B-4bit, backend: mlx-community/Qwen3.6-27B-4bit, context_window: 262144 }
+      - { alias: claude-sonnet-5, backend: mlx-community/Qwen3.6-35B-A3B-4bit, context_window: 262144 }
     llm_router_light_models:
       - { alias: hermes-4-14b, backend: hermes-4-14b }
       - { alias: qwen3-4b, backend: qwen3-4b }
@@ -1866,16 +1866,20 @@
           - _litellm.general_settings.master_key == 'os.environ/LLM_ROUTER_MASTER_KEY'
         fail_msg: "config.yaml.j2 model_list / auth wrong: {{ _litellm.model_list }}"
 
-    - name: Assert explicit context_window models get a real max_input_tokens
+    - name: Assert every large model gets a real max_input_tokens
       ansible.builtin.assert:
         that:
-          # Without an explicit context_window, this mlx-community backend id is
+          # Without an explicit context_window, these mlx-community backend ids are
           # unknown to LiteLLM's cost map and max_input_tokens silently resolves to
-          # null, which is the actual root cause of the Hermes context-collapse bug
-          # this fixes — assert the rendered config carries the real value through.
+          # null — the root cause of the Hermes/OpenWebUI context-collapse bug this
+          # fixes. Assert every large deployment carries its real native context.
+          - (_litellm.model_list | selectattr('model_name', 'equalto', 'gpt-oss-120b') | first).model_info.max_input_tokens == 131072
           - (_litellm.model_list | selectattr('model_name', 'equalto', 'Qwen3-Coder-30B-A3B') | first).model_info.max_input_tokens == 262144
           - (_litellm.model_list | selectattr('model_name', 'equalto', 'Qwen3-Coder-30B-A3B') | first).model_info.max_tokens == 262144
-        fail_msg: "config.yaml.j2 did not render model_info.max_input_tokens for Qwen3-Coder-30B-A3B: {{ _litellm.model_list }}"
+          - (_litellm.model_list | selectattr('model_name', 'equalto', 'Qwen3.6-35B-A3B-4bit') | first).model_info.max_input_tokens == 262144
+          - (_litellm.model_list | selectattr('model_name', 'equalto', 'Qwen3.6-27B-4bit') | first).model_info.max_input_tokens == 262144
+          - (_litellm.model_list | selectattr('model_name', 'equalto', 'claude-sonnet-5') | first).model_info.max_input_tokens == 262144
+        fail_msg: "config.yaml.j2 did not render model_info.max_input_tokens for all large models: {{ _litellm.model_list }}"
 
     - name: Assert routing, health checks, and observability callbacks
       ansible.builtin.assert:

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1866,6 +1866,14 @@
           - _litellm.general_settings.master_key == 'os.environ/LLM_ROUTER_MASTER_KEY'
         fail_msg: "config.yaml.j2 model_list / auth wrong: {{ _litellm.model_list }}"
 
+    - name: Index each model's rendered max_input_tokens by name
+      vars:
+        _ctxd: "{{ _litellm.model_list | selectattr('model_info.max_input_tokens', 'defined') }}"
+      ansible.builtin.set_fact:
+        _ctx: >-
+          {{ dict(_ctxd | map(attribute='model_name') | zip(
+             _ctxd | map(attribute='model_info.max_input_tokens'))) }}
+
     - name: Assert every large model gets a real max_input_tokens
       ansible.builtin.assert:
         that:
@@ -1873,13 +1881,12 @@
           # unknown to LiteLLM's cost map and max_input_tokens silently resolves to
           # null — the root cause of the Hermes/OpenWebUI context-collapse bug this
           # fixes. Assert every large deployment carries its real native context.
-          - (_litellm.model_list | selectattr('model_name', 'equalto', 'gpt-oss-120b') | first).model_info.max_input_tokens == 131072
-          - (_litellm.model_list | selectattr('model_name', 'equalto', 'Qwen3-Coder-30B-A3B') | first).model_info.max_input_tokens == 262144
-          - (_litellm.model_list | selectattr('model_name', 'equalto', 'Qwen3-Coder-30B-A3B') | first).model_info.max_tokens == 262144
-          - (_litellm.model_list | selectattr('model_name', 'equalto', 'Qwen3.6-35B-A3B-4bit') | first).model_info.max_input_tokens == 262144
-          - (_litellm.model_list | selectattr('model_name', 'equalto', 'Qwen3.6-27B-4bit') | first).model_info.max_input_tokens == 262144
-          - (_litellm.model_list | selectattr('model_name', 'equalto', 'claude-sonnet-5') | first).model_info.max_input_tokens == 262144
-        fail_msg: "config.yaml.j2 did not render model_info.max_input_tokens for all large models: {{ _litellm.model_list }}"
+          - _ctx['gpt-oss-120b'] == 131072
+          - _ctx['Qwen3-Coder-30B-A3B'] == 262144
+          - _ctx['Qwen3.6-35B-A3B-4bit'] == 262144
+          - _ctx['Qwen3.6-27B-4bit'] == 262144
+          - _ctx['claude-sonnet-5'] == 262144
+        fail_msg: "config.yaml.j2 did not render max_input_tokens for all large models: {{ _litellm.model_list }}"
 
     - name: Assert routing, health checks, and observability callbacks
       ansible.builtin.assert:


### PR DESCRIPTION
## Root cause

Hermes's brain (the LiteLLM router) advertised **no context window** for the
Qwen3-Coder-30B-A3B large-tier deployment. The backend id
`mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit` is unknown to LiteLLM's
built-in model cost/context map, so `model_info.max_input_tokens` resolved to
`null`. With `enable_pre_call_checks` on, a `null` context gives Hermes no real
ceiling — it falls back to a near-zero context guess and compresses every
request to nothing:

> Context too large (~4,607 tokens) — compressing (1/3)… Context length exceeded (19 tokens). Cannot compress further.

A second latent bug: PR #624 renamed the router alias `qwen3-coder` →
`Qwen3-Coder-30B-A3B` but did not update the `hermes_agent` consumer. The live
router had not been reconverged since, so both sides still matched only by
accident — reconverging the router alone would have orphaned Hermes.

## Fix (IaC, at the source — no live hand-edit)

- **`roles/llm_router`**: optional per-model `context_window` on `large_models`,
  rendered as `model_info.max_input_tokens` / `max_tokens`. Qwen3-Coder-30B-A3B
  set to **262144** (256K) — the model card's real native context.
- **`roles/hermes_agent`**: `hermes_agent_model` → `Qwen3-Coder-30B-A3B` to match
  the current router alias.
- **test**: assert the rendered config carries `max_input_tokens=262144`.

## Verification (live, post-converge)

- `ansible-lint`: pass (0 failures).
- `verify_templates.yml`: 181 assertions pass (incl. the new context assertion).
- Converge (`llm_router_group` + `hermes_agent_group`): green, all hosts `failed=0`.
- `/model/info` for `Qwen3-Coder-30B-A3B`: `max_input_tokens` **null → 262144**.
- `POST /v1/chat/completions` (model `Qwen3-Coder-30B-A3B`, "Reply with the word
  OK"): returns a real completion (`OK`), no context error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)