### PR TITLE
fix(hermes): post Splunk cron output as fresh top-level Slack messages

### DIFF
--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -185,6 +185,13 @@ dedup), and durable knowledge is captured as `llm-wiki` pages (RAG).
 digest posts to the Slack home channel. The quiet deep-dive research run saves
 locally only (`--deliver local`).
 
+**Fresh posts, not one thread.** Each cron run is an isolated session, so its Slack
+output is delivered **flat/top-level** (a new message each time) rather than threaded
+under a single ever-growing root. This is set in `config.yaml`'s `platforms.slack`
+block via `reply_in_thread: false` + `cron_continuable_surface: in_channel`
+(`hermes_agent_slack_reply_in_thread` / `hermes_agent_slack_cron_continuable_surface`),
+rendered only when Slack is configured.
+
 | Job | Schedule (staggered) | Delivery | Posture |
 | --- | --- | --- | --- |
 | `splunk-triage` | `3,18,33,48 * * * *` | DM, silent-unless-anomaly | broad anomaly hunt |

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -92,6 +92,15 @@ hermes_agent_slack_allowed_users: "{{ lookup('env', 'SLACK_MEMBER_ID') | default
 hermes_agent_slack_home_channel: "{{ lookup('env', 'SLACK_HOME_CHANNEL') | default('', true) }}"
 hermes_agent_slack_home_channel_name: "{{ lookup('env', 'SLACK_HOME_CHANNEL_NAME') | default('', true) }}"
 
+# Post scheduled (cron) output as FRESH top-level channel messages, not threaded
+# replies under one ever-growing root. Each cron run is already an isolated
+# session; this makes its Slack surface match. reply_in_thread=false → flat
+# top-level posts; cron_continuable_surface=in_channel → those flat posts stay
+# continuable (an in-channel reply continues that run's session) with no thread.
+# Rendered into config.yaml's platforms.slack block only when Slack is configured.
+hermes_agent_slack_reply_in_thread: false
+hermes_agent_slack_cron_continuable_surface: in_channel
+
 # Daily Slack status report seeded into Hermes' built-in cron scheduler. The
 # role creates the job on converge; the gateway starts executing it on the next
 # daemon run once the Slack gateway is configured.
@@ -233,7 +242,8 @@ hermes_agent_splunk_digest_cron_prompt: >-
   Post a concise Splunk digest to the home channel: what you looked at recently,
   the current normal (top indexes/sourcetypes by volume and their freshness), any
   anomalies still open, and any splunk-auto-* checks you have added or removed.
-  Bounded queries only. This is a routine status post — always deliver it.
+  Bounded queries only. This is a routine status post — ALWAYS write the digest
+  and NEVER reply [SILENT] for this job; [SILENT] is only for the anomaly sweeps.
 
 # Aggregate list the seed loop iterates. Alert jobs DM the operator; the digest
 # posts to the home channel; the quiet deep-dive research run saves locally only.

--- a/roles/hermes_agent/files/skills/dryvist/splunk-monitor/SKILL.md
+++ b/roles/hermes_agent/files/skills/dryvist/splunk-monitor/SKILL.md
@@ -155,6 +155,11 @@ Record baselines even on quiet runs — a quiet run that refreshes "index X is n
 Do not pad an alert to seem busy, and do not stay silent about something real to avoid
 bothering the user. Signal, not noise, in both directions.
 
+**`[SILENT]` is only for the anomaly sweeps** (triage / security / parsing). The
+routine **digest** run must ALWAYS post its summary — never reply `[SILENT]` for the
+digest, even when everything is normal; "everything is normal" is exactly what the
+digest exists to report.
+
 ### 2.7 Grow your own coverage (guardrailed)
 
 When you find a signal that deserves *continuous* watching (not just this run), you may

--- a/roles/hermes_agent/templates/config.yaml.j2
+++ b/roles/hermes_agent/templates/config.yaml.j2
@@ -69,6 +69,21 @@ plugins:
   enabled:
     - observability/otel
 
+{% if hermes_agent_slack_bot_token | length > 0 %}
+# Slack delivery behavior. Every scheduled (cron) run is an isolated, fresh
+# session, so its Slack post should read that way too — a NEW top-level channel
+# message, not another reply threaded under one ever-growing root. Upstream
+# defaults reply_in_thread=true, which makes cron deliveries continue in a single
+# thread; reply_in_thread=false posts them flat/top-level, and
+# cron_continuable_surface=in_channel keeps those flat posts continuable (a reply
+# in the channel still continues that run's session) without a dedicated thread.
+# These are bridged from platforms.<p> by gateway/config.py; Slack enablement
+# still comes from the SLACK_* tokens in .env, so this block only tunes behavior.
+platforms:
+  slack:
+    reply_in_thread: {{ hermes_agent_slack_reply_in_thread | to_json }}
+    cron_continuable_surface: {{ hermes_agent_slack_cron_continuable_surface }}
+{% endif %}
 {% set _mcp_splunk = (hermes_agent_splunk_mcp_enabled | bool) and (hermes_agent_splunk_mcp_url | length > 0) %}
 {# Context7's hosted MCP serves unauthenticated requests (verified: keyless
    `initialize` returns 200); a key only raises the shared rate limit. So this


### PR DESCRIPTION
## What
Scheduled Splunk-monitor runs are each an isolated, fresh session, but Slack **delivery** was threading every digest/alert under one ever-growing root — so they read as a single building conversation instead of discrete fresh reports.

- **Flat, fresh posts:** `config.yaml`'s new `platforms.slack` block sets `reply_in_thread: false` (upstream default `true` threads cron continuations) + `cron_continuable_surface: in_channel` (keeps flat posts continuable via an in-channel reply, no dedicated thread). Bridged by `gateway/config.py`; Slack enablement still comes from the `SLACK_*` `.env` tokens, so this only tunes delivery and renders only when Slack is configured.
- **Digest never silent:** the model was emitting `[SILENT]` on the routine digest (meant only for the anomaly sweeps), suppressing the one post that must always land. Reinforced in the digest prompt and the skill.

## Why
Follow-up to #736 (live feedback): digests were all landing in one Slack thread instead of posting fresh.

## Verification
- `ansible-lint` (production) 0/0, `yamllint` clean, `markdownlint` clean.
- Live: converge, then confirm the next digest posts as a **new top-level channel message** (not a threaded reply) and that a digest run no longer returns `[SILENT]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)