### PR TITLE
fix(hermes): break the OptiQ tool-call loop (repetition_penalty) + stale-stream kill spiral (bounded context)

### DIFF
--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -52,10 +52,22 @@ hermes_agent_installer_path: "/usr/local/lib/hermes-agent-installer-{{ hermes_ag
 hermes_agent_model: "{{ ai_default_model }}"
 hermes_agent_model_base_url: "https://llm.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}/v1"
 hermes_agent_model_api_mode: chat_completions
-# Qwen3.6-35B-A3B's native context window (256K = 262144 tokens). Custom
-# providers carry no context catalog Hermes can probe, so this is declared
-# explicitly (model.context_length in config.yaml.j2).
-hermes_agent_model_context_length: 262144
+# The context window Hermes budgets against and compacts under (it compresses at
+# hermes_agent_context_compression_threshold * this value). The model's TRUE
+# native window is 262144 (Qwen3.6-35B-A3B), but we deliberately DECLARE a
+# smaller 60000 to BOUND PREFILL TIME and break a stale-stream kill/re-prompt
+# spiral confirmed under load: the router's prefix cache is not reused
+# turn-to-turn, so every turn re-prefills the FULL prompt, and prefill emits no
+# stream chunks. A 70-90K-token re-prefill can run longer than
+# hermes_agent_stream_stale_timeout (900s) with zero chunks in flight, tripping a
+# FALSE "stream stale" kill; Hermes then re-prompts "continue where you left
+# off", the context grows, the next re-prefill is longer, and it spirals. Keeping
+# the declared window at 60000 makes compaction fire at ~0.85*60000 = 51000
+# tokens, so a full re-prefill stays well under the 900s stale window. Bounding
+# context is the correct fix — do NOT raise stream_stale_timeout to paper over a
+# runaway prefill. (Custom providers carry no context catalog Hermes can probe,
+# so this is declared explicitly as model.context_length in config.yaml.j2.)
+hermes_agent_model_context_length: 60000
 # ROOT-CAUSE fix for the "Context length exceeded (18/19 tokens). Cannot
 # compress further." death loop confirmed in ~/.hermes/logs/agent.log: the
 # router/backend hard-caps a single completion at 8192 output tokens

--- a/roles/hermes_agent/templates/config.yaml.j2
+++ b/roles/hermes_agent/templates/config.yaml.j2
@@ -12,10 +12,12 @@ model:
   # Custom/vLLM-style providers have no context-window catalog Hermes can
   # probe. Without this, Hermes' own auto-detect logs "Could not detect
   # context length ... defaulting to 256,000 (probe-down)" before falling
-  # back to a hardcoded catalog guess — this makes the real window explicit.
-  # model.context_length is read at agent_init.py as the highest-precedence
-  # override in get_model_context_length (verified against the installed
-  # Hermes 0.18.0 source, not just --help/docs).
+  # back to a hardcoded catalog guess. We declare it explicitly — and
+  # deliberately BELOW the model's native window — to bound per-turn prefill
+  # time and break the stale-stream kill spiral (see the value's rationale in
+  # defaults/main.yml). model.context_length is read at agent_init.py as the
+  # highest-precedence override in get_model_context_length (verified against
+  # the installed Hermes 0.18.0 source, not just --help/docs).
   context_length: {{ hermes_agent_model_context_length }}
   # ROOT CAUSE of the "Context length exceeded (18/19 tokens). Cannot
   # compress further." death loop: the router/backend hard-caps a single

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -103,7 +103,26 @@ llm_router_large_models:
   # explicit max_input_tokens: the wildcard "*" entry below sets none, and a
   # null there makes Hermes/OpenWebUI fall back to a near-zero context guess and
   # compress every request to death.
-  - { alias: Qwen3.6-35B-A3B-OptiQ-4bit, backend: mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit, context_window: 262144 }
+  #
+  # extra_body.repetition_penalty: the anti-repetition-loop fix. In long agentic
+  # sessions this brain emitted ~37 IDENTICAL tool calls per turn (Hermes dedups
+  # + executes once, the model re-emits next turn, the task never advances). The
+  # 20/20-clean agentic bench and the looping production sessions differ only in
+  # sampling. Hermes omits temperature/repetition_penalty, so the serving engine
+  # (vllm-mlx 0.4.0) applies its request-absent fallbacks — temperature 0.7 (NOT
+  # greedy; --default-temperature is unset) and repetition_penalty 1.0 (OFF). A
+  # gentle 1.05 penalty is the one lever whose current effective value is
+  # loop-permitting: it directly taxes verbatim re-emission while staying mild
+  # enough to preserve tool-call JSON validity. extra_body carries it past the
+  # router's drop_params to vllm-mlx, whose chat path honors a request-supplied
+  # repetition_penalty. (temperature is deliberately NOT pinned here: 0.7 would
+  # merely restate the engine fallback the loop already runs under. If 1.05 is
+  # insufficient, the next lever is to match the clean bench's sampling —
+  # temperature ~1.0 / presence_penalty 0.0 — added to this same extra_body.)
+  - alias: Qwen3.6-35B-A3B-OptiQ-4bit
+    backend: mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit
+    context_window: 262144
+    extra_body: { repetition_penalty: 1.05 }
   # claude-sonnet-5 is a Claude Code alias deliberately mapped to a local Qwen3.6
   # backend (PR #624) — not a mis-map; it inherits that backend's 262144 context.
   - { alias: claude-sonnet-5, backend: mlx-community/Qwen3.6-35B-A3B-4bit, context_window: 262144 }

--- a/roles/llm_router/templates/config.yaml.j2
+++ b/roles/llm_router/templates/config.yaml.j2
@@ -20,6 +20,16 @@ model_list:
       model: openai/{{ m.backend }}
       api_base: {{ llm_router_llm_large_base_url }}
       api_key: os.environ/LLM_LARGE_BEARER_TOKEN
+{% if m.extra_body is defined %}
+      # Per-model sampling defaults pinned at the router. extra_body is forwarded
+      # to the OpenAI-compatible backend VERBATIM (litellm_settings.drop_params
+      # would otherwise strip a non-OpenAI param like repetition_penalty before
+      # it reaches the server). See the model entry in defaults for the evidence.
+      extra_body:
+{% for _pk, _pv in m.extra_body.items() %}
+        {{ _pk }}: {{ _pv }}
+{% endfor %}
+{% endif %}
 {% if m.context_window is defined %}
     model_info:
       # These mlx-community backend ids are unknown to LiteLLM's built-in

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -2071,6 +2071,11 @@
       - { alias: Qwen3-Coder-30B-A3B, backend: mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit, context_window: 262144 }
       - { alias: Qwen3.6-35B-A3B-4bit, backend: mlx-community/Qwen3.6-35B-A3B-4bit, context_window: 262144 }
       - { alias: Qwen3.6-27B-4bit, backend: mlx-community/Qwen3.6-27B-4bit, context_window: 262144 }
+      # OptiQ carries a per-model extra_body (repetition_penalty anti-loop fix).
+      - alias: Qwen3.6-35B-A3B-OptiQ-4bit
+        backend: mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit
+        context_window: 262144
+        extra_body: { repetition_penalty: 1.05 }
       - { alias: claude-sonnet-5, backend: mlx-community/Qwen3.6-35B-A3B-4bit, context_window: 262144 }
     llm_router_light_models:
       - { alias: hermes-4-14b, backend: hermes-4-14b }
@@ -2159,6 +2164,24 @@
           - _ctx['Qwen3.6-27B-4bit'] == 262144
           - _ctx['claude-sonnet-5'] == 262144
         fail_msg: "config.yaml.j2 did not render max_input_tokens for all large models: {{ _litellm.model_list }}"
+
+    - name: Assert a large model's extra_body sampling reaches BOTH its deployments
+      ansible.builtin.assert:
+        that:
+          # extra_body must render under litellm_params (so it forwards to the
+          # backend verbatim past drop_params) on both the alias AND physical-id
+          # deployment of the same model — the OptiQ repetition_penalty anti-loop
+          # fix. A model without extra_body must NOT sprout one.
+          - >-
+            (_litellm.model_list | selectattr('model_name', 'equalto', 'Qwen3.6-35B-A3B-OptiQ-4bit')
+             | first).litellm_params.extra_body.repetition_penalty == 1.05
+          - >-
+            (_litellm.model_list | selectattr('model_name', 'equalto', 'mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit')
+             | first).litellm_params.extra_body.repetition_penalty == 1.05
+          - >-
+            'extra_body' not in (_litellm.model_list
+             | selectattr('model_name', 'equalto', 'gpt-oss-120b') | first).litellm_params
+        fail_msg: "config.yaml.j2 did not render per-model extra_body sampling: {{ _litellm.model_list }}"
 
     - name: Assert routing, health checks, and observability callbacks
       ansible.builtin.assert:


### PR DESCRIPTION
Two independent, mutually-reinforcing failure arms on the OptiQ brain
(`ai_default_model`, LiteLLM alias `Qwen3.6-35B-A3B-OptiQ-4bit`), each fixed here.

---

## Arm 1 — the repetition loop (llm_router)

### Symptom
Confirmed at two surfaces on the live Studio: the same sentence repeated ~100+
times (wiki run) and **~37 identical tool calls per turn** (interactive). Hermes
dedups + executes once, the model re-emits next turn, the task never advances.

### Root cause — the missing guardrail (proven, not re-derived)
Every Studio `[REQUEST]` line shows `presence_penalty=0.3 repetition_penalty=None`.
Hermes never sends a repetition penalty, so vllm-mlx 0.4.0 applies its
request-absent fallback `_FALLBACK_REPETITION_PENALTY = 1.0` — penalty **OFF**.
With nothing taxing it, the quantized model reconstructs the identical tokens
every turn.

The "server defaults to greedy" hypothesis is **disproven**: the serve command
has no `--default-temperature`, so an absent temperature resolves to
`_FALLBACK_TEMPERATURE = 0.7` (not `0.0`). Setting the originally-suggested
`temperature: 0.7` would be a no-op — it restates the fallback the loop already
runs under. repetition_penalty is the one lever whose current effective value
permits the loop.

### Fix
`repetition_penalty: 1.05` on the OptiQ alias via `litellm_params.extra_body`.
`extra_body` forwards to the OpenAI-compatible backend **verbatim**, bypassing
`litellm_settings.drop_params` (which would strip a non-OpenAI param). vllm-mlx's
chat path honors a request-supplied `repetition_penalty`
(`_resolve_repetition_penalty(request.repetition_penalty)`). `1.05` is gentle
enough to preserve tool-call JSON validity; the mechanism is a generic optional
`extra_body` passthrough, so bumping toward `1.1` (or adding `temperature ~1.0` /
`presence_penalty 0.0` to match the clean bench) is a one-line change if needed.

---

## Arm 2 — the stale-stream kill/re-prompt spiral (hermes_agent)

### Mechanism (proven)
Under load the brain streams ran **452s → 2962s**, and the router's prefix cache
is **not reused turn-to-turn** (`tokens_to_prefill == prompt_tokens` every turn),
so each turn re-prefills the FULL prompt. Prefill emits no stream chunks, so a
70–90K-token re-prefill can run past the client's `stream_stale_timeout` (900s)
with nothing in flight → a **false** "stream stale" kill → Hermes re-prompts
verbatim `[System: The previous response was cut off by a network error
mid-stream. Continue exactly where you left off...]` → context grows → next
re-prefill is longer → spiral.

### Fix
Declare `model.context_length: 60000` (was 262144). The model's native window is
262144, but Hermes budgets against and compacts under `model.context_length`;
declaring 60000 fires compaction at ~`0.85 * 60000 = 51000` tokens, keeping a
full re-prefill well under the 900s stale window. **Bounding context is the fix —
`stream_stale_timeout` is deliberately left at 900s** (raising it would only mask
a runaway prefill).

The two arms reinforce: Arm 1 stops the loop that inflates context; Arm 2 bounds
the prefill cost of whatever context remains.

---

## Deliberately out of scope

- **The 65536 "overflow" is a myth.** `--max-request-tokens 65536` caps requested
  **output** `max_tokens` only (`_resolve_request_max_tokens` → `"max_tokens
  exceeds server limit"`), not the prompt. OptiQ's native window is 262144, the
  observed ~87k prompt fits and completes. `context_length: 60000` here is a
  prefill-time bound (Arm 2), NOT an overflow guard.
- **No upstream agent loop-guard knob.** The Hermes brain loop's only cap is
  `agent.max_turns` (= `max_iterations`, already 90, session-wide).
  `sampling.max_tool_rounds` is MCP-server-initiated-sampling only;
  `code_execution.max_tool_calls` and `delegation.max_iterations` don't touch the
  main loop. No duplicate-tool-call / loop-detection config exists — gap reported,
  no wrapper invented.

## Verification
- `tests/template_render/verify_templates.yml`: asserts `extra_body
  .repetition_penalty == 1.05` reaches BOTH the OptiQ alias and its physical-id
  deployment, and that a model without `extra_body` doesn't sprout one. Full
  suite `ok=202 failed=0`.
- `ansible-lint` (production profile) + `yamllint`: clean on all changed files.

Does not merge or converge — gated for review.