### PR TITLE
chore(validate-pipeline): remove dead include_vars

### DIFF
--- a/playbooks/validate-pipeline.yml
+++ b/playbooks/validate-pipeline.yml
@@ -680,13 +680,6 @@
     - validation
 
   tasks:
-    - name: Load tofu data for Qdrant validation
-      ansible.builtin.include_vars:
-        file: "{{ playbook_dir }}/../inventory/tofu_inventory.json"
-        name: tofu_data
-      delegate_to: localhost
-      run_once: true
-
     - name: Gather service facts for Qdrant validation
       ansible.builtin.service_facts:
 
@@ -752,13 +745,6 @@
     - validation
 
   tasks:
-    - name: Load tofu data for LlamaIndex validation
-      ansible.builtin.include_vars:
-        file: "{{ playbook_dir }}/../inventory/tofu_inventory.json"
-        name: tofu_data
-      delegate_to: localhost
-      run_once: true
-
     - name: Gather service facts for LlamaIndex validation
       ansible.builtin.service_facts:
 
@@ -828,13 +814,6 @@
     - validation
 
   tasks:
-    - name: Load tofu data for Mailpit validation
-      ansible.builtin.include_vars:
-        file: "{{ playbook_dir }}/../inventory/tofu_inventory.json"
-        name: tofu_data
-      delegate_to: localhost
-      run_once: true
-
     - name: Gather service facts for Mailpit validation
       ansible.builtin.service_facts:
 
@@ -900,13 +879,6 @@
     - validation
 
   tasks:
-    - name: Load tofu data for ntfy validation
-      ansible.builtin.include_vars:
-        file: "{{ playbook_dir }}/../inventory/tofu_inventory.json"
-        name: tofu_data
-      delegate_to: localhost
-      run_once: true
-
     - name: Gather service facts for ntfy validation
       ansible.builtin.service_facts:
 


### PR DESCRIPTION
## What

Removes four redundant `include_vars` tasks from `playbooks/validate-pipeline.yml` — one each at the head of the Qdrant, LlamaIndex, Mailpit, and ntfy validation plays.

## Why they were dead

Each task loaded `inventory/tofu_inventory.json` into a play-scoped `tofu_data`. But every consumer in those plays reads `hostvars['localhost']['tofu_data']`, never the bare `tofu_data` the `include_vars` created. That localhost hostvar is already populated (and asserted) by the top-level `import_playbook: ../inventory/load_tofu.yml` that runs for the whole playbook — the exact same source the HAProxy and Cribl plays consume with no local `include_vars`. The four reloads had no effect on the data the plays actually used.

Verification: grep confirms every `tofu_data` reference in the affected plays is `hostvars['localhost']['tofu_data'][...]`; none reference the play-scoped var.

## Validation

- `ansible-playbook --syntax-check` — passes.
- `ansible-lint` (production profile) — passes, 0 failures.

Net: −28 LOC (four 6-line tasks plus their trailing blank separators).