### PR TITLE
fix(cribl_edge): add required logLevel to in_prometheus_pve input

### DIFF
--- a/roles/cribl_edge/templates/inputs.yml.j2
+++ b/roles/cribl_edge/templates/inputs.yml.j2
@@ -35,6 +35,10 @@ inputs:
     id: in_prometheus_pve
     type: prometheus
     disabled: false
+    # Required by the prometheus input schema in this Cribl version; omitting
+    # it makes Cribl reject the ENTIRE inputs.yml (every syslog input included),
+    # which silently halts all ingestion on converge.
+    logLevel: info
     discoveryType: static
     targetList:
 {% for target in cribl_edge_pve_metrics_targets %}


### PR DESCRIPTION
The B9 PVE-metrics input (`in_prometheus_pve`) omits the `logLevel` property required by the prometheus input schema in this Cribl version. Cribl rejects the **entire** `inputs.yml` on that one invalid input, silently halting **all** syslog ingestion on the Edge the first time this input converges (every syslog family, not just metrics — observed live: unifi/firewall/os/proxy all went dark until `logLevel` was added). Add `logLevel: info`.

Part of the estate-monitoring program (terraform-proxmox #579).