### PR TITLE
fix(rotation): stagger per-router flips + single serving-host actuator

### DIFF
--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -262,8 +262,9 @@ llm_router_rotation_stagger_minutes: >-
 # already-flipped fabric had started.
 llm_router_rotation_actuator: >-
   {{ (groups['llm_router_group'] | sort | first) == inventory_hostname }}
-llm_router_rotation_large_oncalendar: "*-*-* 00:{{ '%02d' | format(llm_router_rotation_stagger_minutes | int) }}:00 UTC"
-llm_router_rotation_optimized_oncalendar: "*-*-* 12:{{ '%02d' | format(llm_router_rotation_stagger_minutes | int) }}:00 UTC"
+llm_router_rotation_stagger_mm: "{{ '%02d' | format(llm_router_rotation_stagger_minutes | int) }}"
+llm_router_rotation_large_oncalendar: "*-*-* 00:{{ llm_router_rotation_stagger_mm }}:00 UTC"
+llm_router_rotation_optimized_oncalendar: "*-*-* 12:{{ llm_router_rotation_stagger_mm }}:00 UTC"
 # Per-phase rendered configs; config.yaml is a symlink to the live one.
 llm_router_rotation_config_large: "{{ llm_router_config_dir }}/config-large.yaml"
 llm_router_rotation_config_optimized: "{{ llm_router_config_dir }}/config-optimized.yaml"

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -247,8 +247,23 @@ llm_router_rotation_alias: ai-default
 llm_router_rotation_large_model: "{{ ai_default_model_large }}"
 llm_router_rotation_optimized_model: "{{ ai_default_model_optimized }}"
 # Fixed-hour UTC schedule. The `UTC` suffix needs systemd >= 252 (Debian 12).
-llm_router_rotation_large_oncalendar: "*-*-* 00:00:00 UTC"
-llm_router_rotation_optimized_oncalendar: "*-*-* 12:00:00 UTC"
+# STAGGERED per router (0/2/4 min by position in the group): every flip
+# restarts litellm, and three simultaneous restarts left HAProxy with NO
+# healthy backend — the 2026-07-10 00:00 UTC flip 503'd every in-flight
+# agent call ("no available server") long enough to exhaust hermes's 3
+# retries. A 2-minute stagger keeps two routers serving while one flips;
+# the ai-default alias differs across routers for at most 4 minutes twice
+# a day, which A/B-comparison tolerates and availability requires.
+llm_router_rotation_stagger_minutes: >-
+  {{ (groups['llm_router_group'] | sort).index(inventory_hostname) * 2 }}
+# Exactly ONE router (the first by sort order, which also flips first)
+# actuates the serving host (unload-all / warm curls). The later, staggered
+# flips would otherwise re-fire unload-all and abort requests the
+# already-flipped fabric had started.
+llm_router_rotation_actuator: >-
+  {{ (groups['llm_router_group'] | sort | first) == inventory_hostname }}
+llm_router_rotation_large_oncalendar: "*-*-* 00:{{ '%02d' | format(llm_router_rotation_stagger_minutes | int) }}:00 UTC"
+llm_router_rotation_optimized_oncalendar: "*-*-* 12:{{ '%02d' | format(llm_router_rotation_stagger_minutes | int) }}:00 UTC"
 # Per-phase rendered configs; config.yaml is a symlink to the live one.
 llm_router_rotation_config_large: "{{ llm_router_config_dir }}/config-large.yaml"
 llm_router_rotation_config_optimized: "{{ llm_router_config_dir }}/config-optimized.yaml"

--- a/roles/llm_router/templates/litellm-rotate.service.j2
+++ b/roles/llm_router/templates/litellm-rotate.service.j2
@@ -14,6 +14,9 @@
 # The curls are best-effort (=-): if the serving host is unreachable at flip
 # time the alias flip must still complete — the fabric then degrades to the
 # old load-on-demand behavior rather than wedging rotation.
+# Only the ACTUATOR router (first by sort, flips first) runs the curls: the
+# later, staggered flips would otherwise re-fire unload-all and abort
+# requests the already-flipped fabric had started.
 
 [Unit]
 Description=Rotate the ai-default router alias to the {{ _rotation_phase }} brain
@@ -33,10 +36,12 @@ EnvironmentFile={{ llm_router_env_file }}
 # Unload-all BEFORE the flip in BOTH phases — unloading after the router
 # restart races incoming requests loading the new phase's models while the
 # old phase's are still resident (memory over-commit).
+{% if llm_router_rotation_actuator | bool %}
 ExecStart=-/usr/bin/curl -fsS -m 60 -X POST -H "Authorization: Bearer ${LLM_LARGE_BEARER_TOKEN}" {{ llm_router_llm_large_base_url | replace('/v1', '') }}/api/models/unload
+{% endif %}
 ExecStart=/usr/bin/ln -sfn {{ _rotation_config }} {{ llm_router_config_file }}
 ExecStart=/usr/bin/systemctl restart {{ llm_router_service }}.service
-{% if _rotation_phase == 'optimized' %}
+{% if _rotation_phase == 'optimized' and llm_router_rotation_actuator | bool %}
 {% for _warm_role in llm_router_rotation_warm_roles %}
 ExecStart=-/usr/bin/curl -fsS -m 300 -X POST -H "Authorization: Bearer ${LLM_LARGE_BEARER_TOKEN}" -H "Content-Type: application/json" -d '{"model":"{{ _warm_role }}","max_tokens":1,"messages":[{"role":"user","content":"warm"}]}' {{ llm_router_llm_large_base_url }}/chat/completions
 {% endfor %}


### PR DESCRIPTION
## Why

Live finding from the first post-evict-rotation flip (2026-07-10 00:00 UTC): all three routers restart litellm at the same second, so HAProxy briefly had **zero** healthy backends — every in-flight agent call got `HTTP 503: no available server` for long enough to exhaust hermes-agent's 3 retries. A triggered digest run failed on exactly this window.

## What

- `OnCalendar` staggered **0/2/4 minutes** by sorted group position — at least two routers serve while one flips. `ai-default` may differ across routers for ≤4 minutes twice a day; availability wins.
- The serving-host actuation (unload-all / warm curls from #814) runs on the **first router only** — the later staggered flips would re-fire unload-all and abort requests the already-flipped fabric had started.

## Verification

- `ansible-lint` production profile: 0 failures.
- Post-converge: `systemctl list-timers 'litellm-rotate-*'` shows 00:00/00:02/00:04 (and 12:0x) across the three routers; next flip leaves HAProxy with healthy backends throughout (no `no available server` burst in hermes logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oEWqS9KGW6hsSuPsKtfxr