### PR TITLE
feat(llm): route llama-swap + litellm logs to the homelab_llm AI listener

### DIFF
--- a/inventory/group_vars/llm_fast_group.yml
+++ b/inventory/group_vars/llm_fast_group.yml
@@ -9,3 +9,13 @@ llama_cpp_gpu: true
 # Restart the llama-swap service on failure (Phase 9 systemd restart policy).
 systemd_restart_policy_services:
   - llama-swap
+
+# Ship the llama-swap serving logs to the homelab_llm AI ingest listener
+# (-> Cribl Stream ai_stamp -> Splunk index=llm) instead of the linux/os
+# catch-all. $programname 'llama-swap' verified locally via
+# `journalctl -o verbose -u llama-swap | grep _COMM` (systemd stamps the unit's
+# executable name). Port from tofu constants ai_log_routing; guarded default =
+# homelab_llm's assigned port for inventories that predate the map.
+syslog_forwarder_program_routes:
+  - program: llama-swap
+    port: "{{ tofu_data.constants.ai_log_routing.homelab_llm.port | default(10323) }}"

--- a/inventory/group_vars/llm_router_group.yml
+++ b/inventory/group_vars/llm_router_group.yml
@@ -8,3 +8,13 @@
 # tier serves from llm-light (CPU on the DR node, pinned awake) only.
 # Flip to true together with the llm-fast unfreeze.
 llm_router_llm_fast_enabled: false
+
+# Ship the LiteLLM router logs to the homelab_llm AI ingest listener
+# (-> Cribl Stream ai_stamp -> Splunk index=llm) instead of the linux/os
+# catch-all. $programname 'litellm' verified locally via
+# `journalctl -o verbose -u litellm | grep _COMM`. Port from tofu constants
+# ai_log_routing; guarded default = homelab_llm's assigned port for
+# inventories that predate the map.
+syslog_forwarder_program_routes:
+  - program: litellm
+    port: "{{ tofu_data.constants.ai_log_routing.homelab_llm.port | default(10323) }}"


### PR DESCRIPTION
Stacked on feat/syslog-program-routes-proxy (uses its
syslog_forwarder_program_routes mechanism).

- llm_fast_group (llama.cpp serving guests, incl. the llm-light CPU
  standby): program route llama-swap -> the homelab_llm AI ingest port
  (tofu constants ai_log_routing.homelab_llm.port, guarded default
  10323), so serving logs land in Splunk index=llm via HAProxy ->
  Cribl Stream ai_stamp instead of the linux/os catch-all.
- llm_router_group (LiteLLM router guests): program route litellm ->
  the same homelab_llm port/index.

The $programname values (llama-swap, litellm — the systemd units'
executable names) are marked verified-locally via
journalctl -o verbose _COMM before rollout.

Validated: ansible-lint (offline) clean on both group_vars files.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EbgZVVvmTwyhQNDLwuhFUv

> [!IMPORTANT]
> Stacked on feat/syslog-program-routes-proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)