### PR TITLE
fix(technitium_dns): repair molecule verify fail_msg templating

### DIFF
--- a/molecule/technitium_dns/verify.yml
+++ b/molecule/technitium_dns/verify.yml
@@ -95,7 +95,7 @@
           Query-log export vars did not derive as expected:
           host='{{ technitium_dns_query_log_syslog_host }}'
           port='{{ technitium_dns_query_log_syslog_port }}'
-          config={{ technitium_dns_query_log_config }}.
+          syslog={{ technitium_dns_query_log_syslog }}.
 
     - name: Assert authoritative zone is the subdomain and forwarders -> gateway
       ansible.builtin.assert:


### PR DESCRIPTION
## Problem

The `Molecule / Molecule (technitium_dns)` CI leg has failed on **every** PR since #774 merged, regardless of whether the PR touches DNS. Failing task: `molecule/technitium_dns/verify.yml` → "Assert the query-log export target derives from the syslog CNAME + tofu port", erroring with:

```
'ansible.builtin.assert' failed: Error while resolving value for 'fail_msg':
  'technitium_dns_query_log_config' is undefined
Finalization of task args for 'ansible.builtin.assert' failed.
```

## Root cause

#774 renamed the query-log config var (`technitium_dns_query_log_config` → `technitium_dns_query_log_syslog`, the block the role now manages) and updated the assert `that:` clauses accordingly — but left the **deleted** var referenced in the task's `fail_msg`. ansible-core finalizes all task args (including `fail_msg`) even when the assertions themselves pass, so the undefined var aborts the task on every run.

## Fix

Point the `fail_msg` at `technitium_dns_query_log_syslog`, the var that survives #774. The diagnostic stays meaningful — it dumps the same syslog dict the assertions check.

## Verification

- `yamllint` clean; `ansible-lint` production profile: `Passed: 0 failure(s), 0 warning(s)`.
- Templating proof: a throwaway probe that forces the assert fail path renders the message cleanly against the role defaults — `failed=0`, full render including `syslog={'address': 'syslog.svc.example.net', 'port': 522, 'protocol': 'TCP', 'enabled': True}`. The undefined-var error is gone.
- This PR's own `Molecule (technitium_dns)` leg going green is the end-to-end proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)