### PR TITLE
feat(hermes_agent,llm_router): production-deployment guardrails for the brain fabric

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -110,8 +110,10 @@ can silently invert.
 
 A pre-production staging instance that catches these violations by *executing*
 the config — the way Hermes itself rejected the 64k-floor violation at startup —
-is tracked as a GitHub issue. It requires a new guest (a terraform-proxmox
+is tracked in [issue #800][staging]. It requires a new guest (a terraform-proxmox
 `deployment.json` change), so it is user-gated.
+
+[staging]: https://github.com/dryvist/ansible-proxmox-apps/issues/800
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,118 @@
+# Deploying the Hermes / LLM serving fabric
+
+The Hermes Agent brain wiring is unusually easy to break at the **config**
+level: a handful of numbers (declared context window, output cap, the timeout
+chain) and one indirection (which router alias the agent's model name resolves
+to) must all agree, across two roles that never share a play, or the agent boots
+into a death loop. On 2026-07-08 four separate config-level mistakes each reached
+production and each took the fabric down:
+
+| Breakage | Root cause | Caught by |
+| --- | --- | --- |
+| Agent refused to start | `context_length` 60000, below Hermes' hard 64,000 floor | L1 context-floor assert; L2 gateway-down + "below the minimum" in journal |
+| Every request compressed to death | brain alias fell through the `*` wildcard → null `max_input_tokens` | L1 router-alias assert; L2 tool-call probe fails |
+| Generations killed mid-stream | server guard below generation time / inverted timeout chain | L1 timeout-ordering assert |
+| "invalid tool call" loop | wrong tool parser / mis-wired brain | L2 tool-call probe returns no valid `function.name` |
+
+Every one was **machine-detectable before or immediately after converge**. The
+two guardrail layers below make that detection automatic, so an unvalidated
+converge can no longer reach production silently.
+
+## The staged deployment path
+
+Always deploy the fabric in this order. Each stage gates the next.
+
+1. **Assert (render-time, Layer 1).** `roles/hermes_agent/tasks/assert.yml` and
+   `roles/llm_router/tasks/assert.yml` run *first* in their roles (imported at
+   the top of `tasks/main.yml`, under the role's own tag). They fail the play
+   before anything is installed if a brain-wiring contract is violated:
+   - `hermes_agent_model_context_length >= 64000` (Hermes Agent hard floor).
+   - the model consumers request resolves to a first-class router alias with a
+     non-null context window (not the `*` wildcard passthrough).
+   - the timeout chain is ordered `hermes read < router attempt` (the outermost
+     link, the nix-darwin server guard, is out of this repo's reach).
+
+2. **Converge.** Apply the roles normally:
+
+   ```bash
+   doppler run -- ansible-playbook \
+     -i inventory/hosts.yml playbooks/site.yml --tags hermes_agent
+   # and, when the router config changed:
+   doppler run -- ansible-playbook \
+     -i inventory/hosts.yml playbooks/site.yml --tags llm_router
+   ```
+
+3. **Verify gate (post-converge, Layer 2).** `roles/hermes_agent/tasks/verify.yml`
+   runs at the end of the role, after handlers flush. It proves the wiring
+   actually works, not just that it rendered:
+   - the `hermes-gateway` service is `active` and stays up (polled with retries);
+   - the gateway journal since the restart contains no fatal config-rejection
+     line (`below the minimum`, `does not exist`);
+   - one **real** chat completion with a `tools` array round-trips through the
+     router at the resolved brain and returns a structurally valid tool call
+     with a non-empty `function.name`.
+
+   Any failure fails the play loudly with the rollback recipe below.
+
+4. **Observe one cron cycle.** The seeded cron fleet (Splunk sweeps, the daily
+   digest, the nightly wiki job) is where a subtly-degraded brain shows up that a
+   single probe cannot. After a converge that changed the brain, watch the home
+   channel through at least one digest post (hourly) before considering the
+   deploy settled.
+
+## Rollback recipe
+
+If the Layer 2 gate fails — or a cron cycle reveals a degraded brain — roll back
+to the previous release tag and re-converge:
+
+```bash
+git checkout "$(git describe --tags --abbrev=0)~" && \
+  doppler run -- ansible-playbook \
+    -i inventory/hosts.yml playbooks/site.yml --tags hermes_agent
+```
+
+Release tags are `release-please` semver tags (`vMAJOR.MINOR.PATCH`);
+`$(git describe --tags --abbrev=0)~` is the commit immediately before the current
+release. Nothing here carries destroy-protection — the fabric is designed to be
+cleanly re-convergeable, so rolling the config back and re-running is the primary
+recovery, never a snapshot restore.
+
+## Rule: every numeric limit traces to a named constraint
+
+Every one of the 2026-07-08 breakages was a bare number that had drifted away
+from the constraint that justified it. So: **every numeric limit in role
+defaults must carry a comment tracing it to a named constraint** — the source of
+truth that dictates the value, not merely a restatement of the value. A reviewer
+must be able to see, from the comment alone, what would have to change in the
+world for the number to be wrong.
+
+The `hermes_agent_model_context_length` default is the exemplar of the pattern:
+the comment enumerates the exact constraints the number answers to — the Hermes
+hard floor (with the outage date), the model's native window, and the
+prefill-within-stale-budget arithmetic — and says *"do not change it without
+re-checking all three."* Follow that shape for any limit you add:
+
+```yaml
+# Constraints this number traces to (do not change it without re-checking each):
+# (1) <hard limit some component enforces, with where it is enforced>
+# (2) <physical/capacity ceiling>
+# (3) <derived relationship it must preserve, e.g. an ordering or a rate>
+some_role_some_limit: 12345
+```
+
+The fabric-wide timeout chain (`ai_stream_read_timeout_seconds`,
+`ai_router_request_timeout_seconds` in `group_vars/all.yml`) is named once for
+the same reason: the ordering invariant is a single source of truth that the
+Layer 1 assert can check across two roles, instead of two unlinked literals that
+can silently invert.
+
+## Staging (planned)
+
+A pre-production staging instance that catches these violations by *executing*
+the config — the way Hermes itself rejected the 64k-floor violation at startup —
+is tracked as a GitHub issue. It requires a new guest (a terraform-proxmox
+`deployment.json` change), so it is user-gated.
+
+---
+
+[docs.jacobpevans.com](https://docs.jacobpevans.com)

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -101,6 +101,21 @@ ai_default_model_optimized: Qwen3.6-35B-A3B-OptiQ-4bit
 ai_default_model_large: Qwen3-Next-80B-A3B-Thinking-4bit
 ai_default_model: "{{ 'ai-default' if ai_rotation_enabled | bool else ai_default_model_optimized }}"
 
+# AI serving timeout chain (client-is-decider). Each OUTER layer must OUTLIVE the
+# inner one, so no intermediate guard kills a still-healthy generation and the
+# CLIENT alone decides when to give up:
+#   nix-darwin vllm-mlx server guard 3600s (external to this repo, not assertable)
+#     > llm_router per-attempt timeout  (ai_router_request_timeout_seconds)
+#       > Hermes client stream read     (ai_stream_read_timeout_seconds)
+# The two in-repo layers are named ONCE here (not as bare literals in each role)
+# so the ordering invariant is a single source of truth AND the hermes_agent
+# Layer-1 assert can verify `read < router` across two roles that never share a
+# play — see roles/hermes_agent/tasks/assert.yml. Consumers:
+# hermes_agent_stream_read_timeout and llm_router_request_timeout_seconds resolve
+# to these, so the rendered configs stay byte-identical to the prior literals.
+ai_stream_read_timeout_seconds: 1800
+ai_router_request_timeout_seconds: 2400
+
 # Resource-domain secrets fetched from OpenBao by the openbao_secrets pre-play,
 # one dict per domain. Defaults to an empty dict for each so every consumer's
 # `bao_<domain>_secrets.X | default(lookup('env','X'), true)` resolves even

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -103,7 +103,10 @@ hermes_agent_model_max_tokens: 32768
 # call". These overrides restore the values Hermes itself auto-applies to
 # endpoints it recognizes as local (read 1800s; stale kept enabled but far
 # above any healthy prefill).
-hermes_agent_stream_read_timeout: 1800
+# The read value is the innermost link of the fabric-wide timeout chain, so it is
+# sourced from the single-source-of-truth constant (all.yml) that the Layer-1
+# assert checks against the router's per-attempt timeout — resolves to 1800.
+hermes_agent_stream_read_timeout: "{{ ai_stream_read_timeout_seconds }}"
 hermes_agent_stream_stale_timeout: 900
 # The api key IS the LiteLLM router master key; source it from the canonical
 # LLM_ROUTER_MASTER_KEY env (same as the llm_router role) so no per-run mapping
@@ -340,3 +343,26 @@ hermes_agent_context7_api_key: ""
 # escalation tool (see README), which will need its own independent flag when
 # wired, not a shared one.
 hermes_agent_codex_mcp_enabled: true
+
+# --- Layer 2 post-converge verification gate (tasks/verify.yml) --------------
+# After the gateway (re)starts, a real end-to-end probe proves the brain wiring
+# actually works before the converge is called done — every 2026-07-08 breakage
+# was a config mistake that a single tool-call probe (or a journal grep) would
+# have surfaced immediately. Disable only where there is no live brain to reach
+# (mirrors llamaindex_verify_router); default on for real converges.
+hermes_agent_verify_enabled: true
+# journalctl tail scanned for fatal config-rejection lines since the restart.
+hermes_agent_verify_journal_lines: 200
+# Fatal startup/config-rejection substrings Hermes emits when the brain wiring is
+# wrong: the context floor rejection ("below the minimum 64,000 required") and an
+# unknown/mis-aliased model ("Model <id> does not exist"). Match => gate fails.
+hermes_agent_verify_fatal_log_patterns:
+  - "below the minimum"
+  - "does not exist"
+# The live tool-call probe forces a tool call through the router at the resolved
+# brain and asserts a structurally valid tool_call comes back (non-empty
+# function.name — the exact "invalid tool call" shape of the outage). Generous
+# per-attempt timeout: the swap-tier brain may be loading on first hit.
+hermes_agent_verify_probe_timeout: 300
+hermes_agent_verify_probe_retries: 3
+hermes_agent_verify_probe_delay: 10

--- a/roles/hermes_agent/tasks/assert.yml
+++ b/roles/hermes_agent/tasks/assert.yml
@@ -1,0 +1,42 @@
+---
+# Layer 1 — render-time contract assertions for the Hermes Agent brain wiring.
+#
+# Every production break on 2026-07-08 was a config-level mistake that was
+# machine-detectable BEFORE the converge reached the running daemon. These
+# asserts encode those invariants and fail the play at the top of the role,
+# before any config is deployed — so a known-bad config never converges.
+#
+# Imported (not included) at the very top of tasks/main.yml so the checks inherit
+# the play's `hermes_agent` tag and ALWAYS run with the role they guard, even
+# under `--tags hermes_agent`. Read-only; safe in check mode.
+
+- name: Assert Hermes Agent brain-wiring contracts hold before converging
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      # (1) Hermes Agent HARD context floor. The agent refuses to start against
+      #     any model declaring under 64,000 tokens ("below the minimum 64,000
+      #     required"); at 60,000 every seeded cron failed on 2026-07-08.
+      #     context_length is declared explicitly in config.yaml.j2 because
+      #     custom/vLLM providers carry no context catalog Hermes can probe.
+      - hermes_agent_model_context_length | int >= 64000
+      # (3) Client-is-decider timeout chain. The Hermes stream read timeout must
+      #     sit BELOW the router's per-attempt timeout so the CLIENT gives up
+      #     first (by design) while the router keeps waiting on a healthy
+      #     generation. Both values are the single-source constants in all.yml;
+      #     the outermost link (nix-darwin vllm-mlx server guard, 3600s) lives
+      #     out of this repo's reach and is not assertable here.
+      - hermes_agent_stream_read_timeout | int < ai_router_request_timeout_seconds | int
+    fail_msg: >-
+      Hermes Agent brain-wiring contract violated (roles/hermes_agent/tasks/assert.yml).
+      (1) model.context_length is {{ hermes_agent_model_context_length }}; it must be
+      >= 64000 — the Hermes Agent hard floor that rejected 60000 at startup and
+      failed every seeded cron on 2026-07-08 (raise hermes_agent_model_context_length).
+      (3) stream read timeout is {{ hermes_agent_stream_read_timeout }} and the router
+      per-attempt timeout is {{ ai_router_request_timeout_seconds }}; read must be < router
+      so the client decides (chain: hermes read < router attempt < nix-darwin server
+      guard 3600). Fix the offending value in all.yml / roles/hermes_agent/defaults.
+    success_msg: >-
+      Hermes Agent brain-wiring contracts hold (context_length
+      {{ hermes_agent_model_context_length }} >= 64000; read
+      {{ hermes_agent_stream_read_timeout }} < router {{ ai_router_request_timeout_seconds }}).

--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -13,6 +13,12 @@
 # provider init from config.yaml alone (it may need its client package on
 # first run).
 
+# Layer 1 — render-time contract assertions. Imported FIRST so a known-bad brain
+# config (context below the 64k floor, inverted timeout chain) fails the play
+# before anything is installed or deployed. Inherits the play's hermes_agent tag.
+- name: Assert brain-wiring contracts before converging
+  ansible.builtin.import_tasks: assert.yml
+
 - name: Install role prerequisites (installer + clone)
   ansible.builtin.apt:
     name:
@@ -409,29 +415,7 @@
 - name: Flush handlers so config/unit changes apply before verification
   ansible.builtin.meta: flush_handlers
 
-# Type=simple reports 'active' the instant the daemon forks, so a single check
-# can pass a service that crashes a moment later. Poll until ActiveState settles
-# on 'active' to confirm the gateway actually stays up.
-- name: Verify the Hermes gateway is active
-  ansible.builtin.systemd:
-    name: hermes-gateway
-  register: hermes_agent_gateway_state
-  until: hermes_agent_gateway_state.status.ActiveState | default('') == 'active'
-  retries: 5
-  delay: 2
-
-# Best-effort: surface the active memory provider. Non-fatal so a Hindsight
-# first-run hiccup doesn't fail the whole converge (verify/fix live).
-- name: Check the active memory provider (non-fatal)
-  ansible.builtin.command: "{{ hermes_agent_bin }} memory status"
-  environment:
-    HERMES_HOME: "{{ hermes_agent_hermes_home }}"
-  become: true
-  become_user: "{{ hermes_agent_user }}"
-  register: hermes_agent_memory_status
-  changed_when: false
-  failed_when: false
-
-- name: Report the active memory provider
-  ansible.builtin.debug:
-    var: hermes_agent_memory_status.stdout_lines
+# Layer 2 — post-converge verification gate (gateway up + clean journal + a real
+# tool-call probe through the router), with a rollback recipe on any failure.
+- name: Verify the brain wiring end-to-end after converge
+  ansible.builtin.import_tasks: verify.yml

--- a/roles/hermes_agent/tasks/verify.yml
+++ b/roles/hermes_agent/tasks/verify.yml
@@ -1,0 +1,142 @@
+---
+# Layer 2 — post-converge verification gate.
+#
+# Runs after the gateway (re)start settles (main.yml flushes handlers first).
+# Proves the brain wiring actually WORKS before the converge is called done: the
+# daemon stays up, its journal shows no fatal config rejection, and one real
+# tool-call round-trips through the router at the resolved brain. Any failure
+# rolls the whole play back with an explicit recovery recipe — none of the
+# 2026-07-08 breakages would have reached "converge succeeded" through this gate.
+#
+# The gate steps live in a block so a failure at ANY step surfaces the same loud
+# rollback hint (rescue) instead of a bare task error. The memory-provider report
+# below is deliberately OUTSIDE the block: it is best-effort telemetry, not a gate.
+
+- name: Post-converge verification gate
+  when: hermes_agent_verify_enabled | bool
+  block:
+    # Type=simple reports 'active' the instant the daemon forks, so a single
+    # check can pass a service that crashes a moment later (exactly how a
+    # context-floor rejection dies). Poll until ActiveState settles on 'active'.
+    - name: Gate — the Hermes gateway is active and stays up
+      ansible.builtin.systemd:
+        name: hermes-gateway
+      register: hermes_agent_gateway_state
+      until: hermes_agent_gateway_state.status.ActiveState | default('') == 'active'
+      retries: 5
+      delay: 2
+
+    - name: Read the gateway journal since the restart
+      ansible.builtin.command: >-
+        journalctl -u hermes-gateway
+        -n {{ hermes_agent_verify_journal_lines }} --no-pager -o cat
+      register: hermes_agent_gateway_journal
+      changed_when: false
+
+    - name: Gate — the journal shows no fatal config-rejection lines
+      ansible.builtin.assert:
+        quiet: true
+        that:
+          - >-
+            hermes_agent_gateway_journal.stdout
+            | regex_findall(hermes_agent_verify_fatal_log_patterns | join('|'))
+            | length == 0
+        fail_msg: >-
+          The Hermes gateway journal contains a fatal config-rejection line
+          (matched one of {{ hermes_agent_verify_fatal_log_patterns | join(', ') }}).
+          This is the daemon refusing the rendered config at startup — e.g. a
+          context_length below the 64,000 floor, or a brain alias the router does
+          not serve. Inspect: journalctl -u hermes-gateway -n
+          {{ hermes_agent_verify_journal_lines }}.
+        success_msg: Gateway journal is clean of fatal config-rejection lines.
+
+    # One REAL end-to-end probe: force a tool call through the router at the
+    # resolved brain and require a structurally valid tool_call back. This is the
+    # exact failure shape of the outage ("Model generated invalid tool call" /
+    # empty function.name). Runs on the hermes host itself — the same network
+    # path and credential the agent uses — not the controller. no_log hides the
+    # bearer token; the separate assert below inspects the (token-free) result.
+    - name: Gate — a real tool call round-trips through the router at the brain
+      ansible.builtin.uri:
+        url: "{{ hermes_agent_model_base_url }}/chat/completions"
+        method: POST
+        headers:
+          Authorization: "Bearer {{ hermes_agent_model_api_key }}"
+        body_format: json
+        body:
+          model: "{{ hermes_agent_model }}"
+          messages:
+            - role: user
+              content: "What is the weather in Paris right now? Use the get_weather tool to find out."
+          tools:
+            - type: function
+              function:
+                name: get_weather
+                description: Get the current weather for a location.
+                parameters:
+                  type: object
+                  properties:
+                    location:
+                      type: string
+                      description: City name, e.g. "Paris".
+                  required:
+                    - location
+          tool_choice: required
+          max_tokens: 256
+          stream: false
+        timeout: "{{ hermes_agent_verify_probe_timeout }}"
+        return_content: true
+      register: hermes_agent_verify_probe
+      retries: "{{ hermes_agent_verify_probe_retries }}"
+      delay: "{{ hermes_agent_verify_probe_delay }}"
+      until: hermes_agent_verify_probe.status | default(0) == 200
+      # no_log protects the bearer token, which Ansible would otherwise echo in
+      # the task invocation on failure; failed_when keeps a non-200 from hard-
+      # failing HERE (that would skip the descriptive assert below and leave the
+      # operator only the no_log'd, opaque module error). The visible assert next
+      # is the actual gate and prints the diagnostic.
+      failed_when: false
+      no_log: true
+
+    - name: Gate — the probe returned a valid tool call with a non-empty function name
+      ansible.builtin.assert:
+        quiet: true
+        that:
+          - hermes_agent_verify_probe.status == 200
+          - >-
+            (hermes_agent_verify_probe.json.choices[0].message.tool_calls | default([]))
+            | map(attribute='function.name') | select('truthy') | list | length > 0
+        fail_msg: >-
+          The brain at {{ hermes_agent_model_base_url }} (model
+          {{ hermes_agent_model }}) did not return a structurally valid tool call
+          (HTTP {{ hermes_agent_verify_probe.status | default('?') }}, no non-empty
+          function.name). This is the outage signature — invalid/empty tool calls
+          from a mis-wired brain (wrong parser, null context, unroutable alias).
+        success_msg: "Brain returned a valid tool call ({{ hermes_agent_model }})."
+
+  rescue:
+    - name: Verification gate failed — fail loudly with a rollback recipe
+      ansible.builtin.fail:
+        msg: >-
+          Hermes Agent post-converge verification gate FAILED — the brain wiring
+          is not serving correctly, so this converge must NOT be trusted in
+          production. Roll back to the previous release and re-converge:
+          `git checkout $(git describe --tags --abbrev=0)~ && doppler run --
+          ansible-playbook -i inventory/hosts.yml playbooks/site.yml --tags
+          hermes_agent`. Original failure is in the task output above.
+
+# Best-effort telemetry (NOT a gate): surface the active memory provider so a
+# Hindsight first-run hiccup is visible without failing the converge.
+- name: Check the active memory provider (non-fatal)
+  ansible.builtin.command: "{{ hermes_agent_bin }} memory status"
+  environment:
+    HERMES_HOME: "{{ hermes_agent_hermes_home }}"
+  become: true
+  become_user: "{{ hermes_agent_user }}"
+  register: hermes_agent_memory_status
+  changed_when: false
+  failed_when: false
+
+- name: Report the active memory provider
+  ansible.builtin.debug:
+    var: hermes_agent_memory_status.stdout_lines

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -172,8 +172,12 @@ llm_router_cooldown_time: 30
 # so the client times out first (by design) while the router waits — and
 # below the 3600s server guard, so num_retries still cover a genuine transient
 # connection blip (which fails fast, well under any of these).
+# The per-attempt timeout is the MIDDLE link of the fabric-wide timeout chain
+# (server guard > this > Hermes client read), so it is sourced from the
+# single-source-of-truth constant (all.yml) the Layer-1 assert checks — resolves
+# to 2400.
 llm_router_num_retries: 2
-llm_router_request_timeout_seconds: 2400
+llm_router_request_timeout_seconds: "{{ ai_router_request_timeout_seconds }}"
 # Background health checks send REAL test requests to every deployment — on the
 # llama-swap fast tier each probe spawns the target model, and with 3 routers
 # probing every model this both churns VRAM constantly and (pre swap-groups)

--- a/roles/llm_router/tasks/assert.yml
+++ b/roles/llm_router/tasks/assert.yml
@@ -1,0 +1,63 @@
+---
+# Layer 1 — render-time contract assertions for the LiteLLM router config.
+#
+# Guards the "compress-death trap": if the model a consumer requests (the Hermes
+# brain, Open WebUI's default) is NOT a first-class alias carrying a non-null
+# context_window, the request falls through to the "*" wildcard passthrough,
+# LiteLLM resolves max_input_tokens to null, and every downstream caller
+# compresses its context to death. This is the render-time half of the check;
+# the hermes_agent Layer 2 gate proves it end-to-end against the live router.
+#
+# Imported at the top of tasks/main.yml so it inherits the `llm_router` tag and
+# always runs with the role. Read-only; safe in check mode.
+
+- name: Assert every brain model consumers request is a real router alias (not the wildcard)
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      # (2) + (4) The fabric default the agent/UI actually request must resolve
+      #     to a first-class alias with a non-null context_window. With rotation
+      #     ON, consumers request the stable `ai-default` alias whose backend is
+      #     swapped per phase, so BOTH phase models must be safe aliases (the
+      #     role derives each rotation entry's real context from this table);
+      #     with rotation OFF, the optimized id is requested directly.
+      - _llm_router_required_safe_models | difference(_llm_router_safe_aliases) | length == 0
+    fail_msg: >-
+      Compress-death trap (roles/llm_router/tasks/assert.yml): model(s)
+      [{{ _llm_router_required_safe_models | difference(_llm_router_safe_aliases) | join(', ') }}]
+      are requested as the fabric brain but are NOT first-class aliases in
+      llm_router_large_models with a non-null context_window. They would fall
+      through to the "*" wildcard passthrough, LiteLLM would resolve
+      max_input_tokens to null, and Hermes/Open WebUI would compress every request
+      to death (outage 2026-07-08). Add each as an aliased entry with an explicit
+      context_window. Constraint: config.yaml.j2 model_info.max_input_tokens.
+    success_msg: >-
+      Router brain aliases carry real context windows
+      ({{ _llm_router_required_safe_models | join(', ') }}).
+  vars:
+    # Large-tier aliases that declare a non-null context_window (the safe set).
+    _llm_router_safe_aliases: >-
+      {{ llm_router_large_models
+         | selectattr('context_window', 'defined')
+         | rejectattr('context_window', 'none')
+         | map(attribute='alias') | list }}
+    # The model ids consumers actually request as the brain: the two rotation
+    # phases when rotation is on, else the single optimized default.
+    _llm_router_required_safe_models: >-
+      {{ [ai_default_model_large, ai_default_model_optimized]
+         if (llm_router_rotation_enabled | bool)
+         else [ai_default_model] }}
+
+- name: Assert consumers resolve to the rotation alias when rotation is enabled
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - ai_default_model == llm_router_rotation_alias
+    fail_msg: >-
+      ai_rotation_enabled is true but ai_default_model ({{ ai_default_model }}) is
+      not the rotation alias ({{ llm_router_rotation_alias }}); consumers would
+      request a model the rotate timers never publish, so the brain would resolve
+      through the wildcard with no context. Constraint: all.yml ai_default_model
+      derivation.
+    success_msg: "Consumers resolve to the stable rotation alias ({{ llm_router_rotation_alias }})."
+  when: llm_router_rotation_enabled | bool

--- a/roles/llm_router/tasks/main.yml
+++ b/roles/llm_router/tasks/main.yml
@@ -2,6 +2,12 @@
 # llm_router — a LiteLLM proxy in a plain LXC (no Docker): a Python venv + a systemd
 # service. Ansible owns the whole platform (user, venv, config, unit). Idempotent.
 
+# Layer 1 — render-time contract assertions. Imported FIRST so a brain alias that
+# would fall through to the null-context wildcard fails the play before the config
+# is rendered or the service restarts. Inherits the play's llm_router tag.
+- name: Assert brain aliases carry real context windows before converging
+  ansible.builtin.import_tasks: assert.yml
+
 - name: Install the Python runtime and git
   ansible.builtin.apt:
     name:


### PR DESCRIPTION
## Why

Production broke four times on 2026-07-08, each from a **config-level** mistake
that was machine-detectable before or immediately after converge. This adds two
guardrail layers plus docs so an unvalidated converge can no longer reach
production silently. **PR only — do not converge/merge from CI.**

## How each 2026-07-08 breakage is now caught

| Breakage | Root cause | Caught by |
| --- | --- | --- |
| Agent refused to start | `context_length` 60000 < Hermes' hard 64,000 floor | **L1** hermes context-floor assert; **L2** gateway-not-active + `below the minimum` in journal |
| Every request compressed to death | brain alias fell through the `*` wildcard → null `max_input_tokens` | **L1** router-alias assert; **L2** tool-call probe fails |
| Generations killed mid-stream | inverted timeout chain / server guard below gen time | **L1** timeout-ordering assert (`read < router`) |
| "invalid tool call" loop | wrong tool parser / mis-wired brain | **L2** tool-call probe returns no valid `function.name` |

## Layer 1 — render-time contract asserts

Imported **first** in each role's `tasks/main.yml`, so they inherit the role's
own tag and always run with the role, failing the play before anything installs.

- `roles/hermes_agent/tasks/assert.yml` — `context_length >= 64000` (hard floor,
  fail_msg cites the outage); `hermes_agent_stream_read_timeout <
  ai_router_request_timeout_seconds` (client-is-decider chain; the outermost link,
  the nix-darwin server guard 3600, is noted as out of repo reach).
- `roles/llm_router/tasks/assert.yml` — the model consumers request resolves to a
  first-class alias with a non-null `context_window` (not the wildcard
  passthrough). When `ai_rotation_enabled`, **both** phase models
  (`ai_default_model_large` / `_optimized`) must resolve, and `ai_default_model`
  must be the rotation alias. Data-driven (a `difference()` over the safe-alias
  set), single assert.

## Layer 2 — post-converge verification gate

`roles/hermes_agent/tasks/verify.yml` (replaces the old inline active-check),
imported after handlers flush:

1. `hermes-gateway` is `active` and stays up (polled, retries).
2. Journal since restart contains no fatal config-rejection line
   (`below the minimum`, `does not exist`).
3. One **real** tools-array chat completion round-trips through the router at the
   resolved brain (`tool_choice: required`, 300s, run on the hermes host itself —
   the agent's own path), asserting HTTP 200 + a tool_call with non-empty
   `function.name`. `no_log` protects the bearer token; a separate visible assert
   renders the diagnostic.
4. Any gate failure → `block`/`rescue` fails loudly with the rollback recipe.

## Layer 3 — docs

`docs/DEPLOYMENT.md`: the staged path (assert → converge → verify gate → observe
one cron cycle), the rollback recipe, and the rule that **every numeric limit in
defaults must trace to a named constraint** (the `context_length` comment as
exemplar). The staging instance is called out as user-gated → see the linked issue.

## Timeout-chain single source of truth

The `read < router` invariant spans two roles that never share a play, so
`ai_stream_read_timeout_seconds` (1800) and `ai_router_request_timeout_seconds`
(2400) are named once in `group_vars/all.yml`; both role defaults now resolve to
them and render **byte-identically**. This is also the docs exemplar for the
"trace every limit to a constraint" rule.

## Ordering note

The hermes context-floor assert enforces `>= 64000`; `main` still ships the
storm-era `60000` default. `fix/hermes-context-64k-minimum` (→ 131072) fixes that
default. If this merges first, the next hermes converge will (correctly) fail the
assert until that hotfix lands — that is the guardrail doing its job. This branch
will be rebased onto `main` before merge so the two land consistent.

## Validation

- `yamllint`, `ansible-lint` (profile: production), `markdownlint`, and full
  `pre-commit run --files` all pass on every touched file.
- The assert/probe Jinja was evaluated against the real variable values:
  router-alias `difference` = `[]`, rotation-alias check True, context-floor True
  at 131072 (False at 60000), timeout ordering True, journal-scan 0 hits, and the
  tool_call extraction returns 1 for a valid call / 0 for empty-or-missing.
- No molecule scenario covers `hermes_agent` or `llm_router`, so no render test
  applies to the touched roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oEWqS9KGW6hsSuPsKtfxr