### PR TITLE
fix(prometheus_stack): variable-driven remote_write keep-list; pass pve_node_exporter

### DIFF
--- a/inventory/group_vars/prometheus_group.yml
+++ b/inventory/group_vars/prometheus_group.yml
@@ -48,3 +48,10 @@ prometheus_stack_extra_scrape_configs: |
 prometheus_stack_remote_write_url: >-
   http://{{ hostvars['localhost']['tofu_data']['containers']['cribl-stream-01']['ip']
   }}:9201/api/v1/write
+
+# The remote_write keep relabel must also pass the PVE host-metrics job —
+# Stream's prometheus_to_netmon pipeline splits it into index=host_metrics.
+prometheus_stack_remote_write_keep_jobs:
+  - blackbox_.*
+  - smokeping
+  - pve_node_exporter

--- a/roles/prometheus_stack/defaults/main.yml
+++ b/roles/prometheus_stack/defaults/main.yml
@@ -88,6 +88,14 @@ prometheus_stack_extra_scrape_configs: ""
 # Set in a private inventory; never commit a real Cribl IP to this public role default.
 prometheus_stack_remote_write_url: ""
 
+# Job allow-list for the remote_write keep relabel (joined into one regex).
+# Only these jobs' samples leave the box — a scrape job added via
+# prometheus_stack_extra_scrape_configs ships nothing until it is also
+# listed here (the pve_node_exporter/host_metrics gotcha).
+prometheus_stack_remote_write_keep_jobs:
+  - blackbox_.*
+  - smokeping
+
 # --- probe modules (HOW to probe; targets come from prometheus_stack_blackbox_jobs) ---
 # icmp        — latency/loss to the modem + ISP hops + public anycast
 # tcp_connect — bare TCP reachability + connect latency

--- a/roles/prometheus_stack/templates/prometheus.yml.j2
+++ b/roles/prometheus_stack/templates/prometheus.yml.j2
@@ -38,7 +38,7 @@ remote_write:
   - url: "{{ prometheus_stack_remote_write_url }}"
     write_relabel_configs:
       - source_labels: [job]
-        regex: "blackbox_.*|smokeping"
+        regex: "{{ prometheus_stack_remote_write_keep_jobs | join('|') }}"
         action: keep
     queue_config:
       capacity: 2500


### PR DESCRIPTION
Follow-up to #728: the remote_write `keep` relabel was hardcoded to `blackbox_.*|smokeping`, so the new `pve_node_exporter` job's samples were dropped before leaving the box — `host_metrics` stayed empty even with the scrape live. Makes the allow-list a role var (`prometheus_stack_remote_write_keep_jobs`, unchanged default) and extends it in the prometheus_group inventory next to the scrape job it gates, with a comment naming the gotcha.

Verification: merge → converge `--tags prometheus` → `| mstats count where index=host_metrics earliest=-10m` > 0 (and netmon_metrics resumes once the reload also picks up the post-rebuild remote_write URL — the running process was still dialing the old pipeline-tier address).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TS3gHC9B5sR5WxvLt9gRE