### PR TITLE
feat(hermes_agent): repoint brain to OptiQ-4bit 35B per agentic bench

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -64,16 +64,19 @@ llm_large_serving_ip: >-
 # router model id (alias or passthrough physical id) served via
 # https://llm.<subdomain>/v1. Change it here — never re-pin it per consumer.
 #
-# Current value: Qwen3.6-35B-A3B (4-bit backend), chosen by PR #753 for the
-# agentic role: Qwen3-Coder-30B is faster single-stream but emits malformed
-# tool calls under agentic load (observed live 2026-07-08: "repairing
-# tool_call with empty function.name", ignored output bounds, unreliable
-# multi-turn runs); the 35B drove the full autonomous llm-wiki loop cleanly.
-# The old "qwen3_5_moe batching crash rules out Qwen3.6" claim was DISPROVEN
-# on the serving host the same day (3-way concurrency, zero crashes).
-# The 2026-07 sweep (HF dataset JacobPEvans/mlx-benchmarks) decides whether a
-# Qwen3.6-35B 8-bit variant supersedes this as a quality upgrade.
-ai_default_model: Qwen3.6-35B-A3B-4bit
+# Current value: Qwen3.6-35B-A3B-OptiQ-4bit, chosen by the 2026-07-08 agentic
+# tool-calling benchmark (8 candidates, results in HF dataset
+# JacobPEvans/mlx-benchmarks). OptiQ-4bit scored 100% valid tool calls with
+# 0/20 multi-turn degradation at concurrency 4 + thinking + large context, at
+# ~7.4 tok/s single-stream large-ctx — the same clean tool-calling as the stock
+# 4-bit brain (PR #753) but ~1.8x its 4.1 tok/s, so it supersedes it. The whole
+# Qwen3.6-35B-A3B family ran under continuous batching at concurrency 4 with
+# zero crashes, retiring the old "qwen3_5_moe batching crash rules out Qwen3.6"
+# claim for good. Qwen3-Coder-30B stays faster single-stream but emits malformed
+# tool calls under agentic load ("repairing tool_call with empty function.name",
+# unreliable multi-turn), so it is not the brain. The stock 4-bit alias
+# (Qwen3.6-35B-A3B-4bit) remains defined in the router for any other consumer.
+ai_default_model: Qwen3.6-35B-A3B-OptiQ-4bit
 
 # Resource-domain secrets fetched from OpenBao by the openbao_secrets pre-play,
 # one dict per domain. Defaults to an empty dict for each so every consumer's

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -64,11 +64,12 @@ hermes_agent_model_context_length: 262144
 # misclassifies that 400 as a context overflow (it matches the bare
 # substring "max_tokens" in any error text) and dies trying to compress an
 # already-minimal conversation instead of lowering the output request.
-# 32768 matches the serving side since the nix-darwin#1539/#1545 rebuild went
-# live on the Mac Studio (2026-07-07): the coder model's per-model
-# maxRequestTokens override is 32768, and hermes-agent's own retry-boost
-# ceiling is max(32768, requested), so the boosted retry lands exactly at the
-# server cap instead of exceeding it.
+# 32768 stays at/below the serving side's per-request token cap. The winning
+# OptiQ-4bit brain (ai_default_model, 2026-07-08 agentic bench) serves with
+# --max-request-tokens 65536 on the Mac Studio, so a 32768 output request plus
+# hermes-agent's own retry-boost ceiling (max(32768, requested)) never exceeds
+# what the server accepts. (The prior stock/coder brains capped at 32768, where
+# this value matched the server exactly; against OptiQ it is a safe margin below.)
 # Capping max_tokens here means an oversized request is never sent.
 hermes_agent_model_max_tokens: 32768
 # Hermes classifies the brain endpoint by HOSTNAME STRING, never by DNS

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -98,6 +98,12 @@ llm_router_large_models:
   - { alias: gpt-oss-120b, backend: mlx-community/gpt-oss-120b-MXFP4-Q8, context_window: 131072 }
   - { alias: Qwen3-Coder-30B-A3B, backend: mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit, context_window: 262144 }
   - { alias: Qwen3.6-35B-A3B-4bit, backend: mlx-community/Qwen3.6-35B-A3B-4bit, context_window: 262144 }
+  # OptiQ-4bit: the agentic-bench-winning brain (ai_default_model, all.yml). A
+  # first-class alias — NOT passthrough — so the default model carries an
+  # explicit max_input_tokens: the wildcard "*" entry below sets none, and a
+  # null there makes Hermes/OpenWebUI fall back to a near-zero context guess and
+  # compress every request to death.
+  - { alias: Qwen3.6-35B-A3B-OptiQ-4bit, backend: mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit, context_window: 262144 }
   # claude-sonnet-5 is a Claude Code alias deliberately mapped to a local Qwen3.6
   # backend (PR #624) — not a mis-map; it inherits that backend's 262144 context.
   - { alias: claude-sonnet-5, backend: mlx-community/Qwen3.6-35B-A3B-4bit, context_window: 262144 }

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -132,15 +132,21 @@ llm_router_cooldown_time: 30
 # (which retry the identical request and hit the identical transient error).
 # request_timeout_seconds bounds a single attempt; large-tier generations can
 # legitimately run for minutes, so this is generous, not a tight SLA.
-# 1200 (was 300): a thinking-mode agentic call on the large tier runs 84-152s
-# healthy and several times that when requests batch — at 300s the router
-# killed those still-healthy attempts, and with allowed_fails: 2 two such
-# kills put the SINGLE large-tier deployment into cooldown, turning one slow
-# burst into a 429 "no deployments" outage for every caller. 1200 stays below
-# agent clients' own 1800s stream ceiling so the router still gives up first
-# and its num_retries remain meaningful.
+# Timeout chain — each OUTER layer outlives the inner one, so no intermediate
+# guard kills a still-healthy generation and the CLIENT is the sole decider:
+#   vllm-mlx server guard 3600s (nix-darwin) > router attempt 2400s >
+#   Hermes client stream read 1800s.
+# 2400 (was 1200, was 300): guards are set to realistic ceilings on the
+# assumption the request almost always completes even at unusually high
+# limits. A 32k-token large-tier generation runs ~1560s at 21 tok/s and longer
+# when requests batch; the old 300s server guard masked everything (proven
+# cause of the 18:27 UTC cron failures) and 1200 here would have been the next
+# binding kill. At 2400 the router now sits ABOVE the client's 1800s ceiling,
+# so the client times out first (by design) while the router waits — and
+# below the 3600s server guard, so num_retries still cover a genuine transient
+# connection blip (which fails fast, well under any of these).
 llm_router_num_retries: 2
-llm_router_request_timeout_seconds: 1200
+llm_router_request_timeout_seconds: 2400
 # Background health checks send REAL test requests to every deployment — on the
 # llama-swap fast tier each probe spawns the target model, and with 3 routers
 # probing every model this both churns VRAM constantly and (pre swap-groups)


### PR DESCRIPTION
## Summary

Repoints the Hermes agent brain (and, by construction, the Open WebUI default chat model) from the stock `Qwen3.6-35B-A3B-4bit` to **`Qwen3.6-35B-A3B-OptiQ-4bit`**, the winner of the 2026-07-08 agentic tool-calling benchmark.

Both consumers resolve `ai_default_model` (single source in `inventory/group_vars/all.yml`), so this is the one edit that moves the human chat UI and the autonomous agent together — no per-consumer re-pin.

## Why OptiQ-4bit

Benchmark: 8 candidates, agentic tool-calling under concurrency 4 + thinking + large context. Results published to HF dataset `JacobPEvans/mlx-benchmarks`.

| Metric | Incumbent (stock 4-bit, #753) | OptiQ-4bit (this PR) |
| --- | --- | --- |
| Valid tool calls | clean | 100% |
| Multi-turn degradation (conc4+thinking+large-ctx) | 0/20 | 0/20 |
| Single-stream large-ctx throughput | 4.1 tok/s | ~7.4 tok/s (~1.8x) |

Same clean tool-calling as the incumbent, ~1.8x the throughput. `Qwen3-Coder-30B` is faster single-stream but emits malformed tool calls under agentic load, so it is not the brain. The whole `Qwen3.6-35B-A3B` family ran continuous batching at concurrency 4 with zero crashes, retiring the old `qwen3_5_moe` batching-crash claim for good.

## Changes

1. **`inventory/group_vars/all.yml`** — flip `ai_default_model` to `Qwen3.6-35B-A3B-OptiQ-4bit`; rewrite the rationale with bench evidence and drop the stale batching-crash mention.
2. **`roles/llm_router/defaults/main.yml`** — add a first-class OptiQ alias mirroring the incumbent entry (`context_window: 262144`). This is **required, not cosmetic**: the wildcard `"*"` passthrough entry carries no `max_input_tokens`, and a null there makes Hermes/OpenWebUI fall back to a near-zero context guess and compress every request to death (the failure mode documented in `config.yaml.j2`). The incumbent `Qwen3.6-35B-A3B-4bit` alias is kept intact for any other consumer. The current template dual-registers each tuned model under both its alias and its physical id, so the served id `mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit` is also covered by exact match.
3. **`roles/hermes_agent/defaults/main.yml`** — reconcile the `hermes_agent_model_max_tokens` comment. The OptiQ brain serves with `--max-request-tokens 65536`, so the unchanged `32768` output cap (plus hermes-agent's `max(32768, requested)` retry-boost ceiling) stays a safe margin below the server limit. `hermes_agent_model_context_length` stays `262144` (same family, native window).

## Verification

- `yamllint` — clean (exit 0).
- `ansible-lint` (production profile) — `Passed: 0 failure(s), 0 warning(s) on 22 files`.
- Standalone Jinja2 render of `roles/llm_router/templates/config.yaml.j2` with the new alias — valid YAML; OptiQ entry renders `model: openai/mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit` with `max_input_tokens: 262144`.
- Served id confirmed live on the serving host: `mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit` is in `/v1/models`; the bench chain log served exactly this id.

## Risks / notes

- Depends on the parallel nix-darwin PR promoting OptiQ to the resident set (`cache-memory-mb 16384` / `max-num-seqs 8`, `--max-request-tokens 65536`). Converge after that rebuild is live so the alias resolves to a loaded model.
- No converge in this PR — brain repoint takes effect on the next `hermes_agent` / `llm_router` converge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oEWqS9KGW6hsSuPsKtfxr

---

## Added: router per-attempt timeout 1200s → 2400s

Second commit, aligning the timeout chain per the "set guards to realistic numbers — assume the request almost always completes even at unusually high limits" directive. New chain, each outer layer outliving the inner one so the **client is the sole decider** and no intermediate guard kills a still-healthy generation:

```
vllm-mlx server guard 3600s (nix-darwin) > router attempt 2400s > Hermes client stream read 1800s
```

- Previously the 300s server guard masked everything (proven cause of the 18:27 UTC cron failures); 1200s here would have been the next binding kill for a 32k-token generation (~1560s at 21 tok/s).
- At 2400 the router now sits **above** the 1800s client ceiling (client times out first, by design) and **below** the 3600s server guard, so `num_retries` still covers a genuine fast-failing transient connection blip.
- File: `roles/llm_router/defaults/main.yml` (`llm_router_request_timeout_seconds`), comment rewritten to match the new chain. yamllint + ansible-lint (production) re-run green.

### Note on CI
The `Molecule / Molecule (technitium_dns)` leg is **red for a pre-existing reason unrelated to this PR** — the same leg fails on PR #774 (which introduced that `verify.yml` assertion and was merged anyway). This PR touches none of `technitium_dns`, `all.yml`-derived DNS vars, or that verify path.
