### PR TITLE
fix(apt_cacher_ng): passthrough packages.microsoft.com HTTPS CONNECT

### DIFF
--- a/roles/apt_cacher_ng/defaults/main.yml
+++ b/roles/apt_cacher_ng/defaults/main.yml
@@ -57,6 +57,14 @@ apt_cacher_ng_docker_passthrough: true
 # repository" with "403 CONNECT denied (ask the admin to allow HTTPS tunnels)".
 apt_cacher_ng_plex_passthrough: true
 
+# Microsoft package repo passthrough. packages.microsoft.com (used by the
+# .NET/ASP.NET Core apt repo — e.g. technitium_install's aspnetcore-runtime)
+# is HTTPS-only and cannot be cached, so apt tunnels it via CONNECT — which
+# apt-cacher-ng denies unless the target is in PassThroughPattern. Without
+# this, any client behind this proxy fails at "apt-get update" with "403
+# CONNECT denied (ask the admin to allow HTTPS tunnels)" for that repo.
+apt_cacher_ng_microsoft_passthrough: true
+
 # Logging
 apt_cacher_ng_verbose_log: 1
 apt_cacher_ng_debug_log: 0

--- a/roles/apt_cacher_ng/templates/acng.conf.j2
+++ b/roles/apt_cacher_ng/templates/acng.conf.j2
@@ -62,6 +62,9 @@ Remap-uburep: file:backends_ubuntu /ubuntu
 {% if apt_cacher_ng_plex_passthrough %}
 {% set _ = passthrough_patterns.append('(^|\\.)(repo|downloads)\\.plex\\.tv:443$') %}
 {% endif %}
+{% if apt_cacher_ng_microsoft_passthrough %}
+{% set _ = passthrough_patterns.append('(^|\\.)packages\\.microsoft\\.com:443$') %}
+{% endif %}
 {% if passthrough_patterns %}
 PassThroughPattern: {{ passthrough_patterns | join('|') }}
 {% endif %}


### PR DESCRIPTION
## Summary
- `technitium-dns-2`'s `apt-get update` through apt-cacher-ng failed the Microsoft .NET repo (used by `technitium_install` for `aspnetcore-runtime-9.0`) with `403 CONNECT denied` — apt-cacher-ng blocks HTTPS CONNECT tunnels by default.
- This looked like a cross-VLAN routing gap at first, but live testing showed the TCP connection to the proxy succeeds fine; the proxy itself rejects the tunnel. Same class of failure as the existing `repo.plex.tv`/`downloads.plex.tv` case, already solved with a passthrough pattern.
- Adds `apt_cacher_ng_microsoft_passthrough` (default `true`), following the existing Docker/Plex toggle pattern.

## Test plan
- [x] `ansible-lint` (production profile): 0 failures on `roles/apt_cacher_ng/`.
- [ ] Live converge-verify `apt-get update` on `technitium-dns-2` (tracked separately in this session).

Assisted-by: Claude:claude-sonnet-5