### PR TITLE
fix(llm_router): drop aliases whose backends are no longer served

### DIFF
--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -21,7 +21,7 @@ VLAN.
   dispatcher (autonomy) even with no messaging platform configured.
 - `HERMES_HOME` (`/var/lib/hermes/.hermes`) lives on a dedicated ZFS data volume —
   memory, skills, profiles, the Kanban DB, sessions and logs — so it is snapshotted
-  and replicated pve→pve3 (the agent's accumulated knowledge is irreplaceable).
+  and replicated to the DR node (the agent's accumulated knowledge is irreplaceable).
 - Points the model backend at the LiteLLM router (`Qwen3-Coder-30B-A3B` via
   `llm.<subdomain>/v1`, OpenAI-compatible, 262144 context); sets memory provider to **Hindsight** (best self-hostable
   June 2026) alongside the always-on `MEMORY.md`/`USER.md`; caps `agent.max_turns`

--- a/roles/llm_router/README.md
+++ b/roles/llm_router/README.md
@@ -16,8 +16,8 @@ tofu inventory). Tools come from the repo's Nix dev shell (`direnv allow`).
 
 | Alias(es) | Backend | Auth |
 | --- | --- | --- |
-| `gpt-oss-120b`, `qwen3-coder` | `llm-large` runner (`/v1`, bearer) | `LLM_LARGE_BEARER_TOKEN` |
-| `hermes-4-14b`, `hermes4`, `qwen3-4b`, `embeddings` | `llm-fast` (GPU) **and** `llm-light` (CPU) | none |
+| `gpt-oss-120b`, `Qwen3-Coder-30B-A3B`, `Qwen3.6-35B-A3B-4bit`, `claude-sonnet-5` | `llm-large` runner (`/v1`, bearer) | `LLM_LARGE_BEARER_TOKEN` |
+| `qwen3-4b`, `embeddings`, `claude-haiku-4-5` | `llm-fast` (GPU) **and** `llm-light` (CPU) | none |
 
 Each light alias is registered as **two deployments** with the same `model_name`
 (the GPU `llm-fast` box and the CPU `llm-light` standby). LiteLLM load-balances the

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -6,9 +6,9 @@
 #
 # Two tiers, both reached through this one proxy:
 #   large — gpt-oss-120b / Qwen3-Coder-30B-A3B / Qwen3.6-35B-A3B-4bit /
-#           Qwen3.6-27B-4bit / claude-sonnet-5 on the neutral `llm-large`
-#           runner (bearer auth). One deployment each; no cross-tier fallback.
-#   light — hermes-4-14b / qwen3-4b / embeddings / claude-haiku-4-5. TWO deployments per
+#           claude-sonnet-5 on the neutral `llm-large` runner (bearer auth).
+#           One deployment each; no cross-tier fallback.
+#   light — qwen3-4b / embeddings / claude-haiku-4-5. TWO deployments per
 #           alias: the GPU `llm-fast` box AND the CPU `llm-light` standby, same
 #           model_name. LiteLLM load-balances the pair and cools a failed
 #           deployment down, so a GPU outage drains to CPU automatically.
@@ -98,7 +98,6 @@ llm_router_large_models:
   - { alias: gpt-oss-120b, backend: mlx-community/gpt-oss-120b-MXFP4-Q8, context_window: 131072 }
   - { alias: Qwen3-Coder-30B-A3B, backend: mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit, context_window: 262144 }
   - { alias: Qwen3.6-35B-A3B-4bit, backend: mlx-community/Qwen3.6-35B-A3B-4bit, context_window: 262144 }
-  - { alias: Qwen3.6-27B-4bit, backend: mlx-community/Qwen3.6-27B-4bit, context_window: 262144 }
   # claude-sonnet-5 is a Claude Code alias deliberately mapped to a local Qwen3.6
   # backend (PR #624) — not a mis-map; it inherits that backend's 262144 context.
   - { alias: claude-sonnet-5, backend: mlx-community/Qwen3.6-35B-A3B-4bit, context_window: 262144 }
@@ -106,10 +105,12 @@ llm_router_large_models:
 # same-name deployments (llm-fast GPU + llm-light CPU) in the rendered config.
 # `embedding: true` marks the entry as an embeddings model_group.
 llm_router_light_models:
-  - { alias: hermes-4-14b, backend: hermes-4-14b }
   - { alias: qwen3-4b, backend: qwen3-4b }
   - { alias: embeddings, backend: embeddings, embedding: true }
-  - { alias: claude-haiku-4-5, backend: hermes-4-14b }
+  # claude-haiku-4-5 is the Claude Code light-tier alias; it maps to the live
+  # light backend (the hermes-4-14b backend it previously targeted is no
+  # longer served anywhere — >=14B GPU serving is barred from the fast tier).
+  - { alias: claude-haiku-4-5, backend: qwen3-4b }
 
 # --- Routing behaviour -------------------------------------------------------
 # Load-balance across same-name deployments; cool a failed one down so traffic


### PR DESCRIPTION
- **fix(llm_router): drop aliases whose backends are no longer served**
- **docs(hermes): generalize node naming in README**
