### PR TITLE
fix(ntp): stage/validate/promote chrony config to fix permission-denied

### DIFF
--- a/roles/ntp/tasks/main.yml
+++ b/roles/ntp/tasks/main.yml
@@ -12,14 +12,39 @@
   tags:
     - ntp
 
-- name: Deploy chrony configuration
+
+# Stage the rendered config, validate it, then promote — so the live file is
+# replaced only after validation passes (transactional). An inline template
+# `validate:` cannot be used: chronyd validates with dropped privileges (the
+# _chrony user) and cannot read the template module's temp file under a
+# non-root become-user's 0700 home (e.g. /home/debian/.ansible/tmp). The
+# staged file lives in chronyd's own config dir and is world-readable (0644),
+# so the privilege-dropped validator can read it.
+- name: Render the chrony configuration to a staging file
   ansible.builtin.template:
     src: chrony.conf.j2
-    dest: "{{ ntp_config_file }}"
+    dest: "{{ ntp_config_file }}.staged"
     owner: root
     group: root
     mode: "0644"
-    validate: chronyd -p -f %s
+  tags:
+    - ntp
+
+- name: Validate the staged chrony configuration
+  ansible.builtin.command: "chronyd -p -f {{ ntp_config_file }}.staged"
+  changed_when: false
+  check_mode: false
+  tags:
+    - ntp
+
+- name: Promote the validated chrony configuration
+  ansible.builtin.copy:
+    src: "{{ ntp_config_file }}.staged"
+    dest: "{{ ntp_config_file }}"
+    remote_src: true
+    owner: root
+    group: root
+    mode: "0644"
   notify: Restart chrony
   tags:
     - ntp


### PR DESCRIPTION
## Summary
- The chrony role's inline `validate: chronyd -p -f %s` fails on any host that converges as a non-root become-user (debian-user VMs: `docker-host`, `iac-platform`, `splunk`) because chronyd validates with dropped privileges (`_chrony`) and can't read the template module's staged file under that user's `0700` home.
- Ports the fix already shipped in the canonical role (dryvist/ansible-proxmox `roles/ntp`, PR #318): render to a world-readable staging file, validate the staged file in place, promote only after validation passes.
- This repo vendors the `ntp` role from `ansible-proxmox` per its README ("Keep both copies aligned when changing") — the two had drifted on this specific fix.

## Test plan
- [x] `ansible-lint` (production profile): 0 failures on `roles/ntp/`.
- [ ] Live converge-verify on `docker-host`, `iac-platform`, `splunk` (tracked separately in this session).

Assisted-by: Claude:claude-sonnet-5