### PR TITLE
feat(download_vpn,servarr_wiring): FlareSolverr for CloudFlare-gated indexers

### DIFF
--- a/molecule/download_vpn/verify.yml
+++ b/molecule/download_vpn/verify.yml
@@ -33,6 +33,10 @@
     download_vpn_qbittorrent_profile_dir: /data/.qbittorrent-profile
     download_vpn_qbittorrent_config_dir: /data/.qbittorrent-profile/qBittorrent/config
     download_vpn_qbittorrent_export_dir: /data/.qbittorrent-profile/exported-torrents
+    # Match the role defaults (verify.yml is standalone — role defaults are not
+    # auto-loaded here) so the FlareSolverr unit assertion can resolve them.
+    download_vpn_flaresolverr_bind_host: "127.0.0.1"
+    download_vpn_flaresolverr_memory_max: "2G"
 
   tasks:
     # --- 1. ruleset content ------------------------------------------------

--- a/molecule/download_vpn/verify.yml
+++ b/molecule/download_vpn/verify.yml
@@ -187,6 +187,30 @@
           the persistent /data tree — the session/queue state would land back
           on the disposable container rootfs.
 
+    # --- 2c. FlareSolverr unit is loopback-bound, capped, killswitch-gated --
+    - name: Read the deployed FlareSolverr systemd unit
+      ansible.builtin.slurp:
+        src: /etc/systemd/system/flaresolverr.service
+      register: fs_unit
+
+    - name: Assert the FlareSolverr unit is loopback-bound, memory-capped, VPN-gated
+      vars:
+        fs: "{{ fs_unit.content | b64decode }}"
+      ansible.builtin.assert:
+        that:
+          # loopback bind only — no LAN exposure, no firewall rule needed
+          - "'Environment=HOST=' ~ download_vpn_flaresolverr_bind_host in fs"
+          - download_vpn_flaresolverr_bind_host == '127.0.0.1'
+          # hard memory ceiling so Chromium is the OOM victim, never qBittorrent
+          - "'MemoryMax=' ~ download_vpn_flaresolverr_memory_max in fs"
+          # cannot start without the killswitch AND the tunnel
+          - "'Requires=download-vpn-killswitch.service download-vpn-wg.service' in fs"
+          - "'BindsTo=download-vpn-wg.service' in fs"
+        fail_msg: >-
+          flaresolverr.service must bind loopback, carry MemoryMax, and require
+          the killswitch + wg tunnel — a regression here risks LAN exposure, an
+          OOM hitting qBittorrent, or a solve on a non-VPN IP.
+
     # --- 3. simulate wg0 down -> no v4/v6 egress ---------------------------
     - name: Ensure IPv6 is disabled (as the role does on real hosts)
       ansible.posix.sysctl:

--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -286,6 +286,29 @@ download_vpn_prowlarr_web_port: >-
 download_vpn_prowlarr_tarball_url: >-
   https://prowlarr.servarr.com/v1/update/master/updatefile?os=linux&runtime=netcore&arch=x64
 
+# --- FlareSolverr (CloudFlare challenge solver) ------------------------------
+# Native Linux x64 binary (bundles headless Chromium). Solves the CF challenge
+# on demand so Prowlarr can query CF-gated indexers (1337x, EZTV); Prowlarr
+# caches the returned cf_clearance + User-Agent and searches itself thereafter.
+# CloudFlare binds that clearance to the SOLVING IP, so FlareSolverr MUST share
+# Prowlarr's VPN egress — hence it lives inside this guest, exiting via wg0
+# under the same killswitch (no new egress rule needed). Bound to loopback:
+# only same-host Prowlarr consumes it, so no LAN exposure and no firewall rule.
+download_vpn_flaresolverr_enabled: true
+# Rolling "latest release" asset URL — no version pin, mirroring the Prowlarr
+# master channel above (the workspace convention is latest-stable, not pinned).
+download_vpn_flaresolverr_tarball_url: >-
+  https://github.com/FlareSolverr/FlareSolverr/releases/latest/download/flaresolverr_linux_x64.tar.gz
+download_vpn_flaresolverr_install_dir: /opt/flaresolverr
+download_vpn_flaresolverr_user: flaresolverr
+download_vpn_flaresolverr_bind_host: "127.0.0.1"
+download_vpn_flaresolverr_port: 8191
+# Hard memory ceiling on the headless-Chromium process. This guest co-hosts
+# qBittorrent (irreplaceable session state) on a host shared with production
+# Plex; the cap guarantees the kernel OOM-kills FlareSolverr (stateless,
+# auto-restarts) rather than qBittorrent or a Plex-serving sibling.
+download_vpn_flaresolverr_memory_max: "2G"
+
 # --- NAT-PMP port forwarding -------------------------------------------------
 # Proton supports NAT-PMP. A systemd service loops natpmpc to keep a forwarded
 # port alive and pushes it into qBittorrent's listen port via the WebUI API.

--- a/roles/download_vpn/tasks/main.yml
+++ b/roles/download_vpn/tasks/main.yml
@@ -719,6 +719,59 @@
     daemon_reload: true
   when: download_vpn_manage_services
 
+# --- Phase 7b: FlareSolverr (CloudFlare challenge solver) --------------------
+# A native binary + bundled headless Chromium, co-located here so its solve
+# traffic shares Prowlarr's wg0 egress (CloudFlare binds the clearance to the
+# solving IP). Loopback-bound; the killswitch already covers its egress.
+- name: Create the FlareSolverr system user
+  ansible.builtin.user:
+    name: "{{ download_vpn_flaresolverr_user }}"
+    system: true
+    create_home: false
+    shell: /usr/sbin/nologin
+    state: present
+  when: download_vpn_flaresolverr_enabled
+
+- name: Check if FlareSolverr is already installed
+  ansible.builtin.stat:
+    path: "{{ download_vpn_flaresolverr_install_dir }}/flaresolverr"
+  register: download_vpn_flaresolverr_bin
+  when: download_vpn_flaresolverr_enabled
+
+- name: Download + extract FlareSolverr
+  ansible.builtin.unarchive:
+    src: "{{ download_vpn_flaresolverr_tarball_url }}"
+    dest: /opt
+    remote_src: true
+    owner: "{{ download_vpn_flaresolverr_user }}"
+    group: "{{ download_vpn_flaresolverr_user }}"
+  # Gated on manage_services so render-only runs (Molecule) skip the ~230 MB
+  # Chromium-bundled tarball — the unit still renders and is asserted there.
+  when:
+    - download_vpn_flaresolverr_enabled
+    - download_vpn_manage_services
+    - not (download_vpn_flaresolverr_bin.stat.exists | default(false))
+
+- name: Deploy FlareSolverr systemd unit
+  ansible.builtin.template:
+    src: flaresolverr.service.j2
+    dest: /etc/systemd/system/flaresolverr.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd
+  when: download_vpn_flaresolverr_enabled
+
+- name: Enable + start FlareSolverr
+  ansible.builtin.systemd:
+    name: flaresolverr.service
+    state: started
+    enabled: true
+    daemon_reload: true
+  when:
+    - download_vpn_flaresolverr_enabled
+    - download_vpn_manage_services
+
 # --- Phase 8: NAT-PMP port forwarding ---------------------------------------
 - name: Deploy NAT-PMP env file (qBittorrent admin password)
   ansible.builtin.copy:

--- a/roles/download_vpn/tasks/validate.yml
+++ b/roles/download_vpn/tasks/validate.yml
@@ -244,6 +244,13 @@
     # wg0, every CF-gated search would fail the moment the clearance was reused.
     # Section E already fetched the tunnel's public IP (download_vpn_vpn_ip);
     # here we make FlareSolverr fetch the same probe and assert the IPs match.
+    - name: Wait for FlareSolverr to be listening (headless Chromium init takes seconds)
+      ansible.builtin.wait_for:
+        host: "{{ download_vpn_flaresolverr_bind_host }}"
+        port: "{{ download_vpn_flaresolverr_port }}"
+        timeout: 90
+      when: download_vpn_flaresolverr_enabled
+
     - name: Solve the IP-probe URL through FlareSolverr
       ansible.builtin.uri:
         url: "http://{{ download_vpn_flaresolverr_bind_host }}:{{ download_vpn_flaresolverr_port }}/v1"
@@ -256,12 +263,20 @@
         status_code: 200
       register: download_vpn_fs_probe
       changed_when: false
+      # The port opening precedes Chromium being ready to solve the first
+      # request; retry until the response actually carries an IPv4.
+      retries: 5
+      delay: 6
+      until: >-
+        (download_vpn_fs_probe.status | default(0)) == 200
+        and (download_vpn_fs_probe.json.solution.response | default('', true)
+             | regex_search('(\d{1,3}\.){3}\d{1,3}')) is not none
       when: download_vpn_flaresolverr_enabled
 
     - name: Assert FlareSolverr's egress IP equals the tunnel exit IP
       vars:
         _fs_ip: >-
-          {{ (download_vpn_fs_probe.json.solution.response
+          {{ (download_vpn_fs_probe.json.solution.response | default('', true)
               | regex_search('(\d{1,3}\.){3}\d{1,3}')) | default('', true) }}
         _wg_ip: "{{ download_vpn_vpn_ip.stdout | trim }}"
       ansible.builtin.assert:

--- a/roles/download_vpn/tasks/validate.yml
+++ b/roles/download_vpn/tasks/validate.yml
@@ -237,6 +237,45 @@
           The lanroute table must route only RFC1918 + unreachable default.
         success_msg: "Marked internet-bound packets cannot egress the LAN NIC (fail-closed)."
 
+    # --- J. FlareSolverr egresses the SAME VPN exit IP as the tunnel --------
+    # CloudFlare binds the cf_clearance cookie FlareSolverr returns to the IP
+    # that solved the challenge. Prowlarr (VPN-egressing) then reuses that
+    # clearance — so if FlareSolverr's Chromium ever exited a different IP than
+    # wg0, every CF-gated search would fail the moment the clearance was reused.
+    # Section E already fetched the tunnel's public IP (download_vpn_vpn_ip);
+    # here we make FlareSolverr fetch the same probe and assert the IPs match.
+    - name: Solve the IP-probe URL through FlareSolverr
+      ansible.builtin.uri:
+        url: "http://{{ download_vpn_flaresolverr_bind_host }}:{{ download_vpn_flaresolverr_port }}/v1"
+        method: POST
+        body_format: json
+        body:
+          cmd: request.get
+          url: "{{ download_vpn_ip_probe_url }}"
+          maxTimeout: 60000
+        status_code: 200
+      register: download_vpn_fs_probe
+      changed_when: false
+      when: download_vpn_flaresolverr_enabled
+
+    - name: Assert FlareSolverr's egress IP equals the tunnel exit IP
+      vars:
+        _fs_ip: >-
+          {{ (download_vpn_fs_probe.json.solution.response
+              | regex_search('(\d{1,3}\.){3}\d{1,3}')) | default('', true) }}
+        _wg_ip: "{{ download_vpn_vpn_ip.stdout | trim }}"
+      ansible.builtin.assert:
+        that:
+          - _fs_ip | length > 0
+          - _fs_ip == _wg_ip
+        fail_msg: >-
+          FlareSolverr egress IP ({{ _fs_ip | default('(none)') }}) does not match
+          the wg0 tunnel exit IP ({{ _wg_ip }}). CloudFlare clearance solved by
+          FlareSolverr would be rejected when Prowlarr reuses it — and a mismatch
+          means FlareSolverr is not exiting the VPN.
+        success_msg: "FlareSolverr egresses the tunnel exit IP ({{ _wg_ip }})."
+      when: download_vpn_flaresolverr_enabled
+
     - name: Report killswitch validation success
       ansible.builtin.debug:
         msg: >-
@@ -244,4 +283,5 @@
           routes via {{ download_vpn_wg_interface }} (Table=auto); no IPv6 default
           route; qBittorrent bound to {{ download_vpn_wg_interface }}; VPN IPv4
           egress works; non-VPN IPv4 + all IPv6 egress refused; LAN-reply routing
-          present (web UIs reachable cross-subnet).
+          present (web UIs reachable cross-subnet); FlareSolverr egress IP matches
+          the tunnel.

--- a/roles/download_vpn/templates/flaresolverr.service.j2
+++ b/roles/download_vpn/templates/flaresolverr.service.j2
@@ -1,0 +1,29 @@
+[Unit]
+Description=FlareSolverr CloudFlare challenge solver (VPN-locked)
+Documentation=https://github.com/FlareSolverr/FlareSolverr
+After=download-vpn-wg.service
+# Boot-safe: FlareSolverr reaches CF-gated trackers via the VPN. Its clearance
+# cookie is bound by CloudFlare to the exit IP, so it must never run without the
+# killswitch AND the tunnel (a solve on a non-VPN IP would both leak and be
+# useless to VPN-egressing Prowlarr).
+Requires=download-vpn-killswitch.service download-vpn-wg.service
+BindsTo=download-vpn-wg.service
+
+[Service]
+Type=simple
+User={{ download_vpn_flaresolverr_user }}
+Group={{ download_vpn_flaresolverr_user }}
+# Loopback bind — only same-host Prowlarr consumes it; no LAN exposure.
+Environment=HOST={{ download_vpn_flaresolverr_bind_host }}
+Environment=PORT={{ download_vpn_flaresolverr_port }}
+Environment=LOG_LEVEL=info
+ExecStart={{ download_vpn_flaresolverr_install_dir }}/flaresolverr
+Restart=on-failure
+RestartSec=10
+# Hard ceiling: headless Chromium is the guaranteed OOM victim, never the
+# co-hosted qBittorrent (session state) or the Plex-serving host.
+MemoryMax={{ download_vpn_flaresolverr_memory_max }}
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/servarr_wiring/defaults/main.yml
+++ b/roles/servarr_wiring/defaults/main.yml
@@ -82,11 +82,9 @@ servarr_wiring_seed_time_minutes: 4320
 # many established trackers (including cached results from retired ones —
 # the best reach for older/low-seed releases); LimeTorrents is a
 # long-established general tracker. All four verified reachable through the
-# tunnel without a Cloudflare solver. Add/remove freely — but Cloudflare-gated
-# trackers (EZTV, 1337x, TorrentGalaxy, …) require FlareSolverr, which is out
-# of scope; adding them here just logs a non-fatal warning at converge.
-# Deliberately excluded: raw DHT crawlers (TorrentProject2, BTdirectory, …) —
-# unmoderated indexes carry a high fake/malware-torrent rate.
+# tunnel without a Cloudflare solver. Add/remove freely. Deliberately excluded:
+# raw DHT crawlers (TorrentProject2, BTdirectory, …) — unmoderated indexes carry
+# a high fake/malware-torrent rate.
 servarr_wiring_prowlarr_indexers:
   - "The Pirate Bay"
   - "YTS"
@@ -94,6 +92,22 @@ servarr_wiring_prowlarr_indexers:
   - "LimeTorrents"
 # Prowlarr app/sync profile applied to each indexer (1 = the default profile).
 servarr_wiring_indexer_app_profile_id: 1
+
+# --- CloudFlare-gated indexers (routed through FlareSolverr) ------------------
+# These indexers sit behind CloudFlare, so Prowlarr can only reach them via a
+# FlareSolverr proxy (see prowlarr_proxies.yml). They are added WITH the
+# flaresolverr tag so Prowlarr routes their requests through the solver.
+# Gated on servarr_wiring_flaresolverr_enabled — when false they are skipped
+# and the non-CF set above is the whole story.
+servarr_wiring_flaresolverr_enabled: true
+# FlareSolverr runs co-located in the download_vpn guest, loopback-bound; the
+# servarr_wiring coordinator IS that guest, so Prowlarr reaches it on localhost.
+servarr_wiring_flaresolverr_host: "http://127.0.0.1:8191"
+# The Prowlarr tag that binds the proxy to the CF indexers (shared tag = routed).
+servarr_wiring_flaresolverr_tag: flaresolverr
+servarr_wiring_prowlarr_cf_indexers:
+  - "1337x"
+  - "EZTV"
 
 # --- Authentication (Sonarr/Radarr/Prowlarr v4 require a valid auth method) ---
 # v4 refuses to serve the UI with AuthenticationMethod=None (it walls off the UI

--- a/roles/servarr_wiring/tasks/main.yml
+++ b/roles/servarr_wiring/tasks/main.yml
@@ -35,9 +35,16 @@
       ansible.builtin.include_tasks: api_keys.yml
 
     # -------------------------------------------------------------------------
-    # 2. Public indexers into Prowlarr (so the Application full-sync has content)
+    # 2a. FlareSolverr indexer proxy + tag (so CF indexers can be routed)
     # -------------------------------------------------------------------------
-    - name: Add public indexers to Prowlarr
+    - name: Wire the FlareSolverr indexer proxy
+      ansible.builtin.include_tasks: prowlarr_proxies.yml
+      when: servarr_wiring_flaresolverr_enabled | bool
+
+    # -------------------------------------------------------------------------
+    # 2b. Public + CF-gated indexers into Prowlarr (Application full-sync content)
+    # -------------------------------------------------------------------------
+    - name: Add indexers to Prowlarr
       ansible.builtin.include_tasks: prowlarr_indexers.yml
 
     # -------------------------------------------------------------------------

--- a/roles/servarr_wiring/tasks/prowlarr_indexers.yml
+++ b/roles/servarr_wiring/tasks/prowlarr_indexers.yml
@@ -12,8 +12,9 @@
 #      we stay resilient to Prowlarr / Cardigann definition drift.
 #
 # The default set (servarr_wiring_prowlarr_indexers) is PUBLIC, non-Cloudflare
-# trackers — no FlareSolverr required. Cloudflare-gated indexers need
-# FlareSolverr (out of scope) and are intentionally excluded.
+# trackers — no proxy required. Cloudflare-gated indexers
+# (servarr_wiring_prowlarr_cf_indexers) are added separately below, tagged so
+# Prowlarr routes them through the FlareSolverr proxy (see prowlarr_proxies.yml).
 
 - name: Fetch Prowlarr indexer schema
   ansible.builtin.uri:
@@ -93,17 +94,69 @@
     - servarr_wiring_indexer_schema.json | selectattr('name', 'equalto', item) | list | length > 0
     - servarr_wiring_indexer_existing.json | selectattr('name', 'equalto', item) | list | length == 0
 
-# Surface any indexer Prowlarr refused (almost always Cloudflare → needs
-# FlareSolverr, out of scope). Non-fatal: the rest of the wiring proceeds.
-- name: Warn about indexers Prowlarr could not add
+# Surface any non-CF indexer Prowlarr refused. Non-fatal: wiring proceeds.
+- name: Warn about public indexers Prowlarr could not add
   ansible.builtin.debug:
     msg: >-
-      Prowlarr did not add indexer "{{ item.item }}" (HTTP
-      {{ item.status | default('n/a') }}) — usually a Cloudflare-gated tracker
-      that needs FlareSolverr (out of scope). Pick a non-Cloudflare public
-      indexer in servarr_wiring_prowlarr_indexers, or add this one in the
-      Prowlarr UI with FlareSolverr configured.
+      Prowlarr did not add public indexer "{{ item.item }}" (HTTP
+      {{ item.status | default('n/a') }}). If it is Cloudflare-gated, move it to
+      servarr_wiring_prowlarr_cf_indexers so it is routed through FlareSolverr;
+      otherwise pick another non-Cloudflare public indexer.
   loop: "{{ servarr_wiring_indexer_add.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item | default('?') }}"
+  when:
+    - not (item.skipped | default(false))
+    - item.status is defined
+    - item.status not in [200, 201]
+
+# --- CloudFlare-gated indexers (routed through FlareSolverr) ------------------
+# Same schema-overlay add, but each carries the flaresolverr tag so Prowlarr
+# proxies its requests through the solver. Requires the FlareSolverr proxy +
+# tag from prowlarr_proxies.yml (imported before this file). Still best-effort:
+# a 400 (e.g. the solver briefly unavailable) must not abort the rest of the
+# wiring. Only runs when FlareSolverr is enabled.
+- name: Add missing CloudFlare-gated Prowlarr indexers (via FlareSolverr, best-effort)
+  ansible.builtin.uri:
+    url: "http://{{ servarr_wiring_prowlarr_host }}:{{ servarr_wiring_prowlarr_port }}/api/v1/indexer"
+    method: POST
+    headers:
+      X-Api-Key: "{{ servarr_wiring_prowlarr_api_key }}"
+    body_format: json
+    body: >-
+      {{ _cf_indexer_template | combine({
+           'enable': true,
+           'appProfileId': servarr_wiring_indexer_app_profile_id,
+           'tags': [servarr_wiring_flaresolverr_tag_id | int]
+         }) }}
+    status_code: [200, 201, 400]
+    return_content: true
+  register: servarr_wiring_cf_indexer_add
+  changed_when: servarr_wiring_cf_indexer_add.status in [200, 201]
+  failed_when: false
+  no_log: true
+  loop: "{{ servarr_wiring_prowlarr_cf_indexers }}"
+  loop_control:
+    label: "{{ item }}"
+  vars:
+    _cf_indexer_template: >-
+      {{ servarr_wiring_indexer_schema.json
+         | selectattr('name', 'equalto', item)
+         | first }}
+  when:
+    - servarr_wiring_flaresolverr_enabled | bool
+    - servarr_wiring_flaresolverr_tag_id is defined
+    - servarr_wiring_indexer_schema.json | selectattr('name', 'equalto', item) | list | length > 0
+    - servarr_wiring_indexer_existing.json | selectattr('name', 'equalto', item) | list | length == 0
+
+- name: Warn about CloudFlare-gated indexers Prowlarr could not add
+  ansible.builtin.debug:
+    msg: >-
+      Prowlarr did not add CF indexer "{{ item.item }}" (HTTP
+      {{ item.status | default('n/a') }}) even via FlareSolverr — check the
+      FlareSolverr proxy is up (flaresolverr.service) and the definition name
+      matches Prowlarr's exactly.
+  loop: "{{ servarr_wiring_cf_indexer_add.results | default([]) }}"
   loop_control:
     label: "{{ item.item | default('?') }}"
   when:

--- a/roles/servarr_wiring/tasks/prowlarr_proxies.yml
+++ b/roles/servarr_wiring/tasks/prowlarr_proxies.yml
@@ -1,0 +1,110 @@
+---
+# Add a FlareSolverr indexer proxy to Prowlarr so CloudFlare-gated indexers can
+# be reached. Prowlarr routes an indexer through a proxy when they share a TAG,
+# so the flow is: ensure the tag -> ensure the proxy (tagged) -> add the CF
+# indexers carrying the same tag (prowlarr_indexers.yml).
+#
+# Schema-driven + idempotent, the same house pattern as prowlarr_apps.yml:
+#   1. Ensure the `flaresolverr` tag exists (GET, POST if missing) -> capture id.
+#   2. GET /api/v1/indexerproxy/schema — the FlareSolverr field template.
+#   3. GET /api/v1/indexerproxy        — what already exists (match by name).
+#   4. If missing, overlay only host + the tag onto the schema template and POST.
+
+- name: Fetch existing Prowlarr tags
+  ansible.builtin.uri:
+    url: "http://{{ servarr_wiring_prowlarr_host }}:{{ servarr_wiring_prowlarr_port }}/api/v1/tag"
+    method: GET
+    headers:
+      X-Api-Key: "{{ servarr_wiring_prowlarr_api_key }}"
+    status_code: 200
+  register: servarr_wiring_tags_existing
+  changed_when: false
+  no_log: true
+
+- name: Create the flaresolverr Prowlarr tag (if missing)
+  ansible.builtin.uri:
+    url: "http://{{ servarr_wiring_prowlarr_host }}:{{ servarr_wiring_prowlarr_port }}/api/v1/tag"
+    method: POST
+    headers:
+      X-Api-Key: "{{ servarr_wiring_prowlarr_api_key }}"
+    body_format: json
+    body:
+      label: "{{ servarr_wiring_flaresolverr_tag }}"
+    status_code: [200, 201]
+  register: servarr_wiring_tag_add
+  changed_when: servarr_wiring_tag_add.status in [200, 201]
+  no_log: true
+  when: >-
+    servarr_wiring_tags_existing.json
+    | selectattr('label', 'equalto', servarr_wiring_flaresolverr_tag)
+    | list | length == 0
+
+# Resolve the tag id whether it already existed or we just created it.
+- name: Resolve the flaresolverr tag id
+  ansible.builtin.set_fact:
+    servarr_wiring_flaresolverr_tag_id: >-
+      {{ (servarr_wiring_tag_add.json.id
+          if (servarr_wiring_tag_add is defined and not (servarr_wiring_tag_add.skipped | default(false)))
+          else (servarr_wiring_tags_existing.json
+                | selectattr('label', 'equalto', servarr_wiring_flaresolverr_tag)
+                | map(attribute='id') | first)) }}
+
+- name: Fetch Prowlarr indexer-proxy schema
+  ansible.builtin.uri:
+    url: "http://{{ servarr_wiring_prowlarr_host }}:{{ servarr_wiring_prowlarr_port }}/api/v1/indexerproxy/schema"
+    method: GET
+    headers:
+      X-Api-Key: "{{ servarr_wiring_prowlarr_api_key }}"
+    status_code: 200
+  register: servarr_wiring_proxy_schema
+  changed_when: false
+  no_log: true
+
+- name: Fetch existing Prowlarr indexer proxies
+  ansible.builtin.uri:
+    url: "http://{{ servarr_wiring_prowlarr_host }}:{{ servarr_wiring_prowlarr_port }}/api/v1/indexerproxy"
+    method: GET
+    headers:
+      X-Api-Key: "{{ servarr_wiring_prowlarr_api_key }}"
+    status_code: 200
+  register: servarr_wiring_proxy_existing
+  changed_when: false
+  no_log: true
+
+# Overlay only the host value onto the FlareSolverr schema template, tag it, and
+# POST. The fields array is rebuilt in pure Jinja (no custom filter): keep every
+# schema field, swapping in our host value for the `host` field.
+- name: Add the FlareSolverr indexer proxy (if missing)
+  ansible.builtin.uri:
+    url: "http://{{ servarr_wiring_prowlarr_host }}:{{ servarr_wiring_prowlarr_port }}/api/v1/indexerproxy"
+    method: POST
+    headers:
+      X-Api-Key: "{{ servarr_wiring_prowlarr_api_key }}"
+    body_format: json
+    body: >-
+      {{ _proxy_template | combine({
+           'name': 'FlareSolverr',
+           'tags': [servarr_wiring_flaresolverr_tag_id | int],
+           'fields': _proxy_fields
+         }) }}
+    status_code: [200, 201]
+  register: servarr_wiring_proxy_add
+  changed_when: servarr_wiring_proxy_add.status in [200, 201]
+  no_log: true
+  vars:
+    _proxy_template: >-
+      {{ servarr_wiring_proxy_schema.json
+         | selectattr('implementation', 'equalto', 'FlareSolverr')
+         | first }}
+    # Only the host value needs overriding; the schema defaults (requestTimeout,
+    # etc.) are complete. Same rebuild pattern as prowlarr_apps.yml: keep every
+    # schema field whose name is NOT overridden, then append our {name, value}.
+    _proxy_overrides:
+      host: "{{ servarr_wiring_flaresolverr_host }}"
+    _proxy_fields: >-
+      {{ (_proxy_template.fields | rejectattr('name', 'in', _proxy_overrides.keys()) | list)
+         + (_proxy_overrides | dict2items(key_name='name', value_name='value')) }}
+  when: >-
+    servarr_wiring_proxy_existing.json
+    | selectattr('name', 'equalto', 'FlareSolverr')
+    | list | length == 0


### PR DESCRIPTION
## Why

The public non-CloudFlare indexer set (TPB, YTS, Knaben, LimeTorrents) leaves a large *arr wanted-missing backlog unfindable. The gap is CF-gated indexers (1337x, EZTV). This adds FlareSolverr to solve the CF challenge so Prowlarr can query them.

## Design (see #764 for why co-located, not the deferred gateway refactor)

CloudFlare binds the `cf_clearance` cookie to the **solving IP**; FlareSolverr is not a fetch-proxy — Prowlarr caches the clearance + User-Agent and searches itself. So the solver **must share Prowlarr's VPN egress**. It therefore runs co-located in the download-vpn guest as a native service, exiting via `wg0` under the existing killswitch.

## download_vpn role (Phase 7b)

- Native `linux_x64` release (bundled headless Chromium), own system user.
- `flaresolverr.service`: **bound `127.0.0.1:8191`** (only same-host Prowlarr consumes it → no LAN exposure, no firewall rule, no killswitch delta), `Requires` the killswitch + tunnel, `MemoryMax=2G` + `Restart=on-failure` so a Chromium OOM kills the stateless solver, never co-hosted qBittorrent or the Plex-serving host.
- `validate.yml` invariant: FlareSolverr's egress IP **must equal** the `wg0` exit IP (else reused clearance would be rejected — and a mismatch means it's not on the VPN).
- Molecule asserts the unit is loopback-bound, capped, and VPN-gated. The 230 MB tarball download is gated on `manage_services` so render-only CI stays lean.

## servarr_wiring

- New `prowlarr_proxies.yml`: idempotent FlareSolverr indexer proxy + shared `flaresolverr` tag (the schema-overlay house pattern; first indexer-proxy config-as-code path in the role).
- CF indexers (`1337x`, `EZTV`) added **with that tag** so Prowlarr routes them through the solver. Best-effort (400 tolerated), gated on `servarr_wiring_flaresolverr_enabled`.

## Verification

- ansible-lint (production profile): pass on all 37 files.
- Live (post-merge, staged under the Plex production-safety gate): memory bump applied 0-destroy, FlareSolverr up + capped, the egress-IP invariant passes, 1337x/EZTV test/add succeed, backlog begins clearing, qBittorrent + Plex unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXiX2uJBEn6HNa2brL6iKd