### PR TITLE
ci: widen CI-completion consumers to fire on develop too

### DIFF
--- a/.github/workflows/ci-doctor.md
+++ b/.github/workflows/ci-doctor.md
@@ -6,7 +6,7 @@ on:
   workflow_run:
     workflows: ["CI Gate"]
     types: [completed]
-    branches: [main]
+    branches: [main, develop]
 if: ${{ github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled' }}
 ---
 

--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -5,7 +5,7 @@ on:
   workflow_run:
     workflows: ["Ansible Lint"]
     types: [completed]
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   actions: read


### PR DESCRIPTION
## What

Widens the `workflow_run` branch filter on the two CI-completion consumer workflows from `[main]` to `[main, develop]`, ahead of the git-flow-next pilot flip:

- `ci-fail-issue.yml` (listens for "Ansible Lint" completions — the shared `_ansible-ci.yml` reusable's own name)
- `ci-doctor.md` (gh-aw agentic CI triage source, listens for "CI Gate" completions) — see lock-file note below

## Why

`develop` becomes a long-lived branch once the pilot flips. A CI failure on a develop-targeted PR should still trigger the auto-issue and auto-doctor flows, not just failures on `main`.

## Scope notes

- No push-triggered CI/lint wrapper workflow exists in this repo — `ci-gate.yml` runs on `pull_request` only with no `branches` restriction, so it already runs against develop-targeted PRs unchanged. No `pull_request`/`push` trigger edits were needed.
- `release-please.yml` stays `main`-only by design.
- `ci-fix.yml`'s `workflow_run` trigger is currently disabled (commented out, `workflow_dispatch`-only), so nothing to widen there.
- `post-merge-docs-review.yml` / `post-merge-tests.yml` have their `push` triggers disabled (commented out) — left as-is.
- `release-please-config.json` / `.release-please-manifest.json` / `release-please.yml` verified present and following the org-standard pattern — no gap.
- Other gh-aw `.md`/`.lock.yml` pairs (`daily-malicious-code-scan`, `link-checker`, `sub-issue-closer`, `repo-health-audit`) are schedule/workflow_dispatch only — no changes needed.

## Known gap — `ci-doctor.lock.yml` not regenerated

Same caveat as the sibling pilot-repo PRs: the only `gh aw` CLI available locally is a "dev" build newer than this repo's pinned version. Compiling with it silently upgrades the entire toolchain (schema version, action SHAs, container images) as a side effect of a one-line trigger change — out of scope here. **Follow-up needed:** regenerate `ci-doctor.lock.yml` with the pinned toolchain so only the `branches` list changes.

## Open PRs targeting main (not retargeted here, per instructions — retarget happens at flip time)

- #815, #814 (JacobPEvans-personal)
- #813, #812, #811 (renovate — will auto-retarget after the default-branch change per Renovate's own behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Assisted-by: Claude:claude-sonnet-5
Claude-Session: https://claude.ai/code/session_01D9EGoFt6YZvquAVYFZURtQ