### PR TITLE
feat(openbao): enable the file audit device and ship it to openbao_audit

### DIFF
--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -278,6 +278,36 @@ openbao_snapshot_ntfy_url: >-
 # (ntfy + journal alert still fire). Set per-node from the healthchecks LXC.
 openbao_snapshot_healthcheck_url: "{{ lookup('env', 'OPENBAO_SNAPSHOT_HC_URL') | default('', true) }}"
 
+# --- Audit device + shipping (file device -> rsyslog imfile -> AI listener) --
+# Enable the file audit device (every node writes its OWN local audit log —
+# the device config replicates cluster-wide, the file does not) and tail it
+# with a dedicated rsyslog imfile ruleset that forwards to the openbao_audit
+# AI ingest listener (syslog CNAME -> HAProxy -> Cribl Stream ai_stamp ->
+# Splunk index=openbao_audit). The dedicated ruleset is load-bearing: audit
+# lines must NOT also hit the syslog_forwarder catch-all (linux/os family) or
+# every secret access would be double-shipped into index=os.
+openbao_audit_enabled: true
+openbao_audit_device_name: file
+openbao_audit_log_dir: /var/log/openbao
+openbao_audit_log_path: "{{ openbao_audit_log_dir }}/audit.log"
+# `bao audit enable` needs a privileged token (BAO_TOKEN via Doppler tier-0 /
+# break-glass, same as openbao_admin_token). When empty the enable step is
+# skipped cleanly — dir/logrotate/rsyslog still converge so the device starts
+# shipping the moment it is enabled.
+openbao_audit_rsyslog_config_path: /etc/rsyslog.d/20-openbao-audit.conf
+openbao_audit_syslog_host: "syslog.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
+# openbao_audit AI ingest port from tofu constants; guarded default = the
+# family's assigned port for inventories that predate ai_log_routing.
+openbao_audit_syslog_port: >-
+  {{ tofu_data.constants.ai_log_routing.openbao_audit.port | default(10331) }}
+openbao_audit_queue_max_disk_space: 256m
+# Logrotate: copytruncate so the running server keeps its file handle (the
+# file audit device only reopens on SIGHUP; truncating in place avoids racing
+# a reload against audit writes).
+openbao_audit_logrotate_path: /etc/logrotate.d/openbao-audit
+openbao_audit_logrotate_rotate: 7
+openbao_audit_logrotate_frequency: daily
+
 # --- Break-glass / bootstrap output (controller-side, never committed) -------
 # init.yml writes recovery shares + root token, and each AppRole's creds, to
 # 0600 files UNDER playbook_dir ON THE CONTROLLER, then prints a LOUD warning to

--- a/roles/openbao/handlers/main.yml
+++ b/roles/openbao/handlers/main.yml
@@ -6,6 +6,12 @@
     daemon_reload: true
   when: ansible_virtualization_type | default('') != 'docker'
 
+- name: Restart rsyslog
+  ansible.builtin.systemd:
+    name: rsyslog
+    state: restarted
+  when: ansible_virtualization_type | default('') != 'docker'
+
 - name: Restart openbao snapshot timer
   ansible.builtin.systemd:
     name: "{{ openbao_snapshot_service_name }}.timer"

--- a/roles/openbao/tasks/audit.yml
+++ b/roles/openbao/tasks/audit.yml
@@ -41,9 +41,12 @@
 
 - name: Enable the file audit device
   ansible.builtin.command:
+    # mode=0640: the device default is 0600, which the syslog group (rsyslog
+    # imfile reader) cannot open — shipping would fail silently.
     cmd: >-
       bao audit enable {{ openbao_audit_device_name }}
       file_path={{ openbao_audit_log_path }}
+      mode=0640
   environment:
     BAO_ADDR: "{{ openbao_api_addr }}"
     BAO_TOKEN: "{{ openbao_admin_token }}"
@@ -69,12 +72,22 @@
 # --- Ship the audit file via a dedicated rsyslog ruleset ----------------------
 # rsyslog is already present on these guests (site.yml applies syslog_forwarder
 # to all non-pipeline LXCs), but install defensively so this role stands alone.
+# update_cache stays false: these guests are firewalled to internal-only
+# egress (see the WAN-free note in main.yml) — a cache refresh would wedge.
 - name: Install rsyslog
   ansible.builtin.apt:
     name: rsyslog
     state: present
-    update_cache: true
-    cache_valid_time: 3600
+    update_cache: false
+
+# The audit dir is 0750 openbao:openbao and the file 0640 — rsyslog runs as
+# the syslog user, so group membership is what grants read access.
+- name: Add the syslog user to the openbao group for audit-log read access
+  ansible.builtin.user:
+    name: syslog
+    groups: "{{ openbao_group }}"
+    append: true
+  notify: Restart rsyslog
 
 - name: Deploy the audit-log rsyslog imfile shipping ruleset
   ansible.builtin.template:
@@ -86,9 +99,9 @@
     validate: rsyslogd -N1 -f %s
   notify: Restart rsyslog
 
+# No unit files are written here, so no daemon_reload.
 - name: Enable and start rsyslog
   ansible.builtin.systemd:
     name: rsyslog
     state: started
     enabled: true
-    daemon_reload: true

--- a/roles/openbao/tasks/audit.yml
+++ b/roles/openbao/tasks/audit.yml
@@ -1,0 +1,94 @@
+---
+# Audit device enable + shipping. Runs on EVERY node (each node writes its own
+# local audit file once the device is enabled cluster-wide); the actual
+# `bao audit enable` API write is idempotent (guarded by `bao audit list`) and
+# needs a privileged token — skipped cleanly when BAO_TOKEN is absent so a
+# pre-provisioning converge stays green.
+
+- name: Create the OpenBao audit log directory
+  ansible.builtin.file:
+    path: "{{ openbao_audit_log_dir }}"
+    state: directory
+    owner: "{{ openbao_user }}"
+    group: "{{ openbao_group }}"
+    mode: "0750"
+
+- name: Deploy the audit logrotate policy
+  ansible.builtin.template:
+    src: openbao-audit-logrotate.j2
+    dest: "{{ openbao_audit_logrotate_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+
+# --- Enable the file audit device (idempotent, token-gated) ------------------
+- name: List enabled audit devices
+  ansible.builtin.command:
+    cmd: bao audit list -format=json
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_admin_token }}"
+  register: openbao_audit_list
+  changed_when: false
+  # rc=0 with a JSON object when devices exist; OpenBao exits non-zero with
+  # "No audit devices are enabled" on a cluster that has none — treat that as
+  # an empty list, fail on anything else (bad token, sealed node, ...).
+  failed_when:
+    - openbao_audit_list.rc != 0
+    - "'No audit devices are enabled' not in (openbao_audit_list.stderr | default(''))"
+  when: openbao_admin_token | length > 0
+  no_log: true
+
+- name: Enable the file audit device
+  ansible.builtin.command:
+    cmd: >-
+      bao audit enable {{ openbao_audit_device_name }}
+      file_path={{ openbao_audit_log_path }}
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_admin_token }}"
+  register: openbao_audit_enable
+  changed_when: openbao_audit_enable.rc == 0
+  when:
+    - openbao_admin_token | length > 0
+    - inventory_hostname == openbao_bootstrap_host
+    - >-
+      (openbao_audit_device_name ~ '/') not in
+      ((openbao_audit_list.stdout | default('{}', true) | from_json)
+       if openbao_audit_list.rc | default(1) == 0 else {})
+  no_log: true
+
+- name: Note when the audit enable step was skipped for a missing token
+  ansible.builtin.debug:
+    msg: >-
+      BAO_TOKEN is not set — skipped `bao audit list/enable`. The audit
+      shipping plumbing (dir, logrotate, rsyslog ruleset) is converged; enable
+      the device with a privileged token to start emitting.
+  when: openbao_admin_token | length == 0
+
+# --- Ship the audit file via a dedicated rsyslog ruleset ----------------------
+# rsyslog is already present on these guests (site.yml applies syslog_forwarder
+# to all non-pipeline LXCs), but install defensively so this role stands alone.
+- name: Install rsyslog
+  ansible.builtin.apt:
+    name: rsyslog
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Deploy the audit-log rsyslog imfile shipping ruleset
+  ansible.builtin.template:
+    src: openbao-audit-rsyslog.conf.j2
+    dest: "{{ openbao_audit_rsyslog_config_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+    validate: rsyslogd -N1 -f %s
+  notify: Restart rsyslog
+
+- name: Enable and start rsyslog
+  ansible.builtin.systemd:
+    name: rsyslog
+    state: started
+    enabled: true
+    daemon_reload: true

--- a/roles/openbao/tasks/main.yml
+++ b/roles/openbao/tasks/main.yml
@@ -228,7 +228,18 @@
     - ansible_virtualization_type | default('') != 'docker'
     - inventory_hostname == openbao_bootstrap_host
 
-# --- Phase 10: automated raft snapshots (all nodes; script leader-gates) -----
+# --- Phase 10: audit device + shipping (all nodes) ---------------------------
+# File audit device (enable is token-gated + bootstrap-host-gated inside) plus
+# the rsyslog imfile ruleset that ships each node's audit log to the
+# openbao_audit AI ingest listener. Skipped under Docker (no systemd/live API),
+# matching the bootstrap/snapshot phases.
+- name: Enable the audit device and ship the audit log
+  ansible.builtin.include_tasks: audit.yml
+  when:
+    - openbao_audit_enabled | bool
+    - ansible_virtualization_type | default('') != 'docker'
+
+# --- Phase 11: automated raft snapshots (all nodes; script leader-gates) -----
 # Deployed on every openbao node so the surviving nodes keep snapshotting after
 # a leadership change. Gated on the snapshot AppRole creds being present: they
 # are emitted by init.yml at bootstrap and injected at converge from tier-0, so

--- a/roles/openbao/templates/openbao-audit-logrotate.j2
+++ b/roles/openbao/templates/openbao-audit-logrotate.j2
@@ -1,0 +1,13 @@
+# {{ ansible_managed }}
+# Rotate the OpenBao file audit device output. copytruncate keeps the running
+# server's file handle valid (the device only reopens on SIGHUP); rsyslog's
+# imfile tracks the truncation via reopenOnTruncate in the shipping ruleset.
+{{ openbao_audit_log_path }} {
+    {{ openbao_audit_logrotate_frequency }}
+    rotate {{ openbao_audit_logrotate_rotate }}
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+}

--- a/roles/openbao/templates/openbao-audit-rsyslog.conf.j2
+++ b/roles/openbao/templates/openbao-audit-rsyslog.conf.j2
@@ -1,0 +1,35 @@
+# {{ ansible_managed }}
+# Ship the OpenBao audit log to the openbao_audit AI ingest listener:
+#   {{ openbao_audit_log_path }}
+#   -> {{ openbao_audit_syslog_host }}:{{ openbao_audit_syslog_port }} (tcp)
+#   -> HAProxy -> Cribl Stream (ai_stamp) -> Splunk index=openbao_audit.
+#
+# The DEDICATED ruleset is load-bearing: bound via the imfile input below, it
+# keeps audit lines OFF the default ruleset, so they never also hit the
+# syslog_forwarder catch-all (10-forward-cribl.conf) and double-ship into the
+# os index. Audit entries are single-line JSON; they ride inside standard
+# syslog framing with the tag below — the Stream syslog input parses the
+# header and ai_stamp stamps index/sourcetype.
+
+module(load="imfile")
+
+ruleset(name="openbao_audit") {
+  action(type="omfwd"
+         target="{{ openbao_audit_syslog_host }}"
+         port="{{ openbao_audit_syslog_port }}"
+         protocol="tcp"
+         queue.type="LinkedList"
+         queue.filename="openbao_audit_fwd"
+         queue.maxDiskSpace="{{ openbao_audit_queue_max_disk_space }}"
+         queue.saveOnShutdown="on"
+         action.resumeRetryCount="-1")
+  stop
+}
+
+input(type="imfile"
+      File="{{ openbao_audit_log_path }}"
+      Tag="openbao-audit:"
+      Severity="info"
+      Facility="local6"
+      reopenOnTruncate="on"
+      Ruleset="openbao_audit")

--- a/tests/e2e/test_openbao_audit.py
+++ b/tests/e2e/test_openbao_audit.py
@@ -1,0 +1,53 @@
+"""OpenBao audit-log shipping test (stub — skipped until converged).
+
+The openbao role enables the file audit device and ships
+/var/log/openbao/audit.log via a dedicated rsyslog imfile ruleset to the
+openbao_audit AI ingest listener (syslog CNAME -> HAProxy -> Cribl Stream
+ai_stamp -> Splunk index=openbao_audit).
+
+Sentinel injection is NOT possible from a runner: audit entries are only
+produced by real API traffic against the cluster, and the audit file is not
+runner-writable. So this is a freshness gate (like test_macos.py) — any
+authenticated request produces an audit entry, and the snapshot timer alone
+guarantees regular traffic.
+
+Skipped until the B7a rollout has converged on the openbao guests AND the
+openbao_audit index exists on the Splunk side; then drop the skip mark.
+"""
+
+import pytest
+
+from .helpers import query_splunk
+
+
+@pytest.mark.skip(
+    reason=(
+        "openbao audit shipping (B7a) not yet converged — enable after the "
+        "audit device + rsyslog ruleset are live and the openbao_audit "
+        "Splunk index exists"
+    )
+)
+class TestOpenBaoAuditFreshness:
+    """Verify OpenBao audit entries keep landing in index=openbao_audit."""
+
+    def test_audit_events_arrive(self, splunk_creds):
+        """At least one audit entry indexed in the last 6h window.
+
+        The raft snapshot timer authenticates every openbao_snapshot_interval
+        (6h), so a fully-silent 6h window means the shipping chain is broken
+        (device disabled, rsyslog ruleset gone, or listener down).
+        """
+        mgmt_url, user, password = splunk_creds
+        results = query_splunk(
+            mgmt_url,
+            user,
+            password,
+            'index=openbao_audit sourcetype="openbao:audit" | head 5',
+            earliest="-6h",
+            timeout=30,
+        )
+        assert results, (
+            "No openbao:audit events in index=openbao_audit within 6h — the "
+            "audit device, the rsyslog imfile ruleset, or the openbao_audit "
+            "ingest path appears broken."
+        )


### PR DESCRIPTION
Every OpenBao node gets an audit trail that lands in Splunk:

- roles/openbao/tasks/audit.yml (new Phase 10, all nodes, Docker-gated
  like bootstrap/snapshot): create /var/log/openbao (0750, openbao),
  deploy a copytruncate logrotate policy, then idempotently enable the
  file audit device — 'bao audit list -format=json' guards the enable
  ('No audit devices are enabled' on empty clusters is tolerated), the
  enable itself runs once on the bootstrap host, and both steps are
  token-gated (BAO_TOKEN / openbao_admin_token) so a pre-provisioning
  converge skips cleanly with a loud debug note instead of failing.
- rsyslog shipping: a dedicated imfile ruleset
  (20-openbao-audit.conf, rsyslogd -N1 validated at deploy) tails the
  audit file and omfwds it over TCP to the openbao_audit AI ingest
  listener (syslog CNAME -> HAProxy -> Cribl Stream ai_stamp -> Splunk
  index=openbao_audit; port from tofu constants ai_log_routing, guarded
  default 10331). The dedicated ruleset + stop keeps audit lines OFF
  the default ruleset so they never double-ship through the
  syslog_forwarder linux/os catch-all. Disk-assisted queue +
  reopenOnTruncate pair with the logrotate policy.
- tests/e2e/test_openbao_audit.py: freshness-gate stub, skip-marked
  until B7a converges and the openbao_audit index exists (sentinel
  injection is impossible from a runner; the 6h snapshot timer
  guarantees regular audit traffic once live).

Validated: ansible-lint (offline) clean, pytest collect-only green.
Not runnable here: live bao CLI flow, rsyslogd -N1, molecule (Docker
converge skips the new phase by design).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EbgZVVvmTwyhQNDLwuhFUv

> [!IMPORTANT]
> Verify 'bao audit list' JSON shape on the deployed OpenBao before converge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)