### PR TITLE
feat(hermes): fix memory tool via hindsight local-embedded; disable SSH password auth

### DIFF
--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -147,7 +147,15 @@ hermes_agent_daily_status_cron_prompt: >-
 # --- Memory: best self-hostable as of June 2026 (Agy-validated) ---
 # Hindsight: local knowledge-graph + multi-strategy retrieval. Runs alongside the
 # always-on built-in MEMORY.md/USER.md. The whole HERMES_HOME is the durable surface.
+# The provider name alone is NOT enough: hindsight defaults to CLOUD mode, and
+# with no HINDSIGHT_API_KEY its is_available() returns false — every memory
+# tool call warns "Memory is not available" (the recurring digest warning).
+# local_embedded runs the daemon in-guest (hindsight-all, ~200 MB, installed
+# below) and needs an LLM for entity extraction — pointed at the same router
+# alias the agent brain uses, so memory never adds an external dependency.
 hermes_agent_memory_provider: hindsight
+hermes_agent_memory_mode: local_embedded
+hermes_agent_memory_llm_model: "{{ ai_default_model }}"
 
 # --- Safety: cap the agentic loop so a runaway can't pin the GPU overnight ---
 hermes_agent_max_turns: 90

--- a/roles/hermes_agent/handlers/main.yml
+++ b/roles/hermes_agent/handlers/main.yml
@@ -4,3 +4,8 @@
     name: hermes-gateway
     state: restarted
     daemon_reload: true
+
+- name: Restart sshd
+  ansible.builtin.systemd:
+    name: ssh
+    state: restarted

--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -174,6 +174,57 @@
     mode: "0640"
   notify: Restart hermes-gateway
 
+# --- Hindsight memory: local embedded daemon ---------------------------------
+# The provider name in config.yaml is not enough: hindsight defaults to CLOUD
+# mode, and with no HINDSIGHT_API_KEY its is_available() is false — every
+# memory tool call fails with "Memory is not available" (the recurring digest
+# warning). local_embedded needs (a) the hindsight-all package in the venv,
+# (b) $HERMES_HOME/hindsight/config.json selecting the mode + the extraction
+# LLM (the same router brain), (c) HINDSIGHT_LLM_API_KEY in .env (rendered by
+# hermes-env.j2).
+- name: Install the Hindsight local-embedded stack into the Hermes venv
+  ansible.builtin.command:
+    cmd: >-
+      {{ hermes_agent_uv_bin }} pip install
+      --python {{ hermes_agent_venv_python }}
+      hindsight-all
+  register: hermes_agent_hindsight_install
+  changed_when: >-
+    'Installed' in hermes_agent_hindsight_install.stderr
+    or 'Uninstalled' in hermes_agent_hindsight_install.stderr
+  when: hermes_agent_memory_provider == 'hindsight' and hermes_agent_memory_mode == 'local_embedded'
+
+- name: Ensure the hindsight config dir exists
+  ansible.builtin.file:
+    path: "{{ hermes_agent_hermes_home }}/hindsight"
+    state: directory
+    owner: "{{ hermes_agent_user }}"
+    group: "{{ hermes_agent_user }}"
+    mode: "0750"
+  when: hermes_agent_memory_provider == 'hindsight'
+
+- name: Deploy the hindsight provider config (mode + embedded-daemon LLM)
+  ansible.builtin.template:
+    src: hindsight-config.json.j2
+    dest: "{{ hermes_agent_hermes_home }}/hindsight/config.json"
+    owner: "{{ hermes_agent_user }}"
+    group: "{{ hermes_agent_user }}"
+    mode: "0640"
+  notify: Restart hermes-gateway
+  when: hermes_agent_memory_provider == 'hindsight'
+
+# --- Guest SSH hardening ------------------------------------------------------
+# Flagged by the agent's own security self-audit: password auth was accepted on
+# the guest's sshd. Ansible reaches this guest via proxmox_pct_remote (through
+# the PVE host), not sshd, so this cannot lock out converges.
+- name: Disable SSH password authentication
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '^#?PasswordAuthentication\s'
+    line: PasswordAuthentication no
+    validate: sshd -t -f %s
+  notify: Restart sshd
+
 # --- Cron model-drift recovery ------------------------------------------------
 # Unpinned cron jobs snapshot the global default model at creation and FAIL
 # CLOSED when model.default later changes: every subsequent fire is skipped

--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -222,7 +222,7 @@
     path: /etc/ssh/sshd_config
     regexp: '^#?PasswordAuthentication\s'
     line: PasswordAuthentication no
-    validate: sshd -t -f %s
+    validate: /usr/sbin/sshd -t -f %s
   notify: Restart sshd
 
 # --- Cron model-drift recovery ------------------------------------------------

--- a/roles/hermes_agent/templates/hermes-env.j2
+++ b/roles/hermes_agent/templates/hermes-env.j2
@@ -4,6 +4,13 @@
 # Brain API key = the LiteLLM router master key.
 HERMES_AGENT_MODEL_API_KEY={{ hermes_agent_model_api_key }}
 
+{% if hermes_agent_memory_provider == 'hindsight' and hermes_agent_memory_mode == 'local_embedded' %}
+# Hindsight local-embedded daemon: its entity-extraction LLM is the same
+# router brain, so it authenticates with the same router master key.
+# Mode/base-url/model live in $HERMES_HOME/hindsight/config.json.
+HINDSIGHT_LLM_API_KEY={{ hermes_agent_model_api_key }}
+{% endif %}
+
 # Slack gateway (Socket Mode). Read directly by the Slack adapter — no
 # config.yaml wiring. Empty when unset, so the gateway simply runs without
 # the Slack platform enabled.

--- a/roles/hermes_agent/templates/hindsight-config.json.j2
+++ b/roles/hermes_agent/templates/hindsight-config.json.j2
@@ -1,0 +1,7 @@
+{
+  "_comment": "{{ ansible_managed }} — hindsight memory provider (mode + embedded-daemon LLM). Secrets stay in .env (HINDSIGHT_LLM_API_KEY).",
+  "mode": "{{ hermes_agent_memory_mode }}",
+  "llm_provider": "openai_compatible",
+  "llm_base_url": "{{ hermes_agent_model_base_url }}",
+  "llm_model": "{{ hermes_agent_memory_llm_model }}"
+}

--- a/roles/hermes_agent/templates/hindsight-config.json.j2
+++ b/roles/hermes_agent/templates/hindsight-config.json.j2
@@ -1,7 +1,7 @@
 {
-  "_comment": "{{ ansible_managed }} — hindsight memory provider (mode + embedded-daemon LLM). Secrets stay in .env (HINDSIGHT_LLM_API_KEY).",
-  "mode": "{{ hermes_agent_memory_mode }}",
+  "_comment": {{ (ansible_managed + " — hindsight memory provider (mode + embedded-daemon LLM). Secrets stay in .env (HINDSIGHT_LLM_API_KEY).") | to_json }},
+  "mode": {{ hermes_agent_memory_mode | to_json }},
   "llm_provider": "openai_compatible",
-  "llm_base_url": "{{ hermes_agent_model_base_url }}",
-  "llm_model": "{{ hermes_agent_memory_llm_model }}"
+  "llm_base_url": {{ hermes_agent_model_base_url | to_json }},
+  "llm_model": {{ hermes_agent_memory_llm_model | to_json }}
 }


### PR DESCRIPTION
## Why

1. **Every digest/sweep logs `Tool memory returned error: Memory is not available`.** Root cause (verified on the guest + upstream source): `config.yaml` sets `provider: hindsight` + `memory_enabled: true`, but the hindsight plugin defaults to **cloud** mode and its `is_available()` requires `HINDSIGHT_API_KEY`/URL — neither is set, so the tool is dead on every call. This is one of the two remaining warnings between the fabric and a zero-warning digest.
2. The agent's own security self-audit flagged password auth accepted on the guest's sshd.

## What

- **hindsight → `local_embedded`** (self-hosted, matching the "best self-hostable" rationale already in the role):
  - install `hindsight-all` into the Hermes venv (mirrors the Slack-extra pattern, idempotent via uv's stderr summary);
  - render `$HERMES_HOME/hindsight/config.json` — mode + `llm_provider: openai_compatible` pointed at the existing router base URL and `ai_default_model` alias, so memory extraction adds **no external dependency**;
  - `HINDSIGHT_LLM_API_KEY` (= the router master key already in `.env`) rendered alongside.
- **`PasswordAuthentication no`** via `lineinfile` + `sshd -t` validation + restart handler. Converges ride `proxmox_pct_remote` (through the PVE host), not sshd — no lockout risk.

## Verification

- `ansible-lint` production profile: 0 failures on the role.
- Post-converge acceptance: run a digest → `agent.log` shows the memory tool succeeding (no "Memory is not available"); `sshd -T | grep passwordauthentication` = no.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oEWqS9KGW6hsSuPsKtfxr