### PR TITLE
feat(hermes): self-directed 24/7 Splunk monitoring (skill + cron fleet)

### DIFF
--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -160,6 +160,52 @@ cleanly before the creds exist.
 | `hermes_agent_splunk_mcp_url` | `""` | Splunk MCP Server endpoint (bao/env) |
 | `hermes_agent_splunk_mcp_token` | `""` | Bearer token (bao/env) |
 
+## Splunk monitoring (self-directed 24/7 analyst)
+
+On top of raw search access, the role turns Hermes into a **self-directed SIEM
+analyst**. It deploys the `dryvist/splunk-monitor` skill and seeds a small fleet
+of cron jobs that carry it. The skill encodes two things that sit together:
+
+- **Hard query-safety rails** — every search must be bounded (`tstats` / `stats` /
+  `head N ≤ 100`, an explicit narrow time window, project only needed fields). This
+  is what stops an unbounded search from flooding the agent's context and crashing
+  the run. The rails are non-negotiable.
+- **Free direction** — *what* to look for is Hermes' call. The skill teaches an
+  investigative method (recall known baselines → orient → hunt → confirm → record →
+  decide delivery) and offers lenses, not a checklist. Hermes learns the
+  environment over time and invents its own angles.
+
+Each cron job runs in a **fresh, isolated agent session**, so context never builds
+up run to run. Anomaly jobs stay silent when nothing is wrong: a run that ends in
+the `[SILENT]` marker suppresses delivery entirely, so a normal sweep costs zero
+notifications. Findings are written to memory (baselines + open issues, for
+dedup), and durable knowledge is captured as `llm-wiki` pages (RAG).
+
+**Routing:** anomaly alerts DM the operator (`slack:<member-id>`); the routine
+digest posts to the Slack home channel. The quiet deep-dive research run saves
+locally only (`--deliver local`).
+
+| Job | Schedule (staggered) | Delivery | Posture |
+| --- | --- | --- | --- |
+| `splunk-triage` | `3,18,33,48 * * * *` | DM, silent-unless-anomaly | broad anomaly hunt |
+| `splunk-security` | `9,39 * * * *` | DM, silent-unless-anomaly | security lens |
+| `splunk-parsing` | `24 * * * *` | DM, silent-unless-anomaly | data-quality / parsing lens |
+| `splunk-deepdive` | `44 */6 * * *` | local (quiet) | characterize one index → wiki + memory |
+| `splunk-digest` | `50 8,20 * * *` | home channel (always) | "what I'm seeing + current normal" |
+
+Cron seeding is idempotent (create-if-absent) and gated on Hermes being able to
+**both** query Splunk (`hermes_agent_splunk_mcp_url` set) **and** deliver to Slack
+(bot + app tokens + home channel set) — a job that can't do both is never created.
+When Hermes finds a signal worth watching continuously it may register its own
+`splunk-auto-*` check and surfaces it in the next digest.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `hermes_agent_splunk_monitor_enabled` | `true` | Deploy the skill + seed the cron fleet |
+| `hermes_agent_splunk_*_cron_name` / `_schedule` / `_prompt` | — | per-job overrides |
+| `hermes_agent_splunk_alert_deliver` | `slack:<member-id>` | DM target for anomaly alerts |
+| `hermes_agent_splunk_digest_deliver` | `slack` | home-channel target for the digest |
+
 ## Live docs (Context7)
 
 Registers Context7's hosted HTTP MCP server (`mcp_servers.context7`) so Hermes

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -159,6 +159,106 @@ hermes_agent_splunk_mcp_enabled: true
 hermes_agent_splunk_mcp_url: ""
 hermes_agent_splunk_mcp_token: ""
 
+# --- Splunk monitor: 24/7 self-directed SIEM analyst -----------------------
+# Seeds a small fleet of Hermes cron jobs, each carrying the dryvist/splunk-monitor
+# skill. That skill encodes the HARD query-safety rails (bounded queries only —
+# tstats/stats/head, narrow time windows) plus a self-directed investigative
+# method: Hermes decides what to hunt for, remembers baselines, and alerts only on
+# confirmed anomalies. Every cron job runs in a FRESH isolated agent session, so
+# context never builds up run-to-run.
+#
+# Routing (user decision): anomaly alerts DM the operator, the routine digest
+# posts to the Slack home channel. Delivery of anomaly jobs is suppressed
+# whenever the run ends in the `[SILENT]` marker (skill contract), so a normal
+# run costs zero notifications.
+#
+# Gated (in tasks) on BOTH the Splunk MCP URL being set (can query) AND the Slack
+# tokens being set (can deliver) — a job that can't do both is never created.
+hermes_agent_splunk_monitor_enabled: true
+
+# DM target for anomaly alerts: `slack:<member-id>` when the operator's Slack
+# member id is known, else fall back to the home channel (`slack`). The digest
+# always goes to the home channel.
+hermes_agent_splunk_alert_deliver: >-
+  {{ 'slack:' ~ hermes_agent_slack_allowed_users
+     if (hermes_agent_slack_allowed_users | length > 0)
+     else 'slack' }}
+hermes_agent_splunk_digest_deliver: slack
+
+# Per-job cron definitions. Prompts stay short — the skill carries the discipline;
+# the prompt only sets each run's posture (a lens, not a checklist) and reinforces
+# the [SILENT]-unless-anomaly / always-deliver-the-digest delivery contract.
+# Minutes are staggered so no two monitoring runs fire in the same minute
+# (bounds concurrent load on the shared LLM serving tier).
+hermes_agent_splunk_triage_cron_name: splunk-triage
+hermes_agent_splunk_triage_cron_schedule: "3,18,33,48 * * * *"
+hermes_agent_splunk_triage_cron_prompt: >-
+  Do a broad, self-directed anomaly sweep of Splunk right now using only bounded
+  queries. Recall your known baselines first, confirm anything surprising with
+  follow-up bounded queries, and record notable findings and updated baselines to
+  memory. If nothing is genuinely off, reply with exactly [SILENT]; otherwise send
+  one concise, numbers-backed alert.
+
+hermes_agent_splunk_security_cron_name: splunk-security
+hermes_agent_splunk_security_cron_schedule: "9,39 * * * *"
+hermes_agent_splunk_security_cron_prompt: >-
+  Sweep Splunk with a security lens this run — firewall-drop spikes, auth-failure
+  spikes, honeypot index hits, unexpected source IPs — all as bounded stats,
+  compared against your remembered baselines. You are not limited to these; flag
+  anything that looks like a threat. Record findings to memory. Reply exactly
+  [SILENT] if clean; otherwise one concise, numbers-backed alert.
+
+hermes_agent_splunk_parsing_cron_name: splunk-parsing
+hermes_agent_splunk_parsing_cron_schedule: "24 * * * *"
+hermes_agent_splunk_parsing_cron_prompt: >-
+  Sweep Splunk with a data-quality lens this run — timestamp-extraction failures,
+  events dated far in the past/future, line-merge anomalies, new or unknown
+  sourcetypes, mis-sized or unparsed events, splunkd parsing warnings — all
+  bounded. Record findings and baselines to memory. Reply exactly [SILENT] if
+  clean; otherwise one concise, numbers-backed alert.
+
+# Quiet research run: builds long-term knowledge (RAG) rather than alerting.
+hermes_agent_splunk_deepdive_cron_name: splunk-deepdive
+hermes_agent_splunk_deepdive_cron_schedule: "44 */6 * * *"
+hermes_agent_splunk_deepdive_cron_prompt: >-
+  Pick ONE index or sourcetype you have not yet characterized well (check your
+  wiki/memory for gaps). Using only bounded queries, learn its normal shape,
+  volume and purpose, then write or update a page in the `splunk` area of your
+  wiki plus a memory baseline. This is a quiet research run — no alert needed.
+
+# Routine status post: always delivered (never [SILENT]).
+hermes_agent_splunk_digest_cron_name: splunk-digest
+hermes_agent_splunk_digest_cron_schedule: "50 8,20 * * *"
+hermes_agent_splunk_digest_cron_prompt: >-
+  Post a concise Splunk digest to the home channel: what you looked at recently,
+  the current normal (top indexes/sourcetypes by volume and their freshness), any
+  anomalies still open, and any splunk-auto-* checks you have added or removed.
+  Bounded queries only. This is a routine status post — always deliver it.
+
+# Aggregate list the seed loop iterates. Alert jobs DM the operator; the digest
+# posts to the home channel; the quiet deep-dive research run saves locally only.
+hermes_agent_splunk_cron_jobs:
+  - name: "{{ hermes_agent_splunk_triage_cron_name }}"
+    schedule: "{{ hermes_agent_splunk_triage_cron_schedule }}"
+    prompt: "{{ hermes_agent_splunk_triage_cron_prompt }}"
+    deliver: "{{ hermes_agent_splunk_alert_deliver }}"
+  - name: "{{ hermes_agent_splunk_security_cron_name }}"
+    schedule: "{{ hermes_agent_splunk_security_cron_schedule }}"
+    prompt: "{{ hermes_agent_splunk_security_cron_prompt }}"
+    deliver: "{{ hermes_agent_splunk_alert_deliver }}"
+  - name: "{{ hermes_agent_splunk_parsing_cron_name }}"
+    schedule: "{{ hermes_agent_splunk_parsing_cron_schedule }}"
+    prompt: "{{ hermes_agent_splunk_parsing_cron_prompt }}"
+    deliver: "{{ hermes_agent_splunk_alert_deliver }}"
+  - name: "{{ hermes_agent_splunk_deepdive_cron_name }}"
+    schedule: "{{ hermes_agent_splunk_deepdive_cron_schedule }}"
+    prompt: "{{ hermes_agent_splunk_deepdive_cron_prompt }}"
+    deliver: local
+  - name: "{{ hermes_agent_splunk_digest_cron_name }}"
+    schedule: "{{ hermes_agent_splunk_digest_cron_schedule }}"
+    prompt: "{{ hermes_agent_splunk_digest_cron_prompt }}"
+    deliver: "{{ hermes_agent_splunk_digest_deliver }}"
+
 # --- Context7 MCP client (current library/framework docs on demand) ---
 # Registers Context7's hosted HTTP MCP server so Hermes can pull up-to-date,
 # version-specific docs mid-task. Bao-first, env fallback (see group_vars); the

--- a/roles/hermes_agent/files/skills/dryvist/splunk-monitor/SKILL.md
+++ b/roles/hermes_agent/files/skills/dryvist/splunk-monitor/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: dryvist-splunk-monitor
+description: Continuously read the homelab Splunk (SIEM) as a self-directed analyst — hunt for anything anomalous with strictly bounded queries, remember baselines, and alert only when something is genuinely off
+version: 1.0.0
+author: dryvist homelab
+license: MIT
+platforms: [linux]
+metadata:
+  hermes:
+    category: research
+    tags: [splunk, siem, monitoring, observability, dryvist]
+    related_skills: [research/llm-wiki, dryvist/github-issues]
+---
+
+# dryvist splunk-monitor
+
+You are the homelab's **self-directed Splunk analyst**. You read the SIEM around the
+clock, decide for yourself what is worth investigating, and surface *anything* that
+looks off — stalled ingest, volume shifts, parsing failures, security signals,
+capacity creep, and problems nobody has thought to look for yet. You learn the
+environment over time and get better at it.
+
+Your Splunk access is the **Splunk MCP server** (registered as `splunk` in your
+config). Its tools: `run_splunk_query` (run SPL), `get_indexes`, `get_sourcetypes`.
+
+Two things are true at once, and both matter:
+
+- **The rails are hard.** How you query is not negotiable (see Section 1). Break a
+  rail and you flood your own context with raw events and crash mid-run — that is the
+  single most common way this job fails.
+- **The direction is yours.** *What* to look for is your call. Section 2 is a method
+  and a set of lenses, not a checklist. Baseline the environment, notice what deviates,
+  chase it down, and invent your own angles.
+
+---
+
+## 1. Query safety rails (MANDATORY — the anti-context-spam contract)
+
+A Splunk search can return millions of raw events. If you pull raw events into your
+context, you will overflow and die. So **every** search you run MUST be bounded:
+
+1. **Aggregate or sample — never dump.** Every search either
+   - **aggregates** with `| tstats …`, `| stats count by …`, `| timechart …`,
+     `| top`, `| rare`, or
+   - takes a **hard sample** with `| head N` where **N ≤ 100**.
+
+   If you want to eyeball raw events, `| head 20 | table _time index sourcetype _raw`
+   — never a bare `index=foo` with no reducing/limiting command.
+
+2. **Always an explicit, narrow time window.** Put `earliest=…latest=now` in the
+   search (e.g. `earliest=-15m`, `earliest=-1h`, `earliest=-24h`). **Never** run an
+   all-time search. Match the window to the question — a freshness check needs minutes,
+   a baseline needs a day.
+
+3. **Inventory and liveness via `tstats`, never `index=*`.** Use metadata:
+
+   ```spl
+   | tstats count, max(_time) as last_time where index=* by index, sourcetype
+   | eval mins_ago = round((now() - last_time)/60, 1)
+   | sort - mins_ago
+   ```
+
+   Never `index=* | stats …` over raw events.
+
+4. **Project only what you need.** Use `| fields …` / `| table …`. Never echo full
+   `_raw` for more than a couple of short sample lines.
+
+5. **One question per query.** No sprawling chained subsearches. If you need two
+   answers, run two small queries.
+
+6. **Do not trust the transport to protect you.** Assume the MCP does **not** cap
+   result size — your SPL is the only thing bounding it. If a result still comes back
+   large, aggregate harder (add `by`, `| stats`, tighter time, bigger bucket) and
+   re-run; do not paginate raw events.
+
+7. **Keep each run small.** You run in a fresh, isolated session with a limited turn
+   budget. A handful of tight queries beats one sprawling investigation. If a thread
+   needs deep work, record where you got to (Section 2.5) and let a later run continue.
+
+If you ever feel the urge to "just look at the raw logs to see what's there,"
+`| head 20` it. There is no exception to the rails.
+
+---
+
+## 2. Investigative method (self-directed)
+
+### 2.1 Recall first (always)
+
+Before querying Splunk, recall what you already know. Check your memory and the
+`splunk` area of your wiki for:
+
+- **known baselines** — which indexes exist, their normal volume/shape, their sources;
+- **already-reported issues** — so you do not re-alert the same thing every 15 minutes.
+
+If you have no baseline yet, that is fine — building it is part of the job.
+
+### 2.2 Orient
+
+Run a couple of bounded inventory queries (the `tstats` metadata query above,
+`get_indexes`, `get_sourcetypes`) to see the current shape of the environment: what is
+ingesting, how much, how recently.
+
+### 2.3 Hunt
+
+Compare what you see against what you remember. When something is surprising —
+an index that went quiet, a volume that jumped, a sourcetype you have never seen — do
+**not** alert yet. Chase it with **follow-up bounded queries** to confirm it is real
+and not a one-off blip. An alert you can't back with numbers is noise.
+
+### 2.4 Lenses — starting angles, not limits
+
+These are angles that tend to surface real problems. Use them as inspiration, rotate
+through them, and **invent your own**. You are explicitly encouraged to look for things
+not on this list — that is the point.
+
+- **Ingest health** — indexes with a stale `max(_time)` (stopped receiving data);
+  volume spikes or drops versus your remembered baseline; blocked ingest queues or
+  license pressure (`index=_internal source=*metrics.log group=queue` — bounded).
+- **Parsing / data quality** — timestamp-extraction failures, events landing far in the
+  past/future (bad `MAX_TIMESTAMP_LOOKAHEAD`), line-merging anomalies (`linecount`
+  outliers), brand-new or unknown sourcetypes, mis-sized events, `_raw` that isn't
+  being parsed into fields.
+- **Splunk's own health** — `index=_internal sourcetype=splunkd log_level IN (ERROR,WARN)
+  earliest=-1h | stats count by component` (bounded); indexer/queue problems.
+- **Security signals** — firewall-drop spikes, authentication-failure spikes, honeypot
+  index hits, source IPs you would not expect. Always as `| stats count by …`, never
+  raw.
+- **Capacity / license** — license volume versus quota, disk/queue pressure, slow creep
+  over days.
+
+### 2.5 Record (this is how you get smarter)
+
+When a run turns up something worth keeping:
+
+- **Memory** — write notable findings and updated baselines to your memory, timestamped,
+  with the exact query and the numbers. This is what makes the *next* run able to say
+  "this is new" instead of re-discovering everything.
+- **Wiki (RAG)** — for durable, reusable knowledge (what an index *is*, its normal shape,
+  a parsing quirk and its fix), add or update a page in the `splunk` area of your wiki
+  via the `llm-wiki` skill. Cite the source. This is your long-term knowledge base.
+
+Record baselines even on quiet runs — a quiet run that refreshes "index X is normal at
+~N events/15m" is valuable.
+
+### 2.6 Decide delivery
+
+- **Genuinely off** → deliver a **concise alert**: one concern per message, plain
+  language, and include the **bounded query** you ran and the **numbers** that make it
+  actionable. No walls of text, no raw events.
+- **Nothing notable** → reply with **exactly `[SILENT]`** and nothing else. The cron
+  system suppresses delivery entirely when your final response contains `[SILENT]`, so
+  a normal run costs the user zero notifications. Use it liberally — silence when all is
+  well is the whole point.
+
+Do not pad an alert to seem busy, and do not stay silent about something real to avoid
+bothering the user. Signal, not noise, in both directions.
+
+### 2.7 Grow your own coverage (guardrailed)
+
+When you find a signal that deserves *continuous* watching (not just this run), you may
+register your own focused check:
+
+```bash
+hermes cron create "<schedule>" "<one focused, bounded task>" \
+  --skill dryvist/splunk-monitor --name splunk-auto-<slug> --deliver <same routing>
+```
+
+Rules for self-added checks:
+
+- **Prefix every one `splunk-auto-`** so they are easy to find and prune.
+- Keep them **focused and bounded** (they inherit these rails via `--skill`).
+- **Announce them** — mention any check you add (or would remove) in the next
+  `splunk-digest` run so the user always sees what you changed.
+- Do not duplicate an existing check; recall first.
+
+---
+
+## 3. Escalation
+
+Use the **local brain first**. If an analysis is genuinely hard — a subtle correlation,
+an unfamiliar log format you cannot parse — you may escalate to Codex as a *second*
+step, but keep the escalation bounded and bring back only the conclusion. Never escalate
+just to avoid running one more small query.
+
+---
+
+## 4. Guardrails (summary)
+
+1. **Bounded queries, always.** Aggregate or `| head N` (N ≤ 100); explicit narrow time
+   window; `tstats` for inventory; project only needed fields. No exceptions.
+2. **Recall before you query; record after you learn.** Dedup against memory so you
+   never re-alert the same thing.
+3. **`[SILENT]` when nothing is wrong.** Alert only on confirmed, numbers-backed
+   anomalies — one concern per message.
+4. **Read-only.** You *read* the SIEM. Never attempt to modify Splunk config, delete
+   data, or change indexes. This skill is analysis only.
+5. **Never leak secrets.** Do not paste tokens or credentials into any alert, wiki page,
+   memory note, or log.
+6. **Small runs.** A few tight queries per fresh session; hand off deep threads via
+   memory rather than blowing the turn budget.

--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -295,6 +295,64 @@
     mode: "0640"
     directory_mode: "0750"
 
+# --- Splunk monitor: skill + self-directed 24/7 SIEM analyst cron fleet ------
+# The skill encodes the hard query-safety rails (bounded queries only) + the
+# self-directed investigative method. It must be materialized BEFORE the cron
+# jobs are seeded so `cron create --skill dryvist/splunk-monitor` resolves it.
+- name: Deploy the dryvist splunk-monitor skill
+  ansible.builtin.copy:
+    src: skills/dryvist/splunk-monitor/
+    dest: "{{ hermes_agent_hermes_home }}/skills/dryvist/splunk-monitor/"
+    owner: "{{ hermes_agent_user }}"
+    group: "{{ hermes_agent_user }}"
+    mode: "0640"
+    directory_mode: "0750"
+  when: hermes_agent_splunk_monitor_enabled | bool
+
+# Seed the monitoring cron fleet idempotently (create-if-absent), gated on the
+# agent being able to BOTH query Splunk (MCP URL set) AND deliver to Slack
+# (tokens + home channel set). Each job runs in a fresh isolated agent session.
+- name: Check which Splunk monitor cron jobs already exist
+  ansible.builtin.command: "{{ hermes_agent_bin }} cron list --all"
+  environment:
+    HERMES_HOME: "{{ hermes_agent_hermes_home }}"
+  become: true
+  become_user: "{{ hermes_agent_user }}"
+  register: hermes_agent_splunk_cron_list
+  changed_when: false
+  failed_when: false
+  when:
+    - hermes_agent_splunk_monitor_enabled | bool
+    - hermes_agent_splunk_mcp_url | length > 0
+    - hermes_agent_slack_bot_token | length > 0
+    - hermes_agent_slack_app_token | length > 0
+    - hermes_agent_slack_home_channel | length > 0
+
+- name: Seed the Splunk monitor cron jobs
+  ansible.builtin.command:
+    cmd: >-
+      {{ hermes_agent_bin }} cron create "{{ item.schedule }}"
+      "{{ item.prompt }}"
+      --name "{{ item.name }}"
+      --skill dryvist/splunk-monitor
+      --deliver "{{ item.deliver }}"
+  environment:
+    HERMES_HOME: "{{ hermes_agent_hermes_home }}"
+  become: true
+  become_user: "{{ hermes_agent_user }}"
+  loop: "{{ hermes_agent_splunk_cron_jobs }}"
+  loop_control:
+    label: "{{ item.name }}"
+  register: hermes_agent_splunk_cron_create
+  changed_when: true
+  when:
+    - hermes_agent_splunk_monitor_enabled | bool
+    - hermes_agent_splunk_mcp_url | length > 0
+    - hermes_agent_slack_bot_token | length > 0
+    - hermes_agent_slack_app_token | length > 0
+    - hermes_agent_slack_home_channel | length > 0
+    - item.name not in (hermes_agent_splunk_cron_list.stdout | default(''))
+
 - name: Deploy the hermes-gateway systemd unit
   ansible.builtin.template:
     src: hermes-gateway.service.j2


### PR DESCRIPTION
## What

Turns the Hermes agent into a **self-directed SIEM analyst** that reads Splunk around the clock, hunts for anomalies on its own, remembers baselines, and reaches the operator in Slack — quietly when all is well, loudly when something is off.

### `dryvist/splunk-monitor` skill
Encodes two things that sit together:
- **Hard query-safety rails (non-negotiable):** every search is bounded — `tstats`/`stats`/`head N≤100`, explicit narrow time window, project only needed fields, `tstats` for inventory (never `index=*`). This is what stops an unbounded search from flooding the agent's context and crashing the run.
- **Free direction (self-learning):** *what* to look for is the agent's call. The skill teaches an investigative method (recall baselines → orient → hunt → confirm → record → decide delivery) and offers lenses, not a fixed checklist. Findings go to memory (dedup); durable knowledge becomes `llm-wiki` pages (RAG).

### Cron fleet (staggered; each runs in a fresh isolated session)
| Job | Schedule | Delivery |
| --- | --- | --- |
| `splunk-triage` | `3,18,33,48 * * * *` | DM, silent-unless-anomaly |
| `splunk-security` | `9,39 * * * *` | DM, silent-unless-anomaly |
| `splunk-parsing` | `24 * * * *` | DM, silent-unless-anomaly |
| `splunk-deepdive` | `44 */6 * * *` | local (quiet) → wiki + memory |
| `splunk-digest` | `50 8,20 * * *` | home channel (always) |

Anomaly runs suppress delivery via the `[SILENT]` marker, so a normal sweep costs zero notifications.

## Why
Prior self-authored monitoring produced vague busywork with no bounded queries, no memory, and no useful signal. This gives the rails + method to make continuous reading actually useful.

## Safety / gating
- Cron seeding is **idempotent** (create-if-absent) and gated on the agent being able to **both** query Splunk (MCP URL set) **and** deliver to Slack (bot + app tokens + home channel set). Inert until both are present.
- Read-only analysis; the skill forbids any Splunk mutation.

## Verification
- `ansible-lint` (production): **0 failures / 0 warnings**
- `yamllint`: clean · `markdownlint`: clean
- Live end-to-end (bounded-query self-test, cron presence, DM alert + channel digest paths, wiki growth, clean agent logs) to be confirmed on converge with `--tags openbao_secrets,hermes_agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)