### PR TITLE
fix(deps,systemd): version ceiling + handler-driven daemon reload

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -14,8 +14,11 @@ collections:
   - name: community.general
     version: ">=10.3.0"  # Required for proxmox_pct_remote connection plugin
 
+  # Better proxmox_pct_remote implementation. Ceiling at <2.0.0: validate_certs
+  # default flips to true at 2.0.0; opt in deliberately rather than inherit
+  # the change silently.
   - name: community.proxmox
-    version: ">=1.4.0"  # Better proxmox_pct_remote implementation
+    version: ">=1.4.0,<2.0.0"
 
   - name: community.docker
     version: ">=3.6.0"  # docker_compose_v2 module added in 3.6.0

--- a/roles/systemd_restart_policy/tasks/main.yml
+++ b/roles/systemd_restart_policy/tasks/main.yml
@@ -17,8 +17,3 @@
     mode: "0644"
   loop: "{{ systemd_restart_policy_services }}"
   notify: Reload systemd daemon
-
-- name: Reload systemd to pick up overrides
-  ansible.builtin.systemd:
-    daemon_reload: true
-  changed_when: false


### PR DESCRIPTION
## Summary

Two small drift fixes surfaced by a cross-repo Ansible survey, converging this repo toward the better pattern already present in a sibling repo:

1. **requirements.yml**: `community.proxmox` was pinned `>=1.4.0` with no upper ceiling. `ansible-proxmox` already pins `>=1.6.0,<2.0.0` with a comment explaining why — `validate_certs`' default flips to `true` at 2.0.0, and the ceiling opts into that behavior change deliberately instead of inheriting it silently on the next collection bump. This PR adds the same `<2.0.0` ceiling and comment here.
2. **roles/systemd_restart_policy**: the role ran an unconditional `daemon_reload: true` task after every deploy, regardless of whether the override template actually changed. `ansible-splunk`'s copy of the same role relies solely on the existing `notify: Reload systemd daemon` handler, which only fires on an actual change. This PR drops the redundant unconditional task so both copies converge on the handler-driven pattern. The role's only caller (`playbooks/site.yml`, Phase 9) is the final play in the run, so the handler still flushes before the playbook ends — no behavior change in when the reload happens, just that it now only happens when needed.

## Evidence

- `ansible-proxmox/requirements.yml` already carries the `<2.0.0` ceiling + comment for `community.proxmox`.
- `ansible-splunk/roles/systemd_restart_policy/tasks/main.yml` has no unconditional reload task — only the notify-driven handler.

## Test plan

- [x] `ansible-lint` (profile production) passes clean: 0 failures, 0 warnings on 667 files.
- [x] Confirmed no overlap with open PRs #744, #714, #694 (different files).
- [x] Confirmed `systemd_restart_policy`'s only caller is the final play in `site.yml`, so handler flush timing is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pj9ZFKDR2iCis44dC2y8Hu