### PR TITLE
feat(syslog): per-program rsyslog routes + proxy family sourcetype split

### DIFF
--- a/inventory/group_vars/haproxy_group.yml
+++ b/inventory/group_vars/haproxy_group.yml
@@ -21,3 +21,12 @@ haproxy_http_frontends:
     backend_host: "{{ hostvars['infisical'].container_ip }}"
     backend_port: "{{ tofu_data.constants.service_ports.infisical_api }}"
     cert_path: "{{ haproxy_ssl_crt_base }}/infisical.pem"
+
+# Split HAProxy's own logs into the proxy syslog family (-> Splunk index=proxy).
+# NOTE: currently inert — the site.yml syslog_forwarder play excludes
+# haproxy_group (the LB must not forward into the receiver it fronts). Kept
+# wired so the route takes effect the moment the forwarder is enabled here
+# with a loop-safe design (e.g. direct-to-Edge target).
+syslog_forwarder_program_routes:
+  - program: haproxy
+    port: "{{ tofu_data.constants.syslog_port_map.proxy.standard | default(523) }}"

--- a/inventory/group_vars/traefik_group.yml
+++ b/inventory/group_vars/traefik_group.yml
@@ -2,3 +2,12 @@
 # traefik group variables
 systemd_restart_policy_services:
   - traefik
+
+# Split Traefik's own logs into the proxy syslog family (-> Splunk index=proxy)
+# instead of the linux/os catch-all. $programname 'traefik' matches the systemd
+# unit name journald stamps on the service's output. Port from tofu constants;
+# guarded default = the proxy family's standard frontend (523) for inventories
+# that predate the family.
+syslog_forwarder_program_routes:
+  - program: traefik
+    port: "{{ tofu_data.constants.syslog_port_map.proxy.standard | default(523) }}"

--- a/roles/cribl_edge/templates/pipelines/syslog/conf.yml.j2
+++ b/roles/cribl_edge/templates/pipelines/syslog/conf.yml.j2
@@ -39,6 +39,23 @@ functions:
       overwrite: false
       regex: /^<\d+>(?:\d+ )?(?:(?<timestamp>\w{3}\s+\d+\s+[\d:]+)|(?<timestamp_iso>\d{4}-\d{2}-\d{2}T[\d:.Z+-]+))\s+(?<log_host>\S+)\s+(?<process>[^\[:\s]+)(?:\[(?<pid>\d+)\])?[:\s]+(?<message>.*)/
 
+{% if 'proxy' in cribl_edge_syslog_routing %}
+  # The proxy family carries BOTH traefik and haproxy program routes on one
+  # port ({{ cribl_edge_syslog_routing.proxy.high }}); refine the sourcetype
+  # from the syslog-header program name (`process`, extracted above) AFTER
+  # regex_extract has run. Unknown programs keep the family sourcetype.
+  - id: eval
+    filter: "__inputId.includes('{{ cribl_edge_syslog_routing.proxy.high }}') && process != null"
+    disabled: false
+    conf:
+      add:
+        - name: sourcetype
+          value: >-
+            process === 'traefik' ? 'traefik:syslog'
+            : process === 'haproxy' ? 'haproxy:syslog'
+            : sourcetype
+
+{% endif %}
   - id: eval
     filter: log_host != null
     disabled: false

--- a/roles/syslog_forwarder/defaults/main.yml
+++ b/roles/syslog_forwarder/defaults/main.yml
@@ -24,3 +24,12 @@ syslog_forwarder_config_path: /etc/rsyslog.d/10-forward-cribl.conf
 # Disk-assisted action queue: buffer through a HAProxy/Cribl outage instead of
 # dropping logs (capped so a long outage can't fill the root filesystem).
 syslog_forwarder_queue_max_disk_space: 256m
+
+# Optional per-program routes rendered ABOVE the catch-all rule: logs whose
+# $programname matches go to the SAME syslog target but on a family-specific
+# port (then `stop`, so they never also hit the catch-all). Lets one guest
+# split a service's logs into its own syslog family (e.g. traefik -> the
+# proxy family port) while everything else keeps flowing to the linux/os port.
+# Format: [{program: <rsyslog $programname>, port: <target port>}]. Ports come
+# from tofu constants (syslog_port_map / ai_log_routing), never literals.
+syslog_forwarder_program_routes: []

--- a/roles/syslog_forwarder/templates/10-forward-cribl.conf.j2
+++ b/roles/syslog_forwarder/templates/10-forward-cribl.conf.j2
@@ -6,6 +6,22 @@
 # host logs + every systemd service (and Docker containers whose compose
 # log-driver is journald). The disk-assisted queue survives a receiver outage
 # instead of dropping logs.
+{% for route in syslog_forwarder_program_routes %}
+# Program route: {{ route.program }} -> {{ syslog_forwarder_target_host }}:{{ route.port }}
+# Rendered ABOVE the catch-all; `stop` keeps these lines off the catch-all port.
+if $programname == '{{ route.program }}' then {
+  action(type="omfwd"
+         target="{{ syslog_forwarder_target_host }}"
+         port="{{ route.port }}"
+         protocol="{{ syslog_forwarder_protocol }}"
+         queue.type="LinkedList"
+         queue.filename="cribl_fwd_{{ route.program }}"
+         queue.maxDiskSpace="{{ syslog_forwarder_queue_max_disk_space }}"
+         queue.saveOnShutdown="on"
+         action.resumeRetryCount="-1")
+  stop
+}
+{% endfor %}
 *.* action(type="omfwd"
            target="{{ syslog_forwarder_target_host }}"
            port="{{ syslog_forwarder_target_port }}"

--- a/tests/e2e/test_proxy_family.py
+++ b/tests/e2e/test_proxy_family.py
@@ -1,0 +1,110 @@
+"""Proxy syslog family (traefik/haproxy program routes) pipeline tests.
+
+The proxy family carries two senders on one port: guests running Traefik or
+HAProxy split those programs' logs off the rsyslog catch-all with
+``syslog_forwarder_program_routes`` and ship them to the family's standard
+frontend. The Cribl Edge syslog pipeline then refines the sourcetype from the
+syslog-header program name (traefik -> traefik:syslog, haproxy ->
+haproxy:syslog); anything else keeps the family sourcetype.
+
+Skips when the inventory has no ``proxy`` entry in ``syslog_port_map``.
+"""
+
+import time
+import uuid
+
+import pytest
+
+from .fixtures import SYSLOG_SOURCES
+from .helpers import make_syslog_message, send_tcp_syslog, wait_for_event
+
+
+PROXY_SOURCES = [s for s in SYSLOG_SOURCES if s.key == "proxy"]
+
+# program name -> the sourcetype the Edge pipeline stamps for it.
+PROGRAM_SOURCETYPES = [
+    ("traefik", "traefik:syslog"),
+    ("haproxy", "haproxy:syslog"),
+]
+PROGRAM_IDS = [program for program, _ in PROGRAM_SOURCETYPES]
+
+
+def _proxy_source():
+    if not PROXY_SOURCES:
+        pytest.skip("No proxy family in constants.syslog_port_map")
+    return PROXY_SOURCES[0]
+
+
+class TestProxyFamilyViaHAProxy:
+    """Validate the proxy family program-name sourcetype split."""
+
+    @pytest.mark.parametrize(
+        ("program", "expected_sourcetype"), PROGRAM_SOURCETYPES, ids=PROGRAM_IDS
+    )
+    def test_program_line_gets_program_sourcetype(
+        self,
+        haproxy_host,
+        splunk_creds,
+        program,
+        expected_sourcetype,
+        pipeline_poll_timeout,
+        pipeline_poll_interval,
+    ):
+        """A <program> syslog line lands in index=proxy with its sourcetype."""
+        source = _proxy_source()
+        mgmt_url, user, password = splunk_creds
+        sentinel = f"e2e-proxy-{program}-{uuid.uuid4().hex[:10]}-{int(time.time())}"
+
+        send_tcp_syslog(
+            haproxy_host,
+            source.standard_port,
+            make_syslog_message(sentinel, program),
+        )
+        results = wait_for_event(
+            mgmt_url,
+            user,
+            password,
+            sentinel,
+            index=source.expected_index,
+            sourcetype=expected_sourcetype,
+            timeout=pipeline_poll_timeout,
+            poll_interval=pipeline_poll_interval,
+        )
+        assert results, (
+            f"Proxy family sentinel {sentinel} (program={program}) did not "
+            f"reach Splunk with index={source.expected_index} "
+            f"sourcetype={expected_sourcetype}"
+        )
+
+    def test_unknown_program_keeps_family_sourcetype(
+        self,
+        haproxy_host,
+        splunk_creds,
+        pipeline_poll_timeout,
+        pipeline_poll_interval,
+    ):
+        """Negative control: other programs keep the family sourcetype."""
+        source = _proxy_source()
+        mgmt_url, user, password = splunk_creds
+        sentinel = f"e2e-proxy-other-{uuid.uuid4().hex[:10]}-{int(time.time())}"
+
+        send_tcp_syslog(
+            haproxy_host,
+            source.standard_port,
+            make_syslog_message(sentinel, "e2e-other-program"),
+        )
+        results = wait_for_event(
+            mgmt_url,
+            user,
+            password,
+            sentinel,
+            index=source.expected_index,
+            sourcetype=source.expected_sourcetype,
+            timeout=pipeline_poll_timeout,
+            poll_interval=pipeline_poll_interval,
+        )
+        assert results, (
+            f"Proxy family sentinel {sentinel} did not keep the family "
+            f"sourcetype {source.expected_sourcetype} in "
+            f"index={source.expected_index}"
+        )

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1273,6 +1273,11 @@
     syslog_forwarder_target_port: 1517
     syslog_forwarder_protocol: tcp
     syslog_forwarder_queue_max_disk_space: 256m
+    # Mirror the group_vars wiring: program-specific routes rendered above
+    # the catch-all (traefik -> the proxy family standard frontend).
+    syslog_forwarder_program_routes:
+      - program: traefik
+        port: 523
     _sf_template_dir: "../../roles/syslog_forwarder/templates"
 
   tasks:
@@ -1310,6 +1315,20 @@
         fail_msg: >-
           10-forward-cribl.conf.j2 did not render the expected omfwd rule
           (selector/target/port/protocol/queue).
+
+    - name: Assert program routes render above the catch-all and stop
+      ansible.builtin.assert:
+        that:
+          - "\"if $programname == 'traefik' then {\" in _sf"
+          - "'port=\"523\"' in _sf"
+          - "'queue.filename=\"cribl_fwd_traefik\"' in _sf"
+          - "'stop' in _sf"
+          # Order is load-bearing: the program route must precede the
+          # catch-all *.* rule, or the catch-all consumes the line first.
+          - "_sf.index(\"$programname == 'traefik'\") < _sf.index('*.*')"
+        fail_msg: >-
+          10-forward-cribl.conf.j2 did not render the program route above the
+          catch-all with its own disk queue and a stop.
 
     - name: Syslog forwarder template rendering PASSED
       ansible.builtin.debug:


### PR DESCRIPTION
Let a guest split a specific service's logs into their own syslog family
while everything else keeps flowing to the linux/os catch-all:

- syslog_forwarder: new optional syslog_forwarder_program_routes
  (list of {program, port}). The template renders one
  'if $programname == <program>' omfwd block per route ABOVE the
  catch-all rule — same target host/protocol and disk-assisted queue
  options, a per-program queue.filename (disk queues must not share
  files), and a 'stop' so routed lines never also hit the catch-all
  port. Order is asserted by the render suite.
- wiring: traefik_group routes traefik -> the proxy family standard
  frontend (tofu constants syslog_port_map.proxy.standard, guarded
  default 523). haproxy_group routes haproxy -> the same port, wired
  but currently inert — the site.yml syslog_forwarder play excludes
  haproxy_group (the LB must not forward into the receiver it fronts);
  the var takes effect when the forwarder is enabled there loop-safely.
- cribl_edge syslog pipeline: after regex_extract (which extracts the
  syslog-header program name into 'process'), a proxy-port-scoped eval
  refines sourcetype: traefik -> traefik:syslog, haproxy ->
  haproxy:syslog, anything else keeps the family sourcetype. Rendered
  only when the inventory carries the proxy family.
- tests: new tests/e2e/test_proxy_family.py (program lines land in
  index=proxy with the program sourcetype; negative control keeps the
  family sourcetype; skips when the map predates the proxy family);
  syslog_forwarder render fixtures assert the route block, its queue
  file, the stop, and its position above the catch-all.

Validated: template_render suite green, pytest collect-only green,
ansible-lint (offline) clean. rsyslogd -N1 validation runs at deploy
time (task validate:) — not runnable here.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EbgZVVvmTwyhQNDLwuhFUv

> [!IMPORTANT]
> feat/homelab-llm-syslog-routes stacks on this. haproxy_group route wired but inert until deliberately enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)