### PR TITLE
fix(cribl): post HEC to the generic /services/collector endpoint

### DIFF
--- a/roles/cribl_edge/templates/outputs.yml.j2
+++ b/roles/cribl_edge/templates/outputs.yml.j2
@@ -7,7 +7,7 @@ outputs:
     id: splunk_hec
     type: splunk_hec
     disabled: false
-    url: "{{ cribl_edge_hec_url }}/services/collector/event"
+    url: "{{ cribl_edge_hec_url }}/services/collector"
     token: "{{ cribl_edge_hec_token }}"
     compress: true
     rejectUnauthorized: false
@@ -33,7 +33,7 @@ outputs:
     id: splunk_hec_{{ idx }}
     type: splunk_hec
     disabled: false
-    url: "{{ cribl_edge_hec_url }}/services/collector/event"
+    url: "{{ cribl_edge_hec_url }}/services/collector"
     token: "{{ ('splunk-hec-' ~ idx) | to_uuid(cribl_edge_hec_namespace) }}"
     compress: true
     rejectUnauthorized: false

--- a/roles/cribl_stream/defaults/main.yml
+++ b/roles/cribl_stream/defaults/main.yml
@@ -76,9 +76,13 @@ cribl_stream_splunk_hec_tls: true
 cribl_stream_splunk_hec_tls_verify: false  # Self-signed cert in lab
 # Single definition shared by the template and the drift check in tasks.
 # No port: the splunk-hec ingress serves on the standard TLS entrypoint.
+# Generic /services/collector, NOT /services/collector/event: the events-only
+# endpoint silently discards metric payloads, which kept every metric index
+# (host_metrics/netmon_metrics/unifi_metrics/llm_metrics) empty. The generic
+# endpoint accepts event and metric payloads alike.
 cribl_stream_splunk_hec_url: >-
   {{ 'https' if cribl_stream_splunk_hec_tls else 'http'
-  }}://{{ cribl_stream_splunk_host }}/services/collector/event
+  }}://{{ cribl_stream_splunk_host }}/services/collector
 
 # Persistent queue
 cribl_stream_pq_enabled: true


### PR DESCRIPTION
Final blocker of the metric legs (#579 L18): every `splunk_hec` output — Stream shared + per-index, Edge shared + per-index — posts to `/services/collector/event`, the **events-only** HEC endpoint, which does not accept metric payloads. So even with the metric indexes now created (they were missing entirely until tonight's ansible-splunk converge — second half of this root cause) and the remote_write leg healthy, every metric sample died at the door: `host_metrics`, `netmon_metrics`, `unifi_metrics`, `llm_metrics` all empty.

Switch the URL to the generic `/services/collector`, which accepts event **and** metric payloads (events are framed identically there — the flowing event families are unaffected). The laptop-side `cribl_docker_stack` templates keep `/event` (they carry events only) and the netmon prober URL is a Cribl-input address, not Splunk.

Verification: converge `cribl_stream` + `cribl_edge`, then `| mstats count where index=host_metrics earliest=-24h` > 0 as the prometheus WAL backlog replays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TS3gHC9B5sR5WxvLt9gRE