### PR TITLE
feat(llm_router): rotation evicts residents for a solo large phase; advertise serving windows

### DIFF
--- a/docs/BRAIN_ROTATION.md
+++ b/docs/BRAIN_ROTATION.md
@@ -132,20 +132,29 @@ measured Next-80B's real per-process peak at **51.5 GB** (scheduler
 `[Metal memory] ... peak=51.5GB` — activations and paged-cache overshoot on top
 of ~46 GB), putting the composition at ~109.5 GB ≥ the trip: all three backends
 crashed (`upstream exited unexpectedly`) within 33 minutes. Budget large-phase
-capacity from **measured peak**, not weights + cache. The cache is deliberately
-kept small (4 GB); the model
-idle-unloads at 900 s back to the 58.6 GB baseline. It is registered in
-`lib/hosts.nix:mlx.models` (see the companion nix-darwin PR), **not** auto-
-discovered — a discovered model would inherit the default model's serve flags
-(wrong parser for a Qwen brain).
+capacity from **measured peak**, not weights + cache.
+
+**The large brain therefore serves SOLO.** The 00:00 UTC flip first unloads
+every model on the serving host (`POST /api/models/unload` through the gate,
+best-effort), so Next-80B's 51.5 GB peak lands on an empty host with ~57 GB of
+headroom instead of stacking on the resident pair. The 12:00 UTC flip unloads
+the large brain and re-warms the resident pair with 1-token completions
+(llama-swap only preloads at proxy startup, not on config flips). Both curls
+degrade gracefully: if the serving host is unreachable the alias flip still
+completes and the fabric falls back to load-on-demand. The model is registered
+in the nix-ai catalog (swap class), **not** auto-discovered — a discovered
+model would inherit the default model's serve flags (wrong parser for a Qwen
+brain).
 
 **Why not `gpt-oss-120b` as the large brain?** It is the biggest local model, but
 it scored **0% valid agentic tool calls** in the 2026-07-08 grid, so serving it as
 Hermes's brain 12h/day would lobotomize tool-calling — the exact regression the
 A/B is meant to surface, not cause. Next-80B benched 100% valid (single run,
-provisional), degrades ~round 17, ~12 tok/s. Both rotation phases carry a 262144
-context, so the `ai-default` alias's `max_input_tokens` is identical across the
-flip.
+provisional), degrades ~round 17, ~12 tok/s. The two phases advertise their
+EFFECTIVE SERVING windows (`llm_router_large_models` — 65536 optimized, 32768
+large), not the 262144 native window: `max_input_tokens` is the fabric's only
+input-length enforcement and what sizes hermes-agent's auto-compaction, so it
+must track what the KV budget actually sustains.
 
 ## Flagship-generation upgrade path (the 50–90 GB tier)
 

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -88,16 +88,26 @@ llm_router_llm_large_base_url: "https://{{ llm_router_llm_large_fqdn }}:{{ llm_r
 # --- Model groups ------------------------------------------------------------
 # large: exposed alias -> the backend's own model id (the serving gate lists
 # models under their full MLX repo ids). One deployment each, bearer-authed.
-# context_window on EVERY entry = the backend's real native context
-# (max_position_embeddings from each mlx-community repo's config.json).
+# context_window on EVERY entry = the backend's EFFECTIVE SERVING window —
+# what its KV-cache budget (nix-ai catalog cacheMemoryMb) sustains — NOT the
+# model's native max_position_embeddings. vllm-mlx enforces no input-length
+# ceiling at all (--max-request-tokens caps OUTPUT tokens; a 113K-token
+# prompt passed a "65536 cap" untouched, 2026-07-09), so this value is the
+# fabric's ONLY input enforcement (enable_pre_call_checks) AND what sizes
+# client behavior: hermes-agent auto-compaction triggers at ~75% of it.
+# Advertising native windows (previously 262144) let agent sessions grow far
+# past the serving ceiling and die mid-stream (Metal buffer exhaustion)
+# instead of compacting. OptiQ gets 65536 (16 GB KV; 113K single-stream
+# validated, 65K leaves 4-way-concurrency headroom); the small-cache tiers
+# get 32768. Native windows for reference: gpt-oss 131072, Qwen3* 262144.
 # LiteLLM has no built-in entry for these mlx-community backend ids, so an
 # unset context_window resolves max_input_tokens to null — clients that read
 # that (e.g. Hermes, OpenWebUI) fall back to a near-zero context guess and
 # compress every request to death (see config.yaml.j2 for the failure mode).
 llm_router_large_models:
-  - { alias: gpt-oss-120b, backend: mlx-community/gpt-oss-120b-MXFP4-Q8, context_window: 131072 }
-  - { alias: Qwen3-Coder-30B-A3B, backend: mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit, context_window: 262144 }
-  - { alias: Qwen3.6-35B-A3B-4bit, backend: mlx-community/Qwen3.6-35B-A3B-4bit, context_window: 262144 }
+  - { alias: gpt-oss-120b, backend: mlx-community/gpt-oss-120b-MXFP4-Q8, context_window: 32768 }
+  - { alias: Qwen3-Coder-30B-A3B, backend: mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit, context_window: 32768 }
+  - { alias: Qwen3.6-35B-A3B-4bit, backend: mlx-community/Qwen3.6-35B-A3B-4bit, context_window: 32768 }
   # OptiQ-4bit: the agentic-bench-winning brain (ai_default_model, all.yml). A
   # first-class alias — NOT passthrough — so the default model carries an
   # explicit max_input_tokens: the wildcard "*" entry below sets none, and a
@@ -121,19 +131,19 @@ llm_router_large_models:
   # temperature ~1.0 / presence_penalty 0.0 — added to this same extra_body.)
   - alias: Qwen3.6-35B-A3B-OptiQ-4bit
     backend: mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit
-    context_window: 262144
+    context_window: 65536
     extra_body: { repetition_penalty: 1.05 }
   # Qwen3-Next-80B Thinking: the large-phase brain for the daily rotation
   # (ai_default_model_large). A first-class alias so the rotating ai-default
-  # entry carries its real 262144 context. Served from the nix-darwin swap tier
-  # (lib/hosts.nix), loaded on demand only while ai-default points at it. Block
-  # style (not the flow one-liner above) only to stay under the 120-char limit.
+  # entry carries its serving window. Served from the nix-ai catalog swap tier,
+  # loaded on demand only while ai-default points at it. Block style (not the
+  # flow one-liner above) only to stay under the 120-char limit.
   - alias: Qwen3-Next-80B-A3B-Thinking-4bit
     backend: mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit
-    context_window: 262144
+    context_window: 32768
   # claude-sonnet-5 is a Claude Code alias deliberately mapped to a local Qwen3.6
-  # backend (PR #624) — not a mis-map; it inherits that backend's 262144 context.
-  - { alias: claude-sonnet-5, backend: mlx-community/Qwen3.6-35B-A3B-4bit, context_window: 262144 }
+  # backend (PR #624) — not a mis-map; it inherits that backend's serving window.
+  - { alias: claude-sonnet-5, backend: mlx-community/Qwen3.6-35B-A3B-4bit, context_window: 32768 }
 # light: exposed aliases -> the llama-swap model_name they map to. Each becomes two
 # same-name deployments (llm-fast GPU + llm-light CPU) in the rendered config.
 # `embedding: true` marks the entry as an embeddings model_group.
@@ -246,3 +256,9 @@ llm_router_rotation_config_optimized: "{{ llm_router_config_dir }}/config-optimi
 # fabric stays on the optimized brain so a bench is never crowded out). The
 # bench runbook touches it to pause and removes it to resume.
 llm_router_rotation_pause_sentinel: "{{ llm_router_config_dir }}/rotation-paused"
+# Serving-host model names (role aliases) the optimized flip re-warms after
+# dropping the large brain — llama-swap only preloads at proxy startup, so the
+# flip itself must reload the resident pair (litellm-rotate.service.j2).
+llm_router_rotation_warm_roles:
+  - coding
+  - tool-calling

--- a/roles/llm_router/templates/litellm-rotate.service.j2
+++ b/roles/llm_router/templates/litellm-rotate.service.j2
@@ -30,13 +30,13 @@ ConditionPathExists=!{{ llm_router_rotation_pause_sentinel }}
 Type=oneshot
 # Bearer for the serving gate (same token the router's large deployments use).
 EnvironmentFile={{ llm_router_env_file }}
-{% if _rotation_phase == 'large' %}
+# Unload-all BEFORE the flip in BOTH phases — unloading after the router
+# restart races incoming requests loading the new phase's models while the
+# old phase's are still resident (memory over-commit).
 ExecStart=-/usr/bin/curl -fsS -m 60 -X POST -H "Authorization: Bearer ${LLM_LARGE_BEARER_TOKEN}" {{ llm_router_llm_large_base_url | replace('/v1', '') }}/api/models/unload
-{% endif %}
 ExecStart=/usr/bin/ln -sfn {{ _rotation_config }} {{ llm_router_config_file }}
 ExecStart=/usr/bin/systemctl restart {{ llm_router_service }}.service
 {% if _rotation_phase == 'optimized' %}
-ExecStart=-/usr/bin/curl -fsS -m 60 -X POST -H "Authorization: Bearer ${LLM_LARGE_BEARER_TOKEN}" {{ llm_router_llm_large_base_url | replace('/v1', '') }}/api/models/unload
 {% for _warm_role in llm_router_rotation_warm_roles %}
 ExecStart=-/usr/bin/curl -fsS -m 300 -X POST -H "Authorization: Bearer ${LLM_LARGE_BEARER_TOKEN}" -H "Content-Type: application/json" -d '{"model":"{{ _warm_role }}","max_tokens":1,"messages":[{"role":"user","content":"warm"}]}' {{ llm_router_llm_large_base_url }}/chat/completions
 {% endfor %}

--- a/roles/llm_router/templates/litellm-rotate.service.j2
+++ b/roles/llm_router/templates/litellm-rotate.service.j2
@@ -1,7 +1,19 @@
 {{ ansible_managed | comment }}
-# Point config.yaml at the {{ _rotation_phase }}-phase config, then bounce the
-# router so LiteLLM reloads it. Fired by litellm-rotate-{{ _rotation_phase }}.timer
+# Point config.yaml at the {{ _rotation_phase }}-phase config, bounce the
+# router so LiteLLM reloads it, and manage the serving host's residents so the
+# phases never fight for memory. Fired by litellm-rotate-{{ _rotation_phase }}.timer
 # (docs/BRAIN_ROTATION.md). The swap is a symlink flip + restart — no script.
+#
+# Resident eviction (goal: the large brain always serves SOLO):
+#   large     — unload every model on the serving host first, so the 80B loads
+#               with full headroom instead of transiently stacking on the
+#               ~58 GB resident pair (the old over-trip).
+#   optimized — unload the large brain, then re-warm the resident pair with
+#               1-token completions (llama-swap only preloads at proxy
+#               startup, not on config flips).
+# The curls are best-effort (=-): if the serving host is unreachable at flip
+# time the alias flip must still complete — the fabric then degrades to the
+# old load-on-demand behavior rather than wedging rotation.
 
 [Unit]
 Description=Rotate the ai-default router alias to the {{ _rotation_phase }} brain
@@ -16,5 +28,16 @@ ConditionPathExists=!{{ llm_router_rotation_pause_sentinel }}
 
 [Service]
 Type=oneshot
+# Bearer for the serving gate (same token the router's large deployments use).
+EnvironmentFile={{ llm_router_env_file }}
+{% if _rotation_phase == 'large' %}
+ExecStart=-/usr/bin/curl -fsS -m 60 -X POST -H "Authorization: Bearer ${LLM_LARGE_BEARER_TOKEN}" {{ llm_router_llm_large_base_url | replace('/v1', '') }}/api/models/unload
+{% endif %}
 ExecStart=/usr/bin/ln -sfn {{ _rotation_config }} {{ llm_router_config_file }}
 ExecStart=/usr/bin/systemctl restart {{ llm_router_service }}.service
+{% if _rotation_phase == 'optimized' %}
+ExecStart=-/usr/bin/curl -fsS -m 60 -X POST -H "Authorization: Bearer ${LLM_LARGE_BEARER_TOKEN}" {{ llm_router_llm_large_base_url | replace('/v1', '') }}/api/models/unload
+{% for _warm_role in llm_router_rotation_warm_roles %}
+ExecStart=-/usr/bin/curl -fsS -m 300 -X POST -H "Authorization: Bearer ${LLM_LARGE_BEARER_TOKEN}" -H "Content-Type: application/json" -d '{"model":"{{ _warm_role }}","max_tokens":1,"messages":[{"role":"user","content":"warm"}]}' {{ llm_router_llm_large_base_url }}/chat/completions
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
## Why

Two coupled reliability holes in the brain fabric:

1. **The large phase over-trips memory.** The first live large phase (2026-07-09) measured Qwen3-Next-80B's real peak at 51.5 GB; stacked on the 58.6 GB resident pair that crossed the ~109 GB cache-clear trip and crashed all three backends in 33 minutes (docs/BRAIN_ROTATION.md capacity math).
2. **Agent sessions grow past the serving ceiling and die mid-stream.** The router advertised model-native context (262144) on every large alias. `max_input_tokens` is the fabric's ONLY input-length enforcement — vllm-mlx's `--max-request-tokens` caps *output* tokens (a 113K-token prompt passed a "65536 cap" untouched) — and it is also what sizes hermes-agent's auto-compaction trigger (~75% of the window). Advertising 262144 meant compaction never fired before the Metal buffer ceiling killed the stream.

## What

- `litellm-rotate.service.j2`: large flip unloads all serving-host models first (`POST /api/models/unload` through the bearer-authed gate); optimized flip unloads the large brain then re-warms `coding` + `tool-calling` with 1-token completions (llama-swap only preloads at proxy startup). All curls are best-effort (`ExecStart=-`) so an unreachable host degrades to load-on-demand instead of wedging rotation.
- `defaults/main.yml`: `context_window` = effective serving window per alias (OptiQ 65536 — 16 GB KV, 113K single-stream validated, 65K leaves 4-way concurrency headroom; small-cache tiers 32768). New `llm_router_rotation_warm_roles`.
- `docs/BRAIN_ROTATION.md`: solo-large-phase design + serving-window rationale.

## Verification

- `ansible-lint` (production profile): 0 failures.
- `/api/models/unload` verified present on the live gate (405 on GET, POST-only route; llama-swap ≥ v235 API).
- Post-converge: next 00:00/12:00 UTC flips observed via `systemctl status litellm-rotate-*` + gate access log; `/running` on the serving host shows solo large brain during the large phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oEWqS9KGW6hsSuPsKtfxr