### PR TITLE
feat(llm): blocklisted passthrough exposure + one shared default model

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -57,6 +57,24 @@ llm_large_serving_ip: >-
 # REPLACES (not merges) any list here, so a definition here would be silently
 # ignored for the technitium hosts. Keep the single authoritative definition there.
 
+# SINGLE SOURCE OF TRUTH for the fabric's default chat/agent model. Both the
+# Hermes Agent brain (hermes_agent_model) and Open WebUI's default chat model
+# (open_webui_default_model) resolve to this, so the human chat UI and the
+# autonomous agent always run the same default by construction. The value is a
+# router model id (alias or passthrough physical id) served via
+# https://llm.<subdomain>/v1. Change it here — never re-pin it per consumer.
+#
+# Current value: Qwen3.6-35B-A3B (4-bit backend), chosen by PR #753 for the
+# agentic role: Qwen3-Coder-30B is faster single-stream but emits malformed
+# tool calls under agentic load (observed live 2026-07-08: "repairing
+# tool_call with empty function.name", ignored output bounds, unreliable
+# multi-turn runs); the 35B drove the full autonomous llm-wiki loop cleanly.
+# The old "qwen3_5_moe batching crash rules out Qwen3.6" claim was DISPROVEN
+# on the serving host the same day (3-way concurrency, zero crashes).
+# The 2026-07 sweep (HF dataset JacobPEvans/mlx-benchmarks) decides whether a
+# Qwen3.6-35B 8-bit variant supersedes this as a quality upgrade.
+ai_default_model: Qwen3.6-35B-A3B-4bit
+
 # Resource-domain secrets fetched from OpenBao by the openbao_secrets pre-play,
 # one dict per domain. Defaults to an empty dict for each so every consumer's
 # `bao_<domain>_secrets.X | default(lookup('env','X'), true)` resolves even

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -42,26 +42,14 @@ hermes_agent_installer_path: "/usr/local/lib/hermes-agent-installer-{{ hermes_ag
 
 # --- Brain: the LiteLLM router (the fabric front door, OpenAI-compatible /v1) ---
 # Reached by its neutral Traefik FQDN — never a hardcoded IP. The router routes by
-# model alias, so the agent just names the model it wants.
-#
-# Qwen3.6-35B-A3B is THE brain for this autonomous, tool-calling role. Qwen3-Coder-30B
-# is faster single-stream but emits malformed tool calls under agentic load (observed
-# live 2026-07-08: repeated "repairing tool_call with empty function.name", ignored
-# output bounds — a 129K-char query result — and unreliable multi-turn runs). The 35B
-# drove the full autonomous llm-wiki loop cleanly where the Coder model failed.
-#
-# The old "avoids the qwen3_5_moe batching crash that rules out Qwen3.6" rationale was
-# DISPROVEN on the Mac Studio (2026-07-08): 3 concurrent requests to Qwen3.6-35B-A3B-4bit
-# completed with zero crashes / zero 402 recovery — 8.7 tok/s single-stream, 3.7-5.7 tok/s
-# each under 3-way batching (graceful degradation, not the 0.1-4 tok/s death-loop the
-# nix-darwin serving comment claimed). That claim came from old, heavily-loaded MacBook
-# Pro tests, not the Studio. The 35B is slower than the Coder model but reliable, which
-# is the right trade for a background monitor. (An 8bit variant is a quality upgrade once
-# it is registered in the router.)
-#
-# Alias must match what the router serves (llm_router role) — currently
-# Qwen3.6-35B-A3B-4bit.
-hermes_agent_model: Qwen3.6-35B-A3B-4bit
+# model alias, so the agent just names the model it wants. The api key is the
+# router master key, env-sourced (SOPS/Doppler).
+# The model itself comes from the fabric-wide ai_default_model single source
+# (inventory/group_vars/all.yml) — shared with open_webui_default_model so the
+# agent brain and the human chat UI always run the same default. Change it
+# THERE (PR #753's why-Qwen3.6 rationale moved there with the value); a
+# per-role re-pin here would silently fork the two again.
+hermes_agent_model: "{{ ai_default_model }}"
 hermes_agent_model_base_url: "https://llm.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}/v1"
 hermes_agent_model_api_mode: chat_completions
 # Qwen3.6-35B-A3B's native context window (256K = 262144 tokens). Custom

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -162,3 +162,13 @@ llm_router_otel_endpoint: "http://cribl-edge.{{ llm_router_subdomain }}:{{ llm_r
 # timeout instead of failing over — routing to it at all is worse than
 # serving CPU-only. Flip together with the llm-fast unfreeze.
 llm_router_llm_fast_enabled: true
+
+# Large-tier passthrough: expose EVERY model the serving gate advertises,
+# not just the aliased ones above. Exposure policy is blocklist-shaped and
+# enforced at the source — the serving host auto-registers every downloaded,
+# memory-fitting MLX model minus its declarative blocklist (nix-ai
+# programs.mlx.discover.blocklist) — so adding a model to the fleet is a
+# download, and removing one is a blocklist entry; the router never needs a
+# per-model edit. llm_router_large_models stays as the stable consumer-facing
+# alias set (exact-match aliases win over the wildcard).
+llm_router_large_passthrough_enabled: true

--- a/roles/llm_router/templates/config.yaml.j2
+++ b/roles/llm_router/templates/config.yaml.j2
@@ -23,6 +23,20 @@ model_list:
       max_tokens: {{ m.context_window }}
 {% endif %}
 {% endfor %}
+{% if llm_router_large_passthrough_enabled | bool %}
+  # --- large tier passthrough: every model the serving gate advertises ---
+  # Exposure is blocklist-shaped, enforced at the source: the serving host
+  # auto-registers every downloaded, memory-fitting MLX model MINUS its
+  # declarative blocklist (nix-ai programs.mlx.discover.blocklist), and this
+  # wildcard forwards any model id not explicitly aliased above to that gate.
+  # No per-model router edit is ever needed; the aliases above remain as
+  # stable consumer-facing names and win over the wildcard on exact match.
+  - model_name: "*"
+    litellm_params:
+      model: openai/*
+      api_base: {{ llm_router_llm_large_base_url }}
+      api_key: os.environ/LLM_LARGE_BEARER_TOKEN
+{% endif %}
   # --- light tier: two deployments per alias (GPU llm-fast + CPU llm-light) ---
   # Same model_name => LiteLLM load-balances the pair and cools a failed deployment
   # down, so a GPU outage drains to the CPU standby automatically.
@@ -78,3 +92,9 @@ litellm_settings:
   # requires the v2 SDK and errors on init with the v3 pip resolves.
   callbacks: ["otel"]
   drop_params: true
+{% if llm_router_large_passthrough_enabled | bool %}
+  # Resolve the wildcard against the gate's live /v1/models so this proxy's
+  # own /v1/models lists every passthrough model (not just the aliases) —
+  # Open WebUI's picker and Hermes both read that listing.
+  check_provider_endpoint: true
+{% endif %}

--- a/roles/open_webui/defaults/main.yml
+++ b/roles/open_webui/defaults/main.yml
@@ -18,10 +18,13 @@ open_webui_port: "{{ tofu_data.constants.service_ports.open_webui_web }}"
 # Backend = the LiteLLM router (the fabric front door), OpenAI-compatible, reached
 # by its neutral FQDN — never a hardcoded IP. The router routes by model alias, so
 # Open WebUI sees every tier through this one endpoint. The api key is the router
-# master key, env-sourced (SOPS/Doppler). Default the chat box to the large tier.
+# master key, env-sourced (SOPS/Doppler).
 open_webui_openai_api_base_url: "https://llm.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}/v1"
 open_webui_openai_api_key: "{{ lookup('env', 'OPEN_WEBUI_OPENAI_API_KEY') }}"
-open_webui_default_model: gpt-oss-120b
+# The chat box default follows the fabric-wide ai_default_model single source
+# (inventory/group_vars/all.yml) — the SAME value the Hermes Agent brain uses,
+# by construction. Change it there, never re-pin here.
+open_webui_default_model: "{{ ai_default_model }}"
 
 # Public URL via Traefik — derived from the PROXMOX_SUBDOMAIN var (pve.<apex>),
 # never hardcoded. Matches the `llm` ingress entry in terraform-proxmox locals.tf.

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -2078,6 +2078,7 @@
       - { alias: embeddings, backend: embeddings, embedding: true }
       - { alias: claude-haiku-4-5, backend: hermes-4-14b }
     llm_router_routing_strategy: simple-shuffle
+    llm_router_large_passthrough_enabled: true
     llm_router_allowed_fails: 2
     llm_router_cooldown_time: 30
     llm_router_num_retries: 2
@@ -2119,6 +2120,13 @@
           - _model_names | select('equalto', 'qwen3-4b') | list | length == 2
           - _model_names | select('equalto', 'embeddings') | list | length == 2
           - _model_names | select('equalto', 'claude-haiku-4-5') | list | length == 2
+          # Large-tier passthrough: exactly one wildcard deployment forwarding
+          # any un-aliased model id to the serving gate (blocklist enforcement
+          # lives at the source — the gate only advertises non-blocked models),
+          # and check_provider_endpoint resolves it in /v1/models listings.
+          - _model_names | select('equalto', '*') | list | length == 1
+          - (_litellm.model_list | selectattr('model_name', 'equalto', '*') | first).litellm_params.model == 'openai/*'
+          - _litellm.litellm_settings.check_provider_endpoint == true
           # Secrets referenced via os.environ, never a literal in the config.
           - "'test-master-key-placeholder' not in (lookup('file', '/tmp/test_litellm_config.yaml'))"
           - _litellm.general_settings.master_key == 'os.environ/LLM_ROUTER_MASTER_KEY'


### PR DESCRIPTION
## Summary

- **Router passthrough (blocklist-shaped exposure):** `llm_router` adds a
  wildcard large-tier deployment (`model_name: "*"` → `openai/*` at the
  serving gate, same bearer) plus `litellm_settings.check_provider_endpoint:
  true`, so the router's own `/v1/models` lists — and routes — every model
  the gate advertises with **zero per-model router edits**. Exposure policy
  is enforced at the source: the serving host auto-registers every
  downloaded, memory-fitting MLX model minus its declarative blocklist
  (companion PR dryvist/nix-ai#1136). Existing aliases stay as stable
  consumer-facing names and win over the wildcard on exact match. Gated by
  `llm_router_large_passthrough_enabled: true` (`| bool`-guarded).
- **One shared default (`ai_default_model`):** new fabric-wide single source
  in `group_vars/all.yml`, consumed by BOTH `hermes_agent_model` and
  `open_webui_default_model` — the agent brain and the human chat UI now run
  the same default **by construction**. Value = `Qwen3.6-35B-A3B-4bit`,
  preserving PR #753's brain repoint (rebased onto it; the why-Qwen3.6
  rationale moved into group_vars with the value). The in-flight 2026-07
  benchmark sweep (HF `JacobPEvans/mlx-benchmarks`) decides whether an 8-bit
  variant supersedes it — a one-line change to this var.
- Render harness covers the new wildcard: exactly one `"*"` deployment →
  `openai/*`, `check_provider_endpoint` enabled.

## Test plan

- [x] `ansible-lint` clean (profile `production`) on all changed files
- [x] `config.yaml.j2` rendered through real Ansible templating with the
      passthrough flag **on and off** — wildcard block +
      `check_provider_endpoint` present/absent correctly, valid YAML both
      ways, alias entries unchanged
- [x] Full `tests/template_render/verify_templates.yml` passes locally
      (201 ok, 0 failed) post-rebase onto 1.95.0
- [ ] Post-merge converge: router `/v1/models` lists the gate's full
      catalog; Open WebUI picker shows it; both consumers default to
      `ai_default_model`

Related: dryvist/nix-ai#1136 (discovery blocklist source of the exposure policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cr9ZPB2B1z4u9WWzSw8ksf