### PR TITLE
fix(haproxy): flush pending config reloads before verifying listeners

### DIFF
--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -114,6 +114,17 @@
     group: haproxy
     mode: '0755'
 
+- name: Apply pending HAProxy/Nginx config reloads before verification
+  # Config-deploy tasks above only `notify` the Reload handlers, which by
+  # default run at the END of the play — after the verification tasks below.
+  # A config change (e.g. a newly added syslog port mapping) would then be
+  # unverified: "Start ... service" is a no-op when the service is already
+  # active, so the running process still serves the OLD config and the
+  # wait_for checks below either pass against stale ports or time out on
+  # ports that only exist in the config that hasn't been loaded yet. Flush
+  # here so Reload haproxy/Reload nginx run before anything is verified.
+  ansible.builtin.meta: flush_handlers
+
 - name: Start HAProxy service
   ansible.builtin.systemd:
     name: "{{ haproxy_service_name }}"


### PR DESCRIPTION
## Summary
- haproxy converged (`ok=20 changed=6`) but `wait_for` timed out on `127.0.0.1:519`/`:1519` (the honeypot syslog family). The config-deploy tasks only `notify` the `Reload haproxy`/`Reload nginx` handlers, which Ansible runs at the END of the play — after the verification tasks in this same task file already ran. `Start HAProxy service` (`state: started`) is a no-op once the service is already active, so the running process kept serving the old config through the whole verification block.
- Confirmed live: the rendered config already had the two honeypot frontends and `haproxy -f ... -c` validated clean, but `ss -tlnp` showed nothing on 519/1519 until a manual `systemctl reload haproxy` — which brought both ports up immediately.
- Adds `meta: flush_handlers` before the service-start/verify block.

## Test plan
- [x] `ansible-lint` (production profile): 0 failures on `roles/haproxy/`.
- [ ] Live converge-verify listeners come up on the haproxy host without a manual reload (tracked separately in this session).

Assisted-by: Claude:claude-sonnet-5