### PR TITLE
feat(configarr): prefer Apple-TV direct-play audio on Sonarr + Radarr

### DIFF
--- a/roles/configarr/defaults/main.yml
+++ b/roles/configarr/defaults/main.yml
@@ -63,3 +63,65 @@ configarr_radarr_templates:
   - radarr-quality-definition-movie
   - radarr-quality-profile-hd-bluray-web
   - radarr-custom-formats-hd-bluray-web
+
+# --- Apple-TV direct-play audio policy (global, Sonarr + Radarr) --------------
+# Prefer releases whose audio direct-plays on Apple TV so Plex never transcodes
+# audio for local playback (the real fix for the random audio dropouts — an
+# EAC3 passthrough handshake that intermittently drops on the AV chain). AC3 is
+# the most reliable Apple-TV passthrough, so it scores highest; DTS/TrueHD/FLAC/
+# PCM force a transcode and are heavily penalized (not hard-rejected, so nothing
+# becomes ungrabbable when only an incompatible release exists). Scores are
+# shared by both apps; only the TRaSH trash_ids differ per app.
+configarr_appletv_audio: true
+configarr_audio_scores:
+  dd: 150 # AC3 / Dolby Digital — most reliable Apple-TV passthrough
+  ddplus: 100 # EAC3 / Dolby Digital Plus
+  ddplus-atmos: 80 # DD+ Atmos (Apple TV supports)
+  aac: 80 # AAC — always direct-plays
+  truehd: -1000
+  truehd-atmos: -1000
+  dts: -1000
+  dts-es: -1000
+  dts-hd-hra: -1000
+  dts-hd-ma: -1000
+  dts-x: -1000
+  flac: -1000
+  pcm: -1000
+  mp3: -1000
+  opus: -500
+# TRaSH-Guides audio custom-format trash_ids, keyed to configarr_audio_scores.
+configarr_sonarr_audio_trash_ids:
+  dd: dbe00161b08a25ac6154c55f95e6318d
+  ddplus: 63487786a8b01b7f20dd2bc90dd4a477
+  ddplus-atmos: 4232a509ce60c4e208d13825b7c06264
+  aac: a50b8a0c62274a7c38b09a9619ba9d86
+  truehd: 1808e4b9cee74e064dfae3f1db99dbfe
+  truehd-atmos: 0d7824bb924701997f874e7ff7d4844a
+  dts: 5964f2a8b3be407d083498e4459d05d0
+  dts-es: c1a25cd67b5d2e08287c957b1eb903ec
+  dts-hd-hra: cfa5fbd8f02a86fc55d8d223d06a5e1f
+  dts-hd-ma: c429417a57ea8c41d57e6990a8b0033f
+  dts-x: 9d00418ba386a083fbf4d58235fc37ef
+  flac: 851bd64e04c9374c51102be3dd9ae4cc
+  pcm: 30f70576671ca933adbdcfc736a69718
+  mp3: 3e8b714263b26f486972ee1e0fe7606c
+  opus: 28f6ef16d61e2d1adfce3156ed8257e3
+configarr_radarr_audio_trash_ids:
+  dd: c2998bd0d90ed5621d8df281e839436e
+  ddplus: 185f1dd7264c4562b9022d963ac37424
+  ddplus-atmos: 1af239278386be2919e1bcee0bde047e
+  aac: 240770601cc226190c367ef59aba7463
+  truehd: 3cafb66171b47f226146a0770576870f
+  truehd-atmos: 496f355514737f7d83bf7aa4d24f8169
+  dts: 1c1a4c5e823891c75bc50380a6866f73
+  dts-es: f9f847ac70a0af62ea4a08280b859636
+  dts-hd-hra: 8e109e50e0a0b83a5098b056e13bf6db
+  dts-hd-ma: dcf3ec6938fa32445f590a4da84256cd
+  dts-x: 2f22d89048b01681dde8afe203bf2e95
+  flac: a570d4a0e56a2874b64e5bfa55202a1b
+  pcm: e7c2fcae07cbada050a0af3357491d7b
+  mp3: 6ba9033150e7896bdc9ec4b44f2b230f
+  opus: a061e2e700f81932daf888599f8a8273
+# Profile names the TRaSH templates above create (assign_scores_to targets).
+configarr_sonarr_audio_profile: "WEB-1080p"
+configarr_radarr_audio_profile: "HD Bluray + WEB"

--- a/roles/configarr/templates/config.yml.j2
+++ b/roles/configarr/templates/config.yml.j2
@@ -17,6 +17,16 @@ sonarr:
 {% for tpl in configarr_sonarr_templates %}
       - template: {{ tpl }}
 {% endfor %}
+{% if configarr_appletv_audio | default(false) %}
+    custom_formats:
+{% for codec, score in configarr_audio_scores.items() %}
+      - trash_ids:
+          - {{ configarr_sonarr_audio_trash_ids[codec] }}
+        assign_scores_to:
+          - name: {{ configarr_sonarr_audio_profile }}
+            score: {{ score }}
+{% endfor %}
+{% endif %}
 
 radarr:
   main:
@@ -28,3 +38,13 @@ radarr:
 {% for tpl in configarr_radarr_templates %}
       - template: {{ tpl }}
 {% endfor %}
+{% if configarr_appletv_audio | default(false) %}
+    custom_formats:
+{% for codec, score in configarr_audio_scores.items() %}
+      - trash_ids:
+          - {{ configarr_radarr_audio_trash_ids[codec] }}
+        assign_scores_to:
+          - name: {{ configarr_radarr_audio_profile }}
+            score: {{ score }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
## What

Adds a global audio custom-format policy in Configarr so **every** Sonarr/Radarr grab prefers audio that **Direct Plays on Apple TV** — keeping Plex from transcoding audio for local playback (the root cause of the random audio dropouts: an EAC3 passthrough handshake that intermittently drops on the AV chain).

## Scoring (shared by both apps)

| Codec | Score | Why |
| --- | --- | --- |
| AC3 (Dolby Digital) | **+150** | Most reliable Apple-TV passthrough |
| EAC3 (Dolby Digital Plus) | +100 | Direct-plays, but the flaky one on some AVRs |
| DD+ Atmos / AAC | +80 | Direct-play |
| DTS / DTS-HD / TrueHD / FLAC / PCM / MP3 | **−1000** | Force a Plex transcode |
| Opus | −500 | Frequently transcoded |

Penalties are heavy but **not** hard rejects, so nothing becomes ungrabbable when only an incompatible release exists. Scores are defined once and shared; only the TRaSH-Guides `trash_ids` differ per app. Applied to the existing `WEB-1080p` (Sonarr) and `HD Bluray + WEB` (Radarr) profiles, gated behind `configarr_appletv_audio`.

## Verification

Converged live against both instances — Configarr diff report applied all 15 CFs + scores to each profile with zero errors (`SONARR: (1/0/0) - RADARR: (1/0/0)`). Idempotent: a second run is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)