### PR TITLE
feat(hermes_agent): wire Slack gateway

### DIFF
--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -30,6 +30,8 @@ VLAN.
   directly by Hermes' own Slack adapter — no `config.yaml` changes needed.
   All five default to empty, so the gateway simply runs Slack-free until they
   are set.
+- Seeds a daily cron job that summarizes the homelab AI fabric status and posts
+  it to the Slack home channel; activation happens on the next converge.
 
 ## Installation
 

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -67,6 +67,9 @@ hermes_agent_model_context_length: 262144
 # misclassifies that 400 as a context overflow (it matches the bare
 # substring "max_tokens" in any error text) and dies trying to compress an
 # already-minimal conversation instead of lowering the output request.
+# Keep this at 8192 until the parked nix-darwin rebuild lands and is activated
+# (nix-darwin#1539 / nix-darwin#1545). After that rebuild is live, the next
+# bump is 32768.
 # Capping max_tokens here means the oversized request is never sent.
 hermes_agent_model_max_tokens: 8192
 # The api key IS the LiteLLM router master key; source it from the canonical
@@ -86,6 +89,15 @@ hermes_agent_slack_app_token: "{{ lookup('env', 'SLACK_HERMES_APP_TOKEN') | defa
 hermes_agent_slack_allowed_users: "{{ lookup('env', 'SLACK_MEMBER_ID') | default('', true) }}"
 hermes_agent_slack_home_channel: "{{ lookup('env', 'SLACK_HOME_CHANNEL') | default('', true) }}"
 hermes_agent_slack_home_channel_name: "{{ lookup('env', 'SLACK_HOME_CHANNEL_NAME') | default('', true) }}"
+
+# Daily Slack status report seeded into Hermes' built-in cron scheduler. The
+# role creates the job on converge; the gateway starts executing it on the next
+# daemon run once the Slack gateway is configured.
+hermes_agent_daily_status_cron_name: homelab-ai-fabric-status
+hermes_agent_daily_status_cron_schedule: "0 9 * * *"
+hermes_agent_daily_status_cron_prompt: >-
+  Summarize the homelab AI fabric status, including router health, Hermes
+  gateway health, DNS readiness, and any merge-ready PRs. Keep it concise.
 
 # --- Memory: best self-hostable as of June 2026 (Agy-validated) ---
 # Hindsight: local knowledge-graph + multi-strategy retrieval. Runs alongside the

--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -112,7 +112,6 @@
     'Installed' in hermes_agent_slack_extra_install.stderr
     or 'Uninstalled' in hermes_agent_slack_extra_install.stderr
   when: hermes_agent_slack_bot_token | length > 0 and hermes_agent_slack_app_token | length > 0
-
 - name: Create the hermes runtime user (HERMES_HOME on the data volume)
   ansible.builtin.user:
     name: "{{ hermes_agent_user }}"

--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -159,6 +159,41 @@
     mode: "0640"
   notify: Restart hermes-gateway
 
+# Hermes ships its own cron scheduler. Seed the daily Slack status report here so
+# the next gateway run picks it up without any manual post-install step.
+- name: Check whether the daily Slack status cron job already exists
+  ansible.builtin.command: "{{ hermes_agent_bin }} cron list --all"
+  environment:
+    HERMES_HOME: "{{ hermes_agent_hermes_home }}"
+  become: true
+  become_user: "{{ hermes_agent_user }}"
+  register: hermes_agent_daily_status_cron_list
+  changed_when: false
+  failed_when: false
+  when:
+    - hermes_agent_slack_bot_token | length > 0
+    - hermes_agent_slack_app_token | length > 0
+    - hermes_agent_slack_home_channel | length > 0
+
+- name: Seed the daily Slack status cron job
+  ansible.builtin.command:
+    cmd: >-
+      {{ hermes_agent_bin }} cron create "{{ hermes_agent_daily_status_cron_schedule }}"
+      "{{ hermes_agent_daily_status_cron_prompt }}"
+      --name "{{ hermes_agent_daily_status_cron_name }}"
+      --deliver slack
+  environment:
+    HERMES_HOME: "{{ hermes_agent_hermes_home }}"
+  become: true
+  become_user: "{{ hermes_agent_user }}"
+  register: hermes_agent_daily_status_cron_create
+  changed_when: true
+  when:
+    - hermes_agent_slack_bot_token | length > 0
+    - hermes_agent_slack_app_token | length > 0
+    - hermes_agent_slack_home_channel | length > 0
+    - hermes_agent_daily_status_cron_name not in (hermes_agent_daily_status_cron_list.stdout | default(''))
+
 - name: Deploy the hermes-gateway systemd unit
   ansible.builtin.template:
     src: hermes-gateway.service.j2


### PR DESCRIPTION
Wires Hermes' Slack gateway via env-driven Socket Mode settings and installs the Slack extra only when the Slack inputs are present.\n\nWhy: Hermes needs the Slack adapter installed and the gateway settings exported separately from the main config.\n\nAuto-rescued from a local in-flight branch.\n\nNeeds rebase: a clean rebase onto origin/main conflicted, so I left the branch unchanged.