### PR TITLE
fix(hermes): repoint brain to Qwen3.6-35B-A3B + hourly Splunk digest

### DIFF
--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -198,7 +198,7 @@ rendered only when Slack is configured.
 | `splunk-security` | `9,39 * * * *` | DM, silent-unless-anomaly | security lens |
 | `splunk-parsing` | `24 * * * *` | DM, silent-unless-anomaly | data-quality / parsing lens |
 | `splunk-deepdive` | `44 */6 * * *` | local (quiet) | characterize one index → wiki + memory |
-| `splunk-digest` | `50 8,20 * * *` | home channel (always) | "what I'm seeing + current normal" |
+| `splunk-digest` | `50 * * * *` | home channel (always) | hourly "what I'm seeing + current normal" heartbeat |
 
 Cron seeding is idempotent (create-if-absent) and gated on Hermes being able to
 **both** query Splunk (`hermes_agent_splunk_mcp_url` set) **and** deliver to Slack

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -42,20 +42,29 @@ hermes_agent_installer_path: "/usr/local/lib/hermes-agent-installer-{{ hermes_ag
 
 # --- Brain: the LiteLLM router (the fabric front door, OpenAI-compatible /v1) ---
 # Reached by its neutral Traefik FQDN — never a hardcoded IP. The router routes by
-# model alias, so the agent just names the model it wants: Qwen3-Coder-30B-A3B
-# on the Mac Studio large tier (non-hybrid MoE, proven stable — avoids the
-# qwen3_5_moe batching crash that rules out Qwen3.6). Replaces the interim
-# hermes-4-14b light-tier brain. The api key is the router master key,
-# env-sourced (SOPS/Doppler).
-# Must match llm_router_large_models' alias exactly (llm_router role,
-# roles/llm_router/defaults/main.yml) — PR #624 renamed the router's alias
-# from the lowercase `qwen3-coder` to the model-id-cased `Qwen3-Coder-30B-A3B`
-# without updating this consumer; the live router hadn't been reconverged
-# since, so both sides still matched by accident until this fix.
-hermes_agent_model: Qwen3-Coder-30B-A3B
+# model alias, so the agent just names the model it wants.
+#
+# Qwen3.6-35B-A3B is THE brain for this autonomous, tool-calling role. Qwen3-Coder-30B
+# is faster single-stream but emits malformed tool calls under agentic load (observed
+# live 2026-07-08: repeated "repairing tool_call with empty function.name", ignored
+# output bounds — a 129K-char query result — and unreliable multi-turn runs). The 35B
+# drove the full autonomous llm-wiki loop cleanly where the Coder model failed.
+#
+# The old "avoids the qwen3_5_moe batching crash that rules out Qwen3.6" rationale was
+# DISPROVEN on the Mac Studio (2026-07-08): 3 concurrent requests to Qwen3.6-35B-A3B-4bit
+# completed with zero crashes / zero 402 recovery — 8.7 tok/s single-stream, 3.7-5.7 tok/s
+# each under 3-way batching (graceful degradation, not the 0.1-4 tok/s death-loop the
+# nix-darwin serving comment claimed). That claim came from old, heavily-loaded MacBook
+# Pro tests, not the Studio. The 35B is slower than the Coder model but reliable, which
+# is the right trade for a background monitor. (An 8bit variant is a quality upgrade once
+# it is registered in the router.)
+#
+# Alias must match what the router serves (llm_router role) — currently
+# Qwen3.6-35B-A3B-4bit.
+hermes_agent_model: Qwen3.6-35B-A3B-4bit
 hermes_agent_model_base_url: "https://llm.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}/v1"
 hermes_agent_model_api_mode: chat_completions
-# Qwen3-Coder-30B-A3B's native context window (256K = 262144 tokens). Custom
+# Qwen3.6-35B-A3B's native context window (256K = 262144 tokens). Custom
 # providers carry no context catalog Hermes can probe, so this is declared
 # explicitly (model.context_length in config.yaml.j2).
 hermes_agent_model_context_length: 262144
@@ -237,7 +246,9 @@ hermes_agent_splunk_deepdive_cron_prompt: >-
 
 # Routine status post: always delivered (never [SILENT]).
 hermes_agent_splunk_digest_cron_name: splunk-digest
-hermes_agent_splunk_digest_cron_schedule: "50 8,20 * * *"
+# Hourly heartbeat: a visible "here's what I'm seeing" post every hour so silence
+# never reads as "is it even running?". Anomaly sweeps stay silent-unless-anomaly.
+hermes_agent_splunk_digest_cron_schedule: "50 * * * *"
 hermes_agent_splunk_digest_cron_prompt: >-
   Post a concise Splunk digest to the home channel: what you looked at recently,
   the current normal (top indexes/sourcetypes by volume and their freshness), any


### PR DESCRIPTION
## What
- **Brain → `Qwen3.6-35B-A3B-4bit`.** Qwen3-Coder-30B-A3B emits malformed tool calls under agentic load (observed live: repeated `repairing tool_call with empty function.name`, a 129K-char query result ignoring the bounded-query rail, multi-turn runs that often didn't finish/post). The 35B drove the full autonomous llm-wiki loop cleanly where the Coder model failed.
- **Disproves the qwen3_5_moe "batching crash" rationale** on the Mac Studio (2026-07-08): 3 concurrent requests to `Qwen3.6-35B-A3B-4bit` completed with **zero crashes / zero 402 recovery** — 8.7 tok/s single-stream, 3.7–5.7 tok/s each under 3-way batching (graceful degradation, not the 0.1–4 tok/s death-loop the serving comment claimed; that claim came from old, heavily-loaded MacBook-Pro tests). Comment reconciled in the role with the evidence.
- **Hourly digest heartbeat** (was 2×/day) so silence never reads as "is it even running?"; anomaly sweeps stay silent-unless-anomaly.

## Why
Follow-up to #736/#744 (live feedback): digests were unreliable (Coder-30B) and too infrequent to reassure.

## Verification
- `ansible-lint` (production) 0/0, `yamllint` clean, `markdownlint` clean.
- Live: converged; concurrency-tested the 35B; confirming a clean 35B digest posting hourly & flat.

Note: the 8-bit `lmstudio-community/Qwen3.6-35B-A3B-MLX-8bit` is a follow-up quality upgrade (needs a Studio rebuild to register + a router alias).

🤖 Generated with [Claude Code](https://claude.com/claude-code)