### PR TITLE
fix(n8n_docker): retry the owner-setup settings read on startup

### DIFF
--- a/roles/n8n_docker/tasks/main.yml
+++ b/roles/n8n_docker/tasks/main.yml
@@ -262,11 +262,17 @@
 # =============================================================================
 
 - name: Read n8n frontend settings (owner-setup state)
+  # /healthz answers 200 slightly before the REST router finishes mounting, so
+  # this can 404 for a few seconds even after the port-accepting/healthz waits
+  # above pass. Retry with the same backoff as the healthz check.
   ansible.builtin.uri:
     url: "http://127.0.0.1:{{ n8n_docker_web_port }}/rest/settings"
     method: GET
     status_code: 200
   register: n8n_docker_settings
+  retries: 12
+  delay: 5
+  until: n8n_docker_settings.status == 200
   changed_when: false
 
 - name: Create the n8n instance owner (first run only)


### PR DESCRIPTION
## Summary
- The "Read n8n frontend settings (owner-setup state)" task hit a live 404 during the first real converge of the new n8n guest: `/healthz` answers 200 slightly before n8n's REST router finishes mounting, so the very next request in the same play can still 404.
- Confirmed live: the identical GET to `/rest/settings` returned 404 during the converge, then 200 moments later with nothing else changed (`showSetupOnFirstLoad: true`, as expected pre-owner-setup).
- Adds the same `retries`/`delay`/`until` backoff already used for the `/healthz` wait immediately above it.

## Test plan
- [x] `ansible-lint` (production profile) passes
- [ ] Re-converge n8n and confirm the task passes without a fatal on first boot