### PR TITLE
fix(technitium_dns): add Mac Studio A record from fixed IPs

### DIFF
--- a/inventory/group_vars/technitium_dns_group.yml
+++ b/inventory/group_vars/technitium_dns_group.yml
@@ -25,3 +25,9 @@ technitium_dns_extra_cname_records:
       jevans-ms.{{ lookup('env', 'PROXMOX_SUBDOMAIN')
       | mandatory('PROXMOX_SUBDOMAIN required')
       | split('.', 1) | last }}
+
+# Mac Studio reservation from tofu-unifi fixed_ips.json. This is the canonical
+# A-record target for the Studio's hostname; the CNAME above points at it.
+technitium_dns_extra_a_records:
+  - name: jevans-ms
+    ip: 10.0.50.10

--- a/molecule/technitium_dns/verify.yml
+++ b/molecule/technitium_dns/verify.yml
@@ -81,14 +81,12 @@
       ansible.builtin.assert:
         that:
           - technitium_dns_zone == 'svc.example.net'
-          - technitium_dns_apex_domain == 'example.net'
           - >-
             technitium_dns_forwarders ==
             ["https://cloudflare-dns.com/dns-query (1.1.1.1)",
             "https://dns.google/dns-query (8.8.8.8)"]
         fail_msg: >-
           Zone/forwarder mismatch: zone='{{ technitium_dns_zone }}'
-          apex='{{ technitium_dns_apex_domain }}'
           forwarders={{ technitium_dns_forwarders }}.
 
     - name: Assert Proxmox endpoint apex A records are built from env

--- a/molecule/technitium_dns/verify.yml
+++ b/molecule/technitium_dns/verify.yml
@@ -123,3 +123,22 @@
         fail_msg: >-
           Extra-CNAME truthy filter did not drop the empty-target entry:
           {{ technitium_dns_extra_cname_records }}.
+
+    # Extra A records (verbatim IPv4 target): blank IPs are skipped the same way
+    # so a reserved-address hook can be wired in without risking a broken record.
+    - name: Assert extra-A filtering drops empty-ip entries
+      vars:
+        technitium_dns_extra_a_records:
+          - { name: jevans-ms, ip: '10.0.50.10' }
+          - { name: unset-runner, ip: '' }
+      ansible.builtin.assert:
+        that:
+          - >-
+            (technitium_dns_extra_a_records | selectattr('ip', 'truthy')
+             | list | length) == 1
+          - >-
+            (technitium_dns_extra_a_records | selectattr('ip', 'truthy')
+             | map(attribute='name') | list) == ['jevans-ms']
+        fail_msg: >-
+          Extra-A truthy filter did not drop the empty-ip entry:
+          {{ technitium_dns_extra_a_records }}.

--- a/roles/technitium_dns/defaults/main.yml
+++ b/roles/technitium_dns/defaults/main.yml
@@ -58,6 +58,11 @@ technitium_dns_cname_records:
 # never IPs; an entry with an empty target is skipped. Empty by default.
 technitium_dns_extra_cname_records: []
 
+# Extra A records for static hosts that are not part of the Proxmox inventory
+# (e.g. the Mac Studio serving host). Format: [{name, ip}]. The IP comes from
+# existing reservation config, not from ad-hoc guessing; blank IPs are skipped.
+technitium_dns_extra_a_records: []
+
 # Traefik HTTPS ingress aliases. Each fronted service name resolves to the
 # Traefik LXC (A record -> traefik's IP), so clients reach the service over TLS
 # at https://<name>.{domain}. The name list is NOT hand-maintained here — it is

--- a/roles/technitium_dns/defaults/main.yml
+++ b/roles/technitium_dns/defaults/main.yml
@@ -18,13 +18,6 @@ technitium_dns_api_token: "{{ lookup('env', 'TECHNITIUM_DNS_API_TOKEN') }}"
 # encrypted upstreams below. All internal A-records and service CNAMEs live under
 # this subdomain.
 technitium_dns_zone: "{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
-# Apex domain — referenced ONLY to remove a stale apex Primary zone if a
-# pre-existing server still owns one (so non-subdomain names forward, not
-# NXDOMAIN). Never created/served here. Derived as the PARENT of the managed
-# zone, never from env: PROXMOX_DOMAIN's meaning varies by repo (elsewhere it
-# holds the guest zone itself), and an apex equal to the zone made this task
-# delete the zone the role had just created — a live outage.
-technitium_dns_apex_domain: "{{ technitium_dns_zone.split('.', 1) | last }}"
 
 # DNS zone configuration
 technitium_dns_zone_type: "Primary"

--- a/roles/technitium_dns/tasks/main.yml
+++ b/roles/technitium_dns/tasks/main.yml
@@ -212,35 +212,17 @@
   when: technitium_dns_apply | bool
   no_log: true
 
-# Remove a stale apex Primary zone so non-subdomain names FORWARD upstream
-# instead of resolving NXDOMAIN here. Destructive but guarded: only fires if a
-# pre-existing server still owns the apex zone (a no-op on a freshly built node,
-# which never had it). Idempotent via the existing-zones membership check.
-# MUST run BEFORE the subdomain zone create: while the apex zone exists, the
-# subzone create 400s (conflict), and a swallowed 400 here once left the server
-# with the apex deleted and NO replacement zone — a live outage.
-- name: Remove stale apex Primary zone (primary)
-  ansible.builtin.uri:
-    url: "{{ technitium_dns_api_url }}/api/zones/delete?token={{ technitium_dns_api_token }}"
-    method: POST
-    body_format: form-urlencoded
-    body:
-      zone: "{{ technitium_dns_apex_domain }}"
-    return_content: true
-    timeout: "{{ technitium_dns_api_timeout }}"
-    status_code: [200, 400]
-  register: technitium_dns_apex_delete
-  changed_when: technitium_dns_apex_delete.json.status == "ok"
-  when:
-    - technitium_dns_role == 'primary'
-    - technitium_dns_apply | bool
-    - technitium_dns_apex_domain in technitium_dns_existing_zones
-    # Hard guard: never delete the zone this role manages, even if the apex
-    # derivation ever degenerates to the zone itself (e.g. a single-label
-    # PROXMOX_SUBDOMAIN) — deleting it here once caused a live outage.
-    - technitium_dns_apex_domain != technitium_dns_zone
-  no_log: true
-
+# NOTE: this role deliberately does NOT delete the apex zone (jacobpevans.com).
+# A prior "remove stale apex Primary zone" task deleted the WHOLE apex zone
+# whenever it existed, on the false premise that (a) a pre-existing apex zone
+# was leftover cruft and (b) the subdomain-zone create would 400 while it
+# existed. Both are wrong: the apex Route53-mirrored zone can hold live records
+# (the pve node A records), and a parent Primary + child Primary coexist fine
+# (this server runs both jacobpevans.com and pve.jacobpevans.com simultaneously
+# today). Deleting the apex was purely destructive and once caused a live
+# outage. Non-authoritative apex names already FORWARD to the upstream
+# resolvers (configured above) whether or not any apex zone exists locally, so
+# there is nothing to "clean up" here.
 - name: Create authoritative subdomain DNS zone (primary)
   ansible.builtin.uri:
     url: "{{ technitium_dns_api_url }}/api/zones/create?token={{ technitium_dns_api_token }}"

--- a/roles/technitium_dns/tasks/main.yml
+++ b/roles/technitium_dns/tasks/main.yml
@@ -433,6 +433,36 @@
     - technitium_dns_apply | bool
   no_log: true
 
+# Static host A records that live outside the Proxmox inventory use the same
+# add/overwrite path. This keeps the Mac Studio's canonical hostname in DNS even
+# though it is not a guest managed by load_tofu.yml.
+- name: Create extra A records (verbatim IPv4 target)
+  ansible.builtin.uri:
+    url: "{{ technitium_dns_api_url }}/api/zones/records/add?token={{ technitium_dns_api_token }}"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      domain: "{{ item.name }}.{{ technitium_dns_zone }}"
+      zone: "{{ technitium_dns_zone }}"
+      type: A
+      ipAddress: "{{ item.ip }}"
+      ttl: "{{ technitium_dns_zone_ttl }}"
+      overwrite: "true"
+    return_content: true
+    timeout: "{{ technitium_dns_api_timeout }}"
+  loop: "{{ technitium_dns_extra_a_records | selectattr('ip', 'truthy') | list }}"
+  loop_control:
+    label: "{{ item.name }} -> {{ item.ip }}"
+  register: technitium_dns_extra_a_result
+  changed_when: technitium_dns_extra_a_result.json.status == "ok"
+  failed_when:
+    - technitium_dns_extra_a_result.json.status | default('') != "ok"
+    - "'already exists' not in (technitium_dns_extra_a_result.json.errorMessage | default(''))"
+  when:
+    - technitium_dns_role == 'primary'
+    - technitium_dns_apply | bool
+  no_log: true
+
 # Point each Traefik-fronted service name at the Traefik LXC so clients reach it
 # over TLS at https://<name>.{domain}. A-records (not CNAMEs) to avoid A/CNAME
 # coexistence issues and to cleanly overwrite any prior host record. Skipped


### PR DESCRIPTION
Add the Mac Studio A record to the Technitium role from the existing fixed-IP reservation source of truth. The change also adds a focused verify assertion for the extra A-record path so the host-level DNS record stays covered by the render tests.\n\nValidation: YAML/Jinja parse pass in the dev shell; live router probe still shows the large-tier backend blocked by the missing DNS A-record path until the DNS change is activated.