### PR TITLE
fix(llm_router): raise per-attempt timeout 300s -> 1200s

### DIFF
--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -126,8 +126,15 @@ llm_router_cooldown_time: 30
 # (which retry the identical request and hit the identical transient error).
 # request_timeout_seconds bounds a single attempt; large-tier generations can
 # legitimately run for minutes, so this is generous, not a tight SLA.
+# 1200 (was 300): a thinking-mode agentic call on the large tier runs 84-152s
+# healthy and several times that when requests batch — at 300s the router
+# killed those still-healthy attempts, and with allowed_fails: 2 two such
+# kills put the SINGLE large-tier deployment into cooldown, turning one slow
+# burst into a 429 "no deployments" outage for every caller. 1200 stays below
+# agent clients' own 1800s stream ceiling so the router still gives up first
+# and its num_retries remain meaningful.
 llm_router_num_retries: 2
-llm_router_request_timeout_seconds: 300
+llm_router_request_timeout_seconds: 1200
 # Background health checks send REAL test requests to every deployment — on the
 # llama-swap fast tier each probe spawns the target model, and with 3 routers
 # probing every model this both churns VRAM constantly and (pre swap-groups)


### PR DESCRIPTION
## Summary

LiteLLM's `router_settings.timeout` (from `llm_router_request_timeout_seconds`) bounds one attempt at 300s. A thinking-mode agentic call on the large tier legitimately runs 84–152s solo and several times that when requests batch, so the router was killing healthy attempts — and with `allowed_fails: 2` two kills put the **single** large-tier deployment into a 30s cooldown, turning one slow burst into a 429 "no deployments available" outage for every caller (Hermes, OpenWebUI, benchmarks alike).

1200s keeps a real bound while sitting below agent clients' 1800s stream-read ceiling (dryvist/ansible-proxmox-apps#766), so the router still gives up first and `num_retries` stays meaningful. `allowed_fails`/`cooldown_time` are left as-is — with the timeout no longer misfiring, the breaker's remaining trigger set is genuine failures, which is what it's for.

## Testing

- `ansible-lint roles/llm_router/` — production profile, 0 failures / 0 warnings.
- Live verification planned with a ≥4-way concurrent thinking-mode benchmark through the router (zero 429s expected) once converged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKbDMD78yNnM55oK9vcP99