### PR TITLE
fix(haproxy): retry service start through the boot DNS warm-up

### DIFF
--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -74,8 +74,18 @@
     content: |
       # HAProxy systemd override for LXC containers
       # BindReadOnlyPaths is not supported in LXC namespaces
+      #
+      # StartLimitIntervalSec=0: the backends are DNS names, and at container
+      # boot the resolver may not answer yet — haproxy then burns the default
+      # 5-start budget and stays dead until someone restarts it by hand
+      # (post-reboot TCP-ingest outage, 2026-07-08). Unlimited retries at a
+      # gentle pace ride out the DNS warm-up instead.
+      [Unit]
+      StartLimitIntervalSec=0
       [Service]
       BindReadOnlyPaths=
+      Restart=on-failure
+      RestartSec=5s
     owner: root
     group: root
     mode: '0644'


### PR DESCRIPTION
Post-reboot incident (2026-07-08): after the node came back, haproxy failed 5 starts in a row while the resolver was still warming up (`backend ... has no server available` → exit at boot; DNS-named backends), exhausted systemd's default start budget, and stayed dead until a manual `systemctl restart` — every TCP ingest family dark while nginx/UDP on the same container was fine. `haproxy -c` validated clean once DNS answered, confirming pure boot-order.

Extends the existing LXC drop-in: `StartLimitIntervalSec=0` + `Restart=on-failure`/`RestartSec=5s`, so the service retries at a gentle pace until the resolver is up. No config-render changes.

Verification: converge is deferred — the haproxy container is otherwise untouched tonight; the drop-in lands with the next routine haproxy converge, and `systemctl show haproxy -p NRestarts,StartLimitIntervalUSec` confirms it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TS3gHC9B5sR5WxvLt9gRE