### PR TITLE
fix(technitium_dns): repair verify fail_msg after #774 var rename

### DIFF
--- a/molecule/technitium_dns/verify.yml
+++ b/molecule/technitium_dns/verify.yml
@@ -95,7 +95,7 @@
           Query-log export vars did not derive as expected:
           host='{{ technitium_dns_query_log_syslog_host }}'
           port='{{ technitium_dns_query_log_syslog_port }}'
-          config={{ technitium_dns_query_log_config }}.
+          syslog={{ technitium_dns_query_log_syslog }}.
 
     - name: Assert authoritative zone is the subdomain and forwarders -> gateway
       ansible.builtin.assert:


### PR DESCRIPTION
## What

`#774` renamed the technitium_dns query-log config vars, but the molecule
verify's "query-log export target" assert still templated the removed
`technitium_dns_query_log_config` inside its `fail_msg`. Ansible finalizes all
task args (including `fail_msg`) **before** evaluating `that:`, so the undefined
var raised:

```
[ERROR]: Finalization of task args for 'ansible.builtin.assert' failed:
  'technitium_dns_query_log_config' is undefined
fatal: [technitium-1-test]: FAILED!  failed=1
fatal: [technitium-2-test]: FAILED!  failed=1
```

on both test hosts, red-lighting the **Molecule (technitium_dns)** job on every
PR in the repo regardless of the assertions.

## Fix

Point the `fail_msg` at the post-#774 `technitium_dns_query_log_syslog` dict
that the same assert already checks (address/port/protocol/enabled). This was
the **only** reference to the removed var (verified via `git grep`); every other
query-log var in `verify.yml` still exists in
`roles/technitium_dns/defaults/main.yml`.

One-line change to `molecule/technitium_dns/verify.yml`.

## Evidence

- `ansible-lint` (production profile): 0 failures / 0 warnings.
- Local molecule is CI-only in this repo, so the Molecule (technitium_dns)
  matrix job here is the live proof — it should flip green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdViJykVq9qAS1jsinng4N
