### PR TITLE
fix(langgraph): render pyproject.toml with valid TOML comments

### DIFF
--- a/roles/langgraph_docker/templates/pyproject.toml.j2
+++ b/roles/langgraph_docker/templates/pyproject.toml.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment('c') }}
+{{ ansible_managed | comment }}
 # Seed LangGraph project — installed with `pip install -e .` in the image so
 # `langgraph dev` finds the graph deps. Pins are the single source of truth in
 # roles/langgraph_docker/defaults/main.yml.


### PR DESCRIPTION
## Problem
The langgraph_docker seed project's `pyproject.toml.j2` opened with `{{ ansible_managed | comment('c') }}`, which renders a **C-style `/* */` block comment**. TOML only supports `#` comments, so `pip install -e .` in the `langgraph-api` image build failed with `tomllib.TOMLDecodeError: Invalid statement (at line 1, column 1)` — the image never built and the server never came up.

## Fix
Use the default `comment` filter (`#`-style), matching the sibling `otel_bootstrap.py.j2`. One-line change.

## Validation
Converged live on the langgraph guest: image builds, `langgraph-api` + `agent-chat-ui` containers come up, `/ok` returns 200, the `agent` graph loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)