### PR TITLE
feat(hermes): wire Codex as an isolated, agent-invoked escalation tool

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -634,6 +634,9 @@
     - agent
     - ai
   roles:
+    # codex_runner MUST run first — hermes_agent's config.yaml references its
+    # sudo grant + resolved Codex binary path (the escalation MCP entry).
+    - role: codex_runner
     - role: hermes_agent
 
 # =============================================================================

--- a/roles/codex_runner/README.md
+++ b/roles/codex_runner/README.md
@@ -1,0 +1,91 @@
+# codex_runner
+
+Installs the OpenAI Codex CLI under a dedicated, low-privilege system user —
+`codex-runner` — isolated from the `hermes` user that `hermes_agent`'s
+gateway daemon runs as. Exists solely to back Hermes' escalation path: Codex
+exposed as an MCP tool, reachable only through a single, narrow sudo grant.
+
+## Why a separate user
+
+Hermes' local terminal tool already runs shell commands as the `hermes` user
+inside its own LXC — the LXC itself is the blast-radius boundary for
+everything Hermes can already do. Codex's ChatGPT-OAuth credential
+(`~/.codex/auth.json`) is a different kind of asset: unlike Hermes' own
+secrets (Splunk token, GitHub App key, etc., all already readable by `hermes`
+today), this one is deliberately kept **outside** that boundary. `hermes`
+gets exactly one capability — running `codex mcp-server` as `codex-runner`,
+nothing else — and never gains filesystem access to that account's home, so
+the OAuth token itself is not directly readable by the agent even though the
+agent can still fully use the tool.
+
+## What it does
+
+- Installs Node.js/npm (Debian packaged, no NodeSource repo) and a
+  version-pinned `@openai/codex` (npm, global, explicit `--prefix` so the
+  binary path is a known fact — see `codex_runner_codex_bin`).
+- Creates the `codex-runner` system user (no login shell — it only ever runs
+  `codex mcp-server`) with a `0700` home directory.
+- Installs a single-command sudoers grant: `hermes` may run exactly
+  `{{ codex_runner_codex_bin }} mcp-server` as `codex-runner`, `NOPASSWD`,
+  nothing broader. Validated with `visudo` before install.
+- Reports (non-fatally) whether Codex's auth has been bootstrapped yet.
+
+## Manual bootstrap (required, cannot be automated)
+
+Codex auth is an interactive ChatGPT OAuth flow — Ansible cannot complete it.
+After this role converges, pick ONE:
+
+**Option A — fresh login on the LXC:**
+
+```bash
+sudo -u codex-runner -H codex login
+```
+
+Follow the printed URL/device code with a ChatGPT Pro/Plus account.
+
+**Option B — copy an already-authenticated session:**
+
+If a workstation already has a working `codex` CLI login (`~/.codex/auth.json`,
+`auth_mode: "chatgpt"`), copy that file to the LXC as `codex-runner`:
+
+```bash
+scp ~/.codex/auth.json <lxc-host>:/tmp/codex-auth.json
+ssh <lxc-host> 'sudo install -o codex-runner -g codex-runner -m 0600 \
+  -D /tmp/codex-auth.json /var/lib/codex-runner/.codex/auth.json && \
+  sudo rm /tmp/codex-auth.json'
+```
+
+Either way, confirm with:
+
+```bash
+sudo -u codex-runner -H codex --version
+sudo -u codex-runner -H codex doctor   # should report auth OK
+```
+
+Until one of these is done, Hermes' `codex` MCP tool is registered but every
+call to it errors — the daemon itself is unaffected (see `hermes_agent`'s
+README, "Escalation (Codex via MCP)").
+
+## Key variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `codex_runner_user` | `codex-runner` | isolated system user |
+| `codex_runner_home` | `/var/lib/codex-runner` | `0700` home (holds `~/.codex/auth.json`) |
+| `codex_runner_codex_version` | `0.130.0` | pinned npm version floor |
+| `codex_runner_npm_prefix` | `/usr/local` | forces a known global-install path |
+| `codex_runner_sudo_grantee` | `hermes` | the only user allowed to invoke Codex |
+| `codex_runner_mcp_command` | `{{ codex_runner_codex_bin }} mcp-server` | the exact, single command the sudo grant covers |
+
+## Group / invocation
+
+Deployed to `hermes_agent_group` (the same host as `hermes_agent`), always
+run *before* `hermes_agent` in `playbooks/site.yml` — Hermes' config
+references this role's sudo grant, so the grant must already exist.
+
+## Not yet live-validated
+
+Verify on first converge: (a) Debian's packaged `nodejs`/`npm` version is new
+enough for the pinned Codex floor — if not, this is a documented follow-up
+(pin a newer Node via a different source), not silently worked around here;
+(b) `codex mcp-server`'s actual tool surface/behavior once authenticated.

--- a/roles/codex_runner/defaults/main.yml
+++ b/roles/codex_runner/defaults/main.yml
@@ -1,0 +1,50 @@
+---
+# codex_runner role defaults — a dedicated, low-privilege OS identity that
+# owns the OpenAI Codex CLI install + its ChatGPT-OAuth credential
+# (~/.codex/auth.json), isolated from the `hermes` user Hermes Agent itself
+# runs as. Hermes reaches Codex only through `codex mcp-server`, invoked via a
+# narrow, single-command sudo grant — Hermes' own filesystem access never
+# includes this user's home, so its OAuth token is not directly readable by
+# the agent even though the agent can still fully USE the tool.
+#
+# This role only makes sense colocated with hermes_agent on the same host
+# (see playbooks/site.yml — added to the same `hermes_agent_group` play,
+# before the hermes_agent role) — nothing else consumes it.
+
+codex_runner_user: codex-runner
+codex_runner_group: codex-runner
+codex_runner_home: /var/lib/codex-runner
+
+# The user Hermes Agent's daemon runs as (roles/hermes_agent's
+# hermes_agent_user) — the ONLY identity granted sudo to run Codex as
+# codex_runner_user. Not hardcoded so the grant stays correct if that role's
+# user is ever renamed.
+codex_runner_sudo_grantee: hermes
+
+# --- Pinned Codex CLI install ------------------------------------------------
+# @openai/codex is a first-party npm package (not a raw-binary release), so
+# there is no upstream sha256 to pin the way hermes_agent's installer is
+# pinned — an exact version string is npm's equivalent lock. 0.130.0 is
+# hermes-agent's own documented floor for its Codex integration; bump this
+# deliberately, not to a floating "latest".
+codex_runner_codex_version: "0.130.0"
+codex_runner_npm_package: "@openai/codex@{{ codex_runner_codex_version }}"
+
+# Debian's packaged nodejs/npm (no NodeSource repo — one fewer external apt
+# source to trust). If the packaged version proves too old for the pinned
+# Codex floor on first converge, that is a documented follow-up, not silently
+# worked around here (see README "Not yet live-validated").
+codex_runner_apt_packages:
+  - nodejs
+  - npm
+
+# npm's global-install location varies by distro packaging; pin it explicitly
+# (--prefix below) instead of trusting whatever the packaged npm defaults to,
+# so this path is a known, stable fact rather than a guess.
+codex_runner_npm_prefix: /usr/local
+codex_runner_codex_bin: "{{ codex_runner_npm_prefix }}/bin/codex"
+
+# Exact command the sudo grant covers — deliberately a single, fixed
+# invocation (no wildcard args): Hermes' `mcp_servers.codex` entry in
+# config.yaml must match this exactly (roles/hermes_agent/templates/config.yaml.j2).
+codex_runner_mcp_command: "{{ codex_runner_codex_bin }} mcp-server"

--- a/roles/codex_runner/tasks/main.yml
+++ b/roles/codex_runner/tasks/main.yml
@@ -1,0 +1,99 @@
+---
+# codex_runner — installs the OpenAI Codex CLI under a dedicated, low-privilege
+# system user, isolated from `hermes` (see defaults/main.yml). Idempotent.
+
+- name: Install Node.js/npm (packaged, no NodeSource repo)
+  ansible.builtin.apt:
+    name: "{{ codex_runner_apt_packages }}"
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Create the codex-runner service group
+  ansible.builtin.group:
+    name: "{{ codex_runner_group }}"
+    system: true
+
+# No login shell: this user only ever runs `codex mcp-server`, invoked by
+# Hermes via the sudo grant below — it never needs an interactive session.
+- name: Create the codex-runner service user
+  ansible.builtin.user:
+    name: "{{ codex_runner_user }}"
+    group: "{{ codex_runner_group }}"
+    home: "{{ codex_runner_home }}"
+    system: true
+    shell: /usr/sbin/nologin
+    create_home: true
+
+# 0700: this is the whole isolation boundary. ~/.codex/auth.json (the ChatGPT
+# OAuth token, populated by the manual bootstrap in README.md) must never be
+# readable by the `hermes` user — only by codex-runner itself and root.
+- name: Lock down the codex-runner home directory
+  ansible.builtin.file:
+    path: "{{ codex_runner_home }}"
+    state: directory
+    owner: "{{ codex_runner_user }}"
+    group: "{{ codex_runner_group }}"
+    mode: "0700"
+
+# @openai/codex is a first-party npm package (no raw-binary release to
+# sha256-pin the way hermes_agent's installer is pinned) — an exact version
+# string is npm's equivalent lock. `--prefix` is explicit rather than trusting
+# whatever the packaged npm's default global prefix happens to be, so
+# codex_runner_codex_bin is a known fact, not a guess.
+#
+# `creates` guards a one-time install, same idiom (and same limitation) as
+# hermes_agent's own installer: bumping codex_runner_codex_version does NOT
+# by itself trigger a reinstall — remove the existing binary first, or add an
+# explicit upgrade task, if the pinned floor moves.
+- name: Install the pinned Codex CLI (npm, global, explicit prefix)
+  ansible.builtin.command:
+    cmd: >-
+      npm install -g --prefix {{ codex_runner_npm_prefix }}
+      {{ codex_runner_npm_package }}
+    creates: "{{ codex_runner_codex_bin }}"
+
+- name: Confirm the Codex CLI meets the pinned version floor
+  ansible.builtin.command:
+    cmd: "{{ codex_runner_codex_bin }} --version"
+  register: codex_runner_version_check
+  changed_when: false
+
+- name: Report installed Codex CLI version
+  ansible.builtin.debug:
+    msg: "{{ codex_runner_version_check.stdout }}"
+
+# Single-command, no-password grant: `hermes` may run exactly
+# `{{ codex_runner_mcp_command }}` as codex-runner — nothing broader. Validated
+# with visudo before it is ever installed; a malformed sudoers file can lock
+# sudo out entirely.
+- name: Install the narrow sudoers grant (hermes -> codex-runner, mcp-server only)
+  ansible.builtin.template:
+    src: codex-runner-sudoers.j2
+    dest: /etc/sudoers.d/codex-runner-mcp
+    owner: root
+    group: root
+    mode: "0440"
+    validate: "visudo -cf %s"
+
+# Auth is a one-time, interactive, human step (ChatGPT OAuth device-code or
+# browser flow) that cannot be scripted here — see README.md for both
+# bootstrap options. This check is informational only: it never fails the
+# converge, it just tells the operator whether the step is still pending,
+# mirroring the repo's existing "report missing creds, don't fail" idiom
+# (roles/openbao_secrets/tasks/fetch_domain.yml).
+- name: Check whether Codex auth has been bootstrapped for codex-runner
+  ansible.builtin.stat:
+    path: "{{ codex_runner_home }}/.codex/auth.json"
+  register: codex_runner_auth_file
+
+- name: Report Codex auth bootstrap status
+  ansible.builtin.debug:
+    msg: >-
+      {{ codex_runner_auth_file.stat.exists
+         | ternary(
+             'Codex auth already present for ' ~ codex_runner_user ~ ' — escalation is live.',
+             codex_runner_home ~ '/.codex/auth.json does not exist yet — Hermes escalation via'
+             ~ ' Codex will error until an operator completes the one-time login (see'
+             ~ ' roles/codex_runner/README.md).'
+           ) }}

--- a/roles/codex_runner/tasks/main.yml
+++ b/roles/codex_runner/tasks/main.yml
@@ -52,16 +52,37 @@
       npm install -g --prefix {{ codex_runner_npm_prefix }}
       {{ codex_runner_npm_package }}
     creates: "{{ codex_runner_codex_bin }}"
+  register: codex_runner_install
 
-- name: Confirm the Codex CLI meets the pinned version floor
-  ansible.builtin.command:
-    cmd: "{{ codex_runner_codex_bin }} --version"
-  register: codex_runner_version_check
-  changed_when: false
+# Only runs the converge that actually installed/upgraded Codex — the
+# version can't drift once the `creates` guard above is satisfied, so
+# re-verifying it every run would fork a Node process for nothing. Inline
+# rather than a handler (noqa: no-handler): this must fail the converge
+# immediately, before the sudoers grant below is installed for a binary that
+# might be older than the pinned floor — a handler would defer the check to
+# end-of-play, after that already happened. Mirrors roles/radarr/tasks/api_key.yml's
+# same-justification inline restart.
+- name: Confirm the installed Codex CLI meets the pinned version floor  # noqa: no-handler
+  when: codex_runner_install.changed
+  block:
+    - name: Read the installed Codex CLI version
+      ansible.builtin.command:
+        cmd: "{{ codex_runner_codex_bin }} --version"
+      register: codex_runner_version_check
+      changed_when: false
 
-- name: Report installed Codex CLI version
-  ansible.builtin.debug:
-    msg: "{{ codex_runner_version_check.stdout }}"
+    - name: Assert the installed version meets the pinned floor
+      ansible.builtin.assert:
+        that:
+          - codex_runner_version_check.stdout is search('\d+\.\d+\.\d+')
+          - (codex_runner_version_check.stdout | regex_search('\d+\.\d+\.\d+'))
+            is version(codex_runner_codex_version, '>=')
+        fail_msg: >-
+          Installed Codex CLI ({{ codex_runner_version_check.stdout }}) is older
+          than the pinned floor {{ codex_runner_codex_version }} — bump
+          codex_runner_codex_version or investigate why npm resolved an older
+          release.
+        quiet: true
 
 # Single-command, no-password grant: `hermes` may run exactly
 # `{{ codex_runner_mcp_command }}` as codex-runner — nothing broader. Validated
@@ -87,13 +108,16 @@
     path: "{{ codex_runner_home }}/.codex/auth.json"
   register: codex_runner_auth_file
 
-- name: Report Codex auth bootstrap status
+- name: Report Codex auth is bootstrapped
   ansible.builtin.debug:
     msg: >-
-      {{ codex_runner_auth_file.stat.exists
-         | ternary(
-             'Codex auth already present for ' ~ codex_runner_user ~ ' — escalation is live.',
-             codex_runner_home ~ '/.codex/auth.json does not exist yet — Hermes escalation via'
-             ~ ' Codex will error until an operator completes the one-time login (see'
-             ~ ' roles/codex_runner/README.md).'
-           ) }}
+      Codex auth already present for {{ codex_runner_user }} — escalation is live.
+  when: codex_runner_auth_file.stat.exists
+
+- name: Report Codex auth is NOT yet bootstrapped
+  ansible.builtin.debug:
+    msg: >-
+      {{ codex_runner_home }}/.codex/auth.json does not exist yet — Hermes
+      escalation via Codex will error until an operator completes the
+      one-time login (see roles/codex_runner/README.md).
+  when: not codex_runner_auth_file.stat.exists

--- a/roles/codex_runner/templates/codex-runner-sudoers.j2
+++ b/roles/codex_runner/templates/codex-runner-sudoers.j2
@@ -1,0 +1,6 @@
+{{ ansible_managed | comment }}
+# Single-command grant: {{ codex_runner_sudo_grantee }} may run exactly
+# `{{ codex_runner_mcp_command }}` as {{ codex_runner_user }}, no password, no
+# other subcommand, no other target user. This is the entire isolation
+# boundary between Hermes and Codex's OAuth credential — keep it this narrow.
+{{ codex_runner_sudo_grantee }} ALL=({{ codex_runner_user }}) NOPASSWD: {{ codex_runner_mcp_command }}

--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -204,4 +204,4 @@ active MCP/delegation target this round.
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
-| `hermes_agent_escalation_enabled` | `true` | Register the Codex MCP server |
+| `hermes_agent_codex_mcp_enabled` | `true` | Register the Codex MCP server |

--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -172,3 +172,36 @@ env fallback; the entry is omitted until the key is set.
 | --- | --- | --- |
 | `hermes_agent_context7_mcp_enabled` | `true` | Register the Context7 MCP server |
 | `hermes_agent_context7_api_key` | `""` | Context7 API key (bao/env) |
+
+## Escalation (Codex via MCP)
+
+Registers `codex mcp-server` (OpenAI's Codex CLI) as an MCP tool
+(`mcp_servers.codex`) — a deliberate escalation path for problems worth a
+stronger model, or a session that's stuck/looping. This is **not** automatic
+on-error fallback (Hermes' own `fallback_providers` feature is intentionally
+unused here); tool use is inherently a per-call, model-chosen decision, so
+the agent reaches for Codex only when it judges the problem warrants it, the
+same way it decides whether to call any other tool.
+
+Codex runs under a completely separate, low-privilege OS user —
+`codex-runner`, provisioned by the sibling `codex_runner` role on the same
+host — never as `hermes`. The MCP entry invokes it through a single-command
+`sudo` grant (`hermes` → `codex-runner`, exactly `codex mcp-server`, nothing
+else); Hermes never gains filesystem access to that user's ChatGPT-OAuth
+credential, so the token itself is not directly readable by the agent even
+though the agent can fully use the tool.
+
+Codex's OAuth login is a manual, one-time, interactive step that cannot be
+automated by Ansible — see `roles/codex_runner/README.md` for both bootstrap
+options (fresh `codex login`, or copying an already-authenticated
+`~/.codex/auth.json`). Until that's done, the MCP entry is present but every
+call to it errors; the daemon itself starts and runs normally regardless.
+
+`OPENROUTER_API_KEY` is already seeded in OpenBao `secret/ai/hermes` (from an
+earlier pass at this problem) but is **not consumed** by anything in this
+role — parked for a possible future escalation option, not wired to an
+active MCP/delegation target this round.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `hermes_agent_escalation_enabled` | `true` | Register the Codex MCP server |

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -183,4 +183,10 @@ hermes_agent_context7_api_key: ""
 # Inert until a human completes the one-time Codex OAuth bootstrap
 # (roles/codex_runner/README.md) — the MCP entry renders regardless, and
 # simply errors on use until then; the daemon itself is unaffected.
-hermes_agent_escalation_enabled: true
+#
+# Named after the tool (matching the sibling hermes_agent_splunk_mcp_enabled /
+# hermes_agent_context7_mcp_enabled flags above), not the broader "escalation"
+# concept — OPENROUTER_API_KEY is already parked as a candidate SECOND
+# escalation tool (see README), which will need its own independent flag when
+# wired, not a shared one.
+hermes_agent_codex_mcp_enabled: true

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -165,3 +165,22 @@ hermes_agent_splunk_mcp_token: ""
 # entry is omitted until the API key is set.
 hermes_agent_context7_mcp_enabled: true
 hermes_agent_context7_api_key: ""
+
+# --- Escalation (Codex via MCP) ---
+# A deliberate, agent-invoked path for problems worth a stronger model or a
+# stuck/looping session — NOT automatic on-error retry (that's
+# fallback_providers, an upstream Hermes feature intentionally unused here).
+# Registers `codex mcp-server` as an MCP tool; tool use is inherently a
+# per-call, model-chosen decision, so the agent reaches for this only when it
+# judges it worth it, same as any other tool.
+#
+# Codex runs under a SEPARATE, isolated OS user (codex_runner role,
+# colocated on this host) — Hermes invokes it via a single-command sudo
+# grant, never gaining filesystem access to that user's ChatGPT-OAuth
+# credential. codex_runner_user/codex_runner_mcp_command come from that
+# role's defaults (same host, same play — see playbooks/site.yml).
+#
+# Inert until a human completes the one-time Codex OAuth bootstrap
+# (roles/codex_runner/README.md) — the MCP entry renders regardless, and
+# simply errors on use until then; the daemon itself is unaffected.
+hermes_agent_escalation_enabled: true

--- a/roles/hermes_agent/templates/config.yaml.j2
+++ b/roles/hermes_agent/templates/config.yaml.j2
@@ -75,7 +75,8 @@ plugins:
    entry renders whenever enabled — the API-key header is added only when a key
    is actually set, below. #}
 {% set _mcp_context7 = (hermes_agent_context7_mcp_enabled | bool) %}
-{% if _mcp_splunk or _mcp_context7 %}
+{% set _mcp_escalation = (hermes_agent_escalation_enabled | bool) %}
+{% if _mcp_splunk or _mcp_context7 or _mcp_escalation %}
 # MCP servers. ${VARS} resolve from .env at connect time, so tokens/endpoints
 # never land in this file. The Splunk entry is omitted until its creds are
 # present; Context7 is keyless so it renders whenever enabled.
@@ -95,6 +96,23 @@ mcp_servers:
     headers:
       CONTEXT7_API_KEY: "${CONTEXT7_API_KEY}"
 {% endif %}
+{% endif %}
+{% if _mcp_escalation %}
+  # Escalation: Codex (ChatGPT-OAuth-backed reasoning), for problems worth a
+  # stronger model or a stuck/looping session — a deliberate per-call tool
+  # choice, not automatic on-error fallback. Runs under a SEPARATE, isolated
+  # OS user (codex_runner role) — this sudo invocation is the only capability
+  # Hermes has; it never gains filesystem access to that user's OAuth
+  # credential. Errors on use (not at daemon startup) until an operator
+  # completes the one-time Codex login — see roles/codex_runner/README.md.
+  codex:
+    command: sudo
+    args:
+      - "-u"
+      - "{{ codex_runner_user }}"
+      - "--"
+      - "{{ codex_runner_codex_bin }}"
+      - "mcp-server"
 {% endif %}
 {% endif %}
 timezone: '{{ hermes_agent_timezone }}'

--- a/roles/hermes_agent/templates/config.yaml.j2
+++ b/roles/hermes_agent/templates/config.yaml.j2
@@ -75,7 +75,7 @@ plugins:
    entry renders whenever enabled — the API-key header is added only when a key
    is actually set, below. #}
 {% set _mcp_context7 = (hermes_agent_context7_mcp_enabled | bool) %}
-{% set _mcp_escalation = (hermes_agent_escalation_enabled | bool) %}
+{% set _mcp_escalation = (hermes_agent_codex_mcp_enabled | bool) %}
 {% if _mcp_splunk or _mcp_context7 or _mcp_escalation %}
 # MCP servers. ${VARS} resolve from .env at connect time, so tokens/endpoints
 # never land in this file. The Splunk entry is omitted until its creds are
@@ -111,8 +111,9 @@ mcp_servers:
       - "-u"
       - "{{ codex_runner_user }}"
       - "--"
-      - "{{ codex_runner_codex_bin }}"
-      - "mcp-server"
+{% for _arg in codex_runner_mcp_command.split(' ') %}
+      - "{{ _arg }}"
+{% endfor %}
 {% endif %}
 {% endif %}
 timezone: '{{ hermes_agent_timezone }}'

--- a/roles/openbao_secrets/defaults/main.yml
+++ b/roles/openbao_secrets/defaults/main.yml
@@ -71,7 +71,10 @@ openbao_secrets_domains:
       - ai/llm         # LLM_ROUTER_MASTER_KEY, LLM_LARGE_BEARER_TOKEN (single seeded KV path)
       - ai/qdrant      # QDRANT_API_KEY
       - ai/open-webui  # OPEN_WEBUI_SECRET_KEY, OPEN_WEBUI_OPENAI_API_KEY
-      - ai/hermes      # HERMES_AGENT_MODEL_API_KEY
+      - ai/hermes      # GH_PAT_WRITE_PROJECT_ISSUES, HERMES_GITHUB_APP_{ID,INSTALLATION_ID,
+                       #   PRIVATE_KEY}, SPLUNK_MCP_{URL,TOKEN}, OPENROUTER_API_KEY (seeded,
+                       #   parked — not consumed by any role yet, see hermes_agent's
+                       #   "Escalation" README section)
       - ai/langfuse    # LANGFUSE_{POSTGRES_PASSWORD,CLICKHOUSE_PASSWORD,REDIS_AUTH,
                        #   S3_ACCESS_KEY_ID,S3_SECRET_ACCESS_KEY,PUBLIC_KEY,SECRET_KEY,
                        #   INIT_USER_EMAIL,INIT_USER_PASSWORD} — fully seeded 2026-07-05


### PR DESCRIPTION
## Summary

- Registers `codex mcp-server` as an MCP tool in Hermes Agent's config —
  a deliberate escalation path for problems worth a stronger model, or a
  stuck/looping session. Reaching for it is a per-call, model-chosen
  decision (like any other tool), not automatic on-error fallback.
- New `codex_runner` role: installs a pinned `@openai/codex` under a
  dedicated, low-privilege OS user isolated from `hermes`. Hermes gets a
  single-command sudoers grant (`codex mcp-server`, NOPASSWD, nothing
  broader) — it never gains filesystem access to that user's ChatGPT-OAuth
  credential.
- `OPENROUTER_API_KEY` (already seeded into OpenBao `secret/ai/hermes`)
  stays parked/unconsumed this round — documented as a candidate for a
  future escalation option, not wired to anything live.

## Test plan

- [x] `ansible-lint` clean (profile `production`) on all new/changed files
- [x] `config.yaml.j2` rendered through real Ansible templating with
      escalation enabled/disabled — correct `mcp_servers.codex` presence
      and valid YAML both ways
- [x] Sudoers template rendered + `visudo -cf` validated
- [ ] **Manual, cannot be automated**: after this converges, an operator
      must bootstrap Codex's ChatGPT OAuth login for the `codex-runner`
      user (`roles/codex_runner/README.md` — two documented options).
      Escalation is registered but every call errors until that's done.

Closes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cr9ZPB2B1z4u9WWzSw8ksf