### PR TITLE
feat(openbao): add dedicated least-privilege hermes reader AppRole

### DIFF
--- a/roles/openbao/README.md
+++ b/roles/openbao/README.md
@@ -193,6 +193,7 @@ plans):
 | `monitoring` | `secret/apps/monitoring` | — | netmon/unifi_metrics/prometheus_stack |
 | `media` | `secret/apps/media` | — | *arr/qBittorrent/Plex stack |
 | `local-llm` | `secret/ai/*` | — | The LLM serving stack itself |
+| `hermes` | `secret/ai/hermes` only | — | Dedicated least-privilege reader for the Hermes agent; NO broad `secret/ai/*` |
 | `public` | `secret/public/*` | — | **Anonymous** — creds NOT keychain-gated; shipped ambiently |
 | `ai-readonly` | `secret/ai/*`, `secret/apps/*` | — | **default AI agent; NO `secret/infra/*`** |
 | `ai-elevated` | `ai-readonly` + `secret/platform/*` | — | trusted infra-touching agents; no write |

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -7,7 +7,7 @@
 # bootstraps the cluster, the secret hierarchy, the RBAC policies, and the
 # AppRoles — one per resource-domain identity (terraform-apply / terrakube-plan
 # / ansible-converge / observability / local-cloud / monitoring / media /
-# local-llm / public / ai-readonly / ai-elevated / snapshot).
+# local-llm / hermes / public / ai-readonly / ai-elevated / snapshot).
 
 # --- Version ----------------------------------------------------------------
 # Pinned to a known-good upstream release. Version bumps follow the repo's
@@ -130,6 +130,8 @@ openbao_homelab_path: homelab
 #   monitoring       — read-only, secret/apps/monitoring
 #   media            — read-only, secret/apps/media
 #   local-llm        — LLM serving stack; read-only, secret/ai/*
+#   hermes           — Hermes AI agent; read-only, secret/ai/hermes ONLY —
+#                      dedicated least-privilege reader, NOT the broad ai subtree
 #   public           — anonymous, non-exploitable facts (domain/subdomain);
 #                      read-only, secret/public/*; creds NOT keychain-gated —
 #                      shipped ambiently like other non-secret internal config
@@ -150,6 +152,8 @@ openbao_media_policy_name: media
 openbao_media_approle_name: media
 openbao_local_llm_policy_name: local-llm
 openbao_local_llm_approle_name: local-llm
+openbao_hermes_policy_name: hermes
+openbao_hermes_approle_name: hermes
 openbao_public_policy_name: public
 openbao_public_approle_name: public
 openbao_ai_readonly_policy_name: ai-readonly
@@ -182,6 +186,8 @@ openbao_approles:
     policy: "{{ openbao_media_policy_name }}"
   - name: "{{ openbao_local_llm_approle_name }}"
     policy: "{{ openbao_local_llm_policy_name }}"
+  - name: "{{ openbao_hermes_approle_name }}"
+    policy: "{{ openbao_hermes_policy_name }}"
   - name: "{{ openbao_public_approle_name }}"
     policy: "{{ openbao_public_policy_name }}"
   - name: "{{ openbao_ai_readonly_approle_name }}"
@@ -209,6 +215,8 @@ openbao_policies:
     template: media-policy.hcl.j2
   - name: "{{ openbao_local_llm_policy_name }}"
     template: local-llm-policy.hcl.j2
+  - name: "{{ openbao_hermes_policy_name }}"
+    template: hermes-policy.hcl.j2
   - name: "{{ openbao_public_policy_name }}"
     template: public-policy.hcl.j2
   - name: "{{ openbao_ai_readonly_policy_name }}"

--- a/roles/openbao/templates/hermes-policy.hcl.j2
+++ b/roles/openbao/templates/hermes-policy.hcl.j2
@@ -1,0 +1,10 @@
+{{ ansible_managed | comment }}
+# OpenBao policy for the `hermes` AppRole — the Hermes AI agent's dedicated,
+# least-privilege reader. Read-only on EXACTLY secret/ai/hermes (its own
+# secret) and nothing else in the ai subtree or any other domain.
+path "{{ openbao_kv_mount }}/data/ai/hermes" {
+  capabilities = ["read"]
+}
+path "{{ openbao_kv_mount }}/metadata/ai/hermes" {
+  capabilities = ["read", "list"]
+}


### PR DESCRIPTION
## Summary

Adds a strict, dedicated `hermes` OpenBao identity (policy + AppRole) for the
Hermes AI agent. Previously the agent read its secrets via the broad
`local-llm` AppRole, which can read ALL of `secret/ai/*`. This grants
**read-only on EXACTLY `secret/ai/hermes` and nothing else** — no wildcard on
the `ai` subtree, no other domain. Least privilege is the whole point.

## What changed

- **New policy template** `roles/openbao/templates/hermes-policy.hcl.j2` —
  `read` on `secret/data/ai/hermes` and `read`/`list` on
  `secret/metadata/ai/hermes` only (no `ai/*` wildcard).
- **`roles/openbao/defaults/main.yml`** — adds `openbao_hermes_policy_name` /
  `openbao_hermes_approle_name`, wires the policy into `openbao_policies` and
  the AppRole into `openbao_approles`, and documents the identity in the RBAC
  comment block. `secret_id_ttl` stays at the role default (0) — the keychain
  lock-state is the access boundary.
- **`roles/openbao/README.md`** — new RBAC table row for the `hermes` AppRole.

Mirrors the role's existing per-domain RBAC pattern exactly (same structure as
`local-llm` / `ai-elevated`).

## Verification

- `yamllint roles/openbao/defaults/main.yml` — clean
- `ansible-lint roles/openbao` — **passed at production profile**, 0 failures
- `markdownlint-cli2 roles/openbao/README.md` — 0 errors

## Deployment note

IaC only. Provisioning is root-gated (`bao policy write` / AppRole creation on
the bootstrap host); the user applies separately. Nothing was applied to any
live system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)