### PR TITLE
feat(hermes): wire GH issues/projects PAT + usage skill

### DIFF
--- a/inventory/group_vars/hermes_agent_group.yml
+++ b/inventory/group_vars/hermes_agent_group.yml
@@ -30,3 +30,11 @@ hermes_agent_splunk_mcp_token: >-
 hermes_agent_context7_api_key: >-
   {{ bao_local_llm_secrets.CONTEXT7_API_KEY
      | default(lookup('env', 'CONTEXT7_API_KEY'), true) }}
+
+# GitHub issues + org projects PAT (read/write Issues in all repos, read/write
+# Projects v2 in the dryvist org). Bao-first (local-llm domain, secret/ai/hermes),
+# env fallback — empty until the token is present. See the dryvist/github-issues
+# skill for usage.
+hermes_agent_github_issues_pat: >-
+  {{ bao_local_llm_secrets.GH_PAT_WRITE_PROJECT_ISSUES
+     | default(lookup('env', 'GH_PAT_WRITE_PROJECT_ISSUES'), true) }}

--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -124,6 +124,21 @@ with an env fallback; the PEM is written to `{{ hermes_agent_hermes_home }}/gith
 Helper unit tests: `roles/hermes_agent/files/skills/dryvist/docs-pr/tests/` — run
 `python -m pytest` from that skill dir (all guardrail logic, no network).
 
+## GitHub issues & projects
+
+Delivers a fine-grained PAT (`GH_PAT_WRITE_PROJECT_ISSUES`) into `.env` giving
+Hermes **read/write Issues across all repos** and **read/write Projects (v2) in
+the `dryvist` org** — for triaging, creating and updating issues and managing
+project boards. It is deliberately least-privilege: **not** for code commits (that
+is the signed `docs-pr` / GitHub App path) and **not** for merges. Bao-first
+(`secret/ai/hermes`, `bao_local_llm_secrets`) with an env fallback; empty until the
+token is set. The bundled `dryvist/github-issues` skill documents the REST (issues)
+and GraphQL (Projects v2) calls and the usage guardrails.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `hermes_agent_github_issues_pat` | `""` | issues + org-projects PAT (bao/env) |
+
 ## Splunk search access
 
 Registers the **Splunk MCP Server** (Splunkbase 7931, deployed by `ansible-splunk`)

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -141,6 +141,15 @@ hermes_agent_github_app_id: ""
 hermes_agent_github_app_installation_id: ""
 hermes_agent_github_app_private_key: ""
 
+# --- GitHub issues + org projects PAT (fine-grained) ---
+# Grants read/write GitHub Issues across ALL repos and read/write Projects (v2)
+# in the dryvist org — for triaging/creating/updating issues and managing project
+# boards. NOT for code commits (that is the signed docs-pr / GitHub App path) and
+# NOT for merges. Bao-first (local-llm domain, secret/ai/hermes), env fallback
+# (see group_vars); empty until the token is present. The bundled
+# dryvist/github-issues skill documents how the agent should use it.
+hermes_agent_github_issues_pat: ""
+
 # --- Splunk MCP client (read/search access to the SIEM) ---
 # Registers the Splunk MCP Server as an HTTP MCP server in config.yaml so Hermes
 # can query the environment (run_splunk_query, get_indexes, ...) with its own

--- a/roles/hermes_agent/files/skills/dryvist/github-issues/SKILL.md
+++ b/roles/hermes_agent/files/skills/dryvist/github-issues/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: dryvist-github-issues
+description: Triage, create and update GitHub Issues (all repos) and manage dryvist org Projects v2
+version: 1.0.0
+author: dryvist homelab
+license: MIT
+platforms: [linux]
+metadata:
+  hermes:
+    category: research
+    tags: [github, issues, projects, dryvist]
+    related_skills: [dryvist/docs-pr, github/github-pr-workflow]
+---
+
+# dryvist github-issues
+
+Manage GitHub **Issues** and **Projects (v2)** using the fine-grained PAT
+`GH_PAT_WRITE_PROJECT_ISSUES`, delivered into this agent's environment (`.env`).
+
+## Purpose
+
+`GH_PAT_WRITE_PROJECT_ISSUES` grants:
+
+- **read + write GitHub Issues across ALL repos** — read, search, create,
+  comment on, update, label and close issues, and
+- **read + write Projects (v2) in the `dryvist` org** — read boards and add /
+  move items on them,
+
+plus a few incidental read scopes. Use it for issue triage and org project-board
+management.
+
+**It is NOT for:**
+
+- **code commits** — signed commits go through the separate `dryvist/docs-pr`
+  skill (GitHub App + `createCommitOnBranch`). This token cannot and must not
+  push code.
+- **merging** — you have no authority to merge, mark ready, or approve anything.
+
+Respect least privilege: this token is scoped to issues + projects only. Do not
+attempt to use it for pushes, PR merges, or any admin action.
+
+## How to use
+
+Call the GitHub **REST API** for issues and the **GraphQL API** for Projects v2,
+authenticating with `Authorization: Bearer $GH_PAT_WRITE_PROJECT_ISSUES`. Read
+the token from the environment at use time — never hardcode it.
+
+### Issues (REST)
+
+Get one issue:
+
+```bash
+curl -sS -H "Authorization: Bearer $GH_PAT_WRITE_PROJECT_ISSUES" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/{owner}/{repo}/issues/{n}
+```
+
+List issues (include closed):
+
+```bash
+curl -sS -H "Authorization: Bearer $GH_PAT_WRITE_PROJECT_ISSUES" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/{owner}/{repo}/issues?state=all&per_page=50"
+```
+
+Search issues across repos:
+
+```bash
+curl -sS -H "Authorization: Bearer $GH_PAT_WRITE_PROJECT_ISSUES" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/search/issues?q=repo:dryvist/ansible-proxmox-apps+is:issue+is:open+label:bug"
+```
+
+Create an issue:
+
+```bash
+curl -sS -X POST -H "Authorization: Bearer $GH_PAT_WRITE_PROJECT_ISSUES" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/{owner}/{repo}/issues \
+  -d '{"title":"fix: honeypot index missing","body":"Details and repro.","labels":["bug"]}'
+```
+
+Comment on an issue:
+
+```bash
+curl -sS -X POST -H "Authorization: Bearer $GH_PAT_WRITE_PROJECT_ISSUES" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/{owner}/{repo}/issues/{n}/comments \
+  -d '{"body":"Confirmed on the latest converge."}'
+```
+
+Update / relabel an issue:
+
+```bash
+curl -sS -X PATCH -H "Authorization: Bearer $GH_PAT_WRITE_PROJECT_ISSUES" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/{owner}/{repo}/issues/{n} \
+  -d '{"labels":["bug","triage"]}'
+```
+
+Close an issue:
+
+```bash
+curl -sS -X PATCH -H "Authorization: Bearer $GH_PAT_WRITE_PROJECT_ISSUES" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/{owner}/{repo}/issues/{n} \
+  -d '{"state":"closed"}'
+```
+
+### Projects v2 (GraphQL)
+
+All Projects v2 calls go to `https://api.github.com/graphql`.
+
+List the dryvist org's projects (get each project's `number`, `title`, `id`):
+
+```bash
+curl -sS -X POST -H "Authorization: Bearer $GH_PAT_WRITE_PROJECT_ISSUES" \
+  https://api.github.com/graphql \
+  -d '{"query":"query { organization(login: \"dryvist\") { projectsV2(first: 20) { nodes { number title id } } } }"}'
+```
+
+Add an issue to a project. First fetch the issue's node id, then add it:
+
+```bash
+# 1) issue node id
+curl -sS -X POST -H "Authorization: Bearer $GH_PAT_WRITE_PROJECT_ISSUES" \
+  https://api.github.com/graphql \
+  -d '{"query":"query { repository(owner: \"dryvist\", name: \"ansible-proxmox-apps\") { issue(number: 123) { id } } }"}'
+
+# 2) add it (projectId from the list query above, contentId = issue node id)
+curl -sS -X POST -H "Authorization: Bearer $GH_PAT_WRITE_PROJECT_ISSUES" \
+  https://api.github.com/graphql \
+  -d '{"query":"mutation { addProjectV2ItemById(input: {projectId: \"PVT_xxx\", contentId: \"I_xxx\"}) { item { id } } }"}'
+```
+
+## Guardrails
+
+1. **Read before you write.** Fetch the repo/issue (and existing comments) before
+   editing, commenting, or closing — never act on a stale assumption.
+2. **Clear, conventional titles.** Use a `type: summary` style (`fix:`, `feat:`,
+   `docs:`, `chore:`) and a concise, specific summary.
+3. **Don't spam.** One focused issue or comment per concern; de-dup against open
+   issues first; do not reopen churn.
+4. **Label appropriately** so triage and project automation can route the item.
+5. **Never leak the token.** Never paste `GH_PAT_WRITE_PROJECT_ISSUES` (or any
+   secret) into an issue body, comment, PR text, or log output.
+6. **Issues + projects only.** This token is least-privilege by design — do not
+   use it (or attempt to use it) for code pushes, PR merges, or admin actions.
+   Code changes are the `dryvist/docs-pr` signed-commit path; merges are human-only.

--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -286,6 +286,15 @@
     mode: "0640"
     directory_mode: "0750"
 
+- name: Deploy the dryvist github-issues skill
+  ansible.builtin.copy:
+    src: skills/dryvist/github-issues/
+    dest: "{{ hermes_agent_hermes_home }}/skills/dryvist/github-issues/"
+    owner: "{{ hermes_agent_user }}"
+    group: "{{ hermes_agent_user }}"
+    mode: "0640"
+    directory_mode: "0750"
+
 - name: Deploy the hermes-gateway systemd unit
   ansible.builtin.template:
     src: hermes-gateway.service.j2

--- a/roles/hermes_agent/templates/hermes-env.j2
+++ b/roles/hermes_agent/templates/hermes-env.j2
@@ -30,6 +30,11 @@ GITHUB_APP_ID={{ hermes_agent_github_app_id }}
 GITHUB_APP_INSTALLATION_ID={{ hermes_agent_github_app_installation_id }}
 GITHUB_APP_PRIVATE_KEY_PATH={{ hermes_agent_hermes_home }}/github-app.pem
 
+# GitHub issues + org projects PAT — read/write Issues (all repos) + Projects v2
+# (dryvist org). Consumed at use time from .env by the dryvist/github-issues
+# skill (Authorization: Bearer $GH_PAT_WRITE_PROJECT_ISSUES). Empty until set.
+GH_PAT_WRITE_PROJECT_ISSUES={{ hermes_agent_github_issues_pat }}
+
 # Splunk MCP client — config.yaml's mcp_servers.splunk resolves these ${VARS} at
 # connect time. Empty until ansible-splunk mints + publishes the token.
 SPLUNK_MCP_URL={{ hermes_agent_splunk_mcp_url }}


### PR DESCRIPTION
## Summary

Delivers a fine-grained GitHub PAT to the Hermes agent so it can manage Issues and org Project boards, and bundles a how-to skill documenting correct, least-privilege usage.

- Token grants **read/write Issues across all repos** and **read/write Projects (v2) in the `dryvist` org**. It is deliberately least-privilege: **not** for code commits (that stays the signed `docs-pr` / GitHub App path) and **not** for merges.
- `defaults/main.yml` + `group_vars/hermes_agent_group.yml`: new `hermes_agent_github_issues_pat`, bao-first (`secret/ai/hermes`, `bao_local_llm_secrets`) with an env fallback, empty until the token is present — mirrors the existing App/Splunk/Context7 mappings exactly.
- `templates/hermes-env.j2`: exports the token into `.env` for use-time consumption by the skill.
- New `roles/hermes_agent/files/skills/dryvist/github-issues/SKILL.md`: documents the REST API (issues) and GraphQL (Projects v2) calls with copy-pasteable `curl` examples, plus guardrails (read-before-write, conventional titles, no token leakage, issues+projects only). Materialized onto the agent home alongside the `docs-pr` skill.
- `README.md`: adds a "GitHub issues & projects" subsection with the variable row.

## Validation

- `yamllint` clean on all changed YAML.
- `ansible-lint` (production profile): **0 failures, 0 warnings** on the role.

No secret values are committed anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hfdwgg1SpMEUYNd61SfKsb