### PR TITLE
fix(inventory): scope the shared OTEL endpoint to all hosts, not just ai_orchestration_group

### DIFF
--- a/inventory/group_vars/ai_orchestration_group.yml
+++ b/inventory/group_vars/ai_orchestration_group.yml
@@ -2,21 +2,11 @@
 # Shared config for the AI-orchestration emitters (Dify, LangFlow, agent-exec).
 # These guests carry the `ai-orchestration` tag → ai_orchestration_group (load_tofu.yml).
 # Langfuse is NOT here — it receives telemetry, it does not emit.
-
-# Internal subdomain + Cribl Edge OTLP/HTTP port, split out so the composed
-# endpoint stays under the 120-char yaml line limit (a folded scalar can't wrap a
-# URL without injecting a space). Port is DRY from the tofu_data constants.
-ai_subdomain: "{{ lookup('env', 'PROXMOX_SUBDOMAIN') | mandatory('PROXMOX_SUBDOMAIN required') }}"
-ai_otel_http_port: >-
-  {{ hostvars['localhost']['tofu_data']['constants']['service_ports']['otel_traces_http'] }}
-
-# Cribl Edge OTLP/HTTP receiver for OpenTelemetry emission. The native OTEL source
-# on Cribl Edge and the Langfuse trace fan-out are configured LIVE (this Cribl
-# version cannot split one input across multiple outputs, so the fork is built and
-# verified against the running Cribl + Langfuse). Apps emit here regardless; the
-# OTLP exporter tolerates an unreachable endpoint (retry/drop), so converge is safe
-# before the source exists.
-ai_orchestration_otel_endpoint: "http://cribl-edge.{{ ai_subdomain }}:{{ ai_otel_http_port }}"
+#
+# ai_subdomain / ai_orchestration_otel_endpoint moved to group_vars/all.yml: the
+# Cribl Edge OTLP receiver is shared by every OTEL-emitting component, not just
+# this tier (hermes_agent/open_webui hit an undefined-var fatal referencing it
+# here before the move, since they aren't ai-orchestration-tagged hosts).
 
 # OpenAI-compatible model endpoint — the LiteLLM router (the fabric front door) at
 # https://llm.<subdomain>/v1. The tier is now expressed by the MODEL ALIAS the tool

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -25,6 +25,16 @@ cribl_hec_input_port: >-
   {{ hostvars['localhost']['tofu_data']['constants']['service_ports']['splunk_hec']
      | default(8088) }}
 
+# Shared Cribl Edge OTLP/HTTP receiver — every OTEL-emitting component (not just
+# the ai-orchestration tier) points here, so this is global rather than scoped to
+# ai_orchestration_group.yml (previously host-only there; roles outside that
+# group, e.g. hermes_agent/open_webui, hit an undefined-var fatal referencing it).
+# Split out so the composed URL stays under the 120-char yaml line limit.
+ai_subdomain: "{{ lookup('env', 'PROXMOX_SUBDOMAIN') | mandatory('PROXMOX_SUBDOMAIN required') }}"
+ai_otel_http_port: >-
+  {{ hostvars['localhost']['tofu_data']['constants']['service_ports']['otel_traces_http'] }}
+ai_orchestration_otel_endpoint: "http://cribl-edge.{{ ai_subdomain }}:{{ ai_otel_http_port }}"
+
 # Auto-managed Technitium CNAME aliases for hosts that resolve outside this zone
 # (e.g. the large-tier model runner). The target is an FQDN from the environment —
 # never an IP — and the record is skipped when the env var is unset.


### PR DESCRIPTION
## Summary
- #665 added `ai_orchestration_otel_endpoint` references to `roles/hermes_agent/defaults/main.yml` and `roles/open_webui/defaults/main.yml`, but that variable lived only in `inventory/group_vars/ai_orchestration_group.yml`.
- Neither `hermes-agent` nor `open-webui` carries the `ai-orchestration` tag (confirmed via terraform state + `inventory/load_tofu.yml` group derivation), so the var was genuinely undefined for both hosts.
- Confirmed live during a converge: `TASK [open_webui : Deploy the Open WebUI environment file]` failed fatal with `'ai_orchestration_otel_endpoint' is undefined`. That single fatal aborted the rest of that `site.yml` run — n8n/langgraph/traefik never even got a PLAY header — so this was silently blocking the whole AI-orchestration tier's converge, not just open_webui/hermes_agent telemetry.
- Fix: move `ai_subdomain` / `ai_otel_http_port` / `ai_orchestration_otel_endpoint` to `group_vars/all.yml`. Every OTEL-emitting component shares the same Cribl Edge receiver, so this belongs at global scope rather than gated behind one tier's tag. Identical computed value — no behavior change for existing `ai_orchestration_group` members (dify/langflow/n8n/langgraph/agent-exec).

## Test plan
- [x] `ansible-lint` (production profile) + `yamllint` pass on both changed files
- [ ] Re-run the site.yml converge and confirm it reaches and completes the n8n/langgraph/traefik/hermes_agent/open_webui plays