### PR TITLE
fix(e2e): rework pipeline validation gaps on current main

### DIFF
--- a/playbooks/validate-pipeline.yml
+++ b/playbooks/validate-pipeline.yml
@@ -126,6 +126,16 @@
 
   vars:
     constants: "{{ hostvars['localhost']['tofu_data']['constants'] }}"
+    # Edge receives backend/high syslog ports from HAProxy. The app-facing
+    # standard ports live on HAProxy, not on Cribl Edge.
+    cribl_edge_syslog_check_ports: >-
+      {{ ((constants.syslog_port_map | default({}) | dict2items
+           | map(attribute='value.high') | list)
+          if ((constants.syslog_port_map | default({})) | length > 0)
+          else (constants.syslog_ports | default({}) | dict2items
+                | rejectattr('key', 'equalto', 'default')
+                | map(attribute='value') | list))
+         | map('int') | unique | sort }}
 
   tasks:
     - name: Gather service facts for Cribl Edge validation
@@ -159,7 +169,7 @@
       ansible.builtin.wait_for:
         port: "{{ item }}"
         timeout: 5
-      loop: "{{ constants.syslog_ports.values() | list | sort }}"
+      loop: "{{ cribl_edge_syslog_check_ports }}"
 
     - name: Check Cribl Edge config directory exists
       # Edge mode (`cribl mode-edge`) loads config from local/edge/, not
@@ -181,7 +191,7 @@
           Cribl Edge validation passed on {{ inventory_hostname }}:
           - Service: running
           - Health API: {{ edge_health.status }}
-          - Syslog ports: all listening
+          - Syslog backend ports: {{ cribl_edge_syslog_check_ports | join(', ') }}
           - Config dir: present
 
 - name: Validate Cribl Stream LXC Containers
@@ -267,18 +277,19 @@
 
   vars:
     constants: "{{ hostvars['localhost']['tofu_data']['constants'] }}"
+    cribl_edge_metrics_api_token: >-
+      {{ lookup('env', 'CRIBL_EDGE_API_TOKEN') | default('', true) }}
 
   tasks:
-    - name: Check Cribl Edge has active inputs
+    - name: Check Cribl Edge metrics API with configured token
       ansible.builtin.uri:
         url: >-
           http://127.0.0.1:{{ constants.service_ports.cribl_edge_api
           }}/api/v1/system/metrics
         method: GET
         headers: "{{
-          {'Authorization': 'Bearer ' + cribl_edge_api_token}
-          if cribl_edge_api_token is defined
-          and cribl_edge_api_token | length > 0
+          {'Authorization': 'Bearer ' + cribl_edge_metrics_api_token}
+          if cribl_edge_metrics_api_token | length > 0
           else omit
           }}"
         status_code:
@@ -286,13 +297,23 @@
       register: cribl_metrics
       failed_when: cribl_metrics.status != 200
       changed_when: false
+      when: cribl_edge_metrics_api_token | length > 0
 
     - name: Display Cribl Edge metrics validation result
       ansible.builtin.debug:
         msg: |
           Cribl Edge metrics check passed on {{ inventory_hostname }}: API responded with 200
-          (auth token used: {{ (cribl_edge_api_token is defined and cribl_edge_api_token | length > 0) | string }})
+          (auth token used: true)
           status: {{ cribl_metrics.status }}
+      when: cribl_edge_metrics_api_token | length > 0
+
+    - name: Display Cribl Edge metrics skip reason
+      ansible.builtin.debug:
+        msg: |
+          Cribl Edge private metrics check skipped on {{ inventory_hostname }}:
+          CRIBL_EDGE_API_TOKEN is not set. Service health, API reachability,
+          syslog listeners, and data-flow tests still validate this Edge node.
+      when: cribl_edge_metrics_api_token | length == 0
 
 - name: E2E Data Pipeline Validation (Syslog via Cribl Edge)
   hosts: cribl_edge[0]

--- a/tests/e2e/test_macos.py
+++ b/tests/e2e/test_macos.py
@@ -18,7 +18,80 @@ HEC endpoint on the Mac — both add deployment complexity without
 materially improving the failure detection signal.
 """
 
+from datetime import datetime, timezone
+
 from .helpers import query_splunk
+
+
+MACOS_INDEX_FILTER = "(index=os OR index=mac_perf)"
+MACOS_SOURCETYPE_FILTER = "sourcetype=macos:*"
+MACOS_NATIVE_FILTER = (
+    "(sourcetype=macos:unified_log OR sourcetype=macos:system:*)"
+)
+
+
+def _format_epoch(epoch):
+    """Return an ISO-8601 UTC timestamp for a Splunk epoch value."""
+    if epoch in (None, ""):
+        return "unknown"
+    try:
+        return (
+            datetime.fromtimestamp(float(epoch), tz=timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+    except (TypeError, ValueError):
+        return str(epoch)
+
+
+def _format_sourcetype_rows(rows):
+    """Format compact sourcetype freshness diagnostics."""
+    if not rows:
+        return "none"
+
+    formatted = []
+    for row in rows[:8]:
+        sourcetype = row.get("sourcetype") or "(missing sourcetype)"
+        index = row.get("index")
+        label = f"{index}/{sourcetype}" if index else sourcetype
+        last_seen = _format_epoch(row.get("last_seen"))
+        seconds_ago = row.get("seconds_ago")
+        count = row.get("count")
+        parts = [f"{label}: last_seen={last_seen}"]
+        if seconds_ago not in (None, ""):
+            parts.append(f"seconds_ago={seconds_ago}")
+        if count not in (None, ""):
+            parts.append(f"count={count}")
+        formatted.append(" ".join(parts))
+    return "; ".join(formatted)
+
+
+def _macos_history_context(mgmt_url, user, password):
+    """Return recent historical macOS sourcetype activity for failure messages."""
+    search_str = (
+        "| tstats latest(_time) as last_seen count WHERE earliest=-30d "
+        f"{MACOS_INDEX_FILTER} {MACOS_SOURCETYPE_FILTER} BY sourcetype "
+        "| eval seconds_ago=round(now() - last_seen, 0) "
+        "| sort 0 -last_seen"
+    )
+    rows = query_splunk(
+        mgmt_url, user, password, search_str, earliest=None, timeout=30
+    )
+    return _format_sourcetype_rows(rows)
+
+
+def _macos_any_index_context(mgmt_url, user, password):
+    """Return recent macOS sourcetype activity across all indexes."""
+    search_str = (
+        "| tstats latest(_time) as last_seen count WHERE earliest=-30d "
+        f"index=* {MACOS_SOURCETYPE_FILTER} BY index sourcetype "
+        "| eval seconds_ago=round(now() - last_seen, 0) "
+        "| sort 0 -last_seen"
+    )
+    rows = query_splunk(
+        mgmt_url, user, password, search_str, earliest=None, timeout=30
+    )
+    return _format_sourcetype_rows(rows)
 
 
 class TestMacOSPipelineFreshness:
@@ -34,8 +107,7 @@ class TestMacOSPipelineFreshness:
         """
         mgmt_url, user, password = splunk_creds
         search_str = (
-            "(index=os OR index=mac_perf) sourcetype=macos:* "
-            "| head 5"
+            f"{MACOS_INDEX_FILTER} {MACOS_SOURCETYPE_FILTER} | head 5"
         )
         results = query_splunk(
             mgmt_url, user, password, search_str, earliest="-5m", timeout=30
@@ -45,7 +117,10 @@ class TestMacOSPipelineFreshness:
             "no events with sourcetype=macos:* in (os OR mac_perf) within "
             "the last 5 minutes. Investigate: Cribl Edge daemon on macbook-m4, "
             "Cribl Cloud enrollment status, Cribl Stream pipelines, and "
-            "Splunk HEC ingestion."
+            "Splunk HEC ingestion. Latest macOS history in last 30d: "
+            f"{_macos_history_context(mgmt_url, user, password)}. "
+            "Any-index macOS history in last 30d: "
+            f"{_macos_any_index_context(mgmt_url, user, password)}"
         )
 
     def test_macos_native_sources_emitting(self, splunk_creds):
@@ -64,14 +139,15 @@ class TestMacOSPipelineFreshness:
         # `macos:system:*` expands as a glob on the indexed sourcetype.
         search_str = (
             "| tstats count WHERE "
-            "(index=os OR index=mac_perf) earliest=-15m "
-            "(sourcetype=macos:unified_log OR sourcetype=macos:system:*) "
+            f"{MACOS_INDEX_FILTER} earliest=-15m "
+            f"{MACOS_NATIVE_FILTER} "
             "BY sourcetype"
         )
         results = query_splunk(
             mgmt_url, user, password, search_str, timeout=30
         )
         sourcetypes_seen = {row.get("sourcetype") for row in results}
+        seen_context = ", ".join(sorted(filter(None, sourcetypes_seen))) or "none"
 
         assert any(
             st == "macos:unified_log" for st in sourcetypes_seen
@@ -79,14 +155,24 @@ class TestMacOSPipelineFreshness:
             "apple_unified_logs source not emitting: no events with "
             "sourcetype=macos:unified_log in last 15m. The native Cribl 4.18 "
             "apple_unified_logs Source on macbook-m4 may be misconfigured "
-            "or the daemon predicate is filtering everything out."
+            "or the daemon predicate is filtering everything out. Native "
+            f"sourcetypes seen in last 15m: {seen_context}. Latest macOS "
+            "history in last 30d: "
+            f"{_macos_history_context(mgmt_url, user, password)}. "
+            "Any-index macOS history in last 30d: "
+            f"{_macos_any_index_context(mgmt_url, user, password)}"
         )
         assert any(
-            st.startswith("macos:system:") for st in sourcetypes_seen
+            (st or "").startswith("macos:system:") for st in sourcetypes_seen
         ), (
             "system_metrics source not emitting: no events with "
             "sourcetype=macos:system:* in last 15m. The native Cribl 4.18 "
-            "system_metrics Source on macbook-m4 may be misconfigured."
+            "system_metrics Source on macbook-m4 may be misconfigured. Native "
+            f"sourcetypes seen in last 15m: {seen_context}. Latest macOS "
+            "history in last 30d: "
+            f"{_macos_history_context(mgmt_url, user, password)}. "
+            "Any-index macOS history in last 30d: "
+            f"{_macos_any_index_context(mgmt_url, user, password)}"
         )
 
     def test_macos_pack_recently_active(self, splunk_creds):
@@ -105,7 +191,7 @@ class TestMacOSPipelineFreshness:
         # actually detects a never-indexed pack vs. a stalled one.
         search_str = (
             "| tstats latest(_time) as last_seen WHERE "
-            "(index=os OR index=mac_perf) sourcetype=macos:* "
+            f"{MACOS_INDEX_FILTER} {MACOS_SOURCETYPE_FILTER} "
             "| where isnotnull(last_seen) "
             "| eval seconds_ago = now() - last_seen | head 1"
         )
@@ -115,7 +201,10 @@ class TestMacOSPipelineFreshness:
         assert results, (
             "no macOS pack events ever indexed in (index=os OR index=mac_perf): "
             "the pack may have never emitted data, or the indexes do not "
-            "exist yet"
+            "exist yet. Latest macOS history in last 30d: "
+            f"{_macos_history_context(mgmt_url, user, password)}. "
+            "Any-index macOS history in last 30d: "
+            f"{_macos_any_index_context(mgmt_url, user, password)}"
         )
 
         # tstats can emit null/missing aggregates even after the filter when


### PR DESCRIPTION
## Summary

- Validate Cribl Edge syslog listeners using `syslog_port_map` backend/high ports, with a flat-port fallback for older data.
- Skip the Cribl Edge private metrics probe cleanly when `CRIBL_EDGE_API_TOKEN` is unset, and print clearer debug output.
- Expand macOS E2E failure messages with recent Splunk history for targeted-index and any-index views.

- Reworked from the stale `fix/e2e-pipeline-validation-gaps` branch and rebased onto current `origin/main`.
