### PR TITLE
fix(hermes-agent): cap model.max_tokens to stop context-overflow death loop

### DIFF
--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -55,6 +55,20 @@ hermes_agent_installer_path: "/usr/local/lib/hermes-agent-installer-{{ hermes_ag
 hermes_agent_model: Qwen3-Coder-30B-A3B
 hermes_agent_model_base_url: "https://llm.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}/v1"
 hermes_agent_model_api_mode: chat_completions
+# Qwen3-Coder-30B-A3B's native context window (256K = 262144 tokens). Custom
+# providers carry no context catalog Hermes can probe, so this is declared
+# explicitly (model.context_length in config.yaml.j2).
+hermes_agent_model_context_length: 262144
+# ROOT-CAUSE fix for the "Context length exceeded (18/19 tokens). Cannot
+# compress further." death loop confirmed in ~/.hermes/logs/agent.log: the
+# router/backend hard-caps a single completion at 8192 output tokens
+# ("max_tokens exceeds server limit (8192)"), but the `custom` provider
+# profile's built-in default_max_tokens is 65536. Hermes' error_classifier
+# misclassifies that 400 as a context overflow (it matches the bare
+# substring "max_tokens" in any error text) and dies trying to compress an
+# already-minimal conversation instead of lowering the output request.
+# Capping max_tokens here means the oversized request is never sent.
+hermes_agent_model_max_tokens: 8192
 # The api key IS the LiteLLM router master key; source it from the canonical
 # LLM_ROUTER_MASTER_KEY env (same as the llm_router role) so no per-run mapping
 # is needed. HERMES_AGENT_MODEL_API_KEY still overrides if explicitly set.

--- a/roles/hermes_agent/templates/config.yaml.j2
+++ b/roles/hermes_agent/templates/config.yaml.j2
@@ -9,6 +9,26 @@ model:
   default: {{ hermes_agent_model }}
   base_url: '{{ hermes_agent_model_base_url }}'
   api_mode: {{ hermes_agent_model_api_mode }}
+  # Custom/vLLM-style providers have no context-window catalog Hermes can
+  # probe. Without this, Hermes' own auto-detect logs "Could not detect
+  # context length ... defaulting to 256,000 (probe-down)" before falling
+  # back to a hardcoded catalog guess — this makes the real window explicit.
+  # model.context_length is read at agent_init.py as the highest-precedence
+  # override in get_model_context_length (verified against the installed
+  # Hermes 0.18.0 source, not just --help/docs).
+  context_length: {{ hermes_agent_model_context_length }}
+  # ROOT CAUSE of the "Context length exceeded (18/19 tokens). Cannot
+  # compress further." death loop: the router/backend hard-caps a single
+  # response to 8192 output tokens ("max_tokens exceeds server limit
+  # (8192)" — confirmed in ~/.hermes/logs/agent.log), but the `custom`
+  # provider profile's built-in default_max_tokens is 65536. Hermes'
+  # error_classifier misclassifies that 400 as a context overflow (its
+  # pattern list matches the literal substring "max_tokens" in ANY error),
+  # so it tries to compress a 1-message conversation with nothing left to
+  # compress instead of just lowering the output request. Capping
+  # model.max_tokens at the server's real limit means the oversized
+  # request is never sent, so the misclassification never triggers.
+  max_tokens: {{ hermes_agent_model_max_tokens }}
   # Resolved from .env at runtime (the LiteLLM router master key).
   api_key: '${HERMES_AGENT_MODEL_API_KEY}'
 


### PR DESCRIPTION
## Summary

Hermes was failing every message with `Context length exceeded (N tokens). Cannot compress further.` A prior fix (#646) corrected the LiteLLM router's advertised context window, but that couldn't fix this — Hermes never reads the window from the router. The bug is entirely Hermes-side.

**Root cause** (confirmed live in `~/.hermes/logs/agent.log` on LXC 517000): the router/backend rejects requests with `max_tokens exceeds server limit (8192)` — a pure output-cap error, since the `custom` provider profile's built-in `default_max_tokens` is 65536. Hermes' `error_classifier.py` matches the bare substring `"max_tokens"` in *any* error text and misclassifies this as a context overflow, then tries to compress an already-minimal 1-message conversation and gives up ("cannot compress further").

- `model.context_length: 262144` — Qwen3-Coder-30B-A3B's native window. Custom providers have no context catalog Hermes can probe (its own log confirms: `Could not detect context length ... defaulting to 256,000 (probe-down)`), so this makes it explicit instead of relying on a guessed catalog match.
- `model.max_tokens: 8192` — caps Hermes' output request at the server's real limit so the oversized request (and the resulting misclassification) is never triggered in the first place.

## Verification (through Hermes itself, not the router)

```
# BEFORE (reproduced on live LXC 517000):
$ hermes -z "reply with just OK"
Context length exceeded (18 tokens). Cannot compress further.

# AFTER converge + gateway restart:
$ hermes -z "reply with just OK"
OK
```

`ansible-lint` (production profile) passes on the changed role.

## Test plan

- [x] Reproduced the failure via `hermes -z` on LXC 517000 before the fix
- [x] Converged `hermes_agent` role via `ansible-playbook playbooks/site.yml --tags hermes_agent`
- [x] Confirmed `~/.hermes/config.yaml` carries both new keys and `hermes config show` parses them
- [x] Re-ran `hermes -z "reply with just OK"` — clean `OK`, no context-overflow log entries
- [x] `ansible-lint roles/hermes_agent/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)