### PR TITLE
fix(hermes): local-grade stream timeouts + cron model-drift recovery

### DIFF
--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -71,6 +71,19 @@ hermes_agent_model_context_length: 262144
 # server cap instead of exceeding it.
 # Capping max_tokens here means an oversized request is never sent.
 hermes_agent_model_max_tokens: 32768
+# Hermes classifies the brain endpoint by HOSTNAME STRING, never by DNS
+# resolution (agent/model_metadata.py is_local_endpoint: loopback, RFC-1918
+# IP literals, container suffixes, dot-less names). Our router base_url is an
+# FQDN, so Hermes applies its strict REMOTE-provider timeouts — 120s stream
+# read, 180s stale-stream kill — to a local model whose thinking-mode prefill
+# on a 20-60K context legitimately exceeds both. Confirmed live 2026-07-08:
+# "Stream stale for 180s (threshold 180s) ... Killing connection" followed by
+# a 0-char truncated stub that surfaces as "Model generated invalid tool
+# call". These overrides restore the values Hermes itself auto-applies to
+# endpoints it recognizes as local (read 1800s; stale kept enabled but far
+# above any healthy prefill).
+hermes_agent_stream_read_timeout: 1800
+hermes_agent_stream_stale_timeout: 900
 # The api key IS the LiteLLM router master key; source it from the canonical
 # LLM_ROUTER_MASTER_KEY env (same as the llm_router role) so no per-run mapping
 # is needed. HERMES_AGENT_MODEL_API_KEY still overrides if explicitly set.
@@ -267,6 +280,13 @@ hermes_agent_splunk_cron_jobs:
     schedule: "{{ hermes_agent_splunk_digest_cron_schedule }}"
     prompt: "{{ hermes_agent_splunk_digest_cron_prompt }}"
     deliver: "{{ hermes_agent_splunk_digest_deliver }}"
+
+# Every cron job this role seeds. The model-drift recovery task (tasks/main.yml)
+# only ever removes jobs on this list — user- and agent-created jobs are never
+# touched.
+hermes_agent_seeded_cron_names: >-
+  {{ [hermes_agent_daily_status_cron_name, hermes_agent_nightly_wiki_cron_name]
+     + (hermes_agent_splunk_cron_jobs | map(attribute='name') | list) }}
 
 # --- Context7 MCP client (current library/framework docs on demand) ---
 # Registers Context7's hosted HTTP MCP server so Hermes can pull up-to-date,

--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -185,15 +185,19 @@
     HERMES_HOME: "{{ hermes_agent_hermes_home }}"
   become: true
   become_user: "{{ hermes_agent_user }}"
+  # The loop expression is templated before `when` would be evaluated
+  # (per-item semantics), so it must be self-safe: default the slurped
+  # content to base64("{}") when jobs.json does not exist yet (fresh
+  # install) — the loop resolves to [] and the task is a no-op.
   loop: >-
-    {{ (hermes_agent_cron_store.content | b64decode | from_json).jobs | default([])
+    {{ (hermes_agent_cron_store.content | default('e30=', true) | b64decode | from_json).jobs
+       | default([])
        | selectattr('name', 'in', hermes_agent_seeded_cron_names)
        | selectattr('model_snapshot', 'defined')
        | rejectattr('model_snapshot', 'none')
        | rejectattr('model_snapshot', 'equalto', hermes_agent_model)
        | map(attribute='name') | list }}
   changed_when: true
-  when: hermes_agent_cron_store.content is defined
 
 # Hermes ships its own cron scheduler. Seed the daily Slack status report here so
 # the next gateway run picks it up without any manual post-install step.

--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -165,6 +165,36 @@
     mode: "0640"
   notify: Restart hermes-gateway
 
+# --- Cron model-drift recovery ------------------------------------------------
+# Unpinned cron jobs snapshot the global default model at creation and FAIL
+# CLOSED when model.default later changes: every subsequent fire is skipped
+# with a provider/model-drift alert (upstream spend guard, hermes-agent
+# #44585), so a brain repoint silently stops the entire seeded fleet. The CLI
+# cannot re-pin an existing job's model, so recovery is: remove the drifted
+# job here and let the create-if-absent seeding below recreate it, snapshotting
+# the new model. No drift means nothing is removed (idempotent).
+- name: Read the cron job store to detect model-snapshot drift
+  ansible.builtin.slurp:
+    src: "{{ hermes_agent_hermes_home }}/cron/jobs.json"
+  register: hermes_agent_cron_store
+  failed_when: false
+
+- name: Remove role-seeded cron jobs whose model snapshot drifted
+  ansible.builtin.command: "{{ hermes_agent_bin }} cron remove {{ item }}"
+  environment:
+    HERMES_HOME: "{{ hermes_agent_hermes_home }}"
+  become: true
+  become_user: "{{ hermes_agent_user }}"
+  loop: >-
+    {{ (hermes_agent_cron_store.content | b64decode | from_json).jobs | default([])
+       | selectattr('name', 'in', hermes_agent_seeded_cron_names)
+       | selectattr('model_snapshot', 'defined')
+       | rejectattr('model_snapshot', 'none')
+       | rejectattr('model_snapshot', 'equalto', hermes_agent_model)
+       | map(attribute='name') | list }}
+  changed_when: true
+  when: hermes_agent_cron_store.content is defined
+
 # Hermes ships its own cron scheduler. Seed the daily Slack status report here so
 # the next gateway run picks it up without any manual post-install step.
 - name: Check whether the daily Slack status cron job already exists

--- a/roles/hermes_agent/templates/hermes-env.j2
+++ b/roles/hermes_agent/templates/hermes-env.j2
@@ -20,6 +20,13 @@ HERMES_OTEL_ENDPOINT={{ hermes_agent_otel_endpoint }}/v1/traces
 HERMES_OTEL_TIMEOUT={{ hermes_agent_otel_timeout }}
 OTEL_SERVICE_NAME={{ hermes_agent_otel_service_name }}
 
+# Local-grade streaming timeouts. The FQDN router base_url defeats Hermes'
+# local-endpoint auto-detection (hostname-string check, no DNS resolution),
+# leaving remote defaults (120s read / 180s stale) that kill slow local
+# thinking-mode streams mid-tool-call. See defaults/main.yml.
+HERMES_STREAM_READ_TIMEOUT={{ hermes_agent_stream_read_timeout }}
+HERMES_STREAM_STALE_TIMEOUT={{ hermes_agent_stream_stale_timeout }}
+
 # llm-wiki
 {% if hermes_agent_wiki_enabled | bool %}
 WIKI_PATH={{ hermes_agent_wiki_path }}


### PR DESCRIPTION
## Summary

- **Stream timeouts**: Hermes' local-endpoint auto-detection checks the hostname **string** (loopback / RFC-1918 literals / container suffixes / dot-less names) and never resolves DNS, so the FQDN LLM-router `base_url` is treated as a REMOTE cloud provider: 120s stream-read timeout + 180s stale-stream kill. A local model's thinking-mode prefill on a 20-60K-token context legitimately exceeds both, so healthy streams were killed mid-tool-call and surfaced as `Model generated invalid tool call` / empty `function.name`. Captured live in `agent.log`:
  ```
  Stream stale for 180s (threshold 180s) — no chunks received. context=~36,273 tokens. Killing connection.
  Partial stream delivered before error; returning length-truncated stub with 0 chars ...
  ERROR cron.scheduler: Job 'splunk-digest' failed: RuntimeError: Model generated invalid tool call:
  ```
  Fix: render `HERMES_STREAM_READ_TIMEOUT=1800` / `HERMES_STREAM_STALE_TIMEOUT=900` into `.env` — read timeout is the exact value Hermes auto-applies to endpoints it recognizes as local (upstream docs *guides/local-llm-on-mac.md*); the stale detector stays enabled, just above any healthy prefill.

- **Cron model-drift recovery**: unpinned cron jobs snapshot the global default model at creation and **fail closed** when `model.default` later changes (upstream spend guard, hermes-agent #44585) — after a brain repoint the whole seeded fleet silently skips. The CLI cannot re-pin an existing job's model, so the role now removes drifted **role-seeded** jobs (allowlist `hermes_agent_seeded_cron_names`; user- and agent-created jobs are never touched) and lets the existing create-if-absent seeding recreate them under the fresh snapshot. Idempotent: no drift → no removal → no change.

## Testing

- `ansible-lint roles/hermes_agent/` — production profile, 0 failures / 0 warnings.
- Drift filter chain verified against synthetic fixtures (drifted seeded job removed; current, pinned/null-snapshot, foreign, and script jobs untouched).
- Template render suite runs in CI (`_molecule.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKbDMD78yNnM55oK9vcP99