### PR TITLE
chore(hermes): bump hermes-agent pin to v2026.7.7.2

### DIFF
--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -31,7 +31,7 @@ hermes_agent_uv_bin: /root/.hermes/bin/uv
 # To move the pinned floor: bump hermes_agent_version AND refresh the sha256
 # (curl the URL below, `sha256sum`). A stale checksum fails the converge loudly —
 # by design, that is the tamper/rug-pull guard.
-hermes_agent_version: "v2026.7.1"
+hermes_agent_version: "v2026.7.7.2"
 hermes_agent_installer_url: >-
   https://raw.githubusercontent.com/NousResearch/hermes-agent/{{
   hermes_agent_version }}/scripts/install.sh


### PR DESCRIPTION
Bumps the pinned hermes-agent floor v2026.7.1 → v2026.7.7.2 (v0.18.1 rollup, ~667 commits).

Why now: the July fixes to the context-compaction subsystem (merge-into-tail summaries preserving head+tail, 75% trigger floor, context window resolved from the real model instead of a 256K default) are the agent-layer half of the local-serving reliability work — runaway agent sessions were growing until the serving ceiling because compaction never triggered against an assumed 256K window.

Installer `install.sh` sha256 is byte-identical between the two tags (verified by fetch+hash), so only the version moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oEWqS9KGW6hsSuPsKtfxr