### PR TITLE
feat(llm): enable the daily brain rotation

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -96,7 +96,7 @@ llm_large_serving_ip: >-
 # the swap tier alongside the 58.6 GB resident pair (~104.6 GB peak < ~109 GB
 # trip) and is registered in nix-darwin lib/hosts.nix — see
 # docs/BRAIN_ROTATION.md for the capacity math and the flagship upgrade path.
-ai_rotation_enabled: false
+ai_rotation_enabled: true
 ai_default_model_optimized: Qwen3.6-35B-A3B-OptiQ-4bit
 ai_default_model_large: Qwen3-Next-80B-A3B-Thinking-4bit
 ai_default_model: "{{ 'ai-default' if ai_rotation_enabled | bool else ai_default_model_optimized }}"


### PR DESCRIPTION
One-line flip of `ai_rotation_enabled` to true. Mechanism + capacity math: docs/BRAIN_ROTATION.md (#791). Prerequisites verified: nix-darwin #1591 merged + jevans-ms rebuilt (RC=0); live load test of the large brain passed (cold swap-in + structured tool call, 38.8s, valid args, no cache-clear storm). Ships the 00:00 UTC large / 12:00 UTC optimized daily A/B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oEWqS9KGW6hsSuPsKtfxr