### PR TITLE
feat(openbao): reconcile ai-orchestrator write AppRole into IaC

### DIFF
--- a/roles/openbao/README.md
+++ b/roles/openbao/README.md
@@ -194,6 +194,7 @@ plans):
 | `media` | `secret/apps/media` | — | *arr/qBittorrent/Plex stack |
 | `local-llm` | `secret/ai/*` | — | The LLM serving stack itself |
 | `public` | `secret/public/*` | — | **Anonymous** — creds NOT keychain-gated; shipped ambiently |
+| `ai-orchestrator` | `secret/ai/*` | `secret/ai/*` (create/update) | AI agent/orchestrator WRITE identity; role_id/secret_id **operator-held in the macOS keychain**, not Doppler-managed |
 | `ai-readonly` | `secret/ai/*`, `secret/apps/*` | — | **default AI agent; NO `secret/infra/*`** |
 | `ai-elevated` | `ai-readonly` + `secret/platform/*` | — | trusted infra-touching agents; no write |
 | `snapshot` | `sys/storage/raft/snapshot` | — | least-priv backup identity |

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -133,6 +133,15 @@ openbao_homelab_path: homelab
 #   public           — anonymous, non-exploitable facts (domain/subdomain);
 #                      read-only, secret/public/*; creds NOT keychain-gated —
 #                      shipped ambiently like other non-secret internal config
+#   ai-orchestrator  — AI agent/orchestrator WRITE identity; read + create/update
+#                      secret/ai/* (the one AI identity that may write). Its
+#                      role_id/secret_id are OPERATOR-HELD in the macOS keychain
+#                      (services BAO_AI_ORCHESTRATOR_ROLE_ID / _SECRET_ID),
+#                      externally managed and NOT Doppler-managed. The secret_id
+#                      is non-expiring and IN ACTIVE USE — converges must stay
+#                      idempotent-existence-only for it and must NEVER regenerate
+#                      it (init.yml only mints creds for AppRoles missing this
+#                      run, so an already-live ai-orchestrator is left untouched).
 #   ai-readonly / ai-elevated / snapshot — unchanged, kept as-is
 openbao_terraform_apply_policy_name: terraform-apply
 openbao_terraform_apply_approle_name: terraform-apply
@@ -152,6 +161,8 @@ openbao_local_llm_policy_name: local-llm
 openbao_local_llm_approle_name: local-llm
 openbao_public_policy_name: public
 openbao_public_approle_name: public
+openbao_ai_orchestrator_policy_name: ai-orchestrator
+openbao_ai_orchestrator_approle_name: ai-orchestrator
 openbao_ai_readonly_policy_name: ai-readonly
 openbao_ai_readonly_approle_name: ai-readonly
 openbao_ai_elevated_policy_name: ai-elevated
@@ -184,6 +195,13 @@ openbao_approles:
     policy: "{{ openbao_local_llm_policy_name }}"
   - name: "{{ openbao_public_approle_name }}"
     policy: "{{ openbao_public_policy_name }}"
+  # ai-orchestrator: role_id/secret_id are OPERATOR-HELD in the macOS keychain
+  # (services BAO_AI_ORCHESTRATOR_ROLE_ID / _SECRET_ID), NOT Doppler-managed.
+  # This AppRole already exists LIVE with a non-expiring secret_id in active
+  # use; init.yml only creates + mints creds for AppRoles missing this run, so
+  # a converge leaves the live role and its secret_id untouched (existence-only).
+  - name: "{{ openbao_ai_orchestrator_approle_name }}"
+    policy: "{{ openbao_ai_orchestrator_policy_name }}"
   - name: "{{ openbao_ai_readonly_approle_name }}"
     policy: "{{ openbao_ai_readonly_policy_name }}"
   - name: "{{ openbao_ai_elevated_approle_name }}"
@@ -211,6 +229,8 @@ openbao_policies:
     template: local-llm-policy.hcl.j2
   - name: "{{ openbao_public_policy_name }}"
     template: public-policy.hcl.j2
+  - name: "{{ openbao_ai_orchestrator_policy_name }}"
+    template: ai-orchestrator-policy.hcl.j2
   - name: "{{ openbao_ai_readonly_policy_name }}"
     template: ai-readonly-policy.hcl.j2
   - name: "{{ openbao_ai_elevated_policy_name }}"

--- a/roles/openbao/templates/ai-orchestrator-policy.hcl.j2
+++ b/roles/openbao/templates/ai-orchestrator-policy.hcl.j2
@@ -1,0 +1,16 @@
+{{ ansible_managed | comment }}
+# OpenBao policy for the ai-orchestrator AppRole — the AI agent/orchestrator's
+# WRITE identity for its own secret domain. Read + create/update on secret/ai/*
+# so agents can persist and rotate their own credentials, and list metadata to
+# discover what exists. Deliberately scoped to secret/ai/* ONLY: no delete, no
+# infra kernel (secret/infra/*), no other app/platform subtrees. This is the
+# one AI identity that may WRITE; ai-readonly/ai-elevated stay read-only.
+# See terraform-proxmox docs/SECRETS_HIERARCHY.md.
+
+path "{{ openbao_kv_mount }}/data/ai/*" {
+  capabilities = ["create", "update", "read"]
+}
+
+path "{{ openbao_kv_mount }}/metadata/ai/*" {
+  capabilities = ["read", "list"]
+}


### PR DESCRIPTION
## What

Adds the `ai-orchestrator` OpenBao AppRole + policy to the openbao role's IaC.
These were created live via the root-bootstrapped API and are in active use,
but were absent from `openbao_policies` / `openbao_approles` — leaving them as
drift. This makes the live AI-agent write credential **durable**: it is now
declared in code so it survives any future reconcile of the RBAC surface.

- `templates/ai-orchestrator-policy.hcl.j2` — `create`/`update`/`read` on
  `secret/ai/*`, `read`/`list` on the matching metadata. The one AI identity
  permitted to write, scoped to its own domain only (no delete, no infra kernel).
- `defaults/main.yml` — name vars + the `{name,policy}` / `{name,template}` rows.
- `README.md` — one RBAC table row.

## Why it's safe for the live credential

`init.yml` is **existence-only**: it checks each AppRole via `bao read
auth/approle/role/<name>` and creates + mints a fresh `secret_id` **only** for
roles missing on that run; it never prunes and never regenerates an existing
role's `secret_id`. The `ai-orchestrator` role already exists live, so a
converge leaves it and its **non-expiring** `secret_id` untouched.

Its `role_id`/`secret_id` are **operator-held in the macOS keychain**
(`BAO_AI_ORCHESTRATOR_ROLE_ID` / `_SECRET_ID`), externally managed and **not**
Doppler-managed. An inline comment documents this so no future change wires it
into a regeneration path.

## Adoption

The live role/policy already exist, so nothing breaks today. A root-privileged
converge (`BAO_TOKEN` supplied) is needed only to *formally adopt* the
declaration; because both already exist, that converge is a no-op for this
identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hfdwgg1SpMEUYNd61SfKsb