### PR TITLE
feat(codex_runner): bootstrap auth.json from OpenBao (create-only)

### DIFF
--- a/inventory/group_vars/hermes_agent_group.yml
+++ b/inventory/group_vars/hermes_agent_group.yml
@@ -38,3 +38,12 @@ hermes_agent_context7_api_key: >-
 hermes_agent_github_issues_pat: >-
   {{ bao_local_llm_secrets.GH_PAT_WRITE_PROJECT_ISSUES
      | default(lookup('env', 'GH_PAT_WRITE_PROJECT_ISSUES'), true) }}
+
+# Codex CLI auth (ChatGPT-OAuth ~/.codex/auth.json) for the isolated
+# codex-runner user. Bao-first (local-llm domain, secret/ai/hermes), env
+# fallback — empty until an operator seeds it. Create-only on the guest: this
+# is only a bootstrap snapshot, and Codex's guest-side refresh takes over after
+# first login (see roles/codex_runner/README.md).
+codex_runner_auth_json: >-
+  {{ bao_local_llm_secrets.CODEX_AUTH_JSON
+     | default(lookup('env', 'CODEX_AUTH_JSON'), true) }}

--- a/roles/codex_runner/README.md
+++ b/roles/codex_runner/README.md
@@ -55,6 +55,15 @@ ssh <lxc-host> 'sudo install -o codex-runner -g codex-runner -m 0600 \
   sudo rm /tmp/codex-auth.json'
 ```
 
+**Option C — seed from OpenBao (bootstrap only):**
+
+Set `CODEX_AUTH_JSON` (the `~/.codex/auth.json` content) at `secret/ai/hermes`
+in the local-llm domain. On converge the role writes it to
+`~/.codex/auth.json` **create-only** — it seeds the initial login and then
+never touches the file again, so Codex's guest-side refresh takes over after
+first use and the live token is never clobbered by the stale snapshot. Leave
+the value empty to fall back to Option A or B.
+
 Either way, confirm with:
 
 ```bash
@@ -76,6 +85,7 @@ README, "Escalation (Codex via MCP)").
 | `codex_runner_npm_prefix` | `/usr/local` | forces a known global-install path |
 | `codex_runner_sudo_grantee` | `hermes` | the only user allowed to invoke Codex |
 | `codex_runner_mcp_command` | `{{ codex_runner_codex_bin }} mcp-server` | the exact, single command the sudo grant covers |
+| `codex_runner_auth_json` | `""` | optional `auth.json` bootstrap snapshot (Bao-first, env fallback); create-only |
 
 ## Group / invocation
 

--- a/roles/codex_runner/defaults/main.yml
+++ b/roles/codex_runner/defaults/main.yml
@@ -48,3 +48,12 @@ codex_runner_codex_bin: "{{ codex_runner_npm_prefix }}/bin/codex"
 # invocation (no wildcard args): Hermes' `mcp_servers.codex` entry in
 # config.yaml must match this exactly (roles/hermes_agent/templates/config.yaml.j2).
 codex_runner_mcp_command: "{{ codex_runner_codex_bin }} mcp-server"
+
+# --- Auth bootstrap (optional) ----------------------------------------------
+# ChatGPT-OAuth token (~/.codex/auth.json content) used to seed auth on first
+# converge. Empty by default; wired Bao-first with env fallback in group_vars.
+# The materialize task is deliberately create-only — Codex rotates its refresh
+# token guest-side after first login, so this bootstrap snapshot must NEVER
+# overwrite a live, already-refreshed token. Leave empty to use the manual
+# bootstrap paths (README "Manual bootstrap") instead.
+codex_runner_auth_json: ""

--- a/roles/codex_runner/tasks/main.yml
+++ b/roles/codex_runner/tasks/main.yml
@@ -97,12 +97,38 @@
     mode: "0440"
     validate: "visudo -cf %s"
 
-# Auth is a one-time, interactive, human step (ChatGPT OAuth device-code or
-# browser flow) that cannot be scripted here — see README.md for both
-# bootstrap options. This check is informational only: it never fails the
-# converge, it just tells the operator whether the step is still pending,
-# mirroring the repo's existing "report missing creds, don't fail" idiom
-# (roles/openbao_secrets/tasks/fetch_domain.yml).
+# Optional bootstrap: seed ~/.codex/auth.json from the Bao-sourced snapshot
+# (codex_runner_auth_json) when present. Deliberately create-only
+# (force: false): Codex rotates its refresh token guest-side after the first
+# login, so a live, already-refreshed token must NEVER be clobbered by this
+# stale bootstrap copy — Bao holds only the one-time snapshot. When the var is
+# empty, both tasks skip and the manual bootstrap paths (README) still apply.
+- name: Ensure the codex-runner .codex directory exists
+  ansible.builtin.file:
+    path: "{{ codex_runner_home }}/.codex"
+    state: directory
+    owner: "{{ codex_runner_user }}"
+    group: "{{ codex_runner_group }}"
+    mode: "0700"
+  when: codex_runner_auth_json | length > 0
+
+- name: Seed Codex auth from the Bao snapshot (create-only, never overwrite)
+  ansible.builtin.copy:
+    content: "{{ codex_runner_auth_json }}"
+    dest: "{{ codex_runner_home }}/.codex/auth.json"
+    owner: "{{ codex_runner_user }}"
+    group: "{{ codex_runner_group }}"
+    mode: "0600"
+    force: false
+  no_log: true
+  when: codex_runner_auth_json | length > 0
+
+# Auth is otherwise a one-time, interactive, human step (ChatGPT OAuth
+# device-code or browser flow) that cannot be scripted here — see README.md for
+# both manual bootstrap options. This check is informational only: it never
+# fails the converge, it just tells the operator whether the step is still
+# pending, mirroring the repo's existing "report missing creds, don't fail"
+# idiom (roles/openbao_secrets/tasks/fetch_domain.yml).
 - name: Check whether Codex auth has been bootstrapped for codex-runner
   ansible.builtin.stat:
     path: "{{ codex_runner_home }}/.codex/auth.json"


### PR DESCRIPTION
Unblocks Hermes's Codex escalation path: the codex MCP config renders on the guest, but `/var/lib/codex-runner/.codex/auth.json` never existed, so every Codex call errored. The role documented only interactive `codex login` or a manual scp; this adds a converge-time bootstrap.

## Change

- **`roles/codex_runner/tasks/main.yml`** — when `codex_runner_auth_json` is non-empty, ensure `~/.codex` exists (`0700`, `codex-runner` owned) then write `auth.json` (`0600`, `codex-runner`, `no_log`). The copy is **create-only** (`force: false`): Codex rotates its refresh token guest-side after first login, so this one-time bootstrap snapshot must never overwrite a live token. Both tasks skip cleanly when the var is empty, preserving the manual bootstrap paths.
- **`inventory/group_vars/hermes_agent_group.yml`** — wire `codex_runner_auth_json` Bao-first (`CODEX_AUTH_JSON`) with env fallback, mirroring the existing `hermes_agent_github_app_private_key` idiom.
- **`roles/codex_runner/defaults/main.yml`** — declare `codex_runner_auth_json: ""` with rationale.
- **`roles/codex_runner/README.md`** — add auth Option C (seed from OpenBao, bootstrap-only) + a key-variables row.

## Notes

- No secret values are handled anywhere in this change — pure role plumbing. The value is dropped into OpenBao out of band.
- Mirrors the closest existing pattern (hermes_agent GitHub App private key materialization).
- Not merged, not converged.

## Verification

- `yamllint` clean (all changed YAML)
- `ansible-lint` clean, **profile `production`** required and passed (0 failures, 0 warnings)
- `markdownlint-cli2` clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oEWqS9KGW6hsSuPsKtfxr