### PR TITLE
feat(media): unattended security upgrades on the downloader + wiring-contract tests

### DIFF
--- a/.github/workflows/_molecule.yml
+++ b/.github/workflows/_molecule.yml
@@ -24,6 +24,7 @@ jobs:
           - llamaindex
           - download_vpn
           - seerr
+          - servarr_wiring
           - sortarr
           - technitium_dns
           - netmon
@@ -86,6 +87,9 @@ jobs:
           #                  built-in dummy fallbacks; services not started in CI)
           #   seerr       -> none (SEERR_API_KEY uses a built-in dummy
           #                  fallback; container not started in CI)
+          #   servarr_wiring -> none (SONARR/RADARR/PROWLARR_API_KEY use
+          #                  built-in dummy fallbacks; manage_services=false,
+          #                  no live *arr APIs in CI)
           #   sortarr     -> none (SONARR_API_KEY/RADARR_API_KEY/
           #                  SORTARR_BASIC_AUTH_PASS use built-in dummy
           #                  fallbacks; container not started in CI)

--- a/molecule/download_vpn/verify.yml
+++ b/molecule/download_vpn/verify.yml
@@ -276,3 +276,25 @@
         fail_msg: >-
           The download_vpn role no longer has a fatal mountpoint guard (with an
           ntfy alert) for both /data and the Prowlarr data dir.
+
+    # --- Unattended security upgrades -----------------------------------------
+    # The guest fetches updates over the tunnel; these apt drop-ins are what
+    # make them APPLY. Reboot must stay manual so a kernel update can never
+    # bounce the tunnel unattended.
+    - name: Read the unattended-upgrades apt drop-ins
+      ansible.builtin.slurp:
+        src: "{{ item }}"
+      register: _unattended_dropins
+      loop:
+        - /etc/apt/apt.conf.d/20auto-upgrades
+        - /etc/apt/apt.conf.d/52unattended-upgrades-local
+
+    - name: Assert unattended security upgrades are enabled and reboot-free
+      ansible.builtin.assert:
+        that:
+          - "'APT::Periodic::Unattended-Upgrade \"1\";' in (_unattended_dropins.results[0].content | b64decode)"
+          - "'APT::Periodic::Update-Package-Lists \"1\";' in (_unattended_dropins.results[0].content | b64decode)"
+          - "'Unattended-Upgrade::Automatic-Reboot \"false\";' in (_unattended_dropins.results[1].content | b64decode)"
+        fail_msg: >-
+          The unattended-upgrades apt drop-ins regressed (periodic apply off,
+          or auto-reboot no longer pinned off).

--- a/molecule/download_vpn/verify.yml
+++ b/molecule/download_vpn/verify.yml
@@ -233,6 +233,28 @@
       changed_when: true
       failed_when: false
 
+    # --- Unattended security upgrades -----------------------------------------
+    # The guest fetches updates over the tunnel; these apt drop-ins are what
+    # make them APPLY. Reboot must stay manual so a kernel update can never
+    # bounce the tunnel unattended.
+    - name: Read the unattended-upgrades apt drop-ins
+      ansible.builtin.slurp:
+        src: "{{ item }}"
+      register: _unattended_dropins
+      loop:
+        - /etc/apt/apt.conf.d/20auto-upgrades
+        - /etc/apt/apt.conf.d/52unattended-upgrades-local
+
+    - name: Assert unattended security upgrades are enabled and reboot-free
+      ansible.builtin.assert:
+        that:
+          - "'APT::Periodic::Unattended-Upgrade \"1\";' in (_unattended_dropins.results[0].content | b64decode)"
+          - "'APT::Periodic::Update-Package-Lists \"1\";' in (_unattended_dropins.results[0].content | b64decode)"
+          - "'Unattended-Upgrade::Automatic-Reboot \"false\";' in (_unattended_dropins.results[1].content | b64decode)"
+        fail_msg: >-
+          The unattended-upgrades apt drop-ins regressed (periodic apply off,
+          or auto-reboot no longer pinned off).
+
 # --- 5. persistent-storage guards (unit-style — gated on manage_services, ----
 # never live in this scenario since there is no real Proton tunnel in CI) -----
 # download_vpn_manage_services is false here (see converge.yml), so the guard
@@ -276,25 +298,3 @@
         fail_msg: >-
           The download_vpn role no longer has a fatal mountpoint guard (with an
           ntfy alert) for both /data and the Prowlarr data dir.
-
-    # --- Unattended security upgrades -----------------------------------------
-    # The guest fetches updates over the tunnel; these apt drop-ins are what
-    # make them APPLY. Reboot must stay manual so a kernel update can never
-    # bounce the tunnel unattended.
-    - name: Read the unattended-upgrades apt drop-ins
-      ansible.builtin.slurp:
-        src: "{{ item }}"
-      register: _unattended_dropins
-      loop:
-        - /etc/apt/apt.conf.d/20auto-upgrades
-        - /etc/apt/apt.conf.d/52unattended-upgrades-local
-
-    - name: Assert unattended security upgrades are enabled and reboot-free
-      ansible.builtin.assert:
-        that:
-          - "'APT::Periodic::Unattended-Upgrade \"1\";' in (_unattended_dropins.results[0].content | b64decode)"
-          - "'APT::Periodic::Update-Package-Lists \"1\";' in (_unattended_dropins.results[0].content | b64decode)"
-          - "'Unattended-Upgrade::Automatic-Reboot \"false\";' in (_unattended_dropins.results[1].content | b64decode)"
-        fail_msg: >-
-          The unattended-upgrades apt drop-ins regressed (periodic apply off,
-          or auto-reboot no longer pinned off).

--- a/molecule/servarr_wiring/converge.yml
+++ b/molecule/servarr_wiring/converge.yml
@@ -1,0 +1,37 @@
+---
+# Molecule converge for the servarr_wiring scenario.
+#
+# Runs the role with servarr_wiring_manage_services=false: the deterministic
+# API-key preflight runs (against the scenario's test keys), but every live
+# wiring step — config.xml edits, Prowlarr indexers/applications, media
+# management — is skipped; there are no running *arr apps in CI. verify.yml
+# asserts on the role's defaults contract (endpoint resolution, auth policy,
+# stewardship floors) instead.
+
+- name: Converge
+  hosts: all
+  become: true
+  gather_facts: true
+
+  vars:
+    servarr_wiring_manage_services: false
+    # Mirror load_tofu.yml so the role's tofu_data lookups resolve. The vmid-ish
+    # 192.168.0.x fixture matches the other media scenarios — synthetic, never
+    # production values.
+    container_ip: "192.168.0.210"
+    tofu_data:
+      containers:
+        sonarr: { reserved_ip: "192.168.0.212" }
+        radarr: { reserved_ip: "192.168.0.213" }
+        download-vpn: { reserved_ip: "192.168.0.210" }
+      constants:
+        media_ports:
+          sonarr_web: 8989
+          radarr_web: 7878
+          prowlarr_web: 9696
+          qbittorrent_web: 8080
+
+  tasks:
+    - name: Include servarr_wiring role
+      ansible.builtin.include_role:
+        name: servarr_wiring

--- a/molecule/servarr_wiring/molecule.yml
+++ b/molecule/servarr_wiring/molecule.yml
@@ -1,0 +1,56 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: servarr-wiring-test
+    # No stable version tags available; geerlingguy only publishes :latest
+    image: geerlingguy/docker-debian12-ansible:latest
+    privileged: true
+    command: ""
+    pre_build_image: true
+    tmpfs:
+      - /run
+      - /tmp
+      - /run/lock
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    groups:
+      - download_vpn_group
+      - lxc_containers
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
+  env:
+    # Deterministic test keys (32 hex). Real values come from SOPS in production.
+    SONARR_API_KEY: "${SONARR_API_KEY:-0123456789abcdef0123456789abcdef}"
+    RADARR_API_KEY: "${RADARR_API_KEY:-abcdef0123456789abcdef0123456789}"
+    PROWLARR_API_KEY: "${PROWLARR_API_KEY:-456789abcdef0123456789abcdef0123}"
+
+verifier:
+  name: ansible
+
+scenario:
+  name: servarr_wiring
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - cleanup
+    - destroy

--- a/molecule/servarr_wiring/prepare.yml
+++ b/molecule/servarr_wiring/prepare.yml
@@ -1,0 +1,15 @@
+---
+# Molecule preparation for the servarr_wiring scenario.
+
+- name: Prepare
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Wait for container to be ready
+      ansible.builtin.wait_for_connection:
+        timeout: 30
+
+    - name: Gather facts
+      ansible.builtin.setup:

--- a/molecule/servarr_wiring/verify.yml
+++ b/molecule/servarr_wiring/verify.yml
@@ -1,0 +1,115 @@
+---
+# Molecule verification for servarr_wiring (defaults-contract layer).
+#
+# The role is almost entirely live API wiring (skipped in CI), so this verify
+# guards the CONTRACTS the live run depends on:
+#   1. Endpoint resolution prefers reserved_ip and falls back ip -> hostvars
+#      -> loopback (the coordinator runs behind the VPN and cannot resolve
+#      internal FQDNs, so this expression is load-bearing).
+#   2. Ports come from the OpenTofu constants, never literals.
+#   3. The auth policy pins a v4-valid method (never None).
+#   4. Data dirs / owners match the app roles' install contract (the
+#      config.xml delegation writes into these exact paths as these users).
+#   5. Tracker-stewardship floors: seed criteria stay at-or-above a
+#      good-citizen baseline, and at least one indexer is defined.
+
+- name: Verify
+  hosts: all
+  become: false
+  gather_facts: false
+
+  vars:
+    # Same synthetic fixture as converge.yml — the defaults under test template
+    # lazily against whatever tofu_data is in scope here.
+    container_ip: "192.168.0.210"
+    tofu_data:
+      containers:
+        sonarr: { reserved_ip: "192.168.0.212" }
+        radarr: { reserved_ip: "192.168.0.213" }
+        download-vpn: { reserved_ip: "192.168.0.210" }
+      constants:
+        media_ports:
+          sonarr_web: 8989
+          radarr_web: 7878
+          prowlarr_web: 9696
+          qbittorrent_web: 8080
+
+  tasks:
+    - name: Load the role defaults (the contract under test)
+      ansible.builtin.include_vars:
+        file: "{{ playbook_dir }}/../../roles/servarr_wiring/defaults/main.yml"
+
+    - name: Assert endpoint hosts resolve from the inventory fixture (reserved_ip first)
+      ansible.builtin.assert:
+        that:
+          - servarr_wiring_sonarr_host == tofu_data.containers['sonarr'].reserved_ip
+          - servarr_wiring_radarr_host == tofu_data.containers['radarr'].reserved_ip
+          - servarr_wiring_prowlarr_host == tofu_data.containers['download-vpn'].reserved_ip
+        fail_msg: "endpoint host resolution no longer prefers the guest's reserved_ip"
+
+    - name: Assert the ip-field fallback still works when reserved_ip is absent
+      vars:
+        # Re-derive the role's expression against a fixture WITHOUT reserved_ip.
+        _fallback_fixture: { containers: { sonarr: { ip: "192.168.0.99" } } }
+        _fallback_host: >-
+          {{ _fallback_fixture.containers['sonarr'].reserved_ip
+             if (_fallback_fixture.containers['sonarr'].reserved_ip | default('', true) | length > 0)
+             else (_fallback_fixture.containers['sonarr'].ip
+                   | default('127.0.0.1', true)) }}
+      ansible.builtin.assert:
+        that:
+          - _fallback_host == '192.168.0.99'
+        fail_msg: "endpoint resolution fallback (reserved_ip -> ip) regressed"
+
+    - name: Assert ports come from the OpenTofu constants
+      ansible.builtin.assert:
+        that:
+          - servarr_wiring_sonarr_port | int == tofu_data.constants.media_ports.sonarr_web
+          - servarr_wiring_radarr_port | int == tofu_data.constants.media_ports.radarr_web
+          - servarr_wiring_prowlarr_port | int == tofu_data.constants.media_ports.prowlarr_web
+        fail_msg: "*arr ports drifted from the tofu constants"
+
+    - name: Assert the auth policy is a v4-valid method (never None)
+      ansible.builtin.assert:
+        that:
+          - servarr_wiring_auth_method in ['Forms', 'Basic', 'External']
+          - servarr_wiring_auth_required in ['Enabled', 'DisabledForLocalAddresses']
+        fail_msg: >-
+          servarr_wiring_auth_method/_required must be a combination *arr v4
+          accepts — AuthenticationMethod=None walls off the UI.
+
+    - name: Assert data dirs and owners match the app roles' install contract
+      ansible.builtin.assert:
+        that:
+          - servarr_wiring_sonarr_data_dir == '/var/lib/sonarr'
+          - servarr_wiring_radarr_data_dir == '/var/lib/radarr'
+          - servarr_wiring_prowlarr_data_dir == '/var/lib/prowlarr'
+          - servarr_wiring_sonarr_user == 'media'
+          - servarr_wiring_radarr_user == 'media'
+          - servarr_wiring_prowlarr_user == 'qbittorrent'
+          - servarr_wiring_group == 'media'
+        fail_msg: >-
+          servarr_wiring's data-dir/owner contract drifted from the app roles —
+          the delegated config.xml writes would land on the wrong path or owner.
+
+    - name: Assert tracker-stewardship floors and indexer presence
+      ansible.builtin.assert:
+        that:
+          # Good-citizen baseline: never seed below ratio 1.0 / 2 days.
+          - servarr_wiring_seed_ratio | float >= 1.0
+          - servarr_wiring_seed_time_minutes | int >= 2880
+          # Without an indexer, Prowlarr syncs nothing and the *arrs find nothing.
+          - servarr_wiring_prowlarr_indexers | length >= 1
+          - servarr_wiring_indexer_app_profile_id | int >= 1
+          - servarr_wiring_sync_level in ['disabled', 'addOnly', 'fullSync']
+        fail_msg: "seed-criteria stewardship floor or indexer contract regressed"
+
+    - name: Assert import safety knobs stay sane
+      ansible.builtin.assert:
+        that:
+          # The recycler must share the /data volume (atomic moves) and the
+          # min-free-space floor must keep real headroom.
+          - servarr_wiring_recycler_bin_path is match('^/data/')
+          - servarr_wiring_recycler_bin_days | int >= 0
+          - servarr_wiring_min_free_space_mb | int >= 1024
+        fail_msg: "recycler-bin/min-free-space import safety contract regressed"

--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -144,6 +144,13 @@ download_vpn_lanroute_reply_networks:
 download_vpn_apt_cacher_host: "{{ hostvars['apt-cacher-ng']['container_ip'] | default('') }}"
 download_vpn_apt_cacher_port: "{{ tofu_data.constants.service_ports.apt_cacher_ng | default(3142) }}"
 
+# --- unattended security upgrades ---------------------------------------------
+# apt egress rides the tunnel in steady state, so updates CAN be fetched — this
+# makes Debian's unattended-upgrades APPLY them (security origin only, stock
+# apt-daily timers, no auto-reboot). The most internet-exposed guest must not
+# sit unpatched between converges/rebuilds.
+download_vpn_unattended_upgrades: true
+
 # --- qBittorrent -------------------------------------------------------------
 download_vpn_qbittorrent_package: qbittorrent-nox
 download_vpn_qbittorrent_user: "{{ download_vpn_user }}"

--- a/roles/download_vpn/tasks/main.yml
+++ b/roles/download_vpn/tasks/main.yml
@@ -147,6 +147,45 @@
          or (not (download_vpn_apt_proxy.failed | default(false))) }}
     cache_valid_time: 3600
 
+# --- Phase 1a: unattended security upgrades ----------------------------------
+# apt egress works in steady state (the default route rides the tunnel), but
+# nothing ever APPLIED the downloaded updates, leaving the most
+# internet-exposed guest unpatched between converges. Debian's own
+# unattended-upgrades closes that: security-origin-only by default, native apt
+# machinery, no bespoke scheduler. Reboots stay manual — the killswitch
+# validator and the BindsTo unit chain recover services, not kernels.
+- name: Install unattended-upgrades
+  ansible.builtin.apt:
+    name: unattended-upgrades
+    state: present
+  when: download_vpn_unattended_upgrades | bool
+
+- name: Enable periodic unattended upgrades
+  ansible.builtin.copy:
+    dest: /etc/apt/apt.conf.d/20auto-upgrades
+    content: |
+      // Managed by Ansible (download_vpn role). List refresh + the
+      // unattended-upgrades apply both ride the stock apt-daily timers.
+      APT::Periodic::Update-Package-Lists "1";
+      APT::Periodic::Unattended-Upgrade "1";
+    owner: root
+    group: root
+    mode: "0644"
+  when: download_vpn_unattended_upgrades | bool
+
+- name: Keep unattended upgrades reboot-free
+  ansible.builtin.copy:
+    dest: /etc/apt/apt.conf.d/52unattended-upgrades-local
+    content: |
+      // Managed by Ansible (download_vpn role). The stock origin allowlist
+      // (security only) is kept; make the no-reboot contract explicit so a
+      // kernel update can never bounce the tunnel unattended.
+      Unattended-Upgrade::Automatic-Reboot "false";
+    owner: root
+    group: root
+    mode: "0644"
+  when: download_vpn_unattended_upgrades | bool
+
 # --- Phase 1b: timezone -----------------------------------------------------
 # The qBittorrent scheduler evaluates SYSTEM LOCAL time, so pin the container to
 # UTC (default) and express the throttle window in UTC. glibc reads the zone at
@@ -647,6 +686,11 @@
     path: "{{ download_vpn_prowlarr_data_dir }}"
     state: directory
     owner: "{{ download_vpn_user }}"
+    # Explicit group (the shared media gid): a from-scratch create must never
+    # inherit the connecting user's default group — the mapped-ownership
+    # contract with media_lxc_features' config-dataset chown assumes owner and
+    # group are both the app's own ids.
+    group: "{{ download_vpn_group }}"
     mode: "0750"
 
 - name: Download + extract Prowlarr


### PR DESCRIPTION
## What

1. **Unattended security upgrades on the VPN-locked downloader guest** (closes #368). The issue's premise — "the locked-down container can't refresh apt in steady state" — no longer holds: apt egress rides the tunnel (verified live). What was missing is anything that *applies* the fetched updates. This enables Debian's own unattended-upgrades: security origin only, stock apt-daily timers, auto-reboot pinned **off** so a kernel update can never bounce the tunnel unattended. A scheduled container rebuild (the issue's original proposal) stays unnecessary — drift reset is already covered by converge + proven rebuild-from-IaC.
2. **Explicit `group:` on the indexer app's data-directory create** — a from-scratch create must not inherit the connecting user's default group (defense-in-depth for the mapped-ownership contract with the host-side config-dataset chown; companion to dryvist/ansible-proxmox#372).
3. **New `molecule/servarr_wiring` scenario** (render-only, `manage_services=false`) guarding the role's defaults contract: endpoint resolution (reserved_ip → ip fallback), tofu-constant ports, v4-valid auth policy, data-dir/owner contract, seed-criteria stewardship floors, import-safety knobs. Matrix line added.
4. Molecule assertions for the new apt drop-ins in the existing downloader scenario.

## Verification

- `ansible-lint` production profile: 0 failures on all touched paths.
- The new verify playbook passes standalone (8/8 tasks, all assertions green).
- Live check on the guest: apt update succeeds in steady state; unattended-upgrades was absent (nothing applied updates) — confirming the gap this closes.

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXiX2uJBEn6HNa2brL6iKd