### PR TITLE
fix(cribl_edge): logLevel is required on the prometheus input schema

### DIFF
--- a/roles/cribl_edge/templates/inputs.yml.j2
+++ b/roles/cribl_edge/templates/inputs.yml.j2
@@ -35,6 +35,11 @@ inputs:
     id: in_prometheus_pve
     type: prometheus
     disabled: false
+    # Required by this Edge build's prometheus input schema — omitting it
+    # fails inputs.yml validation and rejects the WHOLE file (the running
+    # process keeps its previous in-memory config, so the break is silent
+    # until the next restart).
+    logLevel: info
     discoveryType: static
     targetList:
 {% for target in cribl_edge_pve_metrics_targets %}


### PR DESCRIPTION
Follow-up to #724: the homelab Edge build's prometheus-input schema requires `logLevel`, and omitting it rejects the **entire** inputs.yml (`failed to load config`) — silently, because the running process keeps its previous in-memory config until the next restart. Verified in the Edge API log on the pair after the #724 converge; os/proxy ingestion confirmed still flowing on the old in-memory config.

Pins `logLevel: info` on `in_prometheus_pve` with a comment stating the constraint. (The Mac Edge 4.18 schema treats it as optional, which is why the identical shape passes there.)

Verification: merge → re-converge `--tags cribl_edge` → confirm the config-load error is gone and `| mstats count where index=host_metrics earliest=-10m` > 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TS3gHC9B5sR5WxvLt9gRE