### PR TITLE
fix(openbao): validate the full rsyslog config, not the imfile fragment

### DIFF
--- a/roles/openbao/tasks/audit.yml
+++ b/roles/openbao/tasks/audit.yml
@@ -96,8 +96,17 @@
     owner: root
     group: root
     mode: "0644"
-    validate: rsyslogd -N1 -f %s
   notify: Restart rsyslog
+
+# Full-config check, not a fragment `validate: rsyslogd -N1 -f %s`: the
+# fragment alone has no global workDirectory in scope (it lives in
+# rsyslog.conf), and imfile hard-fails validation without one. Checking the
+# master config picks the fragment up from rsyslog.d with the global applied.
+# On failure the play aborts here, so the notified restart never flushes and
+# the running rsyslog keeps its previous config.
+- name: Validate the full rsyslog configuration
+  ansible.builtin.command: rsyslogd -N1
+  changed_when: false
 
 # No unit files are written here, so no daemon_reload.
 - name: Enable and start rsyslog


### PR DESCRIPTION
The L16 openbao audit converge failed on all 7 nodes at the rsyslog ruleset deploy: the fragment-scoped `validate: rsyslogd -N1 -f %s` loads `imfile` with no global `workDirectory` in scope (that global lives in `rsyslog.conf`, not the fragment), and rsyslogd 8.2504 exits 1 on that — so the file never deploys anywhere.

Fix: deploy the template without a fragment validate, then run `rsyslogd -N1` against the master config, which picks the fragment up from `rsyslog.d` with the global applied. On a genuine config error the play still aborts before the notified restart flushes, so the running rsyslog keeps its previous config.

Verification plan: merge → re-run the openbao converge (`--tags apt_proxy,openbao --limit localhost,openbao_group`) → `bao kv get` → prove `index=openbao_audit` receives via Splunk REST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TS3gHC9B5sR5WxvLt9gRE