### PR TITLE
fix(technitium_dns): install query-log exporter from internal mirror + fix config schema

### DIFF
--- a/molecule/technitium_dns/verify.yml
+++ b/molecule/technitium_dns/verify.yml
@@ -85,12 +85,14 @@
           # No dns_query family in the molecule tofu_data stand-in -> the
           # guarded default (the family's standard frontend, 522) applies.
           - technitium_dns_query_log_syslog_port | int == 522
-          - technitium_dns_query_log_config.syslog.enable | bool
+          # Key is `enabled` (the LogExporterApp dnsApp.config schema), not
+          # `enable` — the earlier `enable` shape was silently ignored.
+          - technitium_dns_query_log_config.syslog.enabled | bool
           - technitium_dns_query_log_config.syslog.protocol == 'TCP'
           - technitium_dns_query_log_config.syslog.address == 'syslog.svc.example.net'
           - technitium_dns_query_log_config.syslog.port | int == 522
-          - not (technitium_dns_query_log_config.file.enable | bool)
-          - not (technitium_dns_query_log_config.http.enable | bool)
+          - not (technitium_dns_query_log_config.file.enabled | bool)
+          - not (technitium_dns_query_log_config.http.enabled | bool)
         fail_msg: >-
           Query-log export vars did not derive as expected:
           host='{{ technitium_dns_query_log_syslog_host }}'

--- a/roles/technitium_dns/defaults/main.yml
+++ b/roles/technitium_dns/defaults/main.yml
@@ -144,10 +144,35 @@ technitium_dns_cache_enabled: true
 # forwards each entry to the syslog target below; no separate "enable query
 # logging" server setting is required once the app is installed and configured.
 technitium_dns_query_log_enabled: true
-# VERIFY LOCALLY (see tasks/query_log.yml): the store app name and its config
-# JSON shape must be confirmed against the running Technitium version's
-# /api/apps/listStoreApps output before first apply.
+# App is installed from the INTERNAL object-storage mirror, never the public
+# Technitium DNS App Store: the resolver containers carry the outbound-internal
+# firewall (RFC1918 only) and cannot reach download.technitium.com — a live
+# `listStoreApps` against them times out. Same air-gap the cribl-edge and
+# technitium_install mirrors already solve. `downloadAndInstall` makes the
+# SERVER fetch this URL, and the object-storage endpoint is internal, so no new
+# firewall rule is needed (outbound-internal already permits it).
 technitium_dns_query_log_app_name: "Log Exporter"
+# Mirror endpoint = the object store's HTTPS S3 ingress (`s3.<subdomain>`),
+# same artifacts bucket + technitium/ prefix the server binary mirrors to.
+# MUST be https, not the raw http://<ip>:<port> endpoint technitium_install
+# uses for controller-side get_url: this URL is handed to the Technitium
+# server's /api/apps/downloadAndInstall, which REJECTS any url not starting
+# with https:// (WebServiceAppsApi.cs). The `s3` Traefik ingress serves the
+# bucket over 443 with a valid wildcard cert the resolver already trusts.
+technitium_dns_query_log_app_mirror_endpoint: >-
+  https://s3.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}/artifacts
+# App version tracks the Technitium server release cycle. As with the server
+# tarball, a Renovate bump here is only a SIGNAL — it cannot re-host a private
+# object. On every bump the operator MUST re-seed
+# artifacts/technitium/<this filename> in object-storage from the official
+# store zip (capture LogExporterApp.zip from download.technitium.com on a host
+# with egress, or extract it from the matching technitium/dns-server image).
+# renovate: datasource=docker depName=technitium/dns-server
+technitium_dns_query_log_app_version: "3.0.1"
+technitium_dns_query_log_app_filename: "LogExporterApp-{{ technitium_dns_query_log_app_version }}.zip"
+technitium_dns_query_log_app_url: >-
+  {{ technitium_dns_query_log_app_mirror_endpoint }}/technitium/{{
+  technitium_dns_query_log_app_filename }}
 # Same stable syslog entry point the syslog_forwarder role uses (the `syslog`
 # CNAME this very role creates -> HAProxy). Never a committed literal.
 technitium_dns_query_log_syslog_host: "syslog.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
@@ -156,23 +181,27 @@ technitium_dns_query_log_syslog_host: "syslog.{{ lookup('env', 'PROXMOX_SUBDOMAI
 technitium_dns_query_log_syslog_port: >-
   {{ tofu_data.constants.syslog_port_map.dns_query.standard | default(522) }}
 technitium_dns_query_log_syslog_protocol: "TCP"
-# Desired Log Exporter app config. BEST-EFFORT shape from current Technitium
-# docs (file/http exporters off, syslog exporter on) — the exact key set must
-# be verified locally against the installed app version's config/get output.
+# Desired Log Exporter app config. Key set matches the app's own dnsApp.config
+# schema (LogExporterApp v3.x): the enable flag is `enabled` (NOT `enable`),
+# and a top-level `enableEdnsLogging` exists. The earlier best-effort shape used
+# `enable`, which the app silently ignored — every exporter stayed off and
+# nothing shipped despite a clean config/set. file + http exporters off, syslog
+# exporter on (TCP to the dns_query family frontend).
 technitium_dns_query_log_config:
   maxQueueSize: 1000000
+  enableEdnsLogging: false
   file:
-    path: "./query-logs.json"
-    enable: false
+    path: "./dns_logs.json"
+    enabled: false
   http:
     endpoint: ""
     headers: {}
-    enable: false
+    enabled: false
   syslog:
     address: "{{ technitium_dns_query_log_syslog_host }}"
     port: "{{ technitium_dns_query_log_syslog_port | int }}"
     protocol: "{{ technitium_dns_query_log_syslog_protocol }}"
-    enable: true
+    enabled: true
 
 # --- HA: primary / secondary roles (native AXFR/IXFR zone transfer) -----------
 # The role runs across the whole technitium_dns_group. The PRIMARY authors the

--- a/roles/technitium_dns/tasks/query_log.yml
+++ b/roles/technitium_dns/tasks/query_log.yml
@@ -7,15 +7,14 @@
 # -> read the app's live config -> write the desired config only on drift.
 # Everything is skipped under technitium_dns_apply=false (molecule/CI).
 #
-# VERIFY LOCALLY before first apply (best-effort against current Technitium
-# docs; the HTTP API surface for DNS apps is version-sensitive):
-#   1. the store app's exact `name` in /api/apps/listStoreApps (expected
-#      "Log Exporter" — technitium_dns_query_log_app_name);
-#   2. the config JSON shape in /api/apps/config/get?name=<app> for the
-#      installed app version (technitium_dns_query_log_config mirrors the
-#      documented file/http/syslog exporter blocks);
-#   3. that the app version matches the running server version (the store
-#      list carries per-version download URLs).
+# Install source is the INTERNAL object-storage mirror, not the public DNS App
+# Store: the resolvers are outbound-internal (RFC1918 only) and cannot reach
+# download.technitium.com, so a live listStoreApps against them times out.
+# `downloadAndInstall` takes an arbitrary `url` — we point it at the mirrored
+# app zip (technitium_dns_query_log_app_url, artifacts bucket) instead of a
+# store URL. The object-storage endpoint is internal, so outbound-internal
+# already permits the fetch (no firewall change). Seed the mirror per the
+# re-seed note in defaults/main.yml before first apply.
 
 - name: List installed DNS apps
   ansible.builtin.uri:
@@ -40,48 +39,7 @@
           | map(attribute='name') | list) }}
   when: technitium_dns_apply | bool
 
-- name: Look up the Log Exporter app in the DNS App Store
-  ansible.builtin.uri:
-    url: "{{ technitium_dns_api_url }}/api/apps/listStoreApps?token={{ technitium_dns_api_token }}"
-    method: GET
-    return_content: true
-    timeout: "{{ technitium_dns_api_timeout }}"
-  register: technitium_dns_store_apps
-  changed_when: false
-  failed_when: >-
-    technitium_dns_store_apps.failed or
-    technitium_dns_store_apps.json is not defined or
-    technitium_dns_store_apps.json.status != "ok"
-  when:
-    - technitium_dns_apply | bool
-    - not technitium_dns_query_log_app_installed
-  no_log: true
-
-- name: Resolve the Log Exporter store download URL
-  ansible.builtin.set_fact:
-    technitium_dns_query_log_app_url: >-
-      {{ technitium_dns_store_apps.json.response.storeApps | default([])
-         | selectattr('name', 'equalto', technitium_dns_query_log_app_name)
-         | map(attribute='url') | first | default('') }}
-  when:
-    - technitium_dns_apply | bool
-    - not technitium_dns_query_log_app_installed
-
-- name: Assert the Log Exporter app exists in the DNS App Store
-  ansible.builtin.assert:
-    that:
-      - technitium_dns_query_log_app_url | length > 0
-    fail_msg: >-
-      '{{ technitium_dns_query_log_app_name }}' was not found in this
-      Technitium server's DNS App Store listing. Verify the app name against
-      /api/apps/listStoreApps for the running server version and update
-      technitium_dns_query_log_app_name.
-    quiet: true
-  when:
-    - technitium_dns_apply | bool
-    - not technitium_dns_query_log_app_installed
-
-- name: Install the Log Exporter app from the DNS App Store
+- name: Install the Log Exporter app from the internal object-storage mirror
   ansible.builtin.uri:
     url: >-
       {{ technitium_dns_api_url }}/api/apps/downloadAndInstall?token={{


### PR DESCRIPTION
## Summary

The Splunk `dns` index is under-fed (only synthetic `ansible-e2e-host` events; the two real resolvers emit nothing). The query-log export was added in #689 but **never worked live**. Verifying against the primary resolver surfaced two independent breakages, both fixed here.

## Root causes

1. **Air-gap to the DNS App Store.** The resolvers carry the `outbound-internal` firewall (RFC1918 only) and cannot reach `download.technitium.com` — a live `GET /api/apps/listStoreApps` against the primary **times out after 30s** (`"The operation has timed out"`). So the role's store-lookup + `downloadAndInstall`-from-store-URL path can never run on these containers.
2. **Silent config-schema bug.** The committed app config used the key `enable`, but `LogExporterApp`'s own `dnsApp.config` schema (v3.x, from upstream source) uses **`enabled`** (plus a top-level `enableEdnsLogging`). With the wrong key, every exporter stayed off — `config/set` returned OK but nothing shipped.

## Changes

- **Install from the internal object-storage mirror** (the `artifacts` bucket, `technitium/` prefix — the exact pattern `technitium_install` already uses for the server binary). `downloadAndInstall` accepts an arbitrary `url`; pointed at the mirror. The object-storage endpoint is internal RFC1918, so `outbound-internal` already permits the fetch — **no firewall change**. Drops the timing-out store lookup/resolve/assert tasks.
- **Corrected `technitium_dns_query_log_config`** to the app's real schema (`enabled` ×3, added `enableEdnsLogging`).
- **Staying current**: `# renovate:` signal on the version (tracks the `technitium/dns-server` release cycle, same as the server binary) + the documented operator re-seed procedure. No new scheduler — matches every other mirrored vendor artifact here.

## Before this takes effect (operator step)

Seed `artifacts/technitium/LogExporterApp-3.0.1.zip` in object-storage from the official store zip (the vendor host is a SPOF and is **currently down**, which is precisely why the mirror is the right pattern), then converge `technitium_dns`.

## Verification (post-seed)

`index=dns sourcetype=technitium:dnsquery _index_earliest=-15m | eval skew=_indextime-_time | stats count avg(skew) by host` — expect `technitium-dns` + `technitium-dns-2` both >0, skew <5s. (This proof is what catches the silent config-shape failure the Ansible assert can't.)

- `ansible-lint` (production profile) green. Molecule runs under `technitium_dns_apply=false`, so the query-log tasks are exercised for syntax only.

Related: terraform-proxmox #579 (observability program — `dns` was the one under-fed index in the close-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)