### PR TITLE
feat(servarr_wiring): add Knaben + LimeTorrents public indexers

### DIFF
--- a/roles/servarr_wiring/defaults/main.yml
+++ b/roles/servarr_wiring/defaults/main.yml
@@ -78,13 +78,20 @@ servarr_wiring_seed_time_minutes: 4320
 # can never find releases. These are PUBLIC, non-Cloudflare trackers (no
 # FlareSolverr needed). Names MUST match Prowlarr's indexer DEFINITION names
 # exactly (Indexers -> Add Indexer). The Pirate Bay (general, apibay API) covers
-# TV + movies; YTS adds a movie-focused source. Both are reachable without a
-# Cloudflare solver. Add/remove freely — but Cloudflare-gated trackers (EZTV,
-# 1337x, TorrentGalaxy, …) require FlareSolverr, which is out of scope; adding
-# them here just logs a non-fatal warning at converge.
+# TV + movies; YTS adds a movie-focused source; Knaben is a meta-search over
+# many established trackers (including cached results from retired ones —
+# the best reach for older/low-seed releases); LimeTorrents is a
+# long-established general tracker. All four verified reachable through the
+# tunnel without a Cloudflare solver. Add/remove freely — but Cloudflare-gated
+# trackers (EZTV, 1337x, TorrentGalaxy, …) require FlareSolverr, which is out
+# of scope; adding them here just logs a non-fatal warning at converge.
+# Deliberately excluded: raw DHT crawlers (TorrentProject2, BTdirectory, …) —
+# unmoderated indexes carry a high fake/malware-torrent rate.
 servarr_wiring_prowlarr_indexers:
   - "The Pirate Bay"
   - "YTS"
+  - "Knaben"
+  - "LimeTorrents"
 # Prowlarr app/sync profile applied to each indexer (1 = the default profile).
 servarr_wiring_indexer_app_profile_id: 1
 


### PR DESCRIPTION
Two-indexer coverage (TPB + YTS) left dozens of older/low-seed requests unfindable. Both additions were live-tested through the tunnel via the Prowlarr test API: reachable without a Cloudflare solver. Knaben meta- searches many established trackers (including cached results from retired ones) which is exactly the reach older releases need; LimeTorrents is a long-established general tracker. CF-gated 1337x/EZTV stay excluded (need FlareSolverr), and raw DHT crawlers stay excluded deliberately (unmoderated -> high fake-torrent rate).

Assisted-by: Claude:claude-fable-5
Claude-Session: https://claude.ai/code/session_01HXiX2uJBEn6HNa2brL6iKd