### PR TITLE
feat(ai): n8n + LangGraph roles for the AI orchestration tier

### DIFF
--- a/inventory/load_tofu.yml
+++ b/inventory/load_tofu.yml
@@ -331,6 +331,16 @@
               else []
             ) +
             (
+              ['n8n_group']
+              if 'n8n' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
+              ['langgraph_group']
+              if 'langgraph' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
               ['agent_exec_group']
               if 'agent-exec' in (item.value.tags | default([]))
               else []

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -716,6 +716,26 @@
   roles:
     - role: langflow_docker
 
+- name: Configure n8n workflow automation
+  hosts: n8n_group
+  become: true
+  gather_facts: true
+  tags:
+    - n8n_docker
+    - ai-orchestration
+  roles:
+    - role: n8n_docker
+
+- name: Configure LangGraph server + Agent Chat UI (zero-cloud)
+  hosts: langgraph_group
+  become: true
+  gather_facts: true
+  tags:
+    - langgraph_docker
+    - ai-orchestration
+  roles:
+    - role: langgraph_docker
+
 - name: Configure agent-exec runtime (CrewAI + LangChain)
   hosts: agent_exec_group
   become: true

--- a/roles/dify_docker/defaults/main.yml
+++ b/roles/dify_docker/defaults/main.yml
@@ -157,3 +157,10 @@ dify_docker_admin_email: >-
 dify_docker_admin_password: >-
   {{ lookup('env', 'DIFY_ADMIN_PASSWORD')
      | mandatory('DIFY_ADMIN_PASSWORD must be set (Doppler; openssl rand -base64 24)') }}
+
+# Seed a minimal chat app on first run so there is something to open immediately.
+# Best-effort + idempotent (skipped if an app of this name already exists) and
+# non-fatal (the console app-create shape drifts across Dify minors). Requires
+# model-provider provisioning (it reuses that console session + default model).
+dify_docker_seed_app: true
+dify_docker_seed_app_name: "Homelab Assistant"

--- a/roles/dify_docker/tasks/main.yml
+++ b/roles/dify_docker/tasks/main.yml
@@ -608,3 +608,54 @@
   when: dify_docker_provision_model_provider | bool
   changed_when: false
   no_log: true
+
+# =============================================================================
+# Seed app (best-effort, idempotent, non-fatal). Gives the user a chat app to
+# open immediately. Reuses the console session established above.
+# =============================================================================
+
+- name: List existing Dify apps (seed idempotency check)
+  ansible.builtin.uri:
+    url: "{{ dify_docker_console_api_base }}/apps?page=1&limit=100"
+    method: GET
+    headers:
+      Cookie: "{{ dify_docker_console_cookies }}"
+      X-CSRF-Token: "{{ dify_docker_console_csrf_token }}"
+    status_code: 200
+    return_content: true
+  register: dify_docker_apps_list
+  when:
+    - dify_docker_provision_model_provider | bool
+    - dify_docker_seed_app | bool
+  changed_when: false
+  failed_when: false
+  no_log: true
+
+- name: Create the Dify seed chat app (first run only)
+  ansible.builtin.uri:
+    url: "{{ dify_docker_console_api_base }}/apps"
+    method: POST
+    headers:
+      Cookie: "{{ dify_docker_console_cookies }}"
+      X-CSRF-Token: "{{ dify_docker_console_csrf_token }}"
+    body_format: json
+    body:
+      name: "{{ dify_docker_seed_app_name }}"
+      mode: chat
+      icon_type: emoji
+      icon: "🤖"
+      icon_background: "#FFEAD5"
+      description: "Homelab starter chat app, bound to the workspace default model."
+    status_code: [200, 201]
+  register: dify_docker_seed_app_create
+  # Non-fatal: the console app-create payload drifts across Dify minors, and the
+  # stack is fully usable without the seed (models are already provisioned).
+  failed_when: false
+  changed_when: dify_docker_seed_app_create.status in [200, 201]
+  when:
+    - dify_docker_provision_model_provider | bool
+    - dify_docker_seed_app | bool
+    - dify_docker_apps_list.status | default(0) == 200
+    - dify_docker_seed_app_name not in
+      (dify_docker_apps_list.json.data | default([]) | map(attribute='name') | list)
+  no_log: true

--- a/roles/langgraph_docker/defaults/main.yml
+++ b/roles/langgraph_docker/defaults/main.yml
@@ -1,0 +1,72 @@
+---
+# LangGraph — self-hosted, ZERO-CLOUD. Runs the open-source `langgraph dev`
+# in-memory server (MIT langgraph-cli[inmem]) serving a seed ReAct graph, plus a
+# self-hosted Agent Chat UI built from source. NO LangSmith key, NO cloud egress.
+# https://langchain-ai.github.io/langgraph/
+#
+# Two Docker images are BUILT on the host (no published images exist for either):
+#   - langgraph-api  : python + langgraph-cli[inmem] + the seed graph
+#   - agent-chat-ui  : the langchain-ai/agent-chat-ui Next.js app, pinned commit
+#
+# Tracing: the seed graph imports otel_bootstrap, which exports LangChain/LangGraph
+# spans over OTLP/HTTP to the Cribl Edge receiver (ai_orchestration_otel_endpoint);
+# Cribl forks to Langfuse + Splunk. State is in-memory (resets on restart) — this
+# is a playground, not a durable deployment.
+#
+# All literals live here; templates reference vars only (DRY).
+
+# --- Pins (bump via Renovate or manual review) ---------------------------------
+langgraph_docker_python_image: "python:3.12-slim"
+langgraph_docker_node_image: "node:22-alpine"
+langgraph_docker_cli_version: "0.4.30"          # langgraph-cli[inmem]
+langgraph_docker_langgraph_version: "1.2.8"
+langgraph_docker_langchain_openai_version: "1.3.3"
+langgraph_docker_openllmetry_version: "0.62.1"  # opentelemetry-instrumentation-langchain
+# Agent Chat UI: no tags exist upstream, so pin an exact commit for reproducibility.
+langgraph_docker_chat_ui_repo: "https://github.com/langchain-ai/agent-chat-ui.git"
+langgraph_docker_chat_ui_ref: "1cbd509d387b1e9602a80f05e638058b7543d7cc"
+langgraph_docker_chat_ui_pnpm_version: "10.5.1"
+
+# --- Paths ---------------------------------------------------------------------
+langgraph_docker_data_dir: /opt/langgraph
+langgraph_docker_graph_dir: "{{ langgraph_docker_data_dir }}/graph"      # langgraph-api build context
+langgraph_docker_chat_ui_dir: "{{ langgraph_docker_data_dir }}/agent-chat-ui"  # UI build context (clone)
+
+# --- Compose service names -----------------------------------------------------
+langgraph_docker_api_service: langgraph-api
+langgraph_docker_chat_ui_service: agent-chat-ui
+langgraph_docker_restart_policy: unless-stopped
+
+# --- Public FQDNs (Traefik wildcard cert) --------------------------------------
+langgraph_docker_subdomain: >-
+  {{ lookup('env', 'PROXMOX_SUBDOMAIN') | mandatory('PROXMOX_SUBDOMAIN required') }}
+langgraph_docker_api_fqdn: "langgraph.{{ langgraph_docker_subdomain }}"
+langgraph_docker_chat_ui_fqdn: "langgraph-chat.{{ langgraph_docker_subdomain }}"
+
+# --- Ports (DRY from tofu pipeline_constants; no literals) ----------------------
+_langgraph_docker_api_port_err: >-
+  tofu_data.constants.service_ports.langgraph_api missing —
+  regenerate tofu_inventory.json via `terragrunt output -json ansible_inventory`.
+langgraph_docker_api_port: >-
+  {{ hostvars['localhost']['tofu_data']
+     ['constants']['service_ports']['langgraph_api']
+     | mandatory(_langgraph_docker_api_port_err) }}
+_langgraph_docker_chat_ui_port_err: >-
+  tofu_data.constants.service_ports.agent_chat_ui_web missing —
+  regenerate tofu_inventory.json via `terragrunt output -json ansible_inventory`.
+langgraph_docker_chat_ui_port: >-
+  {{ hostvars['localhost']['tofu_data']
+     ['constants']['service_ports']['agent_chat_ui_web']
+     | mandatory(_langgraph_docker_chat_ui_port_err) }}
+
+# --- Assistant id (matches langgraph.json graph key + Chat UI config) -----------
+langgraph_docker_assistant_id: agent
+
+# --- Model backend: the LiteLLM router (inherited from ai_orchestration_group) ---
+langgraph_docker_llm_base_url: "{{ ai_orchestration_ollama_base_url }}"
+langgraph_docker_llm_api_key: "{{ ai_orchestration_model_api_key }}"
+langgraph_docker_model: "gpt-oss-120b"
+
+# --- OTEL: reuse the shared Cribl Edge endpoint (inherited group var) -----------
+langgraph_docker_otel_endpoint: "{{ ai_orchestration_otel_endpoint }}"
+langgraph_docker_otel_service_name: langgraph

--- a/roles/langgraph_docker/files/agent.py
+++ b/roles/langgraph_docker/files/agent.py
@@ -1,0 +1,41 @@
+"""Homelab LangGraph seed: a minimal ReAct agent wired to the LiteLLM router.
+
+`langgraph dev` serves the ``graph`` exported here (see ``langgraph.json``).
+Tracing is initialised on import via ``otel_bootstrap`` so every run is exported
+over OTLP to the Cribl Edge receiver, which forks to Langfuse + Splunk.
+
+Everything configurable comes from the environment (injected by the compose
+file), so this file carries no secrets and no homelab-specific literals.
+"""
+
+import datetime
+import os
+
+import otel_bootstrap  # noqa: F401  (configures OTLP tracing on import)
+
+from langchain_core.tools import tool
+from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import create_react_agent
+
+
+@tool
+def get_current_time() -> str:
+    """Return the current UTC time as an ISO-8601 string."""
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+model = ChatOpenAI(
+    model=os.environ.get("LLM_MODEL", "gpt-oss-120b"),
+    base_url=os.environ["OPENAI_API_BASE"],
+    api_key=os.environ["OPENAI_API_KEY"],
+    temperature=0,
+)
+
+graph = create_react_agent(
+    model,
+    tools=[get_current_time],
+    prompt=(
+        "You are a helpful homelab assistant running on self-hosted LangGraph. "
+        "Use the available tools when they help answer the question."
+    ),
+)

--- a/roles/langgraph_docker/files/langgraph.json
+++ b/roles/langgraph_docker/files/langgraph.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": ["."],
+  "graphs": {
+    "agent": "./agent.py:graph"
+  }
+}

--- a/roles/langgraph_docker/handlers/main.yml
+++ b/roles/langgraph_docker/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+# Rebuild + recreate the stack when a build context or the compose file changed.
+# build: always relies on Docker layer caching, so unchanged contexts are cheap.
+- name: Rebuild langgraph stack
+  community.docker.docker_compose_v2:
+    project_src: "{{ langgraph_docker_data_dir }}"
+    state: present
+    build: always
+    recreate: always
+  vars:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python
+  no_log: true

--- a/roles/langgraph_docker/meta/main.yml
+++ b/roles/langgraph_docker/meta/main.yml
@@ -1,0 +1,25 @@
+---
+galaxy_info:
+  author: Jacob Evans
+  description: >-
+    Self-hosted, zero-cloud LangGraph on an LXC via Docker Compose: the
+    open-source in-memory `langgraph dev` server (langgraph-cli[inmem]) serving a
+    seed ReAct graph, plus a self-hosted Agent Chat UI built from source. No
+    LangSmith key and no cloud egress; runs are traced to the homelab Cribl OTLP
+    pipeline. Wired to the LiteLLM router for its model backend.
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+  galaxy_tags:
+    - ai
+    - llm
+    - langgraph
+    - docker
+
+dependencies: []
+
+collections:
+  - community.docker

--- a/roles/langgraph_docker/tasks/main.yml
+++ b/roles/langgraph_docker/tasks/main.yml
@@ -1,0 +1,263 @@
+---
+# LangGraph (zero-cloud) Docker deployment.
+#
+# Installs Docker + Compose on the target LXC, assembles two local build contexts
+# (the seed graph for `langgraph dev`, and the agent-chat-ui clone), then builds +
+# runs both via Docker Compose. State is in-memory; there is no postgres/redis.
+#
+# Mirrors the langflow_docker role for the Docker-on-ZFS install; the OTEL/seed
+# pattern is borrowed from agent_exec (OpenLLMetry -> Cribl OTLP).
+
+# =============================================================================
+# Docker + git Installation
+# =============================================================================
+
+- name: Gather OS facts
+  ansible.builtin.setup:
+    filter: ansible_distribution*
+
+- name: Install Docker prerequisites (+ git for the agent-chat-ui clone)
+  ansible.builtin.apt:
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg
+      - lsb-release
+      - git
+    state: present
+    update_cache: true
+
+- name: Create keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+
+- name: Set Docker repository distribution
+  ansible.builtin.set_fact:
+    langgraph_docker_distro: "{{ ansible_distribution | lower }}"
+
+- name: Add Docker GPG key
+  ansible.builtin.get_url:
+    url: "https://download.docker.com/linux/{{ langgraph_docker_distro }}/gpg"
+    dest: /etc/apt/keyrings/docker.asc
+    mode: "0644"
+    force: false
+
+- name: Add Docker repository
+  ansible.builtin.apt_repository:
+    repo: >-
+      deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc]
+      https://download.docker.com/linux/{{ langgraph_docker_distro }}
+      {{ ansible_distribution_release }} stable
+    state: present
+    filename: docker
+
+- name: Install Docker packages
+  ansible.builtin.apt:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-buildx-plugin
+      - docker-compose-plugin
+    state: present
+    update_cache: true
+
+- name: Install fuse-overlayfs for Docker on ZFS-backed LXC containers
+  ansible.builtin.apt:
+    name: fuse-overlayfs
+    state: present
+
+- name: Configure Docker to use fuse-overlayfs storage driver (required for ZFS-backed LXC)
+  ansible.builtin.copy:
+    dest: /etc/docker/daemon.json
+    content: |
+      {
+        "storage-driver": "fuse-overlayfs"
+      }
+    owner: root
+    group: root
+    mode: "0644"
+  register: langgraph_docker_daemon_config
+
+- name: Restart Docker to apply fuse-overlayfs configuration
+  ansible.builtin.systemd:  # noqa: no-handler
+    name: docker
+    state: restarted
+  when: langgraph_docker_daemon_config.changed
+
+- name: Ensure Docker service is running
+  ansible.builtin.systemd:
+    name: docker
+    state: started
+    enabled: true
+
+# =============================================================================
+# Build context 1: the seed graph (langgraph-api image)
+# =============================================================================
+
+- name: Create LangGraph directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  loop:
+    - "{{ langgraph_docker_data_dir }}"
+    - "{{ langgraph_docker_graph_dir }}"
+
+- name: Install the seed graph sources (static)
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "{{ langgraph_docker_graph_dir }}/{{ item }}"
+    owner: root
+    group: root
+    mode: "0644"
+  loop:
+    - agent.py
+    - langgraph.json
+
+- name: Render the seed graph project files (templated pins + OTLP endpoint)
+  ansible.builtin.template:
+    src: "{{ item.src }}"
+    dest: "{{ langgraph_docker_graph_dir }}/{{ item.dest }}"
+    owner: root
+    group: root
+    mode: "0644"
+  loop:
+    - { src: pyproject.toml.j2, dest: pyproject.toml }
+    - { src: otel_bootstrap.py.j2, dest: otel_bootstrap.py }
+    - { src: langgraph.Dockerfile.j2, dest: Dockerfile }
+  notify: Rebuild langgraph stack
+
+# =============================================================================
+# Build context 2: the Agent Chat UI (clone at a pinned commit, then Dockerfile)
+# =============================================================================
+
+- name: Clone agent-chat-ui at the pinned commit
+  ansible.builtin.git:
+    repo: "{{ langgraph_docker_chat_ui_repo }}"
+    dest: "{{ langgraph_docker_chat_ui_dir }}"
+    version: "{{ langgraph_docker_chat_ui_ref }}"
+    depth: 1
+  notify: Rebuild langgraph stack
+
+- name: Render the Agent Chat UI Dockerfile
+  ansible.builtin.template:
+    src: agent-chat-ui.Dockerfile.j2
+    dest: "{{ langgraph_docker_chat_ui_dir }}/Dockerfile"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Rebuild langgraph stack
+
+# =============================================================================
+# Compose file
+# =============================================================================
+
+- name: Render LangGraph docker-compose.yml
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ langgraph_docker_data_dir }}/docker-compose.yml"
+    owner: root
+    group: root
+    mode: "0600"  # contains the LiteLLM router key
+  no_log: true
+  notify: Rebuild langgraph stack
+
+# =============================================================================
+# Python venv for Ansible Docker modules
+# =============================================================================
+
+- name: Install Python venv and pip for dependencies
+  ansible.builtin.apt:
+    name:
+      - python3-pip
+      - python3-venv
+      - python3-full
+    state: present
+    update_cache: true
+
+- name: Create virtualenv for Ansible Python dependencies
+  ansible.builtin.pip:
+    name:
+      - docker
+    state: present
+    virtualenv: /opt/ansible-venv
+    virtualenv_command: python3 -m venv
+
+# =============================================================================
+# Build + deploy via Docker Compose
+# Layer caching keeps rebuilds cheap: the pinned UI clone and seed graph only
+# rebuild when their sources actually change.
+# =============================================================================
+
+- name: Build and deploy LangGraph via docker compose
+  community.docker.docker_compose_v2:
+    project_src: "{{ langgraph_docker_data_dir }}"
+    state: present
+    build: always
+  register: langgraph_docker_compose_result
+  changed_when: >-
+    (langgraph_docker_compose_result.actions | default([]))
+    | selectattr('status', 'in', ['Creating', 'Recreating', 'Pulling', 'Building'])
+    | list | length > 0
+  vars:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python
+  no_log: true
+
+# =============================================================================
+# Health checks
+# =============================================================================
+
+- name: Wait for the LangGraph API port to accept TCP connections
+  ansible.builtin.wait_for:
+    host: 127.0.0.1
+    port: "{{ langgraph_docker_api_port }}"
+    timeout: 300
+
+- name: Verify the LangGraph server /ok endpoint
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ langgraph_docker_api_port }}/ok"
+    method: GET
+    status_code: 200
+  register: langgraph_docker_ok
+  retries: 30
+  delay: 10
+  until: langgraph_docker_ok.status == 200
+  changed_when: false
+
+- name: Confirm the seed assistant graph is registered
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ langgraph_docker_api_port }}/assistants/search"
+    method: POST
+    body_format: json
+    body: {}
+    status_code: 200
+  register: langgraph_docker_assistants
+  changed_when: false
+  failed_when: >-
+    langgraph_docker_assistants.status != 200
+    or (langgraph_docker_assistants.json
+        | selectattr('graph_id', 'equalto', langgraph_docker_assistant_id)
+        | list | length) < 1
+
+- name: Wait for the Agent Chat UI port to accept TCP connections
+  ansible.builtin.wait_for:
+    host: 127.0.0.1
+    port: "{{ langgraph_docker_chat_ui_port }}"
+    timeout: 300
+
+- name: Verify the Agent Chat UI responds
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ langgraph_docker_chat_ui_port }}/"
+    method: GET
+    status_code: 200
+  register: langgraph_docker_ui
+  retries: 20
+  delay: 10
+  until: langgraph_docker_ui.status == 200
+  changed_when: false

--- a/roles/langgraph_docker/templates/agent-chat-ui.Dockerfile.j2
+++ b/roles/langgraph_docker/templates/agent-chat-ui.Dockerfile.j2
@@ -1,0 +1,25 @@
+# {{ ansible_managed }}
+# agent-chat-ui image: the langchain-ai/agent-chat-ui Next.js app, built from a
+# pinned commit. NEXT_PUBLIC_* are inlined at build time (Next.js contract);
+# LANGGRAPH_API_URL is read at runtime by the app's API-passthrough route.
+FROM {{ langgraph_docker_node_image }}
+
+RUN corepack enable && corepack prepare pnpm@{{ langgraph_docker_chat_ui_pnpm_version }} --activate
+WORKDIR /app
+
+COPY . .
+RUN pnpm install --frozen-lockfile
+
+# Client-side config must be present at build time.
+ARG NEXT_PUBLIC_API_URL
+ARG NEXT_PUBLIC_ASSISTANT_ID
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL \
+    NEXT_PUBLIC_ASSISTANT_ID=$NEXT_PUBLIC_ASSISTANT_ID \
+    NEXT_TELEMETRY_DISABLED=1
+RUN pnpm build
+
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT={{ langgraph_docker_chat_ui_port }}
+EXPOSE {{ langgraph_docker_chat_ui_port }}
+CMD ["pnpm", "start"]

--- a/roles/langgraph_docker/templates/docker-compose.yml.j2
+++ b/roles/langgraph_docker/templates/docker-compose.yml.j2
@@ -1,0 +1,37 @@
+---
+# Self-hosted, zero-cloud LangGraph: in-memory `langgraph dev` server + a
+# self-hosted Agent Chat UI. Both images are built from the local contexts below.
+# Rendered by ansible-proxmox-apps/roles/langgraph_docker.
+services:
+  {{ langgraph_docker_api_service }}:
+    build:
+      context: ./graph
+    image: homelab/langgraph-seed:local
+    container_name: "{{ langgraph_docker_api_service }}"
+    environment:
+      # LiteLLM router (fabric front door) — langchain-openai reads these.
+      OPENAI_API_BASE: "{{ langgraph_docker_llm_base_url }}"
+      OPENAI_API_KEY: "{{ langgraph_docker_llm_api_key }}"
+      LLM_MODEL: "{{ langgraph_docker_model }}"
+    ports:
+      - "{{ langgraph_docker_api_port }}:{{ langgraph_docker_api_port }}"
+    restart: {{ langgraph_docker_restart_policy }}
+
+  {{ langgraph_docker_chat_ui_service }}:
+    build:
+      context: ./agent-chat-ui
+      args:
+        # NEXT_PUBLIC_* are inlined at build time (Next.js contract).
+        NEXT_PUBLIC_API_URL: "https://{{ langgraph_docker_chat_ui_fqdn }}/api"
+        NEXT_PUBLIC_ASSISTANT_ID: "{{ langgraph_docker_assistant_id }}"
+    image: homelab/agent-chat-ui:local
+    container_name: "{{ langgraph_docker_chat_ui_service }}"
+    depends_on:
+      - {{ langgraph_docker_api_service }}
+    environment:
+      # Server-side: the API-passthrough route proxies here (no LangSmith key —
+      # the langgraph server is unauthenticated on the internal ai VLAN).
+      LANGGRAPH_API_URL: "http://{{ langgraph_docker_api_service }}:{{ langgraph_docker_api_port }}"
+    ports:
+      - "{{ langgraph_docker_chat_ui_port }}:{{ langgraph_docker_chat_ui_port }}"
+    restart: {{ langgraph_docker_restart_policy }}

--- a/roles/langgraph_docker/templates/langgraph.Dockerfile.j2
+++ b/roles/langgraph_docker/templates/langgraph.Dockerfile.j2
@@ -1,0 +1,15 @@
+# {{ ansible_managed }}
+# langgraph-api image: the zero-cloud in-memory `langgraph dev` server + seed graph.
+FROM {{ langgraph_docker_python_image }}
+
+WORKDIR /app
+COPY . /app
+
+# Install the seed project (pulls langgraph + langchain-openai + OTEL deps from
+# pyproject) plus the in-memory CLI server. No LangSmith/beacon dependency.
+RUN pip install --no-cache-dir -e . "langgraph-cli[inmem]=={{ langgraph_docker_cli_version }}"
+
+EXPOSE {{ langgraph_docker_api_port }}
+
+# In-memory dev server (state resets on restart — playground, not durable).
+CMD ["langgraph", "dev", "--host", "0.0.0.0", "--port", "{{ langgraph_docker_api_port }}", "--no-browser"]

--- a/roles/langgraph_docker/templates/otel_bootstrap.py.j2
+++ b/roles/langgraph_docker/templates/otel_bootstrap.py.j2
@@ -1,0 +1,28 @@
+{{ ansible_managed | comment }}
+"""OpenLLMetry tracing bootstrap for the LangGraph seed (managed by Ansible).
+
+Imported FIRST from agent.py so LangGraph/LangChain runs are exported over
+OTLP/HTTP to the Cribl Edge receiver, which forks traces to Langfuse + Splunk.
+No LangSmith, no cloud egress — all telemetry rides the homelab Cribl pipeline.
+"""
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+# opentelemetry-instrumentation-langchain exports "LangchainInstrumentor"
+# (lowercase c) -- alias to match this file's usage below.
+from opentelemetry.instrumentation.langchain import LangchainInstrumentor as LangChainInstrumentor
+
+_provider = TracerProvider(
+    resource=Resource.create({"service.name": "{{ langgraph_docker_otel_service_name }}"})
+)
+_provider.add_span_processor(
+    BatchSpanProcessor(
+        OTLPSpanExporter(endpoint="{{ langgraph_docker_otel_endpoint }}/v1/traces")
+    )
+)
+trace.set_tracer_provider(_provider)
+
+LangChainInstrumentor().instrument()

--- a/roles/langgraph_docker/templates/pyproject.toml.j2
+++ b/roles/langgraph_docker/templates/pyproject.toml.j2
@@ -1,0 +1,22 @@
+{{ ansible_managed | comment('c') }}
+# Seed LangGraph project — installed with `pip install -e .` in the image so
+# `langgraph dev` finds the graph deps. Pins are the single source of truth in
+# roles/langgraph_docker/defaults/main.yml.
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "homelab-langgraph-seed"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+  "langgraph=={{ langgraph_docker_langgraph_version }}",
+  "langchain-openai=={{ langgraph_docker_langchain_openai_version }}",
+  "opentelemetry-instrumentation-langchain=={{ langgraph_docker_openllmetry_version }}",
+  "opentelemetry-exporter-otlp-proto-http",
+  "opentelemetry-sdk",
+]
+
+[tool.setuptools]
+py-modules = ["agent", "otel_bootstrap"]

--- a/roles/n8n_docker/defaults/main.yml
+++ b/roles/n8n_docker/defaults/main.yml
@@ -1,0 +1,100 @@
+---
+# n8n workflow automation (Community Edition) — self-hosted via Docker Compose in
+# an LXC. Bundled stack: postgres + n8n app. https://docs.n8n.io/hosting/
+#
+# All literals live here; the template references vars only (DRY).
+#
+# Observability note: n8n emits no native OpenTelemetry to the homelab pipeline.
+# It is a workflow builder, not a traced service; individual workflows call the
+# LiteLLM router directly. Do not add OTEL_* env expecting traces.
+
+# Image tags — single source of truth. Bump via Renovate or manual review.
+n8n_docker_app_image: "n8nio/n8n:2.28.7"
+n8n_docker_postgres_image: "postgres:16-alpine"
+
+n8n_docker_container_name: n8n
+n8n_docker_data_dir: /opt/n8n
+n8n_docker_postgres_data_dir: "{{ n8n_docker_data_dir }}/postgres"
+# n8n's home (.n8n): logs, binary-data, and the config file. Workflow + credential
+# state lives in postgres; this holds runtime files only.
+n8n_docker_app_data_dir: "{{ n8n_docker_data_dir }}/data"
+# Seed lives INSIDE the mounted .n8n home so it is visible in the container at
+# {{ n8n_docker_app_internal_data }}/seed for the `n8n import:workflow` exec.
+n8n_docker_seed_dir: "{{ n8n_docker_app_data_dir }}/seed"
+
+# Container-internal mount paths (image contracts — set once, referenced in template).
+n8n_docker_postgres_internal_data: /var/lib/postgresql/data
+n8n_docker_app_internal_data: /home/node/.n8n
+# The n8n image runs as user `node` (uid 1000). In an unprivileged LXC that uid
+# maps straight through, so the bind-mounted home must be owned by 1000 or n8n
+# cannot write its config/logs (postgres self-chowns as root, n8n cannot).
+n8n_docker_app_uid: 1000
+n8n_docker_app_gid: 1000
+
+# Compose service names (also the Docker DNS hostnames used in the DB URL).
+n8n_docker_db_service: postgres
+n8n_docker_app_service: n8n
+
+# Database identity.
+n8n_docker_db_name: n8n
+n8n_docker_db_user: n8n
+
+# Restart policy applied to every service. Also absorbs the first-boot race where
+# n8n starts before postgres finishes initdb — n8n restarts until the DB answers.
+n8n_docker_restart_policy: unless-stopped
+
+# Public FQDN (Traefik fronts https://n8n.<subdomain> with the wildcard cert).
+n8n_docker_subdomain: >-
+  {{ lookup('env', 'PROXMOX_SUBDOMAIN') | mandatory('PROXMOX_SUBDOMAIN required') }}
+n8n_docker_fqdn: "n8n.{{ n8n_docker_subdomain }}"
+
+# Ports pulled from the OpenTofu pipeline_constants (DRY: no port literal here).
+_n8n_docker_web_port_err: >-
+  tofu_data.constants.service_ports.n8n_web missing —
+  regenerate tofu_inventory.json via
+  `terragrunt output -json ansible_inventory`.
+n8n_docker_web_port: >-
+  {{ hostvars['localhost']['tofu_data']
+     ['constants']['service_ports']['n8n_web']
+     | mandatory(_n8n_docker_web_port_err) }}
+_n8n_docker_postgres_port_err: >-
+  tofu_data.constants.service_ports.postgres_default missing —
+  regenerate tofu_inventory.json via
+  `terragrunt output -json ansible_inventory`.
+n8n_docker_postgres_port: >-
+  {{ hostvars['localhost']['tofu_data']
+     ['constants']['service_ports']['postgres_default']
+     | mandatory(_n8n_docker_postgres_port_err) }}
+
+# Model backend for the seed workflow — the LiteLLM router (fabric front door) at
+# https://llm.<subdomain>/v1, inherited from ai_orchestration_group group_vars.
+# Passed into the n8n container env so the seed workflow references it via
+# {{ $env.* }} expressions rather than baking the key into the workflow JSON.
+n8n_docker_llm_base_url: "{{ ai_orchestration_ollama_base_url }}"
+n8n_docker_llm_api_key: "{{ ai_orchestration_model_api_key }}"
+n8n_docker_seed_model: "gpt-oss-120b"
+
+# Secrets — from runtime env; never committed. Whatever injects the env
+# (OpenBao, SOPS, Doppler) is a deployment-time concern, not this role's.
+n8n_docker_db_password: >-
+  {{ lookup('env', 'N8N_DB_PASSWORD')
+     | mandatory('N8N_DB_PASSWORD unset (openssl rand -base64 24; store in OpenBao/SOPS)') }}
+# Owner login email — not a secret; defaults are fine (change it in the UI later).
+n8n_docker_owner_email: >-
+  {{ lookup('env', 'N8N_OWNER_EMAIL') | default('admin@n8n.local', true) }}
+n8n_docker_owner_password: >-
+  {{ lookup('env', 'N8N_OWNER_PASSWORD')
+     | mandatory('N8N_OWNER_PASSWORD unset (>=8 chars, 1 number, 1 capital)') }}
+n8n_docker_owner_firstname: "Homelab"
+n8n_docker_owner_lastname: "Admin"
+
+# N8N_ENCRYPTION_KEY (encrypts stored credentials) — generated once on the LXC and
+# persisted to {{ n8n_docker_data_dir }}/.encryption_key (root:root 0600), then
+# reused so a redeploy does not invalidate stored credentials. Override only to
+# share an explicit value across hosts.
+n8n_docker_encryption_key: ""
+
+# Seed a minimal "hello" workflow (Manual Trigger -> HTTP Request to the LiteLLM
+# router) on first run so there is something to run immediately. Idempotent via a
+# marker file; import failure is non-fatal.
+n8n_docker_seed_workflow: true

--- a/roles/n8n_docker/files/seed-hello-workflow.json
+++ b/roles/n8n_docker/files/seed-hello-workflow.json
@@ -1,0 +1,48 @@
+{
+  "name": "Homelab hello (LiteLLM router)",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "a1a1a1a1-1111-4111-8111-a1a1a1a1a1a1",
+      "name": "When clicking Test workflow",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [0, 0]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.LITELLM_ROUTER_BASE_URL }}/chat/completions",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Authorization", "value": "=Bearer {{ $env.LITELLM_ROUTER_KEY }}" },
+            { "name": "Content-Type", "value": "application/json" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"{{ $env.LITELLM_ROUTER_MODEL }}\",\n  \"messages\": [\n    { \"role\": \"user\", \"content\": \"Say hello from the homelab in one short sentence.\" }\n  ]\n}",
+        "options": {}
+      },
+      "id": "b2b2b2b2-2222-4222-8222-b2b2b2b2b2b2",
+      "name": "LiteLLM chat/completions",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [240, 0]
+    }
+  ],
+  "connections": {
+    "When clicking Test workflow": {
+      "main": [
+        [
+          { "node": "LiteLLM chat/completions", "type": "main", "index": 0 }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "active": false
+}

--- a/roles/n8n_docker/handlers/main.yml
+++ b/roles/n8n_docker/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+# Use state: present with recreate: always so config-only changes (which
+# don't restart unhealthy containers) trigger a full recreate against the
+# new compose file. state: restarted only restarts the existing container
+# with its old config.
+- name: Restart n8n
+  community.docker.docker_compose_v2:
+    project_src: "{{ n8n_docker_data_dir }}"
+    state: present
+    recreate: always
+  vars:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python
+  no_log: true

--- a/roles/n8n_docker/meta/main.yml
+++ b/roles/n8n_docker/meta/main.yml
@@ -1,0 +1,24 @@
+---
+galaxy_info:
+  author: Jacob Evans
+  description: >-
+    Self-hosted n8n workflow automation, Community Edition
+    (https://docs.n8n.io/hosting/) on an LXC container via Docker Compose,
+    backed by PostgreSQL. Builds and runs LLM/automation workflows for the
+    homelab AI-orchestration stack, wired to the LiteLLM router.
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+  galaxy_tags:
+    - ai
+    - automation
+    - n8n
+    - docker
+
+dependencies: []
+
+collections:
+  - community.docker

--- a/roles/n8n_docker/tasks/main.yml
+++ b/roles/n8n_docker/tasks/main.yml
@@ -1,0 +1,319 @@
+---
+# n8n Docker deployment.
+#
+# Installs Docker + Compose on the target LXC, generates (and persists) an
+# N8N_ENCRYPTION_KEY on first run, then deploys the n8nio/n8n image plus a
+# PostgreSQL backend via Docker Compose. Sets up the instance owner and seeds a
+# minimal "hello" workflow via the LiteLLM router.
+#
+# Mirrors the langflow_docker / healthchecks_docker roles (Docker repo +
+# fuse-overlayfs + Python venv for community.docker, then compose deploy +
+# health check).
+
+# =============================================================================
+# Docker Installation
+# =============================================================================
+
+- name: Gather OS facts
+  ansible.builtin.setup:
+    filter: ansible_distribution*
+
+- name: Install Docker prerequisites
+  ansible.builtin.apt:
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg
+      - lsb-release
+    state: present
+    update_cache: true
+
+- name: Create keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+
+- name: Set Docker repository distribution
+  ansible.builtin.set_fact:
+    n8n_docker_distro: "{{ ansible_distribution | lower }}"
+
+- name: Add Docker GPG key
+  ansible.builtin.get_url:
+    url: "https://download.docker.com/linux/{{ n8n_docker_distro }}/gpg"
+    dest: /etc/apt/keyrings/docker.asc
+    mode: "0644"
+    force: false
+
+- name: Add Docker repository
+  ansible.builtin.apt_repository:
+    repo: >-
+      deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc]
+      https://download.docker.com/linux/{{ n8n_docker_distro }}
+      {{ ansible_distribution_release }} stable
+    state: present
+    filename: docker
+
+- name: Install Docker packages
+  ansible.builtin.apt:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-buildx-plugin
+      - docker-compose-plugin
+    state: present
+    update_cache: true
+
+- name: Install fuse-overlayfs for Docker on ZFS-backed LXC containers
+  ansible.builtin.apt:
+    name: fuse-overlayfs
+    state: present
+
+- name: Configure Docker to use fuse-overlayfs storage driver (required for ZFS-backed LXC)
+  ansible.builtin.copy:
+    dest: /etc/docker/daemon.json
+    content: |
+      {
+        "storage-driver": "fuse-overlayfs"
+      }
+    owner: root
+    group: root
+    mode: "0644"
+  register: n8n_docker_daemon_config
+
+- name: Restart Docker to apply fuse-overlayfs configuration
+  ansible.builtin.systemd:  # noqa: no-handler
+    name: docker
+    state: restarted
+  when: n8n_docker_daemon_config.changed
+
+- name: Ensure Docker service is running
+  ansible.builtin.systemd:
+    name: docker
+    state: started
+    enabled: true
+
+# =============================================================================
+# Data Directories
+# Postgres writes to a bind-mounted volume; its image entrypoint self-chowns as
+# root. n8n runs as `node` (uid 1000) and CANNOT chown its own home, so the .n8n
+# mount is chowned to 1000:1000 up front.
+# =============================================================================
+
+- name: Create n8n data subdirectories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  loop:
+    - "{{ n8n_docker_data_dir }}"
+    - "{{ n8n_docker_postgres_data_dir }}"
+
+- name: Create n8n app home (.n8n) + seed subdir owned by the container's node uid
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ n8n_docker_app_uid }}"
+    group: "{{ n8n_docker_app_gid }}"
+    mode: "0755"
+  loop:
+    - "{{ n8n_docker_app_data_dir }}"
+    - "{{ n8n_docker_seed_dir }}"
+
+# =============================================================================
+# N8N_ENCRYPTION_KEY (generate-once, persist on disk)
+# =============================================================================
+# n8n needs a stable encryption key to encrypt stored credentials; if we
+# randomized it per play, every deployment would make previously-stored
+# credentials undecryptable. Persist it in a root-only file the first time the
+# role runs and reuse it thereafter.
+
+- name: Check for existing n8n encryption key
+  ansible.builtin.stat:
+    path: "{{ n8n_docker_data_dir }}/.encryption_key"
+  register: n8n_docker_encryption_key_stat
+
+- name: Generate n8n encryption key (first run only)
+  ansible.builtin.copy:
+    dest: "{{ n8n_docker_data_dir }}/.encryption_key"
+    # 48 alphanumeric chars. Character set specified by unambiguous boolean flags
+    # rather than the password lookup's implicit keyword expansion.
+    content: >-
+      {{ lookup('community.general.random_string',
+                length=48,
+                upper=true, lower=true, numbers=true,
+                special=false) }}
+    owner: root
+    group: root
+    mode: "0600"
+  when: not n8n_docker_encryption_key_stat.stat.exists
+  no_log: true
+
+- name: Read n8n encryption key into memory
+  ansible.builtin.slurp:
+    src: "{{ n8n_docker_data_dir }}/.encryption_key"
+  register: n8n_docker_encryption_key_file
+  no_log: true
+
+- name: Resolve effective encryption key (inventory override or persisted file)
+  ansible.builtin.set_fact:
+    n8n_docker_encryption_key: >-
+      {{ n8n_docker_encryption_key
+         if n8n_docker_encryption_key | length > 0
+         else (n8n_docker_encryption_key_file.content | b64decode | trim) }}
+  no_log: true
+
+# =============================================================================
+# Compose File + seed workflow
+# =============================================================================
+
+- name: Render n8n docker-compose.yml
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ n8n_docker_data_dir }}/docker-compose.yml"
+    owner: root
+    group: root
+    mode: "0600"  # contains encryption key + DB password
+  no_log: true
+  notify: Restart n8n
+
+- name: Install seed workflow
+  # Static JSON — every value resolves from n8n {{ '$env' }} at runtime, so there
+  # are no Ansible vars to template (and no Jinja/{{ '{{ }}' }} conflict to escape).
+  ansible.builtin.copy:
+    src: seed-hello-workflow.json
+    dest: "{{ n8n_docker_seed_dir }}/hello.json"
+    owner: "{{ n8n_docker_app_uid }}"
+    group: "{{ n8n_docker_app_gid }}"
+    mode: "0644"
+  when: n8n_docker_seed_workflow
+
+# =============================================================================
+# Python venv for Ansible Docker modules
+# =============================================================================
+
+- name: Install Python venv and pip for dependencies
+  ansible.builtin.apt:
+    name:
+      - python3-pip
+      - python3-venv
+      - python3-full
+    state: present
+    update_cache: true
+
+- name: Create virtualenv for Ansible Python dependencies
+  ansible.builtin.pip:
+    name:
+      - docker
+    state: present
+    virtualenv: /opt/ansible-venv
+    virtualenv_command: python3 -m venv
+
+# Intentionally do NOT set ansible_python_interpreter via set_fact — that would
+# leak the venv (which only has the `docker` package) to subsequent tasks like
+# uri / wait_for. Scope the venv interpreter to the community.docker tasks only.
+
+# =============================================================================
+# Deploy via Docker Compose
+# =============================================================================
+
+- name: Deploy n8n via docker compose
+  community.docker.docker_compose_v2:
+    project_src: "{{ n8n_docker_data_dir }}"
+    state: present
+  register: n8n_docker_compose_result
+  changed_when: >-
+    (n8n_docker_compose_result.actions | default([]))
+    | selectattr('status', 'in', ['Creating', 'Recreating', 'Pulling', 'Building'])
+    | list | length > 0
+  vars:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python
+  no_log: true
+
+# =============================================================================
+# Health Check
+# First boot can take a couple of minutes: postgres initdb, then n8n running its
+# database migrations against the fresh DB before /healthz answers 200.
+# =============================================================================
+
+- name: Wait for n8n web port to accept TCP connections
+  ansible.builtin.wait_for:
+    host: 127.0.0.1
+    port: "{{ n8n_docker_web_port }}"
+    timeout: 300
+
+- name: Verify n8n /healthz endpoint
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ n8n_docker_web_port }}/healthz"
+    method: GET
+    status_code: 200
+  register: n8n_docker_health
+  retries: 30
+  delay: 10
+  until: n8n_docker_health.status == 200
+  changed_when: false
+
+# =============================================================================
+# Instance owner (idempotent — only when the setup wizard is still pending)
+# =============================================================================
+
+- name: Read n8n frontend settings (owner-setup state)
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ n8n_docker_web_port }}/rest/settings"
+    method: GET
+    status_code: 200
+  register: n8n_docker_settings
+  changed_when: false
+
+- name: Create the n8n instance owner (first run only)
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ n8n_docker_web_port }}/rest/owner/setup"
+    method: POST
+    body_format: json
+    body:
+      email: "{{ n8n_docker_owner_email }}"
+      firstName: "{{ n8n_docker_owner_firstname }}"
+      lastName: "{{ n8n_docker_owner_lastname }}"
+      password: "{{ n8n_docker_owner_password }}"
+    status_code: [200, 201]
+  when: >-
+    n8n_docker_settings.json.data.userManagement.showSetupOnFirstLoad | default(false)
+  no_log: true
+
+# =============================================================================
+# Seed workflow (idempotent via a marker file; import is best-effort/non-fatal)
+# =============================================================================
+
+- name: Check for the seed-import marker
+  ansible.builtin.stat:
+    path: "{{ n8n_docker_data_dir }}/.seed_imported"
+  register: n8n_docker_seed_marker
+  when: n8n_docker_seed_workflow
+
+- name: Import the seed workflow (first run only)
+  ansible.builtin.command:
+    cmd: >-
+      docker exec {{ n8n_docker_container_name }}
+      n8n import:workflow --input={{ n8n_docker_app_internal_data }}/seed/hello.json
+  register: n8n_docker_seed_import
+  changed_when: n8n_docker_seed_import.rc == 0
+  failed_when: false
+  when:
+    - n8n_docker_seed_workflow
+    - not n8n_docker_seed_marker.stat.exists
+
+- name: Record the seed-import marker
+  ansible.builtin.copy:
+    dest: "{{ n8n_docker_data_dir }}/.seed_imported"
+    content: "imported {{ ansible_date_time.iso8601 | default('unknown') }}\n"
+    owner: root
+    group: root
+    mode: "0644"
+  when:
+    - n8n_docker_seed_workflow
+    - not n8n_docker_seed_marker.stat.exists
+    - n8n_docker_seed_import.rc | default(1) == 0

--- a/roles/n8n_docker/templates/docker-compose.yml.j2
+++ b/roles/n8n_docker/templates/docker-compose.yml.j2
@@ -1,0 +1,51 @@
+---
+# Self-hosted n8n (postgres + app) via Docker Compose.
+# Rendered by ansible-proxmox-apps/roles/n8n_docker.
+services:
+  {{ n8n_docker_db_service }}:
+    image: {{ n8n_docker_postgres_image }}
+    environment:
+      POSTGRES_USER: {{ n8n_docker_db_user }}
+      POSTGRES_PASSWORD: "{{ n8n_docker_db_password }}"
+      POSTGRES_DB: {{ n8n_docker_db_name }}
+    volumes:
+      - {{ n8n_docker_postgres_data_dir }}:{{ n8n_docker_postgres_internal_data }}
+    restart: {{ n8n_docker_restart_policy }}
+
+  {{ n8n_docker_app_service }}:
+    image: {{ n8n_docker_app_image }}
+    container_name: "{{ n8n_docker_container_name }}"
+    depends_on:
+      - {{ n8n_docker_db_service }}
+    environment:
+      # Persist workflows/credentials in postgres, not sqlite.
+      DB_TYPE: postgresdb
+      DB_POSTGRESDB_HOST: {{ n8n_docker_db_service }}
+      DB_POSTGRESDB_PORT: "{{ n8n_docker_postgres_port }}"
+      DB_POSTGRESDB_DATABASE: {{ n8n_docker_db_name }}
+      DB_POSTGRESDB_USER: {{ n8n_docker_db_user }}
+      DB_POSTGRESDB_PASSWORD: "{{ n8n_docker_db_password }}"
+      # Stable key so stored credentials survive redeploys (generate-once on host).
+      N8N_ENCRYPTION_KEY: "{{ n8n_docker_encryption_key }}"
+      # Public identity — Traefik terminates TLS and proxies to this port.
+      N8N_HOST: "{{ n8n_docker_fqdn }}"
+      N8N_PORT: "{{ n8n_docker_web_port }}"
+      N8N_PROTOCOL: https
+      N8N_LISTEN_ADDRESS: 0.0.0.0
+      WEBHOOK_URL: "https://{{ n8n_docker_fqdn }}/"
+      N8N_EDITOR_BASE_URL: "https://{{ n8n_docker_fqdn }}/"
+      # One proxy hop (Traefik) — trust X-Forwarded-* for correct URLs/rate-limits.
+      N8N_PROXY_HOPS: "1"
+      # Allow {{ '{{ $env.* }}' }} in node expressions so the seed workflow can read
+      # the router endpoint/key from env instead of baking the key into the JSON.
+      N8N_BLOCK_ENV_ACCESS_IN_NODE: "false"
+      # LiteLLM router (fabric front door) for the seed workflow. The seed HTTP
+      # Request node references these via {{ '{{ $env.LITELLM_ROUTER_* }}' }}.
+      LITELLM_ROUTER_BASE_URL: "{{ n8n_docker_llm_base_url }}"
+      LITELLM_ROUTER_KEY: "{{ n8n_docker_llm_api_key }}"
+      LITELLM_ROUTER_MODEL: "{{ n8n_docker_seed_model }}"
+    ports:
+      - "{{ n8n_docker_web_port }}:{{ n8n_docker_web_port }}"
+    volumes:
+      - {{ n8n_docker_app_data_dir }}:{{ n8n_docker_app_internal_data }}
+    restart: {{ n8n_docker_restart_policy }}

--- a/secrets.enc.yaml
+++ b/secrets.enc.yaml
@@ -21,6 +21,8 @@ LANGFUSE_REDIS_AUTH: ENC[AES256_GCM,data:DyfNOw0SMW0+bWR6+QbS4OCQQZvr30gOSSfmb+b
 LANGFLOW_SUPERUSER: ENC[AES256_GCM,data:s9fN9X4=,iv:vFBamwo5tz/9HkRx2WG7iIqggswISMbXWQrv8DPD8ME=,tag:bWIPmYEbdAng9DUxhhPY0A==,type:str]
 LANGFUSE_S3_ACCESS_KEY_ID: ENC[AES256_GCM,data:AqxfImbQgmaem7ub1sZgFmsIE7VvA2MY,iv:UMVTP8XNhht3siDJC5yEryPZyBdrz2tzWssS+JPkuIA=,tag:sTmCoj4CtJOwExMgU0hTCw==,type:str]
 LANGFUSE_S3_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:BvMUpdIKd1j65U9JGBSiu+HUFxy5X5RW0yaWPB25pnrcZjax7j+BgaykFOcpFNVSO7EQ038oEypuYZgXUJWEtQ==,iv:+tkAn3js4IhL+oZXCIUGJBdeq0dM6Ksbg0NRgBG+bjU=,tag:XtS5RhwAMhh6RGG564LwPg==,type:str]
+N8N_DB_PASSWORD: ENC[AES256_GCM,data:WH9+cLkFWkUFEzt8atS/hzBGr28GHjjLzZjJdO6cK+0=,iv:Weu4ZJcitkOmvYmk4npZketVMcJIhV4pxRe9qnkGbxM=,tag:IOgIUuOWFjXqMagYpPZuHw==,type:str]
+N8N_OWNER_PASSWORD: ENC[AES256_GCM,data:p0XLJdXcuthcatYT+zPeueyRqYTEuaa9,iv:ihKeV1Km+KWwmN6BTST5EASdJYv+U+rsLwgCmf2SnEg=,tag:nPzok0j/dH/S1YTretNrIw==,type:str]
 sops:
     age:
         - enc: |
@@ -32,7 +34,7 @@ sops:
             fSSlce/LFPv5+Qzn6bu04aEOlLuM2azDds00cyhyIj4ur0zXxedvSQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
-    lastmodified: "2026-07-05T13:58:04Z"
-    mac: ENC[AES256_GCM,data:ExB7V6jWJb3ivKRHpEBuGvoTd0trJTW/Jq1fgQHHLFP/TL6R4G5ki3v/sBt7qyOTvD5SSqWUmsjVp68oHcZIihx+vFa9GPwe8beX253ybc6HHpEiYa/iQEpSaY5zQ3x1QZVM+LzWQ5o3gIzXEBAK3JkxO7FnrrU84Jk6BmaRAYo=,iv:rpJ4Io8j1Hvgrq3d3YV7iOzKtpt3iDDTGRYQybZYDS0=,tag:x8DlL3XbE6I0FgNhAIsY6w==,type:str]
+    lastmodified: "2026-07-06T23:55:59Z"
+    mac: ENC[AES256_GCM,data:9jzCuIhtc3YDlpm8NZlW6y3o4kJEo7sQBrL60su2GK8BZAGAj3MgzmoPsFAYPeRJuivinDPXSo9UxsLOzXWUZTyI4rlqGApRmbJbUP38gFmma96Y3UkY8f4i9ltaa7tYgoJc2548HXgRYEUNH2LJA1izFsGqBgLSXoueQYjek5Q=,iv:KTKL0sT68ChUfNHO1/FEEL0FAmUEY38zeW0nW3oGajA=,tag:IuYpELMxsJ0Mvp/oKhZdLg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.1

--- a/secrets.enc.yaml.example
+++ b/secrets.enc.yaml.example
@@ -48,6 +48,15 @@ MSSQL_SA_PASSWORD: your-strong-sa-password-here
 # Qdrant Vector Database
 QDRANT_API_KEY: your-qdrant-api-key-here
 
+# n8n (AI orchestration tier — Community Edition)
+# N8N_DB_PASSWORD:     openssl rand -base64 24
+# N8N_OWNER_PASSWORD:  the console owner login; needs >=8 chars, 1 number, 1 capital
+# N8N_OWNER_EMAIL is optional (role default admin@n8n.local; override via env).
+# The N8N_ENCRYPTION_KEY is generated + persisted ON the host (/opt/n8n/.encryption_key),
+# not stored here. LangGraph needs no new secret (it reuses the LiteLLM router key).
+N8N_DB_PASSWORD: your-strong-db-password-here
+N8N_OWNER_PASSWORD: your-Owner-Pass1-here
+
 # OpenProject Community Edition
 # Generate with: openssl rand -hex 64
 # This value MUST be stable across restarts — rotating it invalidates all


### PR DESCRIPTION
## What

Two new self-hosted apps in the AI orchestration tier, alongside the existing
Dify/LangFlow builders. Both are tag-driven off `ai-orchestration` (so they
inherit the group_vars LiteLLM endpoint, router key, and Cribl OTLP endpoint) and
are fronted by Traefik via dryvist/terraform-proxmox#575.

### `roles/n8n_docker` — n8n Community Edition
- postgres + n8n app, Docker-in-LXC (fuse-overlayfs), mirrors `langflow_docker`.
- **generate-once-persist** `N8N_ENCRYPTION_KEY` (`/opt/n8n/.encryption_key`) so stored credentials survive redeploys.
- Idempotent instance-owner setup via `/rest/owner/setup` (only when the wizard is pending).
- Seed **"hello" workflow**: Manual Trigger → HTTP Request to the LiteLLM router `/chat/completions`, using `{{ $env.* }}` so no key is baked into the workflow JSON.

### `roles/langgraph_docker` — zero-cloud LangGraph
- The MIT in-memory `langgraph dev` server (`langgraph-cli[inmem]`) serving a seed **ReAct** graph, plus a self-hosted **Agent Chat UI** built from a pinned commit (no published image exists).
- **No LangSmith key, no `beacon.langchain.com` egress.** State is in-memory (playground).
- Runs traced over OTLP to **Cribl** (reuses `ai_orchestration_otel_endpoint`) → Langfuse + Splunk. No direct-to-Langfuse.
- Model backend = the LiteLLM router.
- `langgraph.<domain>` (API, also usable by browser Studio `?baseUrl=`) + `langgraph-chat.<domain>` (Agent Chat UI).

### Wiring
- `inventory/load_tofu.yml`: `n8n_group` / `langgraph_group` tag branches.
- `playbooks/site.yml`: two plays in the AI-orchestration phase.
- `roles/dify_docker`: a best-effort, idempotent, **non-fatal** seed chat app (Dify was already fully provisioned).
- `secrets.enc.yaml(.example)`: `N8N_DB_PASSWORD` + `N8N_OWNER_PASSWORD`.

## Verification

- `ansible-lint` (production profile) + `yamllint` — pass
- JSON seed files valid
- Live converge + per-app https smoke tests (owner login, run seed flow, Chat UI, Langfuse trace) tracked in the AI-stack bring-up runbook — CI can't see those.

Depends on dryvist/terraform-proxmox#575 (ports/ingress/inventory) + dryvist/tofu-unifi#67 (DHCP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)