### PR TITLE
feat(llm_router): register tuned models under alias AND physical id

### DIFF
--- a/roles/llm_router/templates/config.yaml.j2
+++ b/roles/llm_router/templates/config.yaml.j2
@@ -5,8 +5,17 @@
 
 model_list:
   # --- large tier: one deployment each, bearer-authed to llm-large ---
+  # Each tuned model is registered under BOTH its consumer-facing alias AND
+  # its physical id: exact model_name matches beat the "*" wildcard below, so
+  # a request naming the physical id still routes to the TUNED deployment
+  # (llama-swap: parsers, preload, batching) instead of falling through to
+  # the zero-config dynamic tier and double-loading the same weights.
+{% set _ns = namespace(seen=[]) %}
 {% for m in llm_router_large_models %}
-  - model_name: {{ m.alias }}
+{% for _name in ([m.alias, m.backend] | unique) %}
+{% if _name not in _ns.seen %}
+{% set _ns.seen = _ns.seen + [_name] %}
+  - model_name: {{ _name }}
     litellm_params:
       model: openai/{{ m.backend }}
       api_base: {{ llm_router_llm_large_base_url }}
@@ -22,6 +31,8 @@ model_list:
       max_input_tokens: {{ m.context_window }}
       max_tokens: {{ m.context_window }}
 {% endif %}
+{% endif %}
+{% endfor %}
 {% endfor %}
 {% if llm_router_large_passthrough_enabled | bool %}
   # --- large tier passthrough: every model the serving gate advertises ---

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -2121,12 +2121,18 @@
           - _model_names | select('equalto', 'embeddings') | list | length == 2
           - _model_names | select('equalto', 'claude-haiku-4-5') | list | length == 2
           # Large-tier passthrough: exactly one wildcard deployment forwarding
-          # any un-aliased model id to the serving gate (blocklist enforcement
-          # lives at the source — the gate only advertises non-blocked models),
-          # and check_provider_endpoint resolves it in /v1/models listings.
+          # any un-aliased model id to the serving gate, and
+          # check_provider_endpoint resolves it in /v1/models listings.
           - _model_names | select('equalto', '*') | list | length == 1
           - (_litellm.model_list | selectattr('model_name', 'equalto', '*') | first).litellm_params.model == 'openai/*'
           - _litellm.litellm_settings.check_provider_endpoint == true
+          # Hybrid guard: every tuned model is ALSO registered under its
+          # physical id (exact match beats the wildcard, so a physical-id
+          # request hits the TUNED deployment, never the dynamic tier), and
+          # a backend shared by two aliases is emitted exactly once.
+          - _model_names | select('equalto', 'mlx-community/gpt-oss-120b-MXFP4-Q8') | list | length == 1
+          - _model_names | select('equalto', 'mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit') | list | length == 1
+          - _model_names | select('equalto', 'mlx-community/Qwen3.6-35B-A3B-4bit') | list | length == 1
           # Secrets referenced via os.environ, never a literal in the config.
           - "'test-master-key-placeholder' not in (lookup('file', '/tmp/test_litellm_config.yaml'))"
           - _litellm.general_settings.master_key == 'os.environ/LLM_ROUTER_MASTER_KEY'


### PR DESCRIPTION
## Summary

Hybrid-tier guard, completing #755: exact `model_name` matches beat the `"*"`
wildcard, so a request naming a tuned model's **physical id** must still land
on the TUNED deployment (llama-swap: parsers, preload, batching) rather than
falling through to the zero-config dynamic tier (dryvist/nix-ai#1136) and
double-loading the same weights beside the resident copy.

Each large-tier entry now renders under both its consumer-facing alias and
its physical backend id — deduped globally, so a backend shared by two
aliases (e.g. `claude-sonnet-5` → the 35B backend) is emitted exactly once.

## Test plan

- [x] `ansible-lint` clean (profile `production`)
- [x] Render harness extended: asserts each physical id present exactly once
      and the shared-backend dedupe; full `verify_templates.yml` passes
      locally (0 failed)

Related: #755 (wildcard passthrough, merged), dryvist/nix-ai#1136 (dynamic tier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cr9ZPB2B1z4u9WWzSw8ksf