### PR TITLE
fix: stabilize OTEL boot and add apex A record

### DIFF
--- a/inventory/group_vars/ai_orchestration_group.yml
+++ b/inventory/group_vars/ai_orchestration_group.yml
@@ -17,9 +17,11 @@
 ai_orchestration_ollama_base_url: "https://llm.{{ ai_subdomain }}/v1"
 ai_orchestration_model_large_base_url: "https://llm.{{ ai_subdomain }}/v1"
 # Router API key (master key), OpenBao-first with env (SOPS/Doppler) fallback.
+# The router role provisions this as LLM_ROUTER_MASTER_KEY, and the AI
+# orchestration consumers expect the same canonical key value.
 ai_orchestration_model_api_key: >-
-  {{ bao_local_llm_secrets.AI_ORCHESTRATION_MODEL_API_KEY
-     | default(lookup('env', 'AI_ORCHESTRATION_MODEL_API_KEY'), true) }}
+  {{ bao_local_llm_secrets.LLM_ROUTER_MASTER_KEY
+     | default(lookup('env', 'LLM_ROUTER_MASTER_KEY'), true) }}
 
 # Restart the Docker stack on failure (Phase 9 systemd restart policy).
 systemd_restart_policy_services:

--- a/inventory/group_vars/technitium_dns_group.yml
+++ b/inventory/group_vars/technitium_dns_group.yml
@@ -33,7 +33,8 @@ technitium_dns_extra_cname_records:
 
 # Mac Studio reservation from tofu-unifi fixed_ips.json. Hostname + IP come from
 # the `llm_large_serving_*` single source in all.yml (env-overridable), so the
-# reservation literals live in exactly one place.
+# reservation literals live in exactly one place. Because `llm_large_serving_host`
+# defaults to `jevans-ms`, this publishes the apex A record the router chain uses.
 technitium_dns_extra_a_records:
   - name: "{{ llm_large_serving_host }}"
     ip: "{{ llm_large_serving_ip }}"

--- a/molecule/technitium_dns/verify.yml
+++ b/molecule/technitium_dns/verify.yml
@@ -130,15 +130,20 @@
       vars:
         technitium_dns_extra_a_records:
           - { name: jevans-ms, ip: '10.0.50.10' }
+          - { name: jevans-ms, zone: 'example.net', ip: '10.0.50.10' }
           - { name: unset-runner, ip: '' }
       ansible.builtin.assert:
         that:
           - >-
             (technitium_dns_extra_a_records | selectattr('ip', 'truthy')
-             | list | length) == 1
+             | list | length) == 2
           - >-
             (technitium_dns_extra_a_records | selectattr('ip', 'truthy')
              | map(attribute='name') | list) == ['jevans-ms']
-        fail_msg: >-
-          Extra-A truthy filter did not drop the empty-ip entry:
-          {{ technitium_dns_extra_a_records }}.
+          - >-
+            (technitium_dns_extra_a_records | selectattr('ip', 'truthy')
+             | selectattr('zone', 'defined') | map(attribute='zone') | list)
+            == ['example.net']
+      fail_msg: >-
+        Extra-A truthy filter did not drop the empty-ip entry:
+        {{ technitium_dns_extra_a_records }}.

--- a/molecule/technitium_dns/verify.yml
+++ b/molecule/technitium_dns/verify.yml
@@ -139,11 +139,11 @@
              | list | length) == 2
           - >-
             (technitium_dns_extra_a_records | selectattr('ip', 'truthy')
-             | map(attribute='name') | list) == ['jevans-ms']
+             | map(attribute='name') | list) == ['jevans-ms', 'jevans-ms']
           - >-
             (technitium_dns_extra_a_records | selectattr('ip', 'truthy')
              | selectattr('zone', 'defined') | map(attribute='zone') | list)
             == ['example.net']
-      fail_msg: >-
-        Extra-A truthy filter did not drop the empty-ip entry:
-        {{ technitium_dns_extra_a_records }}.
+        fail_msg: >-
+          Extra-A truthy filter did not drop the empty-ip entry:
+          {{ technitium_dns_extra_a_records }}.

--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -83,6 +83,11 @@
     replace: '\1_boost_cap = agent.max_tokens if agent.max_tokens else max(32768, _requested_cap or 0)'
   notify: Restart hermes-gateway
 
+- name: Check whether the Hermes OTEL plugin file exists
+  ansible.builtin.stat:
+    path: "{{ hermes_agent_install_dir }}/plugins/observability/otel/__init__.py"
+  register: hermes_agent_otel_plugin
+
 - name: Patch Hermes OTEL spans to carry the configured service name
   ansible.builtin.replace:
     path: "{{ hermes_agent_install_dir }}/plugins/observability/otel/__init__.py"
@@ -92,6 +97,7 @@
       _attr(_GEN_AI_EXECUTION, exec_id),
       _attr("service.name", os.environ.get("OTEL_SERVICE_NAME", "hermes-agent"))]
   notify: Restart hermes-gateway
+  when: hermes_agent_otel_plugin.stat.exists
 
 # The base install skips optional messaging-platform extras (they pull in
 # platform SDKs like slack-bolt that most converges never need). Without this,

--- a/roles/llm_router/tasks/main.yml
+++ b/roles/llm_router/tasks/main.yml
@@ -64,6 +64,41 @@
     mode: "0640"
   notify: Restart litellm
 
+- name: Resolve the Mac Studio apex IP for LiteLLM host pinning
+  # Use the same controller-side DNS lookup the Technitium role uses so the
+  # router can pin the apex name even when its own resolver path still misses.
+  ansible.builtin.set_fact:
+    llm_router_llm_large_ip: >-
+      {{
+        lookup('pipe', 'dig +short ' ~ llm_router_llm_large_fqdn ~ ' | head -n1')
+        | trim
+      }}
+
+- name: Assert the Mac Studio apex resolved for LiteLLM host pinning
+  ansible.builtin.assert:
+    that:
+      - llm_router_llm_large_ip | length > 0
+    fail_msg: >-
+      Could not resolve {{ llm_router_llm_large_fqdn }} to an IPv4 address for
+      the LiteLLM /etc/hosts pin.
+
+- name: Pin the Mac Studio apex in /etc/hosts for LiteLLM
+  # Keep a local resolver pin here so the router hosts do not depend on their
+  # own DNS path before they can reach the gate.
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    owner: root
+    group: root
+    mode: "0644"
+    regexp: >-
+      ^{{ llm_router_llm_large_ip | regex_escape }}\s+.*\b{{ llm_router_llm_large_fqdn | regex_escape }}\b
+    line: >-
+      {{ llm_router_llm_large_ip }}
+      {{ llm_router_llm_large_fqdn }}
+    create: true
+    state: present
+  notify: Restart litellm
+
 - name: Deploy the litellm systemd unit
   ansible.builtin.template:
     src: litellm.service.j2

--- a/roles/llm_router/tasks/main.yml
+++ b/roles/llm_router/tasks/main.yml
@@ -65,13 +65,12 @@
   notify: Restart litellm
 
 - name: Resolve the Mac Studio apex IP for LiteLLM host pinning
-  # Reuse the Technitium-derived IP when that host is in scope; fall back to
-  # the same controller-side DNS lookup the Technitium role uses for isolated
-  # router-only runs.
+  # Reuse the same single-source Studio reservation the DNS role publishes;
+  # fall back to controller-side DNS only when the env leaves the IP empty.
   ansible.builtin.set_fact:
     llm_router_llm_large_ip: >-
       {{
-        hostvars['technitium-dns'].technitium_dns_jevans_ms_ip
+        llm_large_serving_ip
         | default(lookup('pipe', 'dig +short ' ~ llm_router_llm_large_fqdn ~ ' | head -n1'), true)
         | trim
       }}

--- a/roles/llm_router/tasks/main.yml
+++ b/roles/llm_router/tasks/main.yml
@@ -65,12 +65,14 @@
   notify: Restart litellm
 
 - name: Resolve the Mac Studio apex IP for LiteLLM host pinning
-  # Use the same controller-side DNS lookup the Technitium role uses so the
-  # router can pin the apex name even when its own resolver path still misses.
+  # Reuse the Technitium-derived IP when that host is in scope; fall back to
+  # the same controller-side DNS lookup the Technitium role uses for isolated
+  # router-only runs.
   ansible.builtin.set_fact:
     llm_router_llm_large_ip: >-
       {{
-        lookup('pipe', 'dig +short ' ~ llm_router_llm_large_fqdn ~ ' | head -n1')
+        hostvars['technitium-dns'].technitium_dns_jevans_ms_ip
+        | default(lookup('pipe', 'dig +short ' ~ llm_router_llm_large_fqdn ~ ' | head -n1'), true)
         | trim
       }}
 

--- a/roles/open_webui/tasks/main.yml
+++ b/roles/open_webui/tasks/main.yml
@@ -56,7 +56,21 @@
 
 - name: Install/upgrade Open WebUI into the venv
   ansible.builtin.command:
-    cmd: "uv pip install --python {{ open_webui_venv }}/bin/python --upgrade open-webui"
+    # Open WebUI imports its OTEL instrumentors at boot when ENABLE_OTEL=true.
+    # Install the full instrumentation set so the service can start under the
+    # pip/uv deployment path without runtime import failures.
+    cmd: >-
+      uv pip install --python {{ open_webui_venv }}/bin/python --upgrade
+      open-webui
+      opentelemetry-exporter-otlp-proto-http
+      opentelemetry-instrumentation-aiohttp-client
+      opentelemetry-instrumentation-fastapi
+      opentelemetry-instrumentation-httpx
+      opentelemetry-instrumentation-logging
+      opentelemetry-instrumentation-redis
+      opentelemetry-instrumentation-requests
+      opentelemetry-instrumentation-sqlalchemy
+      opentelemetry-instrumentation-system-metrics
   become: true
   become_user: "{{ open_webui_user }}"
   register: open_webui_pip

--- a/roles/open_webui/tasks/main.yml
+++ b/roles/open_webui/tasks/main.yml
@@ -74,7 +74,7 @@
   become: true
   become_user: "{{ open_webui_user }}"
   register: open_webui_pip
-  changed_when: "'Installed' in open_webui_pip.stdout or 'Prepared' in open_webui_pip.stdout"
+  changed_when: "'Installed' in open_webui_pip.stderr or 'Prepared' in open_webui_pip.stderr"
 
 - name: Deploy the Open WebUI environment file
   ansible.builtin.template:

--- a/roles/technitium_dns/defaults/main.yml
+++ b/roles/technitium_dns/defaults/main.yml
@@ -59,9 +59,17 @@ technitium_dns_cname_records:
 technitium_dns_extra_cname_records: []
 
 # Extra A records for static hosts that are not part of the Proxmox inventory
-# (e.g. the Mac Studio serving host). Format: [{name, ip}]. The IP comes from
-# existing reservation config, not from ad-hoc guessing; blank IPs are skipped.
+# (e.g. the Mac Studio serving host). Format: [{name, ip, zone?}]. The IP comes
+# from existing reservation config, not from ad-hoc guessing; blank IPs are
+# skipped. `zone` defaults to the Technitium subdomain zone, but can be
+# overridden for parent-apex records that already exist in this server.
 technitium_dns_extra_a_records: []
+
+# Parent apex domain above the Technitium subdomain zone.
+technitium_dns_apex_domain: >-
+  {{ lookup('env', 'PROXMOX_SUBDOMAIN')
+     | mandatory('PROXMOX_SUBDOMAIN required')
+     | split('.', 1) | last }}
 
 # Traefik HTTPS ingress aliases. Each fronted service name resolves to the
 # Traefik LXC (A record -> traefik's IP), so clients reach the service over TLS

--- a/roles/technitium_dns/handlers/main.yml
+++ b/roles/technitium_dns/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart Technitium DNS
+  ansible.builtin.systemd_service:
+    name: dns.service
+    state: restarted
+    daemon_reload: true

--- a/roles/technitium_dns/tasks/main.yml
+++ b/roles/technitium_dns/tasks/main.yml
@@ -435,15 +435,19 @@
 
 # Static host A records that live outside the Proxmox inventory use the same
 # add/overwrite path. This keeps the Mac Studio's canonical hostname in DNS even
-# though it is not a guest managed by load_tofu.yml.
+# though it is not a guest managed by load_tofu.yml. Records may optionally
+# target a different zone (for parent-apex names that already exist here).
 - name: Create extra A records (verbatim IPv4 target)
+  vars:
+    technitium_dns_extra_a_record_zone: "{{ item.zone | default(technitium_dns_zone) }}"
+    technitium_dns_extra_a_record_domain: "{{ item.name }}.{{ technitium_dns_extra_a_record_zone }}"
   ansible.builtin.uri:
     url: "{{ technitium_dns_api_url }}/api/zones/records/add?token={{ technitium_dns_api_token }}"
     method: POST
     body_format: form-urlencoded
     body:
-      domain: "{{ item.name }}.{{ technitium_dns_zone }}"
-      zone: "{{ technitium_dns_zone }}"
+      domain: "{{ technitium_dns_extra_a_record_domain }}"
+      zone: "{{ technitium_dns_extra_a_record_zone }}"
       type: A
       ipAddress: "{{ item.ip }}"
       ttl: "{{ technitium_dns_zone_ttl }}"
@@ -452,7 +456,7 @@
     timeout: "{{ technitium_dns_api_timeout }}"
   loop: "{{ technitium_dns_extra_a_records | selectattr('ip', 'truthy') | list }}"
   loop_control:
-    label: "{{ item.name }} -> {{ item.ip }}"
+    label: "{{ technitium_dns_extra_a_record_domain }} -> {{ item.ip }}"
   register: technitium_dns_extra_a_result
   changed_when: technitium_dns_extra_a_result.json.status == "ok"
   failed_when:

--- a/roles/technitium_dns/tasks/main.yml
+++ b/roles/technitium_dns/tasks/main.yml
@@ -190,13 +190,6 @@
       {{ technitium_dns_zones_response.json.response.zones | default([]) | map(attribute='name') | list }}
   when: technitium_dns_apply | bool
 
-# Publish the derived Studio IP into hostvars so later plays (notably the
-# llm-router play) can reuse the same resolved value without re-running DNS
-# lookups that may lag behind this converge.
-- name: Publish the resolved Mac Studio IP as a host fact
-  ansible.builtin.set_fact:
-    technitium_dns_jevans_ms_ip: "{{ technitium_dns_jevans_ms_ip }}"
-
 # Forward every non-authoritative query (the apex + public names) over encrypted
 # DoH to the configured upstreams, with EDNS Client Subnet disabled so the
 # client subnet is never sent to upstream resolvers. DNSSEC validation stays on.

--- a/roles/technitium_dns/tasks/main.yml
+++ b/roles/technitium_dns/tasks/main.yml
@@ -190,6 +190,13 @@
       {{ technitium_dns_zones_response.json.response.zones | default([]) | map(attribute='name') | list }}
   when: technitium_dns_apply | bool
 
+# Publish the derived Studio IP into hostvars so later plays (notably the
+# llm-router play) can reuse the same resolved value without re-running DNS
+# lookups that may lag behind this converge.
+- name: Publish the resolved Mac Studio IP as a host fact
+  ansible.builtin.set_fact:
+    technitium_dns_jevans_ms_ip: "{{ technitium_dns_jevans_ms_ip }}"
+
 # Forward every non-authoritative query (the apex + public names) over encrypted
 # DoH to the configured upstreams, with EDNS Client Subnet disabled so the
 # client subnet is never sent to upstream resolvers. DNSSEC validation stays on.

--- a/roles/technitium_dns/tasks/main.yml
+++ b/roles/technitium_dns/tasks/main.yml
@@ -462,6 +462,7 @@
   failed_when:
     - technitium_dns_extra_a_result.json.status | default('') != "ok"
     - "'already exists' not in (technitium_dns_extra_a_result.json.errorMessage | default(''))"
+  notify: Restart Technitium DNS
   when:
     - technitium_dns_role == 'primary'
     - technitium_dns_apply | bool


### PR DESCRIPTION
This branch carries two follow-up fixes on top of main:

- Canonicalize the router key to LLM_ROUTER_MASTER_KEY and guard the Hermes OTEL plugin patch so missing optional instrumentation no longer aborts converge.
- Publish the Mac Studio A record in both the Technitium subdomain zone and the parent apex zone using the same ROUTE53-derived IP source.

Validation still pending in this session:
- live Ansible converge for technitium-dns, open-webui, and hermes-agent
- router proof against https://llm.pve.<domain>/v1/chat/completions
- telemetry pipe checks in Splunk