### PR TITLE
fix(llm): stop Hermes brain 400s and router 500s

### DIFF
--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -55,6 +55,34 @@
       --branch {{ hermes_agent_version }} --skip-setup --non-interactive
     creates: "{{ hermes_agent_bin }}"
 
+# Upstream bug (NousResearch/hermes-agent, agent/conversation_loop.py):
+# the length-continuation and truncated-tool-call retry paths boost
+# max_tokens on each retry, but floor the boost ceiling at
+# `max(32768, requested_cap)` — so when the provider enforces a real hard
+# cap below 32768 (our config.yaml `model.max_tokens: 8192`, matching
+# vllm-mlx's `--max-request-tokens 8192` on the Mac Studio brain), the very
+# first truncation retry re-sends a request the server is guaranteed to
+# 400 identically ("max_tokens exceeds server limit"), burning all retries
+# and surfacing the error to the user instead of completing the response.
+# `agent.max_tokens` is already the user's explicit config-level ceiling;
+# treat it as absolute instead of a floor for the boost. Runs every
+# converge (idempotent regexp match) because `hermes update` self-updates
+# the app out from under this checkout and would silently drop the patch
+# otherwise.
+- name: Patch hermes-agent retry boost to respect the configured max_tokens ceiling
+  ansible.builtin.replace:
+    path: "{{ hermes_agent_install_dir }}/agent/conversation_loop.py"
+    regexp: '^(\s*)_tc_boost_cap = max\(32768, _tc_requested_cap or 0\)$'
+    replace: '\1_tc_boost_cap = agent.max_tokens if agent.max_tokens else max(32768, _tc_requested_cap or 0)'
+  notify: Restart hermes-gateway
+
+- name: Patch hermes-agent length-continuation boost to respect the configured max_tokens ceiling
+  ansible.builtin.replace:
+    path: "{{ hermes_agent_install_dir }}/agent/conversation_loop.py"
+    regexp: '^(\s*)_boost_cap = max\(32768, _requested_cap or 0\)$'
+    replace: '\1_boost_cap = agent.max_tokens if agent.max_tokens else max(32768, _requested_cap or 0)'
+  notify: Restart hermes-gateway
+
 # The base install skips optional messaging-platform extras (they pull in
 # platform SDKs like slack-bolt that most converges never need). Without this,
 # the gateway logs "Platform 'Slack' requirements not met" and refuses to

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -61,12 +61,26 @@ llm_router_large_port: "{{ tofu_data.constants.service_ports.ollama_api }}"
 # --- Backend base URLs (derived; never a hardcoded IP) -----------------------
 llm_router_llm_fast_base_url: "http://llm-fast.{{ llm_router_subdomain }}:{{ llm_router_light_port }}/v1"
 llm_router_llm_light_base_url: "http://llm-light.{{ llm_router_subdomain }}:{{ llm_router_light_port }}/v1"
-# llm-large lives one label under the APEX (the subdomain's parent), not under
-# the internal subdomain: the serving gate's ACME DNS-01 client locates the
-# hosted zone by stripping a single label, so only an apex-level alias gets a
-# cert — an llm-large.<subdomain> name fails the TLS handshake (no SNI cert).
+# The large-tier gate (a caddy TLS front on the Mac Studio, apex-level cert via
+# Route53 DNS-01) reverse-proxies to the host's llama-swap. It has always been
+# addressed apex-level (one label under the subdomain's parent), because the
+# ACME client locates the hosted zone by stripping a single label — an
+# <alias>.<subdomain> name fails the TLS handshake (no SNI cert).
+#
+# The host is reached by its OWN permanent name, not a floating `llm-large`
+# service alias. The alias needed a *second* DNS record published + maintained
+# by something outside this fabric; on 2026-07-06 that record silently vanished
+# (resolved fine at 21:51, NXDOMAIN by 22:42) and every brain request 500'd with
+# ClientConnectorDNSError — a single point of failure with no benefit while there
+# is exactly one serving host. `jevans-ms.<apex>` is that host's canonical record
+# (stable, also its SSH name) and is on the very same caddy cert, so it satisfies
+# the apex-cert constraint identically with no extra record to keep alive.
+# (Restoring/decoupling behind an alias again is a DNS follow-up, not a router
+# concern — see PR notes.)
 llm_router_apex_domain: "{{ llm_router_subdomain | split('.', 1) | last }}"
-llm_router_llm_large_base_url: "https://llm-large.{{ llm_router_apex_domain }}:{{ llm_router_large_port }}/v1"
+llm_router_llm_large_host: jevans-ms
+llm_router_llm_large_fqdn: "{{ llm_router_llm_large_host }}.{{ llm_router_apex_domain }}"
+llm_router_llm_large_base_url: "https://{{ llm_router_llm_large_fqdn }}:{{ llm_router_large_port }}/v1"
 
 # --- Model groups ------------------------------------------------------------
 # large: exposed alias -> the backend's own model id (the serving gate lists
@@ -100,6 +114,16 @@ llm_router_light_models:
 llm_router_routing_strategy: simple-shuffle
 llm_router_allowed_fails: 2
 llm_router_cooldown_time: 30
+# The large tier has ONE deployment per alias (no sibling to fail over to), so
+# a bare TCP hiccup between this router and the mac-studio gate surfaces
+# straight to the caller as a 500. num_retries makes LiteLLM retry the SAME
+# deployment a couple of times before giving up — cheap insurance against a
+# transient connection blip, distinct from Hermes's own client-side retries
+# (which retry the identical request and hit the identical transient error).
+# request_timeout_seconds bounds a single attempt; large-tier generations can
+# legitimately run for minutes, so this is generous, not a tight SLA.
+llm_router_num_retries: 2
+llm_router_request_timeout_seconds: 300
 # Background health checks send REAL test requests to every deployment — on the
 # llama-swap fast tier each probe spawns the target model, and with 3 routers
 # probing every model this both churns VRAM constantly and (pre swap-groups)

--- a/roles/llm_router/templates/config.yaml.j2
+++ b/roles/llm_router/templates/config.yaml.j2
@@ -56,6 +56,11 @@ router_settings:
   # Pre-call context-window checks so an over-long request is not routed to a model
   # that cannot serve it (no cross-tier fallback masks the error).
   enable_pre_call_checks: true
+  # Retry the same deployment on a transient failure (single-deployment large
+  # tier has no sibling to fail over to — see llm_router_num_retries) and bound
+  # how long one attempt waits before LiteLLM calls it a connection failure.
+  num_retries: {{ llm_router_num_retries }}
+  timeout: {{ llm_router_request_timeout_seconds }}
 
 general_settings:
   master_key: os.environ/LLM_ROUTER_MASTER_KEY

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1824,6 +1824,8 @@
     llm_router_routing_strategy: simple-shuffle
     llm_router_allowed_fails: 2
     llm_router_cooldown_time: 30
+    llm_router_num_retries: 2
+    llm_router_request_timeout_seconds: 300
     llm_router_health_check_interval: 300
     llm_router_background_health_checks: false
     llm_router_light_api_key: "sk-noauth"


### PR DESCRIPTION
Two live reliability failures on the Hermes agent gateway (LXC 517000), both root-caused from the gateway journal and both **fixed + verified live** (roles converged against the running hosts).

## Problem A — HTTP 400 \`max_tokens exceeds server limit (8192)\`
Multi-turn conversations 400'd even though \`config.yaml\` already pins \`model.max_tokens: 8192\` (from #656). Root cause is upstream in hermes-agent \`agent/conversation_loop.py\`: the length-continuation and truncated-tool-call retry paths boost the per-request output cap and floor the boost ceiling at \`max(32768, requested_cap)\`. Once any turn triggers that boost, the ephemeral \`_ephemeral_max_output_tokens\` override **persists across turns**, so a later turn's *first* attempt ships 32768 — which the backend (vllm-mlx \`--max-request-tokens 8192\`) rejects identically, burning all three retries and surfacing the error to the user.

Fix: patch both boost sites to clamp at the configured \`agent.max_tokens\` instead of treating it as a floor. Applied idempotently on every converge (regexp \`replace\`) because \`hermes update\` self-updates the app out from under the checkout.

## Problem B — HTTP 500 \`Connection error\` (router → brain)
Not llama-swap cold-start (both Mac Studio workers are resident, \`ttl=0\`, up for days). The router's large-tier backend name \`llm-large.<apex>\` silently went **NXDOMAIN** — litellm died with \`ClientConnectorDNSError: Cannot connect to host llm-large...:11434 [Name or service not known]\`. It resolved fine at 21:51 and was gone by 22:42. That alias required a second DNS record maintained by something outside this fabric.

Fix: repoint the large tier at the serving host's own **permanent** record (\`jevans-ms.<apex>\`) — same caddy cert (the gate already serves both names), same reverse-proxy to llama-swap, one fewer moving part. Verified end-to-end: \`GET /v1/models\` → 200 with both models. Also added \`num_retries\`/\`timeout\` to \`router_settings\` so a transient blip on the single-deployment large tier retries instead of immediately 500ing.

## Verification (live)
\`hermes -z "write a ~600 word explanation of ZFS"\` → full completion, **zero** new 400/500 in the gateway journal after the post-converge restart.

## Follow-ups (not in this PR)
- The vanished \`llm-large.<apex>\` DNS record: its publisher lives outside this repo; this PR sidesteps it rather than restoring it. Worth tracking down separately if the floating alias is still wanted.
- The \`hermes_agent\` role restarts the gateway on every converge (handler \`Restart hermes-gateway\`), SIGTERM-ing any in-flight task ("Gateway shutting down" in Slack). A gentler reload / restart-only-on-real-change is a separate improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)