### PR TITLE
feat(hermes): raise the output-token envelope to the serving cap (32768)

### DIFF
--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -67,11 +67,13 @@ hermes_agent_model_context_length: 262144
 # misclassifies that 400 as a context overflow (it matches the bare
 # substring "max_tokens" in any error text) and dies trying to compress an
 # already-minimal conversation instead of lowering the output request.
-# Keep this at 8192 until the parked nix-darwin rebuild lands and is activated
-# (nix-darwin#1539 / nix-darwin#1545). After that rebuild is live, the next
-# bump is 32768.
-# Capping max_tokens here means the oversized request is never sent.
-hermes_agent_model_max_tokens: 8192
+# 32768 matches the serving side since the nix-darwin#1539/#1545 rebuild went
+# live on the Mac Studio (2026-07-07): the coder model's per-model
+# maxRequestTokens override is 32768, and hermes-agent's own retry-boost
+# ceiling is max(32768, requested), so the boosted retry lands exactly at the
+# server cap instead of exceeding it.
+# Capping max_tokens here means an oversized request is never sent.
+hermes_agent_model_max_tokens: 32768
 # The api key IS the LiteLLM router master key; source it from the canonical
 # LLM_ROUTER_MASTER_KEY env (same as the llm_router role) so no per-run mapping
 # is needed. HERMES_AGENT_MODEL_API_KEY still overrides if explicitly set.


### PR DESCRIPTION
## Summary

Bumps `hermes_agent_model_max_tokens` 8192 → 32768.

## Why now

The existing comment on the 8192 value named its own unblock condition: *"Keep this at 8192 until the parked nix-darwin rebuild lands and is activated (nix-darwin#1539 / nix-darwin#1545). After that rebuild is live, the next bump is 32768."* That rebuild is live on the serving host as of today — verified: the coder model's per-model `maxRequestTokens` override is 32768 in the active generation.

32768 also equals hermes-agent's hardcoded retry-boost ceiling (`max(32768, requested_cap)`), so a truncated response's boosted retry lands exactly at the server cap instead of 400-ing — which was the original death-loop trigger this guard existed to prevent.

## Testing

- Converge `--limit hermes-agent,localhost` after merge (will run + verify recap 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cXrVfFqrTQdYqZvAHpE8j