### PR TITLE
feat(hermes): add llm-wiki knowledge base + autonomous GitHub docs-contributor

### DIFF
--- a/inventory/group_vars/hermes_agent_group.yml
+++ b/inventory/group_vars/hermes_agent_group.yml
@@ -15,3 +15,13 @@ hermes_agent_github_app_installation_id: >-
 hermes_agent_github_app_private_key: >-
   {{ bao_local_llm_secrets.HERMES_GITHUB_APP_PRIVATE_KEY
      | default(lookup('env', 'HERMES_GITHUB_APP_PRIVATE_KEY'), true) }}
+
+# Splunk MCP client creds (read/search access). Bao-first (local-llm domain,
+# secret/ai/hermes), env fallback — empty until ansible-splunk mints + publishes
+# the per-user token (SPLUNK_MCP_TOKEN). URL is the Splunk MCP Server endpoint.
+hermes_agent_splunk_mcp_url: >-
+  {{ bao_local_llm_secrets.SPLUNK_MCP_URL
+     | default(lookup('env', 'SPLUNK_MCP_URL'), true) }}
+hermes_agent_splunk_mcp_token: >-
+  {{ bao_local_llm_secrets.SPLUNK_MCP_TOKEN
+     | default(lookup('env', 'SPLUNK_MCP_TOKEN'), true) }}

--- a/inventory/group_vars/hermes_agent_group.yml
+++ b/inventory/group_vars/hermes_agent_group.yml
@@ -3,3 +3,15 @@
 # systemd_restart_policy role (site.yml Phase 9) rather than hardcoded in the unit.
 systemd_restart_policy_services:
   - hermes-gateway
+
+# GitHub App creds for the autonomous docs-contributor. Bao-first (local-llm
+# domain, secret/ai/hermes), env fallback — empty until the App is provisioned.
+hermes_agent_github_app_id: >-
+  {{ bao_local_llm_secrets.HERMES_GITHUB_APP_ID
+     | default(lookup('env', 'HERMES_GITHUB_APP_ID'), true) }}
+hermes_agent_github_app_installation_id: >-
+  {{ bao_local_llm_secrets.HERMES_GITHUB_APP_INSTALLATION_ID
+     | default(lookup('env', 'HERMES_GITHUB_APP_INSTALLATION_ID'), true) }}
+hermes_agent_github_app_private_key: >-
+  {{ bao_local_llm_secrets.HERMES_GITHUB_APP_PRIVATE_KEY
+     | default(lookup('env', 'HERMES_GITHUB_APP_PRIVATE_KEY'), true) }}

--- a/inventory/group_vars/hermes_agent_group.yml
+++ b/inventory/group_vars/hermes_agent_group.yml
@@ -25,3 +25,8 @@ hermes_agent_splunk_mcp_url: >-
 hermes_agent_splunk_mcp_token: >-
   {{ bao_local_llm_secrets.SPLUNK_MCP_TOKEN
      | default(lookup('env', 'SPLUNK_MCP_TOKEN'), true) }}
+
+# Context7 MCP key (current library docs on demand). Bao-first, env fallback.
+hermes_agent_context7_api_key: >-
+  {{ bao_local_llm_secrets.CONTEXT7_API_KEY
+     | default(lookup('env', 'CONTEXT7_API_KEY'), true) }}

--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -144,3 +144,16 @@ cleanly before the creds exist.
 | `hermes_agent_splunk_mcp_enabled` | `true` | Register the Splunk MCP server |
 | `hermes_agent_splunk_mcp_url` | `""` | Splunk MCP Server endpoint (bao/env) |
 | `hermes_agent_splunk_mcp_token` | `""` | Bearer token (bao/env) |
+
+## Live docs (Context7)
+
+Registers Context7's hosted HTTP MCP server (`mcp_servers.context7`) so Hermes
+can pull **current, version-specific library/framework docs** on demand instead
+of relying on stale training data. The API key is referenced as
+`${CONTEXT7_API_KEY}` (resolved from `.env`), bao-first (`secret/ai/hermes`) with
+env fallback; the entry is omitted until the key is set.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `hermes_agent_context7_mcp_enabled` | `true` | Register the Context7 MCP server |
+| `hermes_agent_context7_api_key` | `""` | Context7 API key (bao/env) |

--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -123,3 +123,24 @@ with an env fallback; the PEM is written to `{{ hermes_agent_hermes_home }}/gith
 
 Helper unit tests: `roles/hermes_agent/files/skills/dryvist/docs-pr/tests/` — run
 `python -m pytest` from that skill dir (all guardrail logic, no network).
+
+## Splunk search access
+
+Registers the **Splunk MCP Server** (Splunkbase 7931, deployed by `ansible-splunk`)
+as an HTTP MCP server in `~/.hermes/config.yaml` (`mcp_servers.splunk`), so Hermes
+can query the environment — `run_splunk_query`, `get_indexes`, `get_sourcetypes` —
+with its own scoped identity. The URL and Bearer token are referenced as
+`${SPLUNK_MCP_URL}` / `${SPLUNK_MCP_TOKEN}` and resolved from `.env` at connect
+time, so neither the endpoint nor the token ever lands in `config.yaml`.
+
+Creds come from OpenBao `secret/ai/hermes` (`bao_local_llm_secrets`) with an env
+fallback. `ansible-splunk` mints the per-user token (a Splunk token is bound to a
+user and inherits its roles) and publishes it as `SPLUNK_MCP_TOKEN`. The
+`mcp_servers.splunk` entry is omitted until the URL is set, so the agent starts
+cleanly before the creds exist.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `hermes_agent_splunk_mcp_enabled` | `true` | Register the Splunk MCP server |
+| `hermes_agent_splunk_mcp_url` | `""` | Splunk MCP Server endpoint (bao/env) |
+| `hermes_agent_splunk_mcp_token` | `""` | Bearer token (bao/env) |

--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -78,3 +78,48 @@ its client package on first run — `memory status` check is non-fatal so it sur
 without failing the converge). Single-profile first; profiles + Kanban teams + a
 messaging gateway are a documented follow-up (the whole `HERMES_HOME` is already
 persisted for them).
+
+## LLM knowledge base (llm-wiki)
+
+Enables the bundled `research/llm-wiki` skill so Hermes builds and maintains an
+interlinked Markdown "second brain" from raw sources (build / query / lint /
+maintain, with SHA256 source-drift detection). The wiki lives at `WIKI_PATH` =
+`{{ hermes_agent_wiki_path }}` (`/var/lib/hermes/wiki`) — under the persistent
+ZFS volume, so it is snapshotted and replicated. A nightly cron seeds a
+lint/health-check. Context compression is enabled (`summary_model` pointed at the
+router, since the upstream Google default is unreachable here) so long autonomous
+sessions don't overflow.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `hermes_agent_wiki_enabled` | `true` | enable llm-wiki + create the wiki dir |
+| `hermes_agent_wiki_path` | `{{ hermes_agent_home }}/wiki` | persistent wiki root (`WIKI_PATH`) |
+| `hermes_agent_context_compression_enabled` | `true` | auto-shrink long sessions |
+| `hermes_agent_context_compression_threshold` | `0.85` | compress at 85% of context |
+| `hermes_agent_nightly_wiki_cron_*` | — | nightly lint/health-check cron |
+
+## Autonomous GitHub docs-contributor
+
+Gives Hermes a **read public dryvist repos + open signed, draft, no-merge doc PRs**
+capability against `dryvist/docs` and `dryvist/docs-starlight`, via a dedicated
+GitHub App (`hermes-docs-bot`). Commits are authored through the
+`createCommitOnBranch` GraphQL mutation so GitHub marks them **Verified/signed**
+(a plain `git push` is rejected by the org's required-signatures ruleset). The
+bundled `dryvist/docs-pr` skill enforces the guardrails: draft-only, attribution
+triad, dated branches, `docs:` Conventional-Commit titles, per-repo/day caps +
+de-dup, secret redaction, and absolute privacy routing (sensitive → docs-starlight
+only). **No-merge** is guaranteed by the org ruleset (human review + signatures,
+the App is not a bypass actor), not by the token scope.
+
+App creds are delivered from OpenBao `secret/ai/hermes` (`bao_local_llm_secrets`)
+with an env fallback; the PEM is written to `{{ hermes_agent_hermes_home }}/github-app.pem`
+(`0600`, `no_log`). The role stays inert until the creds are set.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `hermes_agent_github_app_id` | `""` | GitHub App ID (bao/env) |
+| `hermes_agent_github_app_installation_id` | `""` | App installation ID (bao/env) |
+| `hermes_agent_github_app_private_key` | `""` | App PEM (bao/env; written to a 0600 file) |
+
+Helper unit tests: `roles/hermes_agent/files/skills/dryvist/docs-pr/tests/` — run
+`python -m pytest` from that skill dir (all guardrail logic, no network).

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -140,3 +140,12 @@ hermes_agent_nightly_wiki_cron_prompt: "Run a lint and health-check on the wiki.
 hermes_agent_github_app_id: ""
 hermes_agent_github_app_installation_id: ""
 hermes_agent_github_app_private_key: ""
+
+# --- Splunk MCP client (read/search access to the SIEM) ---
+# Registers the Splunk MCP Server as an HTTP MCP server in config.yaml so Hermes
+# can query the environment (run_splunk_query, get_indexes, ...) with its own
+# scoped token. Bao-first, env fallback (see group_vars). An empty URL disables
+# the server entry, so the agent starts cleanly before the Splunk creds exist.
+hermes_agent_splunk_mcp_enabled: true
+hermes_agent_splunk_mcp_url: ""
+hermes_agent_splunk_mcp_token: ""

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -126,3 +126,17 @@ hermes_agent_otel_timeout: 5
 # the foreground-supervised form the CLI's own --help calls out as "useful for
 # systemd" — it runs in-process under our unit instead of trying to manage one.
 hermes_agent_gateway_cmd: "{{ hermes_agent_bin }} gateway run --replace"
+
+# --- llm-wiki knowledge base ---
+hermes_agent_wiki_enabled: true
+hermes_agent_wiki_path: "{{ hermes_agent_home }}/wiki"
+hermes_agent_context_compression_enabled: true
+hermes_agent_context_compression_threshold: 0.85
+hermes_agent_nightly_wiki_cron_name: hermes-nightly-wiki
+hermes_agent_nightly_wiki_cron_schedule: "0 2 * * *"
+hermes_agent_nightly_wiki_cron_prompt: "Run a lint and health-check on the wiki."
+
+# --- autonomous GitHub docs-contributor ---
+hermes_agent_github_app_id: ""
+hermes_agent_github_app_installation_id: ""
+hermes_agent_github_app_private_key: ""

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -149,3 +149,10 @@ hermes_agent_github_app_private_key: ""
 hermes_agent_splunk_mcp_enabled: true
 hermes_agent_splunk_mcp_url: ""
 hermes_agent_splunk_mcp_token: ""
+
+# --- Context7 MCP client (current library/framework docs on demand) ---
+# Registers Context7's hosted HTTP MCP server so Hermes can pull up-to-date,
+# version-specific docs mid-task. Bao-first, env fallback (see group_vars); the
+# entry is omitted until the API key is set.
+hermes_agent_context7_mcp_enabled: true
+hermes_agent_context7_api_key: ""

--- a/roles/hermes_agent/files/skills/dryvist/docs-pr/SKILL.md
+++ b/roles/hermes_agent/files/skills/dryvist/docs-pr/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: dryvist-docs-pr
+description: Open signed, draft, no-merge doc PRs to dryvist docs repos
+version: 1.0.0
+author: dryvist homelab
+license: MIT
+platforms: [linux]
+metadata:
+  hermes:
+    category: research
+    tags: [github, documentation, dryvist]
+    related_skills: [research/llm-wiki, github/github-pr-workflow]
+---
+
+# dryvist docs-pr
+
+Contribute documentation to the two dryvist doc sites by opening **draft,
+never-merged** pull requests whose commits are **GitHub-verified** (signed). Use
+this after you have curated knowledge in the `llm-wiki` and identified a concrete,
+sourced documentation improvement.
+
+Repos:
+- `dryvist/docs` (PUBLIC, Mintlify) — user-facing public docs, docs.jacobpevans.com.
+- `dryvist/docs-starlight` (PRIVATE, Astro Starlight) — internal docs, docs.dryvist.com.
+
+## Hard rules (never violate)
+
+1. **Draft only. Never merge.** Every PR opens as a draft. You have no authority
+   to merge, mark ready, or approve. A human reviews and merges. The org ruleset
+   also blocks you — do not try to work around it.
+2. **Signed commits via the API only.** Commit exclusively through
+   `scripts/open_signed_pr.py` (GitHub App + `createCommitOnBranch`). NEVER
+   `git commit`/`git push` — the org requires signed commits and a plain push is
+   rejected.
+3. **Privacy routing is absolute.** Anything internal, sensitive, or secret
+   (hostnames, internal domains, IPs, tokens, private topology) goes to
+   `docs-starlight` ONLY — never to the public `docs`. When unsure, treat it as
+   sensitive. Redact secrets from every string before it leaves the machine.
+4. **No emoji** anywhere in branch names, titles, commit messages, or bodies.
+5. **Attribution triad** on every PR: title suffix ` [routine:hermes]`, label
+   `cloud-routine`, and a `## Provenance` block in the body naming the source(s).
+6. **Caps + de-dup.** Max 1 open PR per repo per day from this skill. Before
+   opening, list existing open PRs and skip if a matching `docs:` PR already
+   exists. If over the cap or a duplicate, decline cleanly — do nothing.
+7. **Small, sourced, voice-preserving.** One focused improvement per PR. Cite
+   provenance. Never restyle or rewrite an author's voice.
+8. **Fail loud.** If App creds are missing or a preflight check fails, stop and
+   report — never fall back to an unsigned or non-draft path.
+
+## Procedure
+
+1. Preflight: `python scripts/open_signed_pr.py --preflight` — confirms the App
+   token mints. Abort on failure.
+2. Decide the target repo by privacy (rule 3). Confirm the change is worth a PR
+   (a real, sourced improvement — otherwise decline).
+3. Prepare the file change(s) as full new file contents.
+4. De-dup: check open PRs; if a matching `docs:` PR exists or the daily cap is
+   hit, stop.
+5. Open the PR via the helper — it creates a dated branch
+   `docs/hermes/<slug>-<YYYY-MM-DD>`, commits signed via the API, and opens a
+   DRAFT PR with the attribution triad. Report the PR URL. Do not touch it again.
+
+## Verification
+
+- The helper's unit tests (`tests/test_open_signed_pr.py`) assert: draft=True,
+  dated branch, `docs:` Conventional-Commit title with the `[routine:hermes]`
+  suffix, `## Provenance` body block, cap/de-dup logic, secret redaction, and
+  privacy routing (sensitive content never targets public `docs`). Run:
+  `python -m pytest tests/ -q`.
+- A live PR is proof only if `gh api repos/<owner>/<repo>/pulls/<n>` shows
+  `draft: true` and the head commit's `verification.verified == true`.

--- a/roles/hermes_agent/files/skills/dryvist/docs-pr/scripts/open_signed_pr.py
+++ b/roles/hermes_agent/files/skills/dryvist/docs-pr/scripts/open_signed_pr.py
@@ -26,7 +26,8 @@ PRIVATE_REPO = "docs-starlight"
 DAILY_CAP = 1
 
 _EMOJI = re.compile(
-    "[\U0001f000-\U0001faff\U00002600-\U000027bf\U0001f1e6-\U0001f1ff←-⇿⌀-⏿]"
+    "[\U0001f000-\U0001faff\U00002600-\U000027bf\U0001f1e6-\U0001f1ff"
+    "\u2190-\u21ff\u2300-\u23ff]"  # + arrows + miscellaneous-technical
 )
 # Obvious secret shapes to scrub from anything leaving the machine.
 _SECRET_PATTERNS = [

--- a/roles/hermes_agent/files/skills/dryvist/docs-pr/scripts/open_signed_pr.py
+++ b/roles/hermes_agent/files/skills/dryvist/docs-pr/scripts/open_signed_pr.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Open a signed, draft, no-merge documentation PR to a dryvist docs repo.
+
+Commits are authored by the `hermes-docs-bot` GitHub App via the
+`createCommitOnBranch` GraphQL mutation, so GitHub marks them Verified/signed —
+satisfying the org's non-bypassable required-signatures ruleset. A plain
+`git push` would be rejected, so this is the ONLY sanctioned write path.
+
+The pure guardrail helpers (naming, title/body, redaction, privacy routing,
+cap/de-dup) contain no network calls and are unit-tested. Network access is
+isolated behind functions that take a githubkit client, so tests inject a mock.
+"""
+from __future__ import annotations
+
+import base64
+import datetime as _dt
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+
+ATTRIBUTION_SUFFIX = " [routine:hermes]"
+PROVENANCE_LABEL = "cloud-routine"
+PUBLIC_REPO = "docs"
+PRIVATE_REPO = "docs-starlight"
+DAILY_CAP = 1
+
+_EMOJI = re.compile(
+    "[\U0001f000-\U0001faff\U00002600-\U000027bf\U0001f1e6-\U0001f1ff←-⇿⌀-⏿]"
+)
+# Obvious secret shapes to scrub from anything leaving the machine.
+_SECRET_PATTERNS = [
+    re.compile(r"gh[pousr]_[A-Za-z0-9]{20,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", re.S),
+    re.compile(r"(?i)bearer\s+[A-Za-z0-9._\-]{16,}"),
+    re.compile(r"(?i)(api[_-]?key|token|secret|password)\s*[:=]\s*\S+"),
+]
+
+
+class DocsPRError(RuntimeError):
+    """Fatal, fail-loud error — never swallow into an unsigned/non-draft path."""
+
+
+# --------------------------------------------------------------------------- #
+# Pure guardrail helpers (unit-tested; no network)                            #
+# --------------------------------------------------------------------------- #
+def has_emoji(text: str) -> bool:
+    return bool(_EMOJI.search(text or ""))
+
+
+def slugify(summary: str) -> str:
+    s = re.sub(r"[^a-z0-9]+", "-", (summary or "").lower()).strip("-")
+    return (s or "update")[:48]
+
+
+def dated_branch(summary: str, today: _dt.date | None = None) -> str:
+    day = (today or _dt.date.today()).isoformat()
+    return f"docs/hermes/{slugify(summary)}-{day}"
+
+
+def build_title(summary: str) -> str:
+    summary = (summary or "").strip()
+    if has_emoji(summary):
+        raise DocsPRError("emoji not allowed in PR title")
+    body = summary if summary.lower().startswith("docs:") else f"docs: {summary}"
+    return body + ATTRIBUTION_SUFFIX
+
+
+def build_body(summary: str, sources: list[str]) -> str:
+    if has_emoji(summary):
+        raise DocsPRError("emoji not allowed in PR body")
+    src = "\n".join(f"- {redact(s)}" for s in (sources or [])) or "- (none recorded)"
+    return (
+        f"{redact(summary).strip()}\n\n"
+        "## Provenance\n\n"
+        "Opened autonomously by the Hermes agent's `dryvist-docs-pr` skill. "
+        "Draft only; a human reviews and merges.\n\n"
+        f"Sources:\n{src}\n"
+    )
+
+
+def redact(text: str) -> str:
+    out = text or ""
+    for pat in _SECRET_PATTERNS:
+        out = pat.sub("[REDACTED]", out)
+    return out
+
+
+def pick_repo(sensitive: bool, requested: str) -> str:
+    """Enforce privacy routing: sensitive content is docs-starlight ONLY."""
+    if sensitive:
+        if requested == PUBLIC_REPO:
+            raise DocsPRError("sensitive content must not target the public docs repo")
+        return PRIVATE_REPO
+    if requested not in (PUBLIC_REPO, PRIVATE_REPO):
+        raise DocsPRError(f"unknown target repo: {requested!r}")
+    return requested
+
+
+def is_duplicate(open_pr_titles: list[str], title: str) -> bool:
+    key = title.split(ATTRIBUTION_SUFFIX)[0].strip().lower()
+    return any(key and key in (t or "").lower() for t in open_pr_titles)
+
+
+def within_cap(open_pr_count_today: int, cap: int = DAILY_CAP) -> bool:
+    return open_pr_count_today < cap
+
+
+@dataclass
+class FileChange:
+    path: str
+    contents: str
+
+    def as_addition(self) -> dict:
+        data = base64.b64encode(self.contents.encode()).decode()
+        return {"path": self.path, "contents": data}
+
+
+@dataclass
+class PRRequest:
+    owner: str
+    requested_repo: str
+    summary: str
+    sources: list[str]
+    changes: list[FileChange]
+    sensitive: bool = False
+    open_pr_titles: list[str] = field(default_factory=list)
+    open_pr_count_today: int = 0
+
+
+def plan_pr(req: PRRequest) -> dict:
+    """Pure planning step: resolve repo/branch/title/body, enforce all guardrails.
+
+    Returns a dict describing the PR to open, or raises DocsPRError. Raises a
+    *skip* sentinel (returns {'skip': reason}) for cap/dup — a clean no-op.
+    """
+    repo = pick_repo(req.sensitive, req.requested_repo)
+    if not req.changes:
+        raise DocsPRError("no file changes to commit")
+    title = build_title(req.summary)
+    if not within_cap(req.open_pr_count_today):
+        return {"skip": "daily cap reached"}
+    if is_duplicate(req.open_pr_titles, title):
+        return {"skip": "duplicate PR already open"}
+    return {
+        "owner": req.owner,
+        "repo": repo,
+        "branch": dated_branch(req.summary),
+        "title": title,
+        "body": build_body(req.summary, req.sources),
+        "additions": [c.as_addition() for c in req.changes],
+        "label": PROVENANCE_LABEL,
+        "draft": True,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Network layer (thin; a mock client is injected in tests)                    #
+# --------------------------------------------------------------------------- #
+_COMMIT_MUTATION = """
+mutation($input: CreateCommitOnBranchInput!) {
+  createCommitOnBranch(input: $input) { commit { url oid } }
+}
+"""
+
+
+def make_client():
+    app_id = os.environ.get("GITHUB_APP_ID", "")
+    inst_id = os.environ.get("GITHUB_APP_INSTALLATION_ID", "")
+    key_path = os.environ.get("GITHUB_APP_PRIVATE_KEY_PATH", "")
+    if not (app_id and inst_id and key_path and os.path.exists(key_path)):
+        raise DocsPRError(
+            "missing GitHub App creds (GITHUB_APP_ID / _INSTALLATION_ID / _PRIVATE_KEY_PATH)"
+        )
+    from githubkit import AppInstallationAuthStrategy, GitHub  # lazy import
+
+    private_key = open(key_path).read()
+    return GitHub(AppInstallationAuthStrategy(int(app_id), private_key, int(inst_id)))
+
+
+def _head_oid(gh, owner: str, repo: str, branch: str) -> str:
+    return gh.rest.git.get_ref(owner, repo, f"heads/{branch}").parsed_data.object_.sha
+
+
+def _default_branch(gh, owner: str, repo: str) -> str:
+    return gh.rest.repos.get(owner, repo).parsed_data.default_branch
+
+
+def open_pr_via_api(gh, plan: dict) -> str:
+    """Create the dated branch, commit signed via GraphQL, open a DRAFT PR."""
+    owner, repo, branch = plan["owner"], plan["repo"], plan["branch"]
+    base = _default_branch(gh, owner, repo)
+    base_oid = _head_oid(gh, owner, repo, base)
+    gh.rest.git.create_ref(owner, repo, ref=f"refs/heads/{branch}", sha=base_oid)
+    gh.graphql(
+        _COMMIT_MUTATION,
+        {
+            "input": {
+                "branch": {
+                    "repositoryNameWithOwner": f"{owner}/{repo}",
+                    "branchName": branch,
+                },
+                "message": {"headline": plan["title"]},
+                "fileChanges": {"additions": plan["additions"], "deletions": []},
+                "expectedHeadOid": base_oid,
+            }
+        },
+    )
+    pr = gh.rest.pulls.create(
+        owner, repo, title=plan["title"], head=branch, base=base,
+        body=plan["body"], draft=True,
+    ).parsed_data
+    try:
+        gh.rest.issues.add_labels(owner, repo, pr.number, labels=[plan["label"]])
+    except Exception:  # label is best-effort; never block the PR on it
+        pass
+    return pr.html_url
+
+
+def preflight() -> None:
+    gh = make_client()
+    login = gh.rest.apps.get_authenticated().parsed_data.slug
+    print(f"preflight OK: app={login}")
+
+
+def main(argv: list[str]) -> int:
+    if "--preflight" in argv:
+        preflight()
+        return 0
+    print("import this module and call plan_pr()/open_pr_via_api(); --preflight to check creds")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    try:
+        sys.exit(main(sys.argv[1:]))
+    except DocsPRError as exc:
+        print(f"FATAL: {exc}", file=sys.stderr)
+        sys.exit(2)

--- a/roles/hermes_agent/files/skills/dryvist/docs-pr/scripts/open_signed_pr.py
+++ b/roles/hermes_agent/files/skills/dryvist/docs-pr/scripts/open_signed_pr.py
@@ -26,7 +26,10 @@ PRIVATE_REPO = "docs-starlight"
 DAILY_CAP = 1
 
 _EMOJI = re.compile(
-    "[\U0001f000-\U0001faff\U00002600-\U000027bf\U0001f1e6-\U0001f1ff"
+    # \U0001f1e6-\U0001f1ff (regional indicators) is already inside the
+    # \U0001f000-\U0001faff block, so it is intentionally not repeated \u2014
+    # a nested range trips CodeQL py/overly-large-range (overlapping ranges).
+    "[\U0001f000-\U0001faff\U00002600-\U000027bf"
     "\u2190-\u21ff\u2300-\u23ff]"  # + arrows + miscellaneous-technical
 )
 # Obvious secret shapes to scrub from anything leaving the machine.

--- a/roles/hermes_agent/files/skills/dryvist/docs-pr/tests/test_open_signed_pr.py
+++ b/roles/hermes_agent/files/skills/dryvist/docs-pr/tests/test_open_signed_pr.py
@@ -1,0 +1,125 @@
+"""Unit tests for the dryvist docs-pr signed-PR helper. No network calls."""
+import base64
+import datetime as dt
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+import open_signed_pr as m  # noqa: E402
+
+
+def test_dated_branch_shape():
+    b = m.dated_branch("Add Hermes wiki section", today=dt.date(2026, 7, 8))
+    assert b == "docs/hermes/add-hermes-wiki-section-2026-07-08"
+    assert b.startswith("docs/hermes/") and b.endswith("2026-07-08")
+
+
+def test_build_title_prefixes_and_suffixes():
+    t = m.build_title("document the wiki")
+    assert t == "docs: document the wiki [routine:hermes]"
+    # does not double-prefix
+    assert m.build_title("docs: already").startswith("docs: already")
+    assert t.endswith(m.ATTRIBUTION_SUFFIX)
+
+
+def test_title_and_body_reject_emoji():
+    with pytest.raises(m.DocsPRError):
+        m.build_title("shipped it \U0001f680")
+    with pytest.raises(m.DocsPRError):
+        m.build_body("done \U0001f389", [])
+
+
+def test_body_has_provenance_block():
+    body = m.build_body("summary text", ["https://example.com/a"])
+    assert "## Provenance" in body
+    assert "https://example.com/a" in body
+
+
+def test_redaction_scrubs_secrets():
+    assert "ghp_" not in m.redact("token ghp_" + "a" * 36)
+    assert "[REDACTED]" in m.redact("api_key=supersecretvalue")
+    pem = "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----"
+    assert "PRIVATE KEY" not in m.redact(pem)
+
+
+def test_privacy_routing_blocks_sensitive_to_public():
+    assert m.pick_repo(True, "docs-starlight") == "docs-starlight"
+    with pytest.raises(m.DocsPRError):
+        m.pick_repo(True, "docs")  # sensitive -> public is forbidden
+    assert m.pick_repo(False, "docs") == "docs"
+
+
+def test_cap_and_dedup():
+    assert m.within_cap(0, cap=1) is True
+    assert m.within_cap(1, cap=1) is False
+    titles = ["docs: document the wiki [routine:hermes]"]
+    assert m.is_duplicate(titles, "docs: document the wiki [routine:hermes]") is True
+    assert m.is_duplicate(titles, "docs: something else [routine:hermes]") is False
+
+
+def test_plan_pr_skips_on_cap_and_dup():
+    req = m.PRRequest(
+        owner="dryvist", requested_repo="docs", summary="x",
+        sources=[], changes=[m.FileChange("a.md", "hi")],
+        open_pr_count_today=1,
+    )
+    assert m.plan_pr(req).get("skip")  # cap reached
+    req2 = m.PRRequest(
+        owner="dryvist", requested_repo="docs", summary="dup",
+        sources=[], changes=[m.FileChange("a.md", "hi")],
+        open_pr_titles=["docs: dup [routine:hermes]"],
+    )
+    assert m.plan_pr(req2).get("skip")  # duplicate
+
+
+def test_plan_pr_happy_path_is_draft_and_encoded():
+    req = m.PRRequest(
+        owner="dryvist", requested_repo="docs", summary="Add wiki docs",
+        sources=["wiki/entities/hermes.md"],
+        changes=[m.FileChange("infrastructure/hermes-agent.mdx", "body")],
+    )
+    plan = m.plan_pr(req)
+    assert plan["draft"] is True
+    assert plan["repo"] == "docs"
+    assert plan["branch"].startswith("docs/hermes/add-wiki-docs-")
+    assert plan["title"] == "docs: Add wiki docs [routine:hermes]"
+    add = plan["additions"][0]
+    assert base64.b64decode(add["contents"]).decode() == "body"
+
+
+def test_plan_pr_requires_changes():
+    with pytest.raises(m.DocsPRError):
+        m.plan_pr(m.PRRequest("dryvist", "docs", "x", [], []))
+
+
+def test_open_pr_via_api_uses_draft_and_signed_commit():
+    gh = mock.MagicMock()
+    gh.rest.repos.get.return_value.parsed_data.default_branch = "main"
+    gh.rest.git.get_ref.return_value.parsed_data.object_.sha = "baseoid123"
+    gh.rest.pulls.create.return_value.parsed_data.html_url = "https://github.com/dryvist/docs/pull/9"
+    gh.rest.pulls.create.return_value.parsed_data.number = 9
+    plan = {
+        "owner": "dryvist", "repo": "docs", "branch": "docs/hermes/x-2026-07-08",
+        "title": "docs: x [routine:hermes]", "body": "b",
+        "additions": [{"path": "a.md", "contents": "aGk="}], "label": "cloud-routine",
+        "draft": True,
+    }
+    url = m.open_pr_via_api(gh, plan)
+    assert url == "https://github.com/dryvist/docs/pull/9"
+    # branch created from base oid, PR opened as draft, commit via graphql (signed)
+    gh.rest.git.create_ref.assert_called_once()
+    assert gh.graphql.call_count == 1
+    _, kwargs = gh.rest.pulls.create.call_args
+    assert kwargs["draft"] is True
+    gq_args = gh.graphql.call_args[0]
+    assert gq_args[1]["input"]["expectedHeadOid"] == "baseoid123"
+
+
+def test_make_client_fails_loud_without_creds(monkeypatch):
+    for v in ("GITHUB_APP_ID", "GITHUB_APP_INSTALLATION_ID", "GITHUB_APP_PRIVATE_KEY_PATH"):
+        monkeypatch.delenv(v, raising=False)
+    with pytest.raises(m.DocsPRError):
+        m.make_client()

--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -200,6 +200,92 @@
     - hermes_agent_slack_home_channel | length > 0
     - hermes_agent_daily_status_cron_name not in (hermes_agent_daily_status_cron_list.stdout | default(''))
 
+- name: Ensure the wiki directory exists
+  ansible.builtin.file:
+    path: "{{ hermes_agent_wiki_path }}"
+    state: directory
+    owner: "{{ hermes_agent_user }}"
+    group: "{{ hermes_agent_user }}"
+    mode: "0750"
+  when: hermes_agent_wiki_enabled | bool
+
+- name: Materialize llm-wiki skill
+  ansible.builtin.copy:
+    src: "{{ hermes_agent_install_dir }}/skills/research/llm-wiki"
+    dest: "{{ hermes_agent_hermes_home }}/skills/"
+    remote_src: true
+    owner: "{{ hermes_agent_user }}"
+    group: "{{ hermes_agent_user }}"
+    mode: preserve
+  when: hermes_agent_wiki_enabled | bool
+
+- name: Check whether the nightly wiki cron job already exists
+  ansible.builtin.command: "{{ hermes_agent_bin }} cron list --all"
+  environment:
+    HERMES_HOME: "{{ hermes_agent_hermes_home }}"
+  become: true
+  become_user: "{{ hermes_agent_user }}"
+  register: hermes_agent_wiki_cron_list
+  changed_when: false
+  failed_when: false
+  when: hermes_agent_wiki_enabled | bool
+
+- name: Seed the nightly wiki cron job
+  ansible.builtin.command:
+    cmd: >-
+      {{ hermes_agent_bin }} cron create "{{ hermes_agent_nightly_wiki_cron_schedule }}"
+      "{{ hermes_agent_nightly_wiki_cron_prompt }}"
+      --name "{{ hermes_agent_nightly_wiki_cron_name }}"
+  environment:
+    HERMES_HOME: "{{ hermes_agent_hermes_home }}"
+  become: true
+  become_user: "{{ hermes_agent_user }}"
+  register: hermes_agent_wiki_cron_create
+  changed_when: true
+  when:
+    - hermes_agent_wiki_enabled | bool
+    - hermes_agent_nightly_wiki_cron_name not in (hermes_agent_wiki_cron_list.stdout | default(''))
+
+- name: Deploy the GitHub App private key
+  ansible.builtin.copy:
+    content: "{{ hermes_agent_github_app_private_key }}"
+    dest: "{{ hermes_agent_hermes_home }}/github-app.pem"
+    owner: "{{ hermes_agent_user }}"
+    group: "{{ hermes_agent_user }}"
+    mode: "0600"
+  no_log: true
+  when: hermes_agent_github_app_private_key | length > 0
+
+- name: Install githubkit into the Hermes venv
+  ansible.builtin.command:
+    cmd: >-
+      {{ hermes_agent_uv_bin }} pip install
+      --python {{ hermes_agent_venv_python }}
+      githubkit
+  register: hermes_agent_githubkit_install
+  changed_when: >-
+    'Installed' in hermes_agent_githubkit_install.stderr
+    or 'Uninstalled' in hermes_agent_githubkit_install.stderr
+  when: hermes_agent_github_app_private_key | length > 0
+
+- name: Materialize upstream github skills
+  ansible.builtin.copy:
+    src: "{{ hermes_agent_install_dir }}/skills/github"
+    dest: "{{ hermes_agent_hermes_home }}/skills/"
+    remote_src: true
+    owner: "{{ hermes_agent_user }}"
+    group: "{{ hermes_agent_user }}"
+    mode: preserve
+
+- name: Deploy the dryvist docs-pr skill
+  ansible.builtin.copy:
+    src: skills/dryvist/docs-pr/
+    dest: "{{ hermes_agent_hermes_home }}/skills/dryvist/docs-pr/"
+    owner: "{{ hermes_agent_user }}"
+    group: "{{ hermes_agent_user }}"
+    mode: "0640"
+    directory_mode: "0750"
+
 - name: Deploy the hermes-gateway systemd unit
   ansible.builtin.template:
     src: hermes-gateway.service.j2

--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -261,7 +261,7 @@
     cmd: >-
       {{ hermes_agent_uv_bin }} pip install
       --python {{ hermes_agent_venv_python }}
-      githubkit
+      'githubkit[auth-app]'
   register: hermes_agent_githubkit_install
   changed_when: >-
     'Installed' in hermes_agent_githubkit_install.stderr

--- a/roles/hermes_agent/templates/config.yaml.j2
+++ b/roles/hermes_agent/templates/config.yaml.j2
@@ -69,4 +69,14 @@ plugins:
   enabled:
     - observability/otel
 
+{% if hermes_agent_splunk_mcp_enabled | bool and hermes_agent_splunk_mcp_url | length > 0 %}
+# Splunk MCP Server (read/search the SIEM). ${VARS} resolve from .env at
+# connect time, so the token/endpoint never land in this file. Omitted until
+# ansible-splunk mints + publishes the token (empty URL disables it).
+mcp_servers:
+  splunk:
+    url: "${SPLUNK_MCP_URL}"
+    headers:
+      Authorization: "Bearer ${SPLUNK_MCP_TOKEN}"
+{% endif %}
 timezone: '{{ hermes_agent_timezone }}'

--- a/roles/hermes_agent/templates/config.yaml.j2
+++ b/roles/hermes_agent/templates/config.yaml.j2
@@ -57,6 +57,14 @@ security:
   redact_secrets: true
   tirith_enabled: true
 
+# Auto-shrink long autonomous sessions. summary_model MUST be a model our router
+# serves — the upstream default (google/gemini-3-flash-preview) is unreachable
+# here (no external egress/key), which would make compression fail mid-session.
+compression:
+  enabled: {{ hermes_agent_context_compression_enabled | to_json }}
+  threshold: {{ hermes_agent_context_compression_threshold }}
+  summary_model: {{ hermes_agent_model }}
+
 plugins:
   enabled:
     - observability/otel

--- a/roles/hermes_agent/templates/config.yaml.j2
+++ b/roles/hermes_agent/templates/config.yaml.j2
@@ -69,14 +69,25 @@ plugins:
   enabled:
     - observability/otel
 
-{% if hermes_agent_splunk_mcp_enabled | bool and hermes_agent_splunk_mcp_url | length > 0 %}
-# Splunk MCP Server (read/search the SIEM). ${VARS} resolve from .env at
-# connect time, so the token/endpoint never land in this file. Omitted until
-# ansible-splunk mints + publishes the token (empty URL disables it).
+{% set _mcp_splunk = (hermes_agent_splunk_mcp_enabled | bool) and (hermes_agent_splunk_mcp_url | length > 0) %}
+{% set _mcp_context7 = (hermes_agent_context7_mcp_enabled | bool) and (hermes_agent_context7_api_key | length > 0) %}
+{% if _mcp_splunk or _mcp_context7 %}
+# MCP servers. ${VARS} resolve from .env at connect time, so tokens/endpoints
+# never land in this file. Each entry is omitted until its creds are present.
 mcp_servers:
+{% if _mcp_splunk %}
+  # Splunk MCP Server — read/search the SIEM (run_splunk_query, get_indexes, ...).
   splunk:
     url: "${SPLUNK_MCP_URL}"
     headers:
       Authorization: "Bearer ${SPLUNK_MCP_TOKEN}"
+{% endif %}
+{% if _mcp_context7 %}
+  # Context7 — current, version-specific library/framework docs on demand.
+  context7:
+    url: "https://mcp.context7.com/mcp"
+    headers:
+      CONTEXT7_API_KEY: "${CONTEXT7_API_KEY}"
+{% endif %}
 {% endif %}
 timezone: '{{ hermes_agent_timezone }}'

--- a/roles/hermes_agent/templates/config.yaml.j2
+++ b/roles/hermes_agent/templates/config.yaml.j2
@@ -70,10 +70,15 @@ plugins:
     - observability/otel
 
 {% set _mcp_splunk = (hermes_agent_splunk_mcp_enabled | bool) and (hermes_agent_splunk_mcp_url | length > 0) %}
-{% set _mcp_context7 = (hermes_agent_context7_mcp_enabled | bool) and (hermes_agent_context7_api_key | length > 0) %}
+{# Context7's hosted MCP serves unauthenticated requests (verified: keyless
+   `initialize` returns 200); a key only raises the shared rate limit. So this
+   entry renders whenever enabled — the API-key header is added only when a key
+   is actually set, below. #}
+{% set _mcp_context7 = (hermes_agent_context7_mcp_enabled | bool) %}
 {% if _mcp_splunk or _mcp_context7 %}
 # MCP servers. ${VARS} resolve from .env at connect time, so tokens/endpoints
-# never land in this file. Each entry is omitted until its creds are present.
+# never land in this file. The Splunk entry is omitted until its creds are
+# present; Context7 is keyless so it renders whenever enabled.
 mcp_servers:
 {% if _mcp_splunk %}
   # Splunk MCP Server — read/search the SIEM (run_splunk_query, get_indexes, ...).
@@ -86,8 +91,10 @@ mcp_servers:
   # Context7 — current, version-specific library/framework docs on demand.
   context7:
     url: "https://mcp.context7.com/mcp"
+{% if hermes_agent_context7_api_key | length > 0 %}
     headers:
       CONTEXT7_API_KEY: "${CONTEXT7_API_KEY}"
+{% endif %}
 {% endif %}
 {% endif %}
 timezone: '{{ hermes_agent_timezone }}'

--- a/roles/hermes_agent/templates/hermes-env.j2
+++ b/roles/hermes_agent/templates/hermes-env.j2
@@ -34,3 +34,6 @@ GITHUB_APP_PRIVATE_KEY_PATH={{ hermes_agent_hermes_home }}/github-app.pem
 # connect time. Empty until ansible-splunk mints + publishes the token.
 SPLUNK_MCP_URL={{ hermes_agent_splunk_mcp_url }}
 SPLUNK_MCP_TOKEN={{ hermes_agent_splunk_mcp_token }}
+
+# Context7 MCP client — config.yaml's mcp_servers.context7 resolves this ${VAR}.
+CONTEXT7_API_KEY={{ hermes_agent_context7_api_key }}

--- a/roles/hermes_agent/templates/hermes-env.j2
+++ b/roles/hermes_agent/templates/hermes-env.j2
@@ -29,3 +29,8 @@ WIKI_PATH={{ hermes_agent_wiki_path }}
 GITHUB_APP_ID={{ hermes_agent_github_app_id }}
 GITHUB_APP_INSTALLATION_ID={{ hermes_agent_github_app_installation_id }}
 GITHUB_APP_PRIVATE_KEY_PATH={{ hermes_agent_hermes_home }}/github-app.pem
+
+# Splunk MCP client — config.yaml's mcp_servers.splunk resolves these ${VARS} at
+# connect time. Empty until ansible-splunk mints + publishes the token.
+SPLUNK_MCP_URL={{ hermes_agent_splunk_mcp_url }}
+SPLUNK_MCP_TOKEN={{ hermes_agent_splunk_mcp_token }}

--- a/roles/hermes_agent/templates/hermes-env.j2
+++ b/roles/hermes_agent/templates/hermes-env.j2
@@ -19,3 +19,13 @@ HERMES_OTEL_ENABLED=1
 HERMES_OTEL_ENDPOINT={{ hermes_agent_otel_endpoint }}/v1/traces
 HERMES_OTEL_TIMEOUT={{ hermes_agent_otel_timeout }}
 OTEL_SERVICE_NAME={{ hermes_agent_otel_service_name }}
+
+# llm-wiki
+{% if hermes_agent_wiki_enabled | bool %}
+WIKI_PATH={{ hermes_agent_wiki_path }}
+{% endif %}
+
+# GitHub docs-contributor
+GITHUB_APP_ID={{ hermes_agent_github_app_id }}
+GITHUB_APP_INSTALLATION_ID={{ hermes_agent_github_app_installation_id }}
+GITHUB_APP_PRIVATE_KEY_PATH={{ hermes_agent_hermes_home }}/github-app.pem


### PR DESCRIPTION
## Summary
Wires two capabilities into the `hermes_agent` role (the deployed NousResearch Hermes autonomous agent):

1. **llm-wiki knowledge base** — enables the bundled `research/llm-wiki` skill: build/query/lint/maintain an interlinked Markdown "second brain" at `WIKI_PATH=/var/lib/hermes/wiki` (persistent ZFS, snapshotted). Context compression enabled with `summary_model` pointed at our router (the upstream `google/gemini-3-flash-preview` default is unreachable here). Nightly lint/health cron seeded.
2. **Autonomous GitHub docs-contributor** — Hermes reads public `dryvist` repos and opens **signed, draft, no-merge** doc PRs to `dryvist/docs` + `dryvist/docs-starlight` as a dedicated GitHub App (`hermes-docs-bot`).

## Discovery findings (upstream hermes-agent)
- Built-in skills load by **materialization** into `$HERMES_HOME/skills/` (the startup scanner picks them up) — no `skills:` enable block needed; `skills.config` is only for skills needing prompted settings.
- `github` skill reads `GITHUB_APP_ID` / `GITHUB_APP_INSTALLATION_ID` / `GITHUB_APP_PRIVATE_KEY_PATH` from `${HERMES_HOME}/.env`; `gh` not required (git+REST fallback), so we adopt **githubkit** + `createCommitOnBranch` for GitHub-verified/signed commits.
- Context compression is config-based (`compression:`), summary model overridable.

## Security posture
- App creds delivered from OpenBao `secret/ai/hermes` via `bao_local_llm_secrets` (env fallback); PEM written to `github-app.pem` `0600` `no_log`. Role stays inert until creds are set.
- Signed commits only (createCommitOnBranch) — a plain `git push` is rejected by the org ruleset.
- **No-merge** guaranteed by the org ruleset (human review + signatures; the App is not a bypass actor), enforced/hardened in dryvist/tofu-github#27 — not by token scope. PRs are draft-only.
- `dryvist/docs-pr` skill guardrails: draft-only, attribution triad, dated branches, `docs:` titles, per-repo/day cap + de-dup, secret redaction, absolute privacy routing (sensitive -> docs-starlight only).

## New variables
`hermes_agent_wiki_enabled/_path`, `hermes_agent_context_compression_*`, `hermes_agent_nightly_wiki_cron_*`, `hermes_agent_github_app_id/_installation_id/_private_key`. See role README.

## Static gates (verbatim)
- `ansible-lint roles/hermes_agent/` -> **Passed: 0 failure(s), 0 warning(s) on 11 files. Profile 'production' was required, and it passed.**
- `yamllint` -> clean (rc 0)
- `ansible-playbook site.yml --syntax-check` -> exit 0
- template-render fixture -> `failed=0`
- `pytest` (docs-pr helper) -> **12 passed**

Runtime App creds are provisioned separately in OpenBao (not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)