### PR TITLE
feat(llm_router): daily brain rotation via a stable ai-default alias

### DIFF
--- a/docs/BRAIN_ROTATION.md
+++ b/docs/BRAIN_ROTATION.md
@@ -75,9 +75,9 @@ router guests — a fast uvicorn bounce, acceptable as a scheduled 00:00/12:00 b
 `inventory/group_vars/all.yml` (one place, no scattered duplicates):
 
 ```yaml
-ai_rotation_enabled: false                              # master switch
-ai_default_model_optimized: Qwen3.6-35B-A3B-OptiQ-4bit  # 12:00 UTC brain
-ai_default_model_large: gpt-oss-120b                    # 00:00 UTC brain (interim; see capacity)
+ai_rotation_enabled: false                                 # master switch
+ai_default_model_optimized: Qwen3.6-35B-A3B-OptiQ-4bit     # 12:00 UTC brain
+ai_default_model_large: Qwen3-Next-80B-A3B-Thinking-4bit   # 00:00 UTC brain
 # Derived pointer every consumer already reads. When rotation is off it equals
 # the optimized id (byte-identical to the old literal); when on it is the alias.
 ai_default_model: "{{ 'ai-default' if ai_rotation_enabled | bool else ai_default_model_optimized }}"
@@ -106,67 +106,62 @@ rotation; a phase id not in the table fails the converge loud.
 With `ai_rotation_enabled: false` none of this renders; the base
 `config.yaml` is the real file it is today.
 
-## Capacity math (the real blocker for the future large model)
+## Capacity math
 
-Serving host: the Mac Studio, 128 GB, ~118 GB wired ceiling.
+Serving host: the Mac Studio, 128 GB, ~118 GB wired ceiling, ~109 GB cache-clear
+trip (`gpuMemoryUtilization 0.80`).
 
-**Current `nix-darwin` main residents** (`lib/hosts.nix`):
+**Current `nix-darwin` main residents** (`lib/hosts.nix`, release 1.73.0 / #1589):
 
 | Resident | Weights | KV cache |
 | --- | --- | --- |
-| `gpt-oss-120b-MXFP4-Q8` (default) | 63.3 GB | 6.0 GB |
 | `Qwen3-Coder-30B-A3B-4bit` (coding) | 17.1 GB | 6.0 GB |
-| **Resident total** | **80.4 GB** | **12.0 GB → 92.4 GB** |
+| `Qwen3.6-35B-A3B-OptiQ-4bit` (tool-calling) | 19.5 GB | 16.0 GB |
+| **Resident total** | **36.6 GB** | **22.0 GB → 58.6 GB** |
 
-Swap headroom under the 118 GB ceiling ≈ **25.6 GB**. The swap-tier
-`Qwen3.6-35B-A3B-4bit` (20.4 GB + 3 GB cache) fits; OptiQ-4bit (~19.5 GB + cache)
-fits and is served today via nix-ai auto-discovery.
+`gpt-oss-120b` is **no longer preloaded** (it failed the agentic gate at 0%): it
+drops to on-demand and idle-unloads. Auto-discovery is force-disabled fleet-wide
+(`hosts/common/mlx-no-autodiscover.nix`), so every swap model is registered
+explicitly.
 
-Which large candidate fits alongside the 92.4 GB resident pair:
+**The large phase (`Qwen3-Next-80B-A3B-Thinking-4bit`) fits the swap tier:**
+58.6 GB residents + ~42 GB weights + 4 GB cache **≈ 104.6 GB**, under the ~109 GB
+trip. The cache is deliberately kept small (4 GB) to hold that margin; the model
+idle-unloads at 900 s back to the 58.6 GB baseline. It is registered in
+`lib/hosts.nix:mlx.models` (see the companion nix-darwin PR), **not** auto-
+discovered — a discovered model would inherit the default model's serve flags
+(wrong parser for a Qwen brain).
 
-- **`gpt-oss-120b` (interim)** — already a resident, so **0 extra bytes**; it is
-  the large phase at no memory cost.
-- **`Qwen3-Next-80B-A3B-Thinking-4bit`** — 42 GB on disk. Does **not** fit:
-  92.4 + 42 + cache ≈ 137 GB, well over the 118 GB ceiling. The auto-discover
-  preflight (`disk × 1.3 = 54.6 GB > available`) even refuses to register it.
+**Why not `gpt-oss-120b` as the large brain?** It is the biggest local model, but
+it scored **0% valid agentic tool calls** in the 2026-07-08 grid, so serving it as
+Hermes's brain 12h/day would lobotomize tool-calling — the exact regression the
+A/B is meant to surface, not cause. Next-80B benched 100% valid (single run,
+provisional), degrades ~round 17, ~12 tok/s. Both rotation phases carry a 262144
+context, so the `ai-default` alias's `max_input_tokens` is identical across the
+flip.
 
-**This is the correction to the campaign brief.** The brief assumed residents of
-`coder-30B + OptiQ ≈ 58.6 GB`, under which Next-80B (42 GB) fits. That is **not**
-the deployed `nix-darwin` main config, which keeps `gpt-oss-120b` resident
-(80.4 GB pair). Under the deployed config, **Next-80B cannot be served at all
-without evicting a resident** — it is not a "swap-tier registration + llama-swap
-handles it" job, because it does not fit the swap headroom.
+## Flagship-generation upgrade path (the 50–90 GB tier)
 
-So the interim large model is **`gpt-oss-120b`**, which is already resident, needs
-**no `nix-darwin` change**, and is a genuinely different, larger brain than the
-35B OptiQ — a real A/B at zero memory cost. Note the per-phase context differs and
-is handled automatically: gpt-oss-120b = 131072, OptiQ = 262144 (both already in
-the router alias table).
+A future large brain (a Qwopus-class 50–90 GB flagship) that does **not** co-reside
+with the 58.6 GB resident pair under the ~109 GB trip needs a **serving-side**
+change first — this rotation cannot conjure memory. In priority order:
 
-## Flagship-generation upgrade path (Next-80B and the 50–90 GB tier)
-
-A large model that does not co-reside with the resident pair (Next-80B today, a
-Qwopus-class 50–90 GB flagship later) needs a **serving-side** change first — this
-rotation cannot conjure memory. In priority order:
-
-1. **Reconcile the resident set in `nix-darwin` `lib/hosts.nix`.** Either drop
-   `gpt-oss-120b` as resident (the brief's assumed `coder-30B + OptiQ` pair frees
-   ~34 GB) so Next-80B fits as swap, **or** move to an llama-swap **group-swap**
-   where the large brain and a resident are mutually exclusive (`groupSwap = true`
-   is already a supported knob; it is off today precisely to keep both warm).
-2. **Register the large model explicitly** in `lib/hosts.nix:mlx.models` with its
-   own tool-call/reasoning parser args (Next-80B is `qwen3_next` — the early
-   "batches crash" reputation is **retired** per `mlx-benchmarks` model-notes, but
-   automatic prefix caching stays unsupported and MTP/spec-decode must stay off).
-   Auto-discovery is not sufficient: discovered models inherit the **default**
-   model's serve flags (gpt-oss's harmony parser), which is wrong for a Qwen brain.
+1. **Reconcile the resident set / swap policy in `nix-darwin` `lib/hosts.nix`.**
+   Either trim a resident (or its cache) to free room for the flagship as swap, or
+   move to an llama-swap **group-swap** where the flagship and a resident are
+   mutually exclusive (`groupSwap = true` is already a supported knob; it is off
+   today to keep both brains warm).
+2. **Register the flagship explicitly** in `lib/hosts.nix:mlx.models` with its own
+   tool-call/reasoning parser args (the Next-80B entry is the worked example: the
+   `qwen3_next` "batches crash" reputation is **retired** per `mlx-benchmarks`
+   model-notes, but automatic prefix caching stays unsupported and MTP/spec-decode
+   must stay off). Auto-discovery is force-disabled, so registration is mandatory.
 3. **Add the first-class router alias** (one line in `llm_router_large_models`,
    `context_window: 262144`) so `ai-default` can resolve its backend + context.
 4. Flip `ai_default_model_large` to the new id and converge.
 
-The flagship generation therefore works as **night-model-resident / day-model-swap
-via group-swap**, decided in `nix-darwin`; this repo's rotation is unchanged (it
-only ever swaps which alias `ai-default` maps to).
+The flagship generation is decided in `nix-darwin` (resident/swap policy); this
+repo's rotation is unchanged — it only ever swaps which alias `ai-default` maps to.
 
 ## Failure modes and guards
 
@@ -196,13 +191,15 @@ only ever swaps which alias `ai-default` maps to).
 
 ## Open questions for the gate
 
-1. **Interim large = `gpt-oss-120b`?** It is the only zero-serving-change option.
-   Confirm it is an acceptable agentic brain for the large phase, or accept that
-   the A/B will expose its agentic tool-calling quality (OptiQ won the 2026-07-08
-   bench; gpt-oss-120b was not in that field).
-2. **Enable now or after serving reconcile?** Shipping disabled is safe and
-   byte-identical. Flipping `ai_rotation_enabled: true` with the `gpt-oss-120b`
-   interim works today; Next-80B needs the `nix-darwin` resident reconcile first.
+1. **Enable sequencing.** Shipping disabled is safe and byte-identical. Enabling
+   the rotation requires, in order: merge the companion `nix-darwin` PR (Next-80B
+   swap registration) → rebuild jevans-ms → a live load test of the `ai-default`
+   alias flip (confirm Next-80B swaps in under the trip and serves tool calls) →
+   flip `ai_rotation_enabled: true` and converge.
+2. **Bench maturity.** Next-80B's 100%-valid agentic result is a single,
+   provisional run. If the maturity policy (≥4 runs, both environment classes)
+   later demotes it, the large-phase id is a one-line change here + a swap entry
+   in `nix-darwin`.
 3. **Per-guest rotation (3 routers, 3 timers) vs a single owner?** This design
    rotates per router guest (idempotent, resilient, no elected owner). All three
    bounce `litellm` within `AccuracySec` at the mark.

--- a/docs/BRAIN_ROTATION.md
+++ b/docs/BRAIN_ROTATION.md
@@ -1,0 +1,208 @@
+# Daily brain rotation
+
+A built-in daily A/B for the LLM fabric: the fabric-wide default model rotates
+between a **large** brain and an **optimized** brain on a fixed UTC schedule, so
+the Hermes agent and the Open WebUI chat box always run the same default and that
+default alternates twice a day.
+
+- **00:00 UTC** → the **large** model.
+- **12:00 UTC** → the **optimized** model.
+
+The whole feature is behind `ai_rotation_enabled` (default `false`). With it off,
+every rendered artifact is byte-identical to a non-rotating converge — this repo
+can carry the mechanism without changing live behaviour until the switch is
+flipped.
+
+## Chosen actuator: a stable router alias whose backend rotates
+
+Consumers (Hermes, Open WebUI) point at one **stable** router alias, `ai-default`,
+forever. Only the LiteLLM router's mapping of `ai-default` → concrete backend
+flips at 00:00/12:00. Nothing else in the fabric moves.
+
+```text
+Hermes  ─┐
+         ├─ model id "ai-default" ──▶  LiteLLM router  ──▶  { large | optimized }
+OpenWebUI┘        (never changes)         (mapping flips 2×/day)
+```
+
+### Why this shape, and why not the others
+
+Four actuators were evaluated. The alias rotation is the only one that is
+**CI-credential-free, idempotent under Ansible, and free of a gateway restart and
+cron-snapshot churn** at the same time.
+
+1. **Scheduled GitHub Actions workflow** that converges with
+   `-e ai_default_model=…` — **discarded.** Ansible converge is interactive-only
+   in this repo (see `AGENTS.md` → "Development workflow"); the self-hosted
+   runners run read-only E2E *tests*, not credentialed converge. Standing up
+   converge-in-CI would mean plumbing OpenBao AppRoles, SSH keys, and Doppler
+   into GHA — a large new secret surface for a twice-daily toggle.
+2. **systemd timer on a guest that re-renders its own Ansible-managed config**
+   and restarts the gateway — **discarded.** A guest mutating an Ansible-owned
+   file out-of-band fights idempotency (the next converge reverts it) and still
+   restarts the gateway (SIGTERM mid-chat) twice daily.
+3. **Router-level alias rotation** (this design) — **chosen.** The twice-daily
+   mutation is a single local symlink the router role manages as a
+   deterministic, converge-safe value and the timers own between converges.
+   Consumer configs stay static, so no gateway restart and no cron churn.
+4. **Terrakube scheduled run / other existing timers** — none applies; no
+   scheduled-converge primitive exists here.
+
+### What the alias buys us (the three things a concrete-id rotation breaks)
+
+Rotating the **concrete** model id everywhere (the naïve approach) forces a
+twice-daily converge, because:
+
+1. **Open WebUI** — `DEFAULT_MODELS` is set from env with
+   `ENABLE_PERSISTENT_CONFIG=false`, so it is authoritative only at **container
+   start**. Changing the concrete id means restarting the Open WebUI container
+   twice a day.
+2. **Hermes cron jobs** — unpinned jobs snapshot `model.default` at creation and
+   **fail closed** on drift (upstream spend guard); they only re-seed on a
+   converge (`roles/hermes_agent/tasks/main.yml`). A concrete-id change without a
+   converge would silently stop the seeded cron fleet until the next converge.
+3. **Hermes gateway** — a converge re-renders `config.yaml`/`.env` and restarts
+   `hermes-gateway` (SIGTERM), killing any in-flight agent turn.
+
+Pointing both consumers at the stable `ai-default` alias makes all three
+non-issues: `model.default` stays `ai-default` (cron snapshots never drift),
+`DEFAULT_MODELS` stays `ai-default` (no Open WebUI restart), and the gateway is
+never touched by a rotation. The only process that restarts is `litellm` on the
+router guests — a fast uvicorn bounce, acceptable as a scheduled 00:00/12:00 blip.
+
+## Single source of truth for the model pair
+
+`inventory/group_vars/all.yml` (one place, no scattered duplicates):
+
+```yaml
+ai_rotation_enabled: false                              # master switch
+ai_default_model_optimized: Qwen3.6-35B-A3B-OptiQ-4bit  # 12:00 UTC brain
+ai_default_model_large: gpt-oss-120b                    # 00:00 UTC brain (interim; see capacity)
+# Derived pointer every consumer already reads. When rotation is off it equals
+# the optimized id (byte-identical to the old literal); when on it is the alias.
+ai_default_model: "{{ 'ai-default' if ai_rotation_enabled | bool else ai_default_model_optimized }}"
+```
+
+Both phase ids **must** be first-class aliases in
+`roles/llm_router/defaults/main.yml:llm_router_large_models` — the router resolves
+each phase's backend **and** its `context_window` from that existing table, so the
+rotating `ai-default` alias always carries an explicit `max_input_tokens` (a null
+there is the compress-to-death trap). No context values are duplicated for the
+rotation; a phase id not in the table fails the converge loud.
+
+## Mechanism (router role, `ai_rotation_enabled: true` only)
+
+1. Render **two** complete configs from the one `config.yaml.j2`, differing only
+   in the `ai-default` entry's backend/context: `config-large.yaml`,
+   `config-optimized.yaml`.
+2. `config.yaml` becomes a **symlink** to the phase that matches the current UTC
+   hour (computed on the guest via `date -u`), so a converge always lands on the
+   correct live phase and never clobbers it to the wrong one.
+3. Two declarative systemd timers (`litellm-rotate-large.timer` at `00:00 UTC`,
+   `litellm-rotate-optimized.timer` at `12:00 UTC`) each start a oneshot that does
+   exactly `ln -sfn config-<phase>.yaml config.yaml` + `systemctl restart litellm`.
+   No wrapper script, no time math — the schedule lives in `OnCalendar`.
+
+With `ai_rotation_enabled: false` none of this renders; the base
+`config.yaml` is the real file it is today.
+
+## Capacity math (the real blocker for the future large model)
+
+Serving host: the Mac Studio, 128 GB, ~118 GB wired ceiling.
+
+**Current `nix-darwin` main residents** (`lib/hosts.nix`):
+
+| Resident | Weights | KV cache |
+| --- | --- | --- |
+| `gpt-oss-120b-MXFP4-Q8` (default) | 63.3 GB | 6.0 GB |
+| `Qwen3-Coder-30B-A3B-4bit` (coding) | 17.1 GB | 6.0 GB |
+| **Resident total** | **80.4 GB** | **12.0 GB → 92.4 GB** |
+
+Swap headroom under the 118 GB ceiling ≈ **25.6 GB**. The swap-tier
+`Qwen3.6-35B-A3B-4bit` (20.4 GB + 3 GB cache) fits; OptiQ-4bit (~19.5 GB + cache)
+fits and is served today via nix-ai auto-discovery.
+
+Which large candidate fits alongside the 92.4 GB resident pair:
+
+- **`gpt-oss-120b` (interim)** — already a resident, so **0 extra bytes**; it is
+  the large phase at no memory cost.
+- **`Qwen3-Next-80B-A3B-Thinking-4bit`** — 42 GB on disk. Does **not** fit:
+  92.4 + 42 + cache ≈ 137 GB, well over the 118 GB ceiling. The auto-discover
+  preflight (`disk × 1.3 = 54.6 GB > available`) even refuses to register it.
+
+**This is the correction to the campaign brief.** The brief assumed residents of
+`coder-30B + OptiQ ≈ 58.6 GB`, under which Next-80B (42 GB) fits. That is **not**
+the deployed `nix-darwin` main config, which keeps `gpt-oss-120b` resident
+(80.4 GB pair). Under the deployed config, **Next-80B cannot be served at all
+without evicting a resident** — it is not a "swap-tier registration + llama-swap
+handles it" job, because it does not fit the swap headroom.
+
+So the interim large model is **`gpt-oss-120b`**, which is already resident, needs
+**no `nix-darwin` change**, and is a genuinely different, larger brain than the
+35B OptiQ — a real A/B at zero memory cost. Note the per-phase context differs and
+is handled automatically: gpt-oss-120b = 131072, OptiQ = 262144 (both already in
+the router alias table).
+
+## Flagship-generation upgrade path (Next-80B and the 50–90 GB tier)
+
+A large model that does not co-reside with the resident pair (Next-80B today, a
+Qwopus-class 50–90 GB flagship later) needs a **serving-side** change first — this
+rotation cannot conjure memory. In priority order:
+
+1. **Reconcile the resident set in `nix-darwin` `lib/hosts.nix`.** Either drop
+   `gpt-oss-120b` as resident (the brief's assumed `coder-30B + OptiQ` pair frees
+   ~34 GB) so Next-80B fits as swap, **or** move to an llama-swap **group-swap**
+   where the large brain and a resident are mutually exclusive (`groupSwap = true`
+   is already a supported knob; it is off today precisely to keep both warm).
+2. **Register the large model explicitly** in `lib/hosts.nix:mlx.models` with its
+   own tool-call/reasoning parser args (Next-80B is `qwen3_next` — the early
+   "batches crash" reputation is **retired** per `mlx-benchmarks` model-notes, but
+   automatic prefix caching stays unsupported and MTP/spec-decode must stay off).
+   Auto-discovery is not sufficient: discovered models inherit the **default**
+   model's serve flags (gpt-oss's harmony parser), which is wrong for a Qwen brain.
+3. **Add the first-class router alias** (one line in `llm_router_large_models`,
+   `context_window: 262144`) so `ai-default` can resolve its backend + context.
+4. Flip `ai_default_model_large` to the new id and converge.
+
+The flagship generation therefore works as **night-model-resident / day-model-swap
+via group-swap**, decided in `nix-darwin`; this repo's rotation is unchanged (it
+only ever swaps which alias `ai-default` maps to).
+
+## Failure modes and guards
+
+- **Rotation fires during an active chat.** The `litellm` restart drops
+  in-flight requests on the router tier only — not the agent session or its
+  history — and clients retry. Accepted as the scheduled 00:00/12:00 blip.
+  Hermes tolerates the underlying model changing between turns because each
+  completion is stateless.
+- **A managed bench window is active.** The large brain must not load and
+  collide with a bench. `litellm-rotate-large.service` carries
+  `ConditionPathExists=!<config_dir>/rotation-paused`; the bench runbook
+  `touch`es that sentinel to keep the fabric on the optimized (small) brain,
+  and should `systemctl start litellm-rotate-optimized` to flip down
+  immediately if a bench begins mid-large-phase. Removing the sentinel resumes
+  rotation at the next fire. No codified bench-window signal exists in the
+  repos today, so this sentinel is the wiring point.
+- **The large model fails to load.** llama-swap loads lazily on first request,
+  so a bad large id surfaces as 500s on `ai-default` until 12:00. Documented
+  follow-up (not in this PR): have the rotate-large oneshot warm and verify the
+  model against the gate, reverting the symlink on failure.
+- **A converge lands mid-phase.** The symlink target is computed from the
+  guest's current UTC hour, so a converge always re-affirms the correct live
+  phase instead of resetting it.
+- **A phase id is not in the alias table.** The converge fails loud — the
+  phase→backend/context resolution asserts membership in
+  `llm_router_large_models`.
+
+## Open questions for the gate
+
+1. **Interim large = `gpt-oss-120b`?** It is the only zero-serving-change option.
+   Confirm it is an acceptable agentic brain for the large phase, or accept that
+   the A/B will expose its agentic tool-calling quality (OptiQ won the 2026-07-08
+   bench; gpt-oss-120b was not in that field).
+2. **Enable now or after serving reconcile?** Shipping disabled is safe and
+   byte-identical. Flipping `ai_rotation_enabled: true` with the `gpt-oss-120b`
+   interim works today; Next-80B needs the `nix-darwin` resident reconcile first.
+3. **Per-guest rotation (3 routers, 3 timers) vs a single owner?** This design
+   rotates per router guest (idempotent, resilient, no elected owner). All three
+   bounce `litellm` within `AccuracySec` at the mark.

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -86,13 +86,19 @@ llm_large_serving_ip: >-
 # rendered output is byte-identical to a non-rotating converge. The two phase
 # ids MUST each be a first-class alias in llm_router_large_models so the router
 # can resolve their backend + context_window (a null max_input_tokens is the
-# compress-to-death trap). gpt-oss-120b is the interim large brain: it is
-# already a Studio resident, so it needs no nix-darwin change and fits the
-# memory budget with zero extra bytes (Qwen3-Next-80B-A3B does NOT fit the
-# current resident pair — see docs/BRAIN_ROTATION.md capacity math).
+# compress-to-death trap).
+#
+# Large brain = Qwen3-Next-80B-A3B-Thinking-4bit: a genuinely bigger brain that
+# is STILL a competent agent tool-caller (100% valid agentic tool calls, single
+# run). gpt-oss-120b is deliberately NOT the large brain — it scored 0% valid
+# agentic tool calls, so serving it as Hermes's brain for 12h/day would
+# lobotomize tool-calling, the exact opposite of the A/B's purpose. next80 fits
+# the swap tier alongside the 58.6 GB resident pair (~104.6 GB peak < ~109 GB
+# trip) and is registered in nix-darwin lib/hosts.nix — see
+# docs/BRAIN_ROTATION.md for the capacity math and the flagship upgrade path.
 ai_rotation_enabled: false
 ai_default_model_optimized: Qwen3.6-35B-A3B-OptiQ-4bit
-ai_default_model_large: gpt-oss-120b
+ai_default_model_large: Qwen3-Next-80B-A3B-Thinking-4bit
 ai_default_model: "{{ 'ai-default' if ai_rotation_enabled | bool else ai_default_model_optimized }}"
 
 # Resource-domain secrets fetched from OpenBao by the openbao_secrets pre-play,

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -76,7 +76,24 @@ llm_large_serving_ip: >-
 # tool calls under agentic load ("repairing tool_call with empty function.name",
 # unreliable multi-turn), so it is not the brain. The stock 4-bit alias
 # (Qwen3.6-35B-A3B-4bit) remains defined in the router for any other consumer.
-ai_default_model: Qwen3.6-35B-A3B-OptiQ-4bit
+#
+# Daily brain rotation (docs/BRAIN_ROTATION.md): when ai_rotation_enabled is
+# true, the fabric default becomes the STABLE router alias `ai-default`, whose
+# backend the llm_router role rotates on a UTC schedule — 00:00 -> the large
+# brain, 12:00 -> the optimized brain — giving a built-in daily A/B without
+# touching the Hermes gateway, Open WebUI, or the cron-snapshot fleet. When it
+# is false (default) ai_default_model equals the optimized id below, so the
+# rendered output is byte-identical to a non-rotating converge. The two phase
+# ids MUST each be a first-class alias in llm_router_large_models so the router
+# can resolve their backend + context_window (a null max_input_tokens is the
+# compress-to-death trap). gpt-oss-120b is the interim large brain: it is
+# already a Studio resident, so it needs no nix-darwin change and fits the
+# memory budget with zero extra bytes (Qwen3-Next-80B-A3B does NOT fit the
+# current resident pair — see docs/BRAIN_ROTATION.md capacity math).
+ai_rotation_enabled: false
+ai_default_model_optimized: Qwen3.6-35B-A3B-OptiQ-4bit
+ai_default_model_large: gpt-oss-120b
+ai_default_model: "{{ 'ai-default' if ai_rotation_enabled | bool else ai_default_model_optimized }}"
 
 # Resource-domain secrets fetched from OpenBao by the openbao_secrets pre-play,
 # one dict per domain. Defaults to an empty dict for each so every consumer's

--- a/roles/llm_router/README.md
+++ b/roles/llm_router/README.md
@@ -25,6 +25,20 @@ pair and cools a failed deployment down (`allowed_fails` / `cooldown_time`), so 
 outage drains to CPU automatically. There is **no** cross-tier fallback — a large
 request that fails surfaces the error rather than silently degrading to a small model.
 
+## Daily brain rotation (optional)
+
+When `ai_rotation_enabled` (in `group_vars/all.yml`) is `true`, the router exposes
+one stable alias, `ai-default`, that Hermes and Open WebUI point at permanently,
+and two systemd timers flip which backend it maps to on a UTC schedule: **00:00 →
+the large brain, 12:00 → the optimized brain** (`ai_default_model_large` /
+`ai_default_model_optimized`, both first-class aliases in `llm_router_large_models`).
+The flip is a `config.yaml` symlink swap between two pre-rendered per-phase configs
+plus a `litellm` restart — no gateway restart, no Hermes cron churn. A
+`ConditionPathExists` sentinel (`rotation-paused`) lets a bench window keep the
+fabric on the optimized brain. Off by default: `config.yaml` is a single static
+file and the render is byte-identical. Full rationale, capacity math, and the
+flagship upgrade path: [`docs/BRAIN_ROTATION.md`](../../docs/BRAIN_ROTATION.md).
+
 ## Observability
 
 `litellm_settings.callbacks: ["otel"]`:

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -123,6 +123,14 @@ llm_router_large_models:
     backend: mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit
     context_window: 262144
     extra_body: { repetition_penalty: 1.05 }
+  # Qwen3-Next-80B Thinking: the large-phase brain for the daily rotation
+  # (ai_default_model_large). A first-class alias so the rotating ai-default
+  # entry carries its real 262144 context. Served from the nix-darwin swap tier
+  # (lib/hosts.nix), loaded on demand only while ai-default points at it. Block
+  # style (not the flow one-liner above) only to stay under the 120-char limit.
+  - alias: Qwen3-Next-80B-A3B-Thinking-4bit
+    backend: mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit
+    context_window: 262144
   # claude-sonnet-5 is a Claude Code alias deliberately mapped to a local Qwen3.6
   # backend (PR #624) — not a mis-map; it inherits that backend's 262144 context.
   - { alias: claude-sonnet-5, backend: mlx-community/Qwen3.6-35B-A3B-4bit, context_window: 262144 }

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -210,3 +210,27 @@ llm_router_llm_fast_enabled: true
 # per-model edit. llm_router_large_models stays as the stable consumer-facing
 # alias set (exact-match aliases win over the wildcard).
 llm_router_large_passthrough_enabled: true
+
+# --- Daily brain rotation (docs/BRAIN_ROTATION.md) ---------------------------
+# When enabled, the router exposes ONE stable alias (`ai-default`) that Hermes
+# and Open WebUI point at permanently, and two systemd timers rotate which
+# backend that alias maps to: 00:00 UTC -> the large brain, 12:00 UTC -> the
+# optimized brain. Consumers never change, so no gateway restart and no cron
+# churn — only `litellm` bounces on this tier at the mark. Off by default: the
+# whole block below is inert and config.yaml renders exactly as it did before.
+llm_router_rotation_enabled: "{{ ai_rotation_enabled | default(false) | bool }}"
+llm_router_rotation_alias: ai-default
+# The two phases, by their first-class alias id in llm_router_large_models above
+# (the role resolves each to its backend + context_window from that table).
+llm_router_rotation_large_model: "{{ ai_default_model_large }}"
+llm_router_rotation_optimized_model: "{{ ai_default_model_optimized }}"
+# Fixed-hour UTC schedule. The `UTC` suffix needs systemd >= 252 (Debian 12).
+llm_router_rotation_large_oncalendar: "*-*-* 00:00:00 UTC"
+llm_router_rotation_optimized_oncalendar: "*-*-* 12:00:00 UTC"
+# Per-phase rendered configs; config.yaml is a symlink to the live one.
+llm_router_rotation_config_large: "{{ llm_router_config_dir }}/config-large.yaml"
+llm_router_rotation_config_optimized: "{{ llm_router_config_dir }}/config-optimized.yaml"
+# Bench-window guard: while this sentinel exists the large timer no-ops (the
+# fabric stays on the optimized brain so a bench is never crowded out). The
+# bench runbook touches it to pause and removes it to resume.
+llm_router_rotation_pause_sentinel: "{{ llm_router_config_dir }}/rotation-paused"

--- a/roles/llm_router/handlers/main.yml
+++ b/roles/llm_router/handlers/main.yml
@@ -4,3 +4,15 @@
     name: "{{ llm_router_service }}"
     state: restarted
     daemon_reload: true
+
+# Apply a changed rotation unit (new OnCalendar / ExecStart) — restart re-arms
+# the timer with daemon-reload. Skipped under Docker (no functional systemd).
+- name: Restart rotation timers
+  ansible.builtin.systemd:
+    name: "litellm-rotate-{{ item }}.timer"
+    state: restarted
+    daemon_reload: true
+  loop:
+    - large
+    - optimized
+  when: ansible_virtualization_type | default('') != 'docker'

--- a/roles/llm_router/tasks/main.yml
+++ b/roles/llm_router/tasks/main.yml
@@ -55,14 +55,35 @@
   no_log: true
   notify: Restart litellm
 
-- name: Deploy the LiteLLM proxy config
+# Rotation turns config.yaml into a symlink (rotation.yml). If rotation is later
+# disabled, drop that symlink first so the static render below writes a real file
+# at the same path rather than being ambiguous about the link.
+- name: Stat the LiteLLM config path
+  ansible.builtin.stat:
+    path: "{{ llm_router_config_file }}"
+  register: llm_router_config_stat
+
+- name: Drop a stale rotation symlink when rotation is disabled
+  ansible.builtin.file:
+    path: "{{ llm_router_config_file }}"
+    state: absent
+  when:
+    - not (llm_router_rotation_enabled | bool)
+    - llm_router_config_stat.stat.islnk | default(false)
+
+- name: Deploy the static LiteLLM proxy config (rotation disabled)
   ansible.builtin.template:
     src: config.yaml.j2
     dest: "{{ llm_router_config_file }}"
     owner: root
     group: "{{ llm_router_group }}"
     mode: "0640"
+  when: not (llm_router_rotation_enabled | bool)
   notify: Restart litellm
+
+- name: Configure daily brain rotation (per-phase configs + timers)
+  ansible.builtin.include_tasks: rotation.yml
+  when: llm_router_rotation_enabled | bool
 
 - name: Resolve the Mac Studio apex IP for LiteLLM host pinning
   # Reuse the same single-source Studio reservation the DNS role publishes;

--- a/roles/llm_router/tasks/rotation.yml
+++ b/roles/llm_router/tasks/rotation.yml
@@ -1,0 +1,110 @@
+---
+# Daily brain rotation (docs/BRAIN_ROTATION.md). Included from main.yml only when
+# llm_router_rotation_enabled is true. Renders one full config per phase (they
+# differ solely in the ai-default alias backend), points config.yaml at the phase
+# matching the current UTC half-day, and installs the two systemd timers that flip
+# the symlink + bounce litellm at 00:00 / 12:00 UTC. When rotation is disabled
+# none of this runs and main.yml renders the single static config as before.
+
+- name: Build the rotation phase table (model + rendered config + schedule)
+  ansible.builtin.set_fact:
+    llm_router_rotation_phases:
+      large:
+        model: "{{ llm_router_rotation_large_model }}"
+        config: "{{ llm_router_rotation_config_large }}"
+        oncalendar: "{{ llm_router_rotation_large_oncalendar }}"
+      optimized:
+        model: "{{ llm_router_rotation_optimized_model }}"
+        config: "{{ llm_router_rotation_config_optimized }}"
+        oncalendar: "{{ llm_router_rotation_optimized_oncalendar }}"
+
+- name: Assert both rotation phase models are first-class router aliases
+  ansible.builtin.assert:
+    that:
+      - llm_router_large_models | selectattr('alias', 'equalto', item.value.model) | list | length == 1
+    fail_msg: >-
+      Rotation phase model '{{ item.value.model }}' is not a first-class alias in
+      llm_router_large_models — add it (with context_window) so the ai-default
+      alias can resolve its backend + context. (docs/BRAIN_ROTATION.md)
+    quiet: true
+  loop: "{{ llm_router_rotation_phases | dict2items }}"
+  loop_control:
+    label: "{{ item.key }} -> {{ item.value.model }}"
+
+- name: Render the per-phase LiteLLM configs (ai-default -> that phase's brain)
+  ansible.builtin.template:
+    src: config.yaml.j2
+    dest: "{{ item.value.config }}"
+    owner: root
+    group: "{{ llm_router_group }}"
+    mode: "0640"
+  loop: "{{ llm_router_rotation_phases | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  vars:
+    _alias_entry: "{{ llm_router_large_models | selectattr('alias', 'equalto', item.value.model) | first }}"
+    llm_router_rotation_active_backend: "{{ _alias_entry.backend }}"
+    llm_router_rotation_active_context: "{{ _alias_entry.context_window }}"
+  notify: Restart litellm
+
+- name: Determine the current rotation phase from the guest's UTC hour
+  ansible.builtin.command: date -u +%H
+  register: llm_router_rotation_utc_hour
+  changed_when: false
+
+- name: Point config.yaml at the config for the current UTC half-day
+  # force + a computed target means a converge always re-affirms the correct live
+  # phase (00:00-11:59 UTC = large, 12:00-23:59 = optimized) instead of resetting
+  # it to a fixed default; the timers own the flip between converges.
+  ansible.builtin.file:
+    src: >-
+      {{ llm_router_rotation_config_large
+         if (llm_router_rotation_utc_hour.stdout | int) < 12
+         else llm_router_rotation_config_optimized }}
+    dest: "{{ llm_router_config_file }}"
+    state: link
+    force: true
+    follow: false
+  notify: Restart litellm
+
+- name: Deploy the rotation systemd service units
+  ansible.builtin.template:
+    src: litellm-rotate.service.j2
+    dest: "/etc/systemd/system/litellm-rotate-{{ item.key }}.service"
+    owner: root
+    group: root
+    mode: "0644"
+  loop: "{{ llm_router_rotation_phases | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  vars:
+    _rotation_phase: "{{ item.key }}"
+    _rotation_config: "{{ item.value.config }}"
+  notify: Restart rotation timers
+
+- name: Deploy the rotation systemd timer units
+  ansible.builtin.template:
+    src: litellm-rotate.timer.j2
+    dest: "/etc/systemd/system/litellm-rotate-{{ item.key }}.timer"
+    owner: root
+    group: root
+    mode: "0644"
+  loop: "{{ llm_router_rotation_phases | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  vars:
+    _rotation_phase: "{{ item.key }}"
+    _rotation_oncalendar: "{{ item.value.oncalendar }}"
+  notify: Restart rotation timers
+
+# Skipped under Docker (molecule) — no functional systemd init in the container.
+- name: Enable and start the rotation timers
+  ansible.builtin.systemd:
+    name: "litellm-rotate-{{ item }}.timer"
+    state: started
+    enabled: true
+    daemon_reload: true
+  loop:
+    - large
+    - optimized
+  when: ansible_virtualization_type | default('') != 'docker'

--- a/roles/llm_router/templates/config.yaml.j2
+++ b/roles/llm_router/templates/config.yaml.j2
@@ -44,6 +44,22 @@ model_list:
 {% endif %}
 {% endfor %}
 {% endfor %}
+{% if llm_router_rotation_active_backend is defined and llm_router_rotation_active_backend %}
+  # --- daily brain rotation: the one stable alias consumers point at ---
+  # (docs/BRAIN_ROTATION.md). Hermes + Open WebUI address `{{ llm_router_rotation_alias }}`
+  # forever; the systemd rotate timers swap which per-phase config.yaml symlink
+  # is live, so this entry's backend flips 00:00/12:00 UTC without touching any
+  # consumer. Context is the live phase model's real window (never null — a null
+  # max_input_tokens is the compress-to-death trap the aliased entries avoid).
+  - model_name: {{ llm_router_rotation_alias }}
+    litellm_params:
+      model: openai/{{ llm_router_rotation_active_backend }}
+      api_base: {{ llm_router_llm_large_base_url }}
+      api_key: os.environ/LLM_LARGE_BEARER_TOKEN
+    model_info:
+      max_input_tokens: {{ llm_router_rotation_active_context }}
+      max_tokens: {{ llm_router_rotation_active_context }}
+{% endif %}
 {% if llm_router_large_passthrough_enabled | bool %}
   # --- large tier passthrough: every model the serving gate advertises ---
   # Exposure is blocklist-shaped, enforced at the source: the serving host

--- a/roles/llm_router/templates/litellm-rotate.service.j2
+++ b/roles/llm_router/templates/litellm-rotate.service.j2
@@ -1,0 +1,20 @@
+{{ ansible_managed | comment }}
+# Point config.yaml at the {{ _rotation_phase }}-phase config, then bounce the
+# router so LiteLLM reloads it. Fired by litellm-rotate-{{ _rotation_phase }}.timer
+# (docs/BRAIN_ROTATION.md). The swap is a symlink flip + restart — no script.
+
+[Unit]
+Description=Rotate the ai-default router alias to the {{ _rotation_phase }} brain
+Documentation=https://github.com/JacobPEvans/ansible-proxmox-apps
+After={{ llm_router_service }}.service
+{% if _rotation_phase == 'large' %}
+# Bench-window guard: skip the large flip while the pause sentinel exists, so a
+# managed benchmark on the serving host is never crowded out by the big brain
+# loading. Removing the sentinel resumes rotation at the next fire.
+ConditionPathExists=!{{ llm_router_rotation_pause_sentinel }}
+{% endif %}
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ln -sfn {{ _rotation_config }} {{ llm_router_config_file }}
+ExecStart=/usr/bin/systemctl restart {{ llm_router_service }}.service

--- a/roles/llm_router/templates/litellm-rotate.timer.j2
+++ b/roles/llm_router/templates/litellm-rotate.timer.j2
@@ -1,0 +1,16 @@
+{{ ansible_managed | comment }}
+# Fire the {{ _rotation_phase }}-brain rotation at {{ _rotation_oncalendar }}
+# (docs/BRAIN_ROTATION.md). Rendered by the llm_router role.
+
+[Unit]
+Description=Daily fabric-brain rotation to the {{ _rotation_phase }} model
+
+[Timer]
+OnCalendar={{ _rotation_oncalendar }}
+AccuracySec=1s
+# Run a rotation missed during downtime on the next boot, so the live phase is
+# always correct for the current UTC half-day even after an outage.
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## What

Optional **daily A/B for the LLM fabric**: with `ai_rotation_enabled: true`, the fabric-wide default model rotates between a **large** and an **optimized** brain on a fixed UTC schedule — **00:00 → large, 12:00 → optimized** — so the Hermes agent and the Open WebUI chat box always run the same default and it alternates twice a day.

Design note (rationale, capacity math, upgrade path): [`docs/BRAIN_ROTATION.md`](docs/BRAIN_ROTATION.md). **Companion serving PR** (registers the large brain in the Studio swap tier): dryvist/nix-darwin#1591 — must merge + rebuild before this can be enabled.

## Chosen actuator: a stable router alias whose backend rotates

Hermes and Open WebUI point at one stable alias, `ai-default`, forever. Only the LiteLLM router's mapping of `ai-default → concrete backend` flips at 00:00/12:00 — a `config.yaml` symlink swap between two pre-rendered per-phase configs plus a `litellm` restart. Nothing else moves.

This is the **only** actuator that is CI-credential-free, idempotent under Ansible, and free of a gateway restart **and** cron churn at once:

- **Open WebUI** `DEFAULT_MODELS` is env-authoritative only at container start → a concrete-id rotation would restart the container twice daily. Alias avoids it.
- **Hermes cron jobs** snapshot `model.default` and fail closed on drift (re-seed only on converge) → alias keeps `model.default` = `ai-default`, so snapshots never drift.
- **Hermes gateway** is re-rendered + SIGTERM'd by a converge. Alias never touches it.

Discarded: scheduled GHA converge (converge is interactive-only here; self-hosted runners run read-only E2E tests) and a guest re-rendering its own Ansible-owned config (fights idempotency + restarts the gateway).

## Single source of truth (`group_vars/all.yml`)

```yaml
ai_rotation_enabled: false
ai_default_model_optimized: Qwen3.6-35B-A3B-OptiQ-4bit
ai_default_model_large: Qwen3-Next-80B-A3B-Thinking-4bit
ai_default_model: "{{ 'ai-default' if ai_rotation_enabled | bool else ai_default_model_optimized }}"
```

Both phase ids are first-class aliases in `llm_router_large_models`; the role resolves each phase's backend **and** `context_window` from that table (both are 262144, so the alias's `max_input_tokens` is identical across the flip).

## Large brain = Qwen3-Next-80B (NOT gpt-oss-120b)

Correcting an earlier draft that read a **stale** local `nix-darwin`. Current main (release 1.73.0 / #1589): residents = `Coder-30B` + `OptiQ-4bit` ≈ **58.6 GB**; `gpt-oss-120b` is demoted to on-demand (not preloaded); auto-discovery is force-disabled. Under that budget **Next-80B fits the swap tier**: 58.6 + ~42 weights + 4 cache ≈ **104.6 GB**, under the ~109 GB cache-clear trip.

`gpt-oss-120b` is deliberately **not** the large brain — it scored **0% valid agentic tool calls**, so serving it as Hermes's brain 12h/day would lobotomize tool-calling, the exact regression the A/B must surface, not cause. Next-80B benched 100% valid (single run, provisional).

## Safety / behaviour

- **Off by default.** With `ai_rotation_enabled: false` the render is **byte-identical** to today (verified by rendering the template both ways).
- **Bench-window guard.** `litellm-rotate-large.service` carries `ConditionPathExists=!<config_dir>/rotation-paused`.
- **Converge-safe.** `config.yaml`'s symlink target is computed from the guest's current UTC hour, so a converge re-affirms the correct live phase.

## Checks

`yamllint`, `ansible-lint` (profile **production**, 0 failures/0 warnings), `--syntax-check`, `markdownlint` all clean. Template render verified: alias entry absent when disabled, present with correct backend/context when enabled.

## NOT done here (gated)

- **Not converged, not merged.**
- Enable sequencing: merge nix-darwin#1591 → rebuild jevans-ms → live load test of the `ai-default` flip → then flip `ai_rotation_enabled: true` + converge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)