### PR TITLE
feat(telemetry): instrument hermes_agent + open_webui via Cribl OTLP

### DIFF
--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -99,6 +99,11 @@ hermes_agent_max_turns: 90
 # target host's configured zone.
 hermes_agent_timezone: "UTC"
 
+# --- Observability: bundled OTLP/HTTP plugin (Cribl Edge fan-out) -----------
+hermes_agent_otel_endpoint: "{{ ai_orchestration_otel_endpoint }}"
+hermes_agent_otel_service_name: hermes-agent
+hermes_agent_otel_timeout: 5
+
 # systemd ExecStart: the long-running gateway daemon. It drives the built-in cron
 # scheduler + the Kanban dispatcher even with no messaging platform configured.
 # `gateway start` is for interactive/manual use — it shells out to manage its

--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -83,6 +83,16 @@
     replace: '\1_boost_cap = agent.max_tokens if agent.max_tokens else max(32768, _requested_cap or 0)'
   notify: Restart hermes-gateway
 
+- name: Patch Hermes OTEL spans to carry the configured service name
+  ansible.builtin.replace:
+    path: "{{ hermes_agent_install_dir }}/plugins/observability/otel/__init__.py"
+    regexp: '^(\s*)attrs = \[_attr\(_GEN_AI_SESSION, session_id\), _attr\(_GEN_AI_EXECUTION, exec_id\)\]$'
+    replace: >-
+      \1attrs = [_attr(_GEN_AI_SESSION, session_id),
+      _attr(_GEN_AI_EXECUTION, exec_id),
+      _attr("service.name", os.environ.get("OTEL_SERVICE_NAME", "hermes-agent"))]
+  notify: Restart hermes-gateway
+
 # The base install skips optional messaging-platform extras (they pull in
 # platform SDKs like slack-bolt that most converges never need). Without this,
 # the gateway logs "Platform 'Slack' requirements not met" and refuses to

--- a/roles/hermes_agent/templates/config.yaml.j2
+++ b/roles/hermes_agent/templates/config.yaml.j2
@@ -57,4 +57,8 @@ security:
   redact_secrets: true
   tirith_enabled: true
 
+plugins:
+  enabled:
+    - observability/otel
+
 timezone: '{{ hermes_agent_timezone }}'

--- a/roles/hermes_agent/templates/hermes-env.j2
+++ b/roles/hermes_agent/templates/hermes-env.j2
@@ -12,3 +12,10 @@ SLACK_APP_TOKEN={{ hermes_agent_slack_app_token }}
 SLACK_ALLOWED_USERS={{ hermes_agent_slack_allowed_users }}
 SLACK_HOME_CHANNEL={{ hermes_agent_slack_home_channel }}
 SLACK_HOME_CHANNEL_NAME={{ hermes_agent_slack_home_channel_name }}
+
+# Built-in OTLP/HTTP observability plugin. Cribl Edge receives the spans and
+# fans them out downstream; no direct Langfuse export.
+HERMES_OTEL_ENABLED=1
+HERMES_OTEL_ENDPOINT={{ hermes_agent_otel_endpoint }}/v1/traces
+HERMES_OTEL_TIMEOUT={{ hermes_agent_otel_timeout }}
+OTEL_SERVICE_NAME={{ hermes_agent_otel_service_name }}

--- a/roles/llm_router/README.md
+++ b/roles/llm_router/README.md
@@ -27,10 +27,8 @@ request that fails surfaces the error rather than silently degrading to a small 
 
 ## Observability
 
-`litellm_settings.callbacks: ["langfuse", "otel"]`:
+`litellm_settings.callbacks: ["otel"]`:
 
-- **Langfuse** success logging (`LANGFUSE_*` env; empty keys → the callback no-ops,
-  so a converge before Langfuse exists still comes up).
 - **OTLP/HTTP** traces to the Cribl Edge collector
   (`http://cribl-edge.<subdomain>:<otel_traces_http>/v1/traces`).
 

--- a/roles/open_webui/defaults/main.yml
+++ b/roles/open_webui/defaults/main.yml
@@ -32,6 +32,10 @@ open_webui_url: "https://{{ open_webui_hostname }}"
 # store in Doppler/SOPS. Must NOT change between runs or sessions invalidate.
 open_webui_secret_key: "{{ lookup('env', 'OPEN_WEBUI_SECRET_KEY') }}"
 
+# --- Observability: native OTLP/HTTP to the shared Cribl Edge receiver --------
+open_webui_otel_endpoint: "{{ ai_orchestration_otel_endpoint }}"
+open_webui_otel_service_name: open-webui
+
 # Headless first-run admin (the first signup becomes the admin account), so
 # the UI never shows the "Create Admin Account" wizard.
 open_webui_admin_email: >-

--- a/roles/open_webui/templates/open-webui.env.j2
+++ b/roles/open_webui/templates/open-webui.env.j2
@@ -19,3 +19,14 @@ WEBUI_AUTH_COOKIE_SECURE=true
 WEBUI_SESSION_COOKIE_SAME_SITE=lax
 WEBUI_AUTH_COOKIE_SAME_SITE=lax
 ENABLE_WEBSOCKET_SUPPORT=true
+
+# Native OpenTelemetry: traces + metrics to the shared Cribl Edge receiver.
+ENABLE_OTEL=true
+ENABLE_OTEL_TRACES=true
+ENABLE_OTEL_METRICS=true
+ENABLE_OTEL_LOGS=false
+OTEL_OTLP_SPAN_EXPORTER=http
+OTEL_METRICS_OTLP_SPAN_EXPORTER=http
+OTEL_EXPORTER_OTLP_ENDPOINT={{ open_webui_otel_endpoint }}
+OTEL_METRICS_EXPORTER_OTLP_ENDPOINT={{ open_webui_otel_endpoint }}
+OTEL_SERVICE_NAME={{ open_webui_otel_service_name }}


### PR DESCRIPTION
| Component | Sink | Mechanism |
| --- | --- | --- |
| `hermes_agent` | `ai_orchestration_otel_endpoint` (Cribl Edge OTLP receiver) | Enable bundled `observability/otel`, set `HERMES_OTEL_*` env, and tag spans with `OTEL_SERVICE_NAME=hermes-agent`. |
| `open_webui` | `ai_orchestration_otel_endpoint` (Cribl Edge OTLP receiver) | Use native Open WebUI OTEL env vars with `OTEL_OTLP_SPAN_EXPORTER=http`, `OTEL_METRICS_OTLP_SPAN_EXPORTER=http`, and `OTEL_SERVICE_NAME=open-webui`. |
| `llm_router` docs | N/A | Update README to match the existing OTEL-only config and remove the stale Langfuse callback reference. |

Converge and live verification happen downstream; this PR only wires the telemetry paths and validates syntax/lint locally.