### PR TITLE
refactor(dns): single-source the llm-large serving host + IP

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -44,14 +44,18 @@ ai_orchestration_otel_endpoint: "http://cribl-edge.{{ ai_subdomain }}:{{ ai_otel
 # defaults are the current live values, so with the env unset the rendered output
 # is byte-identical to before.
 llm_large_serving_host: "{{ (lookup('env', 'LLM_LARGE_RUNNER_HOST') or 'jevans-ms') | split('.') | first }}"
-llm_large_serving_ip: "{{ lookup('env', 'LLM_LARGE_RUNNER_IP') | default('10.0.50.10', true) }}"
+# IP default is the local Studio reservation ONLY when no external runner host is
+# configured. If LLM_LARGE_RUNNER_HOST points at an external host without an
+# explicit LLM_LARGE_RUNNER_IP, resolve to empty so the A-record truthy filter
+# skips it (never point an external name at the local IP).
+llm_large_serving_ip: >-
+  {{ lookup('env', 'LLM_LARGE_RUNNER_IP')
+     or ('' if lookup('env', 'LLM_LARGE_RUNNER_HOST') else '10.0.50.10') }}
 
-# Auto-managed Technitium CNAME aliases for hosts that resolve outside this zone
-# (e.g. the large-tier model runner). The target is an FQDN from the environment —
-# never an IP — and the record is skipped when the env var is unset.
-technitium_dns_extra_cname_records:
-  - name: llm-large
-    target: "{{ lookup('env', 'LLM_LARGE_RUNNER_HOST') }}"
+# NOTE: the `llm-large` CNAME record lives in group_vars/technitium_dns_group.yml,
+# NOT here — an `extra_cname_records` list defined in the more-specific group file
+# REPLACES (not merges) any list here, so a definition here would be silently
+# ignored for the technitium hosts. Keep the single authoritative definition there.
 
 # Resource-domain secrets fetched from OpenBao by the openbao_secrets pre-play,
 # one dict per domain. Defaults to an empty dict for each so every consumer's

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -35,6 +35,17 @@ ai_otel_http_port: >-
   {{ hostvars['localhost']['tofu_data']['constants']['service_ports']['otel_traces_http'] }}
 ai_orchestration_otel_endpoint: "http://cribl-edge.{{ ai_subdomain }}:{{ ai_otel_http_port }}"
 
+# Heavy-tier LLM serving host (the Mac Studio) — SINGLE SOURCE OF TRUTH for its
+# short hostname and reserved IP, so neither literal is repeated across roles or
+# group_vars (llm_router, technitium_dns). The host is a tofu-unifi fixed_ips.json
+# reservation and is NOT a PVE guest, so it is absent from the tofu ansible
+# inventory; parameterize it from the environment instead (LLM_LARGE_RUNNER_HOST
+# is the FQDN used for the llm-large alias below — take its short host here). The
+# defaults are the current live values, so with the env unset the rendered output
+# is byte-identical to before.
+llm_large_serving_host: "{{ (lookup('env', 'LLM_LARGE_RUNNER_HOST') or 'jevans-ms') | split('.') | first }}"
+llm_large_serving_ip: "{{ lookup('env', 'LLM_LARGE_RUNNER_IP') | default('10.0.50.10', true) }}"
+
 # Auto-managed Technitium CNAME aliases for hosts that resolve outside this zone
 # (e.g. the large-tier model runner). The target is an FQDN from the environment —
 # never an IP — and the record is skipped when the env var is unset.

--- a/inventory/group_vars/technitium_dns_group.yml
+++ b/inventory/group_vars/technitium_dns_group.yml
@@ -19,15 +19,18 @@ technitium_dns_retired_records:
 # target; the router pool dials this name with the gate bearer). The Studio's
 # name lives at the APEX (parent of the guest zone), so derive it from
 # PROXMOX_SUBDOMAIN — PROXMOX_DOMAIN holds the guest zone in this environment.
+# The Studio host itself comes from `llm_large_serving_host` (all.yml single
+# source), never a literal repeated here.
 technitium_dns_extra_cname_records:
   - name: llm-large
     target: >-
-      jevans-ms.{{ lookup('env', 'PROXMOX_SUBDOMAIN')
+      {{ llm_large_serving_host }}.{{ lookup('env', 'PROXMOX_SUBDOMAIN')
       | mandatory('PROXMOX_SUBDOMAIN required')
       | split('.', 1) | last }}
 
-# Mac Studio reservation from tofu-unifi fixed_ips.json. This is the canonical
-# A-record target for the Studio's hostname; the CNAME above points at it.
+# Mac Studio reservation from tofu-unifi fixed_ips.json. Hostname + IP come from
+# the `llm_large_serving_*` single source in all.yml (env-overridable), so the
+# reservation literals live in exactly one place.
 technitium_dns_extra_a_records:
-  - name: jevans-ms
-    ip: 10.0.50.10
+  - name: "{{ llm_large_serving_host }}"
+    ip: "{{ llm_large_serving_ip }}"

--- a/inventory/group_vars/technitium_dns_group.yml
+++ b/inventory/group_vars/technitium_dns_group.yml
@@ -23,10 +23,13 @@ technitium_dns_retired_records:
 # source), never a literal repeated here.
 technitium_dns_extra_cname_records:
   - name: llm-large
+    # An external LLM_LARGE_RUNNER_HOST is already a full FQDN — use it verbatim.
+    # Otherwise build the local record from the single-source short host + apex.
     target: >-
-      {{ llm_large_serving_host }}.{{ lookup('env', 'PROXMOX_SUBDOMAIN')
+      {{ lookup('env', 'LLM_LARGE_RUNNER_HOST')
+      or (llm_large_serving_host ~ '.' ~ (lookup('env', 'PROXMOX_SUBDOMAIN')
       | mandatory('PROXMOX_SUBDOMAIN required')
-      | split('.', 1) | last }}
+      | split('.', 1) | last)) }}
 
 # Mac Studio reservation from tofu-unifi fixed_ips.json. Hostname + IP come from
 # the `llm_large_serving_*` single source in all.yml (env-overridable), so the

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -78,7 +78,10 @@ llm_router_llm_light_base_url: "http://llm-light.{{ llm_router_subdomain }}:{{ l
 # (Restoring/decoupling behind an alias again is a DNS follow-up, not a router
 # concern — see PR notes.)
 llm_router_apex_domain: "{{ llm_router_subdomain | split('.', 1) | last }}"
-llm_router_llm_large_host: jevans-ms
+# Host comes from the `llm_large_serving_host` single source (all.yml,
+# env-overridable) so the Studio's name is not a literal repeated across roles —
+# still its own permanent per-host record, NOT the floating alias (see above).
+llm_router_llm_large_host: "{{ llm_large_serving_host }}"
 llm_router_llm_large_fqdn: "{{ llm_router_llm_large_host }}.{{ llm_router_apex_domain }}"
 llm_router_llm_large_base_url: "https://{{ llm_router_llm_large_fqdn }}:{{ llm_router_large_port }}/v1"
 


### PR DESCRIPTION
## Problem
`jevans-ms` (the Mac Studio hostname) and its reserved IP `10.0.50.10` were **hardcoded in three places** — `roles/llm_router/defaults/main.yml`, and the `technitium_dns_group` CNAME target + A record — duplicating a value that must live in exactly one place (parameterize always; identifiers come from a single source, not scattered literals).

## Change
Introduce `llm_large_serving_host` / `llm_large_serving_ip` in `group_vars/all.yml` as the **single source of truth**, env-overridable via `LLM_LARGE_RUNNER_HOST` / `LLM_LARGE_RUNNER_IP`, with the **current live values as the ONLY defaults** — so with the env unset the rendered output is **byte-identical** to before. `llm_router` and `technitium_dns` now reference these vars.

## Safety
- **No behavior change** (defaults = current values; env unset → identical render). ansible-lint (profile production) passes.
- **Does NOT reintroduce the floating `llm-large` alias** that NXDOMAIN'd on 2026-07-06 — the Studio keeps its own permanent per-host record; only the repeated literals are removed.
- The IP has no tofu ansible-inventory source (the Studio is a **tofu-unifi reservation**, not a PVE guest), so it's parameterized from the environment rather than a scattered literal — a cleaner tofu-output path would be a follow-up.

## Coordination
Touches `technitium_dns_group.yml`, which **#679 also edits** — #679 should rebase onto this and route its new jevans-ms references through `llm_large_serving_host`/`_ip` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)