### PR TITLE
fix(cribl-edge): finalize the unifi_fw split regex from live gateway samples

### DIFF
--- a/roles/cribl_edge/defaults/main.yml
+++ b/roles/cribl_edge/defaults/main.yml
@@ -46,13 +46,15 @@ cribl_edge_syslog_ports: "{{ cribl_edge_syslog_port_mappings.values() | list }}"
 # index=firewall sourcetype=ubiquiti:firewall BEFORE the plain unifi branch;
 # everything else on the port stays index=unifi.
 #
-# PLACEHOLDER PATTERN — covers the common UniFi kernel iptables rule-hit tag
-# ("[WAN_LOCAL-4001-D]" / "[LAN_IN-RET-A]"-style), the kernel packet-header
-# dump ("IN=eth0 OUT= MAC=..."), and suricata IPS alerts. L9 finalizes this
-# from live gateway samples — adjust HERE only (single source of truth), the
-# pipeline template just interpolates it.
+# Finalized 2026-07-07 from 20 live gateway samples (L9). Live UDW rule-hit
+# tags carry a numeric rule index after the action ("[LOCAL_CUSTOM1-A-2147483647]",
+# "[LAN_CUSTOM1-A-10000]"), legacy USG tags do not ("[WAN_LOCAL-4001-D]") —
+# the optional trailing -\d+ covers both. The kernel packet-header dump
+# ("IN= OUT=br8 MAC=") and suricata IPS alerts complete the alternation.
+# Adjust HERE only (single source of truth), the pipeline template just
+# interpolates it.
 cribl_edge_unifi_fw_match: >-
-  \[[A-Z][A-Z0-9_-]*-[AD]\]|\bIN=\S* OUT=\S* MAC=|suricata
+  \[[A-Z][A-Z0-9_.-]*-[ADR](-\d+)?\]|\bIN=\S* OUT=\S* MAC=|suricata
 
 # Edge API bind port from tofu constants (no hardcoded values).
 # Templated into local/edge/cribl.yml with host 0.0.0.0 so the API is

--- a/tests/e2e/test_unifi_fw.py
+++ b/tests/e2e/test_unifi_fw.py
@@ -47,6 +47,16 @@ def _make_fw_message(sentinel):
     )
 
 
+def _make_fw_message_udw(sentinel):
+    """A live UDW-format rule-hit line (action + numeric rule index)."""
+    timestamp = _get_syslog_timestamp()
+    return (
+        f"<13>{timestamp} UDW UDW [LAN_CUSTOM1-A-10000] DESCR=\"Allow All\" "
+        f"IN=br0 OUT=br5 MAC=aa:bb:cc:dd:ee:ff SRC=192.0.2.10 DST=192.0.2.20 "
+        f"LEN=64 {sentinel}"
+    )
+
+
 def _make_admin_message(sentinel):
     """A UniFi management-plane line (must NOT match the fw split regex)."""
     timestamp = _get_syslog_timestamp()
@@ -84,6 +94,36 @@ class TestUnifiFirewallSplit:
         )
         assert results, (
             f"UniFi firewall sentinel {sentinel} did not reach Splunk with "
+            f"index=firewall sourcetype=ubiquiti:firewall"
+        )
+
+    def test_udw_firewall_line_routes_to_firewall_index(
+        self,
+        haproxy_host,
+        splunk_creds,
+        pipeline_poll_timeout,
+        pipeline_poll_interval,
+    ):
+        """A live UDW-format rule-hit line (numeric rule index) also splits."""
+        source = _unifi_source()
+        mgmt_url, user, password = splunk_creds
+        sentinel = f"e2e-unifi-fw-udw-{uuid.uuid4().hex[:10]}-{int(time.time())}"
+
+        send_tcp_syslog(
+            haproxy_host, source.standard_port, _make_fw_message_udw(sentinel)
+        )
+        results = wait_for_event(
+            mgmt_url,
+            user,
+            password,
+            sentinel,
+            index="firewall",
+            sourcetype="ubiquiti:firewall",
+            timeout=pipeline_poll_timeout,
+            poll_interval=pipeline_poll_interval,
+        )
+        assert results, (
+            f"UDW-format firewall sentinel {sentinel} did not reach Splunk with "
             f"index=firewall sourcetype=ubiquiti:firewall"
         )
 


### PR DESCRIPTION
L9 of terraform-proxmox#579: regex finalized from live UDW samples (numeric rule-index tags), legacy USG shape kept, admin/dhcp negatives verified. Adds a UDW-format e2e positive test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)