### PR TITLE
fix(technitium_dns): pin Log Exporter to running server's app version + manage only syslog block

### DIFF
--- a/molecule/technitium_dns/verify.yml
+++ b/molecule/technitium_dns/verify.yml
@@ -85,14 +85,12 @@
           # No dns_query family in the molecule tofu_data stand-in -> the
           # guarded default (the family's standard frontend, 522) applies.
           - technitium_dns_query_log_syslog_port | int == 522
-          # Key is `enabled` (the LogExporterApp dnsApp.config schema), not
-          # `enable` — the earlier `enable` shape was silently ignored.
-          - technitium_dns_query_log_config.syslog.enabled | bool
-          - technitium_dns_query_log_config.syslog.protocol == 'TCP'
-          - technitium_dns_query_log_config.syslog.address == 'syslog.svc.example.net'
-          - technitium_dns_query_log_config.syslog.port | int == 522
-          - not (technitium_dns_query_log_config.file.enabled | bool)
-          - not (technitium_dns_query_log_config.http.enabled | bool)
+          # Role manages ONLY the syslog block (merged over the app's live
+          # config at apply time); `enabled` is the real flag (not `enable`).
+          - technitium_dns_query_log_syslog.enabled | bool
+          - technitium_dns_query_log_syslog.protocol == 'TCP'
+          - technitium_dns_query_log_syslog.address == 'syslog.svc.example.net'
+          - technitium_dns_query_log_syslog.port | int == 522
         fail_msg: >-
           Query-log export vars did not derive as expected:
           host='{{ technitium_dns_query_log_syslog_host }}'

--- a/roles/technitium_dns/defaults/main.yml
+++ b/roles/technitium_dns/defaults/main.yml
@@ -161,18 +161,27 @@ technitium_dns_query_log_app_name: "Log Exporter"
 # bucket over 443 with a valid wildcard cert the resolver already trusts.
 technitium_dns_query_log_app_mirror_endpoint: >-
   https://s3.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}/artifacts
-# App version tracks the Technitium server release cycle. As with the server
-# tarball, a Renovate bump here is only a SIGNAL — it cannot re-host a private
-# object. On every bump the operator MUST re-seed
-# artifacts/technitium/<this filename> in object-storage from the official
-# store zip (capture LogExporterApp.zip from download.technitium.com on a host
-# with egress, or extract it from the matching technitium/dns-server image).
+# App version is pinned to the Log Exporter build compatible with the RUNNING
+# server (14.3 -> the highest store entry whose serverVersion <= ours is
+# 14.2.0 -> app 2.1). NOT the latest (3.0.1 needs server 15.3). A Renovate bump
+# is only a SIGNAL — it cannot re-host a private object. On a server upgrade the
+# operator MUST (1) pick the app version for the new serverVersion from the
+# store manifest (https://go.technitium.com/?id=44), (2) re-seed
+# artifacts/technitium/<filename> in object-storage from a clean-egress host
+# (the homelab is UDW-blocked from Technitium — use a GitHub Actions runner),
+# and (3) update the version + sha256 below. NOTE app v3.x renamed the
+# `ebableEdnsLogging` typo key below to `enableEdnsLogging` — fix that in the
+# config too on a 3.x bump.
 # renovate: datasource=docker depName=technitium/dns-server
-technitium_dns_query_log_app_version: "3.0.1"
+technitium_dns_query_log_app_version: "2.1"
 technitium_dns_query_log_app_filename: "LogExporterApp-{{ technitium_dns_query_log_app_version }}.zip"
 technitium_dns_query_log_app_url: >-
   {{ technitium_dns_query_log_app_mirror_endpoint }}/technitium/{{
   technitium_dns_query_log_app_filename }}
+# sha256 of the mirrored zip — documents the exact pinned build (the
+# downloadAndInstall API has no checksum param, so this is verified by the
+# operator at seed time, not enforced at install). Update with the version.
+technitium_dns_query_log_app_sha256: "53e84d2c3b8715e5fd59b415b57920bd4845ef8cb38cc935c25bddb89915c7fd"
 # Same stable syslog entry point the syslog_forwarder role uses (the `syslog`
 # CNAME this very role creates -> HAProxy). Never a committed literal.
 technitium_dns_query_log_syslog_host: "syslog.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
@@ -181,27 +190,15 @@ technitium_dns_query_log_syslog_host: "syslog.{{ lookup('env', 'PROXMOX_SUBDOMAI
 technitium_dns_query_log_syslog_port: >-
   {{ tofu_data.constants.syslog_port_map.dns_query.standard | default(522) }}
 technitium_dns_query_log_syslog_protocol: "TCP"
-# Desired Log Exporter app config. Key set matches the app's own dnsApp.config
-# schema (LogExporterApp v3.x): the enable flag is `enabled` (NOT `enable`),
-# and a top-level `enableEdnsLogging` exists. The earlier best-effort shape used
-# `enable`, which the app silently ignored — every exporter stayed off and
-# nothing shipped despite a clean config/set. file + http exporters off, syslog
-# exporter on (TCP to the dns_query family frontend).
-technitium_dns_query_log_config:
-  maxQueueSize: 1000000
-  enableEdnsLogging: false
-  file:
-    path: "./dns_logs.json"
-    enabled: false
-  http:
-    endpoint: ""
-    headers: {}
-    enabled: false
-  syslog:
-    address: "{{ technitium_dns_query_log_syslog_host }}"
-    port: "{{ technitium_dns_query_log_syslog_port | int }}"
-    protocol: "{{ technitium_dns_query_log_syslog_protocol }}"
-    enabled: true
+# The ONLY block this role manages — merged over the app's own live config
+# (see tasks/query_log.yml), so we never mirror the app's other keys or its
+# version-specific spellings. `enabled` (NOT `enable`) is the real flag; the
+# earlier `enable` shape was silently ignored, so nothing ever shipped.
+technitium_dns_query_log_syslog:
+  address: "{{ technitium_dns_query_log_syslog_host }}"
+  port: "{{ technitium_dns_query_log_syslog_port | int }}"
+  protocol: "{{ technitium_dns_query_log_syslog_protocol }}"
+  enabled: true
 
 # --- HA: primary / secondary roles (native AXFR/IXFR zone transfer) -----------
 # The role runs across the whole technitium_dns_group. The PRIMARY authors the

--- a/roles/technitium_dns/tasks/query_log.yml
+++ b/roles/technitium_dns/tasks/query_log.yml
@@ -78,8 +78,25 @@
   when: technitium_dns_apply | bool
   no_log: true
 
+# Manage ONLY the syslog exporter block: merge our syslog settings over the
+# app's own live config and write that back. This role never has to mirror the
+# app's other keys (maxQueueSize/file/http and the version-specific
+# `ebableEdnsLogging` typo v2.x ships / `enableEdnsLogging` v3.x uses), so it
+# stays idempotent AND correct across app versions — the drift compare is our
+# merged desired vs live, and only the syslog keys we set can differ.
+- name: Compute the desired Log Exporter config (app config + our syslog block)
+  ansible.builtin.set_fact:
+    technitium_dns_query_log_live_config: >-
+      {{ technitium_dns_query_log_live.json.response.config
+         | default('{}', true) | from_json }}
+    technitium_dns_query_log_desired_config: >-
+      {{ (technitium_dns_query_log_live.json.response.config
+          | default('{}', true) | from_json)
+         | combine({'syslog': technitium_dns_query_log_syslog}, recursive=true) }}
+  when: technitium_dns_apply | bool
+
 # config/set is an unconditional overwrite on the Technitium side — the drift
-# compare (parsed live JSON vs desired dict) is what keeps re-runs change-free.
+# compare (merged desired vs live) is what keeps re-runs change-free.
 - name: Configure Log Exporter syslog export (drift-gated)
   ansible.builtin.uri:
     url: >-
@@ -89,7 +106,7 @@
     body_format: form-urlencoded
     body:
       name: "{{ technitium_dns_query_log_app_name }}"
-      config: "{{ technitium_dns_query_log_config | to_json }}"
+      config: "{{ technitium_dns_query_log_desired_config | to_json }}"
     return_content: true
     timeout: "{{ technitium_dns_api_timeout }}"
   register: technitium_dns_query_log_set
@@ -100,7 +117,5 @@
     technitium_dns_query_log_set.json.status != "ok"
   when:
     - technitium_dns_apply | bool
-    - >-
-      (technitium_dns_query_log_live.json.response.config | default('{}', true)
-       | from_json) != technitium_dns_query_log_config
+    - technitium_dns_query_log_desired_config != technitium_dns_query_log_live_config
   no_log: true


### PR DESCRIPTION
Follow-up to #759 — corrects it against the **live** resolver. `index=dns` is now flowing end-to-end (proven below); this was the last under-fed index from the observability program (terraform-proxmox #579).

## What #759 got wrong (found by verifying live, not just reading code)

- **Version**: #759 pinned Log Exporter **3.0.1**, which requires DNS server **15.3**. The running server is **14.3** → the compatible build is **2.1** (highest store entry with `serverVersion <= ours`). Installing 3.0.1 would fail/misbehave. Pinned 2.1 + its sha256, with a note to re-pick from the store manifest on a server upgrade.
- **Config schema**: the v2.x app ships a misspelled `ebableEdnsLogging` key (v3.x renames it to `enableEdnsLogging`). Committing the app's whole config dict would mean carrying a vendor typo and re-breaking on every version bump.

## Fix

- Manage **only** the syslog exporter block and **merge** it over the app's own live config (`combine(recursive=true)`), so the role never mirrors the app's other keys or version-specific spellings. Idempotent and version-robust.
- App zip mirrored to `artifacts/technitium/` (fetched via a clean-egress GitHub Actions runner — the homelab is UDW-blocked from the vendor host) and installs over the https `s3` ingress (`downloadAndInstall` rejects non-https URLs).

## Verification (live)

- Converge installs the app from the mirror, sets the syslog exporter, restarts Technitium — `technitium-dns: failed=0`.
- `index=dns sourcetype=technitium:dnsquery` receives from the primary resolver at correct event-time (**skew ~0s**).
- Idempotent: the app is registered under the expected name (install skips) and live config equals desired (config/set skips) — verified against the live API.
- `ansible-lint` (production profile) green; molecule updated.

The secondary resolver is a separate, pre-existing gap (its container is not running on its node) — out of scope here.

Related: #759, #760, terraform-proxmox #579.

🤖 Generated with [Claude Code](https://claude.com/claude-code)