### PR TITLE
fix(technitium): stop printing the freshly-minted API token in converge output

### DIFF
--- a/roles/technitium_install/tasks/main.yml
+++ b/roles/technitium_install/tasks/main.yml
@@ -187,13 +187,6 @@
   failed_when: technitium_install_token_result.json.status | default('') != "ok"
   no_log: true
 
-- name: Display API token for Doppler storage  # noqa: no-handler
-  ansible.builtin.debug:
-    msg: >-
-      Technitium API token created. Add to Doppler:
-      doppler secrets set TECHNITIUM_DNS_API_TOKEN='{{ technitium_install_token_result.json.token }}'
-  when: technitium_install_token_result is changed
-
 - name: Verify Technitium DNS is healthy
   # Technitium authenticates API calls via ?token=... query parameter,
   # NOT via an X-Api-Token header. The header is silently ignored and


### PR DESCRIPTION
## Summary

Removes the `Display API token for Doppler storage` debug task that printed the raw Technitium API token into converge output whenever the token was (re)created.

## Why

- The token lands in every captured converge log/transcript — a standing secret-leak vector.
- It's redundant: the install play manages the token lifecycle itself now (it rotated the token during today's converge without any human copy step).

Found as a staged-but-uncommitted improvement left in the main checkout by a prior session; committing it properly so it stops blocking `git pull`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cXrVfFqrTQdYqZvAHpE8j