### PR TITLE
fix(inventory): repoint containers['object-storage'] lookups to renamed key 's3'

### DIFF
--- a/inventory/group_vars/cribl_edge.yml
+++ b/inventory/group_vars/cribl_edge.yml
@@ -9,8 +9,7 @@ systemd_restart_policy_services:
 # The `infra/cribl-linux-x64.tgz` object is staged by the workstation
 # during initial bootstrap (upstream has no stable versioned URL for
 # "latest", so we mirror the current build rather than chasing a moving
-# target). The container key is hyphenated, so bracket notation is required
-# (dot notation mis-parses as subtraction).
+# target).
 cribl_edge_tarball_url: >-
-  http://{{ tofu_data.containers['object-storage'].ip }}:{{
+  http://{{ tofu_data.containers['s3'].ip }}:{{
   tofu_data.constants.service_ports.object_storage_s3 }}/splunk-addons/infra/cribl-linux-x64.tgz

--- a/inventory/group_vars/cribl_stream_group.yml
+++ b/inventory/group_vars/cribl_stream_group.yml
@@ -5,8 +5,7 @@ systemd_restart_policy_services:
 # Cribl Stream containers have the `outbound-internal` firewall group applied
 # (RFC1918 only), so they cannot reach cdn.cribl.io directly. Serve the
 # tarball from the object-storage (RustFS) artifact store — same binary as
-# Cribl Edge, different runtime configuration. The container key is hyphenated,
-# so bracket notation is required (dot notation mis-parses as subtraction).
+# Cribl Edge, different runtime configuration.
 cribl_stream_tarball_url: >-
-  http://{{ tofu_data.containers['object-storage'].ip }}:{{
+  http://{{ tofu_data.containers['s3'].ip }}:{{
   tofu_data.constants.service_ports.object_storage_s3 }}/splunk-addons/infra/cribl-linux-x64.tgz

--- a/roles/idrac_kvm_docker/defaults/main.yml
+++ b/roles/idrac_kvm_docker/defaults/main.yml
@@ -9,11 +9,11 @@ idrac_kvm_docker_build_dir: /opt/idrac-kvm/build
 # URL of a tar archive whose top level is an `app/` directory holding the AVCT client
 # (app/avctKVM.jar, app/lib/*.jar, app/lib/*.so, app/lib/META-INF/*). Defaults to the
 # internal object-storage `idrac` bucket (anonymous-read on the internal network); the
-# host + port resolve from the published inventory — never a committed literal. The
-# container key is hyphenated, so bracket notation is required. Override wholesale to
-# stage from a different mirror / NAS. On a re-stage, update the sha256 below to match.
+# host + port resolve from the published inventory — never a committed literal.
+# Override wholesale to stage from a different mirror / NAS. On a re-stage, update
+# the sha256 below to match.
 idrac_kvm_docker_avct_artifact_url: >-
-  http://{{ tofu_data.containers['object-storage'].ip }}:{{
+  http://{{ tofu_data.containers['s3'].ip }}:{{
   tofu_data.constants.service_ports.object_storage_s3 }}/idrac/app.tar
 # sha256 of the artifact — pins the exact build (integrity verification at fetch time).
 idrac_kvm_docker_avct_artifact_sha256: "66d6df8c566f096bde20e99902a4ba679c95162eaf7f4633b843bb5534948ac9"

--- a/roles/technitium_install/defaults/main.yml
+++ b/roles/technitium_install/defaults/main.yml
@@ -38,11 +38,10 @@ technitium_install_dotnet_pkg: "aspnetcore-runtime-9.0"
 
 # Mirror endpoint for the Technitium app tarball. The host + port resolve from
 # the published inventory (the object-storage container) — never a committed
-# literal. The container key is hyphenated, so bracket notation is required
-# (dot notation mis-parses as subtraction). Override technitium_install_app_url
-# wholesale to point at a different mirror.
+# literal. Override technitium_install_app_url wholesale to point at a different
+# mirror.
 technitium_install_mirror_endpoint: >-
-  http://{{ tofu_data.containers['object-storage'].ip }}:{{
+  http://{{ tofu_data.containers['s3'].ip }}:{{
   tofu_data.constants.service_ports.object_storage_s3 }}/artifacts
 # Version matches the upstream Docker tag so Renovate can compare + flag updates.
 # IMPORTANT: the artifact is mirror-hosted, so a Renovate version bump is only a


### PR DESCRIPTION
## What

The terraform-proxmox published ansible inventory is renaming the `containers` map key `object-storage` → `s3`. The container's hostname/FQDN (`s3.jacobpevans.com`) and all `service_ports` keys are **unchanged**, and the container **tag** `object-storage` is also unchanged (so `object_storage_group` and the `object_storage` role are unaffected). Only the map **key** used to look the container up changes.

This PR repoints the four `containers['object-storage']` key lookups in this repo:

- `inventory/group_vars/cribl_edge.yml` — `cribl_edge_tarball_url`
- `inventory/group_vars/cribl_stream_group.yml` — `cribl_stream_tarball_url`
- `roles/idrac_kvm_docker/defaults/main.yml` — `idrac_kvm_docker_avct_artifact_url`
- `roles/technitium_install/defaults/main.yml` — `technitium_install_mirror_endpoint`

Also drops now-false comments that justified bracket notation by the key being hyphenated (`s3` is not hyphenated).

## Coordination

**Do not merge alone.** This must merge **together with the upstream inventory republish** that renames the key. The orchestrator merges once the new-key inventory is published.

## Unchanged on purpose

The `object-storage` **tag** check in `inventory/load_tofu.yml` (builds `object_storage_group`), the `object-storage` play tag in `playbooks/site.yml`, the `object_storage` role and its systemd/user/dir names, the `platform/object-storage` OpenBao secret paths, the `object_storage_s3` service-port key, and all `object-storage`/RustFS prose and CHANGELOG entries — none are containers-map key lookups.