### PR TITLE
feat(cribl-edge): split UniFi firewall/IPS traffic out of the unifi index

### DIFF
--- a/roles/cribl_edge/defaults/main.yml
+++ b/roles/cribl_edge/defaults/main.yml
@@ -40,6 +40,20 @@ cribl_edge_syslog_port_mappings: >-
   {{ out }}
 cribl_edge_syslog_ports: "{{ cribl_edge_syslog_port_mappings.values() | list }}"
 
+# UniFi firewall/IPS split: raw-content match (JS regex BODY, no slashes)
+# applied to events arriving on the unifi syslog family port. Lines matching
+# this pattern are UniFi gateway firewall/IPS traffic and are re-routed to
+# index=firewall sourcetype=ubiquiti:firewall BEFORE the plain unifi branch;
+# everything else on the port stays index=unifi.
+#
+# PLACEHOLDER PATTERN — covers the common UniFi kernel iptables rule-hit tag
+# ("[WAN_LOCAL-4001-D]" / "[LAN_IN-RET-A]"-style), the kernel packet-header
+# dump ("IN=eth0 OUT= MAC=..."), and suricata IPS alerts. L9 finalizes this
+# from live gateway samples — adjust HERE only (single source of truth), the
+# pipeline template just interpolates it.
+cribl_edge_unifi_fw_match: >-
+  \[[A-Z][A-Z0-9_-]*-[AD]\]|\bIN=\S* OUT=\S* MAC=|suricata
+
 # Edge API bind port from tofu constants (no hardcoded values).
 # Templated into local/edge/cribl.yml with host 0.0.0.0 so the API is
 # reachable from the internal network, not just 127.0.0.1.

--- a/roles/cribl_edge/templates/pipelines/syslog/conf.yml.j2
+++ b/roles/cribl_edge/templates/pipelines/syslog/conf.yml.j2
@@ -14,16 +14,25 @@ functions:
       add:
         # index/sourcetype conditionals are generated from the tofu
         # syslog_port_map (cribl_edge_syslog_routing) — routing truth lives
-        # in terraform-proxmox constants, not here.
+        # in terraform-proxmox constants, not here. The unifi family gets a
+        # firewall/IPS split first: raw lines matching
+        # cribl_edge_unifi_fw_match re-route to index=firewall
+        # sourcetype=ubiquiti:firewall before the plain unifi branch.
         - name: index
           value: >-
 {% for family, entry in cribl_edge_syslog_routing | dictsort %}
+{% if family == 'unifi' %}
+            __inputId.includes('{{ entry.high }}') && /{{ cribl_edge_unifi_fw_match }}/.test(_raw) ? 'firewall' :
+{% endif %}
             __inputId.includes('{{ entry.high }}') ? '{{ entry.index }}' :
 {% endfor %}
             'main'
         - name: sourcetype
           value: >-
 {% for family, entry in cribl_edge_syslog_routing | dictsort %}
+{% if family == 'unifi' %}
+            __inputId.includes('{{ entry.high }}') && /{{ cribl_edge_unifi_fw_match }}/.test(_raw) ? 'ubiquiti:firewall' :
+{% endif %}
             __inputId.includes('{{ entry.high }}') ? '{{ entry.sourcetype }}' :
 {% endfor %}
             'syslog'

--- a/tests/e2e/test_unifi_fw.py
+++ b/tests/e2e/test_unifi_fw.py
@@ -1,0 +1,110 @@
+"""UniFi firewall/IPS split tests.
+
+The Cribl Edge syslog pipeline re-routes UniFi gateway firewall/IPS lines
+(raw content matching ``cribl_edge_unifi_fw_match``) arriving on the unifi
+syslog family port to ``index=firewall sourcetype=ubiquiti:firewall``, while
+everything else on the port keeps the plain unifi routing. This suite drives
+both sides of that split through HAProxy.
+
+Skips when the inventory has no ``unifi`` entry in ``syslog_port_map``.
+"""
+
+import time
+import uuid
+
+import pytest
+
+from .fixtures import SYSLOG_SOURCES
+from .helpers import send_tcp_syslog, wait_for_event
+
+
+UNIFI_SOURCES = [s for s in SYSLOG_SOURCES if s.key == "unifi"]
+
+
+def _unifi_source():
+    if not UNIFI_SOURCES:
+        pytest.skip("No unifi family in constants.syslog_port_map")
+    return UNIFI_SOURCES[0]
+
+
+def _make_fw_message(sentinel):
+    """A UniFi kernel iptables rule-hit line (matches the fw split regex)."""
+    timestamp = time.strftime("%b %d %H:%M:%S", time.gmtime())
+    return (
+        f"<4>{timestamp} usg kernel: [WAN_LOCAL-4001-D] "
+        f"IN=eth8 OUT= MAC=aa:bb:cc:dd:ee:ff SRC=203.0.113.9 DST=192.0.2.1 "
+        f"PROTO=TCP SPT=51515 DPT=22 {sentinel}"
+    )
+
+
+def _make_admin_message(sentinel):
+    """A UniFi management-plane line (must NOT match the fw split regex)."""
+    timestamp = time.strftime("%b %d %H:%M:%S", time.gmtime())
+    return (
+        f"<14>{timestamp} usg mcad: mgmt.admin login accepted "
+        f"for administrator {sentinel}"
+    )
+
+
+class TestUnifiFirewallSplit:
+    """Validate the unifi -> firewall/IPS index split at the Edge pipeline."""
+
+    def test_firewall_line_routes_to_firewall_index(
+        self,
+        haproxy_host,
+        splunk_creds,
+        pipeline_poll_timeout,
+        pipeline_poll_interval,
+    ):
+        """A kernel firewall rule-hit line lands in index=firewall."""
+        source = _unifi_source()
+        mgmt_url, user, password = splunk_creds
+        sentinel = f"e2e-unifi-fw-{uuid.uuid4().hex[:10]}-{int(time.time())}"
+
+        send_tcp_syslog(haproxy_host, source.standard_port, _make_fw_message(sentinel))
+        results = wait_for_event(
+            mgmt_url,
+            user,
+            password,
+            sentinel,
+            index="firewall",
+            sourcetype="ubiquiti:firewall",
+            timeout=pipeline_poll_timeout,
+            poll_interval=pipeline_poll_interval,
+        )
+        assert results, (
+            f"UniFi firewall sentinel {sentinel} did not reach Splunk with "
+            f"index=firewall sourcetype=ubiquiti:firewall"
+        )
+
+    def test_admin_line_stays_in_unifi_index(
+        self,
+        haproxy_host,
+        splunk_creds,
+        pipeline_poll_timeout,
+        pipeline_poll_interval,
+    ):
+        """Negative control: a management-plane line keeps the unifi routing."""
+        source = _unifi_source()
+        mgmt_url, user, password = splunk_creds
+        sentinel = f"e2e-unifi-admin-{uuid.uuid4().hex[:10]}-{int(time.time())}"
+
+        send_tcp_syslog(
+            haproxy_host, source.standard_port, _make_admin_message(sentinel)
+        )
+        results = wait_for_event(
+            mgmt_url,
+            user,
+            password,
+            sentinel,
+            index=source.expected_index,
+            sourcetype=source.expected_sourcetype,
+            timeout=pipeline_poll_timeout,
+            poll_interval=pipeline_poll_interval,
+        )
+        assert results, (
+            f"UniFi admin sentinel {sentinel} did not reach Splunk with "
+            f"index={source.expected_index} "
+            f"sourcetype={source.expected_sourcetype} — the firewall split "
+            f"regex may be over-matching"
+        )

--- a/tests/e2e/test_unifi_fw.py
+++ b/tests/e2e/test_unifi_fw.py
@@ -20,16 +20,26 @@ from .helpers import send_tcp_syslog, wait_for_event
 
 UNIFI_SOURCES = [s for s in SYSLOG_SOURCES if s.key == "unifi"]
 
+pytestmark = pytest.mark.skipif(
+    not UNIFI_SOURCES,
+    reason="No unifi family in constants.syslog_port_map"
+)
+
 
 def _unifi_source():
-    if not UNIFI_SOURCES:
-        pytest.skip("No unifi family in constants.syslog_port_map")
     return UNIFI_SOURCES[0]
+
+
+def _get_syslog_timestamp():
+    """Generate an RFC 3164 compliant English syslog timestamp."""
+    months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+    t = time.gmtime()
+    return f"{months[t.tm_mon - 1]} {t.tm_mday:2d} {time.strftime('%H:%M:%S', t)}"
 
 
 def _make_fw_message(sentinel):
     """A UniFi kernel iptables rule-hit line (matches the fw split regex)."""
-    timestamp = time.strftime("%b %d %H:%M:%S", time.gmtime())
+    timestamp = _get_syslog_timestamp()
     return (
         f"<4>{timestamp} usg kernel: [WAN_LOCAL-4001-D] "
         f"IN=eth8 OUT= MAC=aa:bb:cc:dd:ee:ff SRC=203.0.113.9 DST=192.0.2.1 "
@@ -39,7 +49,7 @@ def _make_fw_message(sentinel):
 
 def _make_admin_message(sentinel):
     """A UniFi management-plane line (must NOT match the fw split regex)."""
-    timestamp = time.strftime("%b %d %H:%M:%S", time.gmtime())
+    timestamp = _get_syslog_timestamp()
     return (
         f"<14>{timestamp} usg mcad: mgmt.admin login accepted "
         f"for administrator {sentinel}"

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1428,6 +1428,71 @@
           - force_splunk_meta: conditional evals + valid mask schema (matchRegex/replaceExpr)
           - prometheus_to_netmon: eval coerces non-finite values + stamps index=netmon_metrics
 
+- name: Render and verify the cribl_edge syslog pipeline (unifi fw split)
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    # Mirror roles/cribl_edge/defaults/main.yml: a representative subset of the
+    # tofu syslog_port_map plus the firewall-split match pattern.
+    cribl_edge_syslog_routing:
+      unifi: { standard: 514, high: 1514, index: unifi, sourcetype: "ubiquiti:unifi" }
+      linux: { standard: 517, high: 1517, index: os, sourcetype: syslog }
+    cribl_edge_unifi_fw_match: >-
+      \[[A-Z][A-Z0-9_-]*-[AD]\]|\bIN=\S* OUT=\S* MAC=|suricata
+    _template_dir: "../../roles/cribl_edge/templates"
+
+  tasks:
+    - name: Render the edge syslog pipeline to /tmp
+      ansible.builtin.template:
+        src: "{{ _template_dir }}/pipelines/syslog/conf.yml.j2"
+        dest: /tmp/test_cribl_edge_syslog_pipeline.yml
+        mode: "0644"
+
+    - name: Read the rendered edge syslog pipeline
+      ansible.builtin.slurp:
+        src: /tmp/test_cribl_edge_syslog_pipeline.yml
+      register: _edge_syslog_raw
+
+    - name: Decode and parse the rendered edge syslog pipeline
+      ansible.builtin.set_fact:
+        _edge_syslog: "{{ _edge_syslog_raw.content | b64decode }}"
+        _edge_syslog_yaml: "{{ _edge_syslog_raw.content | b64decode | from_yaml }}"
+
+    - name: Extract the rendered index/sourcetype expressions
+      ansible.builtin.set_fact:
+        _edge_index_expr: >-
+          {{ (_edge_syslog_yaml.functions | first).conf.add
+             | selectattr('name', 'equalto', 'index') | map(attribute='value') | first }}
+        _edge_sourcetype_expr: >-
+          {{ (_edge_syslog_yaml.functions | first).conf.add
+             | selectattr('name', 'equalto', 'sourcetype') | map(attribute='value') | first }}
+
+    - name: Assert the unifi firewall/IPS split branch precedes the plain unifi branch
+      ansible.builtin.assert:
+        that:
+          # The fw branch tests _raw against the match pattern on the unifi port.
+          - "\".test(_raw) ? 'firewall' :\" in _edge_index_expr"
+          - "\".test(_raw) ? 'ubiquiti:firewall' :\" in _edge_sourcetype_expr"
+          # Ternary chains evaluate in order — the fw branch MUST come first,
+          # otherwise the plain unifi branch swallows every gateway line.
+          - "_edge_index_expr.index(\".test(_raw) ? 'firewall'\") < _edge_index_expr.index(\"? 'unifi'\")"
+          # Non-unifi families are untouched (single plain branch each).
+          - "\"__inputId.includes('1517') ? 'os' :\" in _edge_index_expr"
+          - "_edge_index_expr.count('.test(_raw)') == 1"
+        fail_msg: >-
+          The unifi firewall/IPS split did not render before the plain unifi
+          branch (or leaked into other families): {{ _edge_index_expr }}
+
+    - name: Cribl Edge syslog pipeline rendering PASSED
+      ansible.builtin.debug:
+        msg: |
+          cribl_edge syslog pipeline assertions passed:
+          - unifi fw/IPS split branch (regex on _raw) renders BEFORE the plain
+            unifi branch, stamping index=firewall sourcetype=ubiquiti:firewall
+          - other families keep their single plain branch
+
 - name: Render and verify unifi_metrics templates
   hosts: localhost
   connection: local


### PR DESCRIPTION
The UniFi gateway ships management-plane logs AND kernel firewall/IPS
rule-hit lines on the same syslog family port (unifi, 514/1514), so
gateway firewall traffic was landing in index=unifi with
sourcetype=ubiquiti:unifi instead of the firewall index the palo_alto /
cisco_asa families already use.

- new cribl_edge_unifi_fw_match default: a JS regex body (PLACEHOLDER —
  covers the kernel iptables rule-hit tag, the IN=/OUT=/MAC= packet
  header dump, and suricata IPS alerts; L9 finalizes it from live
  gateway samples, adjust in defaults only).
- pipelines/syslog/conf.yml.j2: the generated index/sourcetype ternary
  chains gain a branch BEFORE the plain unifi branch — unifi high port
  AND /match/.test(_raw) -> index=firewall,
  sourcetype=ubiquiti:firewall. Ternary order is load-bearing and now
  asserted by the render suite.
- tests: new tests/e2e/test_unifi_fw.py (crafted kernel FW line ->
  index=firewall sourcetype=ubiquiti:firewall; negative-control admin
  line stays index=unifi); new template_render play parses the rendered
  pipeline and asserts the fw branch precedes the unifi branch and does
  not leak into other families.

Validated: template_render suite green, pytest collect-only green,
ansible-lint (offline) clean, placeholder regex checked against the
positive/negative sample lines used in the e2e test.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EbgZVVvmTwyhQNDLwuhFUv

> [!IMPORTANT]
> The match regex is a PLACEHOLDER — finalized from 20 live samples (L9) before converge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)