### PR TITLE
fix(technitium_dns): remove apex-zone-delete time bomb

### DIFF
--- a/molecule/technitium_dns/verify.yml
+++ b/molecule/technitium_dns/verify.yml
@@ -81,14 +81,12 @@
       ansible.builtin.assert:
         that:
           - technitium_dns_zone == 'svc.example.net'
-          - technitium_dns_apex_domain == 'example.net'
           - >-
             technitium_dns_forwarders ==
             ["https://cloudflare-dns.com/dns-query (1.1.1.1)",
             "https://dns.google/dns-query (8.8.8.8)"]
         fail_msg: >-
           Zone/forwarder mismatch: zone='{{ technitium_dns_zone }}'
-          apex='{{ technitium_dns_apex_domain }}'
           forwarders={{ technitium_dns_forwarders }}.
 
     - name: Assert Proxmox endpoint apex A records are built from env

--- a/roles/technitium_dns/defaults/main.yml
+++ b/roles/technitium_dns/defaults/main.yml
@@ -18,13 +18,6 @@ technitium_dns_api_token: "{{ lookup('env', 'TECHNITIUM_DNS_API_TOKEN') }}"
 # encrypted upstreams below. All internal A-records and service CNAMEs live under
 # this subdomain.
 technitium_dns_zone: "{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
-# Apex domain — referenced ONLY to remove a stale apex Primary zone if a
-# pre-existing server still owns one (so non-subdomain names forward, not
-# NXDOMAIN). Never created/served here. Derived as the PARENT of the managed
-# zone, never from env: PROXMOX_DOMAIN's meaning varies by repo (elsewhere it
-# holds the guest zone itself), and an apex equal to the zone made this task
-# delete the zone the role had just created — a live outage.
-technitium_dns_apex_domain: "{{ technitium_dns_zone.split('.', 1) | last }}"
 
 # DNS zone configuration
 technitium_dns_zone_type: "Primary"

--- a/roles/technitium_dns/tasks/main.yml
+++ b/roles/technitium_dns/tasks/main.yml
@@ -212,35 +212,17 @@
   when: technitium_dns_apply | bool
   no_log: true
 
-# Remove a stale apex Primary zone so non-subdomain names FORWARD upstream
-# instead of resolving NXDOMAIN here. Destructive but guarded: only fires if a
-# pre-existing server still owns the apex zone (a no-op on a freshly built node,
-# which never had it). Idempotent via the existing-zones membership check.
-# MUST run BEFORE the subdomain zone create: while the apex zone exists, the
-# subzone create 400s (conflict), and a swallowed 400 here once left the server
-# with the apex deleted and NO replacement zone — a live outage.
-- name: Remove stale apex Primary zone (primary)
-  ansible.builtin.uri:
-    url: "{{ technitium_dns_api_url }}/api/zones/delete?token={{ technitium_dns_api_token }}"
-    method: POST
-    body_format: form-urlencoded
-    body:
-      zone: "{{ technitium_dns_apex_domain }}"
-    return_content: true
-    timeout: "{{ technitium_dns_api_timeout }}"
-    status_code: [200, 400]
-  register: technitium_dns_apex_delete
-  changed_when: technitium_dns_apex_delete.json.status == "ok"
-  when:
-    - technitium_dns_role == 'primary'
-    - technitium_dns_apply | bool
-    - technitium_dns_apex_domain in technitium_dns_existing_zones
-    # Hard guard: never delete the zone this role manages, even if the apex
-    # derivation ever degenerates to the zone itself (e.g. a single-label
-    # PROXMOX_SUBDOMAIN) — deleting it here once caused a live outage.
-    - technitium_dns_apex_domain != technitium_dns_zone
-  no_log: true
-
+# NOTE: this role deliberately does NOT delete the apex zone (jacobpevans.com).
+# A prior "remove stale apex Primary zone" task deleted the WHOLE apex zone
+# whenever it existed, on the false premise that (a) a pre-existing apex zone
+# was leftover cruft and (b) the subdomain-zone create would 400 while it
+# existed. Both are wrong: the apex Route53-mirrored zone can hold live records
+# (the pve node A records), and a parent Primary + child Primary coexist fine
+# (this server runs both jacobpevans.com and pve.jacobpevans.com simultaneously
+# today). Deleting the apex was purely destructive and once caused a live
+# outage. Non-authoritative apex names already FORWARD to the upstream
+# resolvers (configured above) whether or not any apex zone exists locally, so
+# there is nothing to "clean up" here.
 - name: Create authoritative subdomain DNS zone (primary)
   ansible.builtin.uri:
     url: "{{ technitium_dns_api_url }}/api/zones/create?token={{ technitium_dns_api_token }}"


### PR DESCRIPTION
## Problem

The `technitium_dns` role's *"Remove stale apex Primary zone"* task deleted the **entire** apex zone (e.g. `jacobpevans.com`) on a primary converge whenever it existed. Its guard only prevented deleting the *managed subdomain* zone (`apex != zone`); nothing stopped it from wiping the parent zone that holds the pve node A records and any other apex records.

Root cause — two false premises baked into the task:
1. A pre-existing apex Primary zone is leftover cruft to remove so names forward.
2. The subdomain-zone create would `400` while the apex zone existed, so the apex had to be deleted first.

Both are wrong:
- The apex zone can hold **live records**. On this cluster it locally mirrors the public Route53 `jacobpevans.com` zone (pve node A records).
- A parent Primary and a child Primary **coexist fine** — the live server runs `jacobpevans.com` **and** `pve.jacobpevans.com` as Primary zones simultaneously today (verified against the running Technitium API).
- Non-authoritative apex names already forward to the configured upstream resolvers whether or not a local apex zone exists, so there was nothing to "clean up".

Per the task's own comment, this destructive delete had already caused a live outage once.

## Fix

Remove the destructive task entirely and drop the now-unused `technitium_dns_apex_domain` derivation. No replacement is needed — forwarding of non-authoritative names is unchanged.

## Validation

- `ansible-lint` clean (production profile).
- `molecule/technitium_dns` verify assertions pass (run directly; the docker driver is broken in the local sandbox).
- Live-verified against the running primary Technitium (`technitium-dns` LXC): after a converge the apex `jacobpevans.com` zone survives intact and pve1/2/3 records are untouched.

## Note (separate follow-up, not in this PR)

Making `pve4.jacobpevans.com` resolvable is a **Route53** change, not a Technitium one. By design (documented in `terraform-proxmox/aws-infra/modules/route53-records`), Technitium is authoritative only for the guest subdomain `pve.<domain>` and **forwards apex names to public resolvers**; the public Route53 `jacobpevans.com` zone is the single source of truth for `pveN.<domain>`. pve1/2/3 resolve because they exist in Route53; pve4 must be added there (e.g. `ROUTE53_A_RECORDS`), not to Technitium's inert local apex zone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)