### PR TITLE
feat(media): auto-remux non-AppleTV audio to AC3 on *arr import

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -847,6 +847,9 @@
     - media
   roles:
     - role: sonarr
+    # Apple-TV Direct-Play audio guard: ffmpeg + the import-time AC3 remux
+    # script the servarr_wiring Custom Script Connect invokes on this host.
+    - role: media_remux
 
 - name: Configure Radarr (LAN-only movie PVR)
   hosts: radarr_group
@@ -857,6 +860,9 @@
     - media
   roles:
     - role: radarr
+    # Apple-TV Direct-Play audio guard (same script as Sonarr; reads the
+    # radarr_* env vars when Radarr's Custom Script Connect fires).
+    - role: media_remux
 
 - name: Configure Plex Media Server (LAN-only)
   hosts: plex_group

--- a/roles/media_remux/defaults/main.yml
+++ b/roles/media_remux/defaults/main.yml
@@ -1,0 +1,37 @@
+---
+# media_remux role defaults — the Apple-TV Direct-Play audio guard, deployed on
+# the Sonarr/Radarr hosts. This role only puts the tool + script on disk
+# (ffmpeg + a universal remux script the *arr "Custom Script" Connect calls on
+# import/upgrade). The API-side registration of that Connect lives in the
+# servarr_wiring role (notifications.yml). One script serves both apps: it reads
+# whichever of the sonarr_*/radarr_* env vars the caller set.
+
+media_remux_manage: true
+
+# Where the script lives on the *arr host. servarr_wiring registers this exact
+# path as the CustomScript `path` field — keep the two in sync via the matching
+# servarr_wiring_remux_script_path default.
+media_remux_dir: /opt/appletv-remux
+media_remux_script: "{{ media_remux_dir }}/appletv-remux.sh"
+media_remux_log: /var/log/appletv-remux.log
+
+# Service user the *arr process (and therefore the script) runs as — must match
+# the sonarr/radarr role user so the log + library files are writable.
+media_remux_user: media
+media_remux_group: media
+
+# AC3 target bitrate (640k = the Dolby-recommended 5.1 ceiling).
+media_remux_bitrate: 640k
+
+# Codecs an Apple-TV AVR passes through reliably → left untouched. Everything
+# else (eac3, dts, truehd, flac, …) is remuxed to AC3. EAC3 is treated as
+# non-compatible on purpose: the first Apple-TV's EAC3 (Dolby Digital Plus)
+# passthrough handshake is the original fault this guard exists to prevent.
+media_remux_compatible_codecs_re: '^(ac3|aac)$'
+
+# ntfy alert target on remux failure. Mirrors the sonarr role's ntfy derivation
+# (repo ntfy LXC + notification-port convention).
+media_remux_ntfy_topic: media
+media_remux_ntfy_url: >-
+  http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
+  tofu_data.constants.notification_ports.ntfy_http }}/{{ media_remux_ntfy_topic }}

--- a/roles/media_remux/meta/main.yml
+++ b/roles/media_remux/meta/main.yml
@@ -1,0 +1,21 @@
+---
+galaxy_info:
+  role_name: media_remux
+  author: JacobPEvans
+  description: Apple-TV Direct-Play audio guard (ffmpeg + import-time AC3 remux) for Sonarr/Radarr
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+
+  galaxy_tags:
+    - media
+    - plex
+    - transcode
+    - resiliency
+
+dependencies: []

--- a/roles/media_remux/tasks/main.yml
+++ b/roles/media_remux/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+# Deploy the Apple-TV Direct-Play audio guard (ffmpeg + universal remux script)
+# on the Sonarr/Radarr hosts. The servarr_wiring role registers the *arr Custom
+# Script Connect that calls the script this role installs.
+
+- name: Install ffmpeg (remux/transcode toolkit)
+  ansible.builtin.apt:
+    name: ffmpeg
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  when: media_remux_manage | bool
+
+- name: Ensure the media_remux script directory exists
+  ansible.builtin.file:
+    path: "{{ media_remux_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: media_remux_manage | bool
+
+# state:touch with preserved timestamps is idempotent — creates the log on first
+# run, then reports no change on subsequent runs. The *arr service user owns it
+# so the (non-root) script can append.
+- name: Create the media_remux log writable by the service user
+  ansible.builtin.file:
+    path: "{{ media_remux_log }}"
+    state: touch
+    owner: "{{ media_remux_user }}"
+    group: "{{ media_remux_group }}"
+    mode: "0664"
+    modification_time: preserve
+    access_time: preserve
+  when: media_remux_manage | bool
+
+- name: Deploy the Apple-TV remux script
+  ansible.builtin.template:
+    src: appletv-remux.sh.j2
+    dest: "{{ media_remux_script }}"
+    owner: root
+    group: root
+    mode: "0755"
+  when: media_remux_manage | bool

--- a/roles/media_remux/templates/appletv-remux.sh.j2
+++ b/roles/media_remux/templates/appletv-remux.sh.j2
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# {{ ansible_managed }}
+# appletv-remux.sh — Apple-TV Direct-Play audio guard for Sonarr/Radarr.
+#
+# Invoked by the *arr "Custom Script" Connect on import + upgrade. If a freshly
+# imported file's primary audio is a codec an Apple-TV AVR won't reliably pass
+# through (anything other than AC3/AAC — notably EAC3, DTS, TrueHD, FLAC), remux
+# the primary audio to AC3 5.1 IN PLACE so every client Direct Plays. Video +
+# subtitles are stream-copied (fast, lossless) and the original container/
+# extension is preserved, so the *arr database path never changes.
+#
+# Runs DETACHED (setsid) so it never blocks the *arr import pipeline; a per-file
+# lock stops concurrent imports racing the same file; failures alert ntfy.
+# Idempotent: an already-compatible file is a no-op.
+set -uo pipefail
+
+LOG="{{ media_remux_log }}"
+NTFY_URL="{{ media_remux_ntfy_url }}"
+BITRATE="{{ media_remux_bitrate }}"
+COMPAT_RE='{{ media_remux_compatible_codecs_re }}'
+
+log() { printf '%s %s\n' "$(date -Is 2>/dev/null || date)" "$*" >>"$LOG" 2>/dev/null || true; }
+notify() {
+  [ -n "$NTFY_URL" ] || return 0
+  curl -fsS -m 15 -H "Title: appletv-remux FAILED" -H "Priority: high" \
+    -H "Tags: rotating_light" -d "$1" "$NTFY_URL" >/dev/null 2>&1 || true
+}
+
+# ---------------------------------------------------------------------------
+# Worker: the actual remux. Re-exec'd detached with the file passed as argv so
+# spaces/commas in filenames survive intact (no re-quoting through a string).
+# ---------------------------------------------------------------------------
+if [ "${1:-}" = "--worker" ]; then
+  f="$2"; codec="$3"
+  lockid="$(printf '%s' "$f" | md5sum 2>/dev/null | cut -c1-16)"
+  lock="/tmp/appletv-remux.${lockid:-$$}.lock"
+  if ! mkdir "$lock" 2>/dev/null; then log "already remuxing, skip: $f"; exit 0; fi
+  trap 'rmdir "$lock" 2>/dev/null || true' EXIT
+
+  [ -f "$f" ] || { log "file vanished: $f"; exit 0; }
+  dir="$(dirname "$f")"; base="$(basename "$f")"; ext="${base##*.}"
+  tmp="$dir/.appletv-remux.$$.$ext"
+
+  # Preserve the source channel layout; only cap to 5.1 when the source exceeds
+  # it (AC3 tops out at 6 channels — an 8-channel TrueHD source needs -ac 6).
+  ch="$(ffprobe -v error -select_streams a:0 -show_entries stream=channels \
+        -of default=nw=1:nk=1 "$f" 2>/dev/null)"
+  aopts=(-c:a ac3 -b:a "$BITRATE")
+  if [ "${ch:-0}" -gt 6 ] 2>/dev/null; then aopts+=(-ac 6); fi
+
+  # mkv copies any subtitle codec; other containers may reject a sub copy, so
+  # only carry subtitles through for mkv (the fleet default).
+  mapopts=(-map 0:v -map 0:a:0 "${aopts[@]}" -c:v copy)
+  case "$ext" in
+    mkv | MKV) mapopts+=(-map 0:s? -c:s copy) ;;
+  esac
+
+  log "remux start ($codec -> ac3): $f"
+  if ! ffmpeg -y -nostdin -i "$f" "${mapopts[@]}" "$tmp" >>"$LOG" 2>&1; then
+    log "ffmpeg FAILED: $f"; rm -f "$tmp"; notify "ffmpeg failed: $base"; exit 1
+  fi
+
+  # Verify: primary audio is now AC3 and the duration matches within 3s.
+  nc="$(ffprobe -v error -select_streams a:0 -show_entries stream=codec_name -of default=nw=1:nk=1 "$tmp" 2>/dev/null)"
+  d1="$(ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 "$f" 2>/dev/null)"
+  d2="$(ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 "$tmp" 2>/dev/null)"
+  ok="$(awk -v a="$d1" -v b="$d2" 'BEGIN{x=a-b; if(x<0)x=-x; print (a+0>0 && x<=3)?1:0}')"
+  if [ "$nc" != "ac3" ] || [ "$ok" != "1" ]; then
+    log "verify FAILED nc=$nc d1=$d1 d2=$d2: $f"; rm -f "$tmp"; notify "verify failed: $base"; exit 1
+  fi
+
+  # Keep the original owner + perms, then atomically replace at the SAME path so
+  # the *arr DB stays in sync (no phantom "file missing" re-download).
+  chown --reference="$f" "$tmp" 2>/dev/null || true
+  chmod --reference="$f" "$tmp" 2>/dev/null || true
+  mv -f "$tmp" "$f"
+  log "remux OK: $f"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Dispatcher: invoked by the *arr Custom Script Connect (env vars, not argv).
+# ---------------------------------------------------------------------------
+FILE="${sonarr_episodefile_path:-${radarr_moviefile_path:-}}"
+EVENT="${sonarr_eventtype:-${radarr_eventtype:-}}"
+
+# The *arr "Test" button fires an on-test event with no file — succeed so the
+# Connect saves cleanly.
+case "$EVENT" in
+  Test | test) log "test event ok"; exit 0 ;;
+esac
+[ -n "$FILE" ] || { log "no file path (event=${EVENT:-none}) — nothing to do"; exit 0; }
+[ -f "$FILE" ] || { log "file missing: $FILE"; exit 0; }
+
+codec="$(ffprobe -v error -select_streams a:0 -show_entries stream=codec_name -of default=nw=1:nk=1 "$FILE" 2>/dev/null)"
+if [ -z "$codec" ]; then log "probe failed: $FILE"; notify "probe failed: $FILE"; exit 0; fi
+if printf '%s' "$codec" | grep -qE "$COMPAT_RE"; then
+  log "compatible ($codec) — skip: $FILE"; exit 0
+fi
+
+# Detach so the *arr import pipeline is never blocked by the transcode.
+setsid "$0" --worker "$FILE" "$codec" </dev/null >>"$LOG" 2>&1 &
+log "queued remux ($codec -> ac3): $FILE"
+exit 0

--- a/roles/servarr_wiring/defaults/main.yml
+++ b/roles/servarr_wiring/defaults/main.yml
@@ -133,6 +133,14 @@ servarr_wiring_recycler_bin_days: 14
 # previously killed qBittorrent for days). 25600 MB = 25 GiB headroom.
 servarr_wiring_min_free_space_mb: 25600
 
+# --- Apple-TV Direct-Play audio guard (Custom Script Connect) -----------------
+# Registers the media_remux script (deployed on each *arr host by the
+# media_remux role) as an onImport/onUpgrade Custom Script, so a non-AC3/AAC
+# import is auto-remuxed to AC3. Keep the path in sync with media_remux_script
+# (roles/media_remux/defaults/main.yml).
+servarr_wiring_remux_notif_name: "AppleTV AC3 Remux"
+servarr_wiring_remux_script_path: /opt/appletv-remux/appletv-remux.sh
+
 # --- Test / orchestration toggle ---------------------------------------------
 # When false (Molecule), the role only validates inputs and renders nothing
 # live — there are no running *arr apps in CI. The live deploy leaves it true.

--- a/roles/servarr_wiring/tasks/main.yml
+++ b/roles/servarr_wiring/tasks/main.yml
@@ -71,3 +71,23 @@
         _arr_host: "{{ servarr_wiring_radarr_host }}"
         _arr_port: "{{ servarr_wiring_radarr_port }}"
         _arr_api_key: "{{ servarr_wiring_radarr_api_key }}"
+
+    # -------------------------------------------------------------------------
+    # 5. Apple-TV Direct-Play audio guard: register the media_remux Custom
+    #    Script Connect (onImport/onUpgrade) so non-AC3/AAC imports auto-remux.
+    # -------------------------------------------------------------------------
+    - name: Register the Apple-TV remux Custom Script for Sonarr
+      ansible.builtin.include_tasks: notifications.yml
+      vars:
+        _arr_name: sonarr
+        _arr_host: "{{ servarr_wiring_sonarr_host }}"
+        _arr_port: "{{ servarr_wiring_sonarr_port }}"
+        _arr_api_key: "{{ servarr_wiring_sonarr_api_key }}"
+
+    - name: Register the Apple-TV remux Custom Script for Radarr
+      ansible.builtin.include_tasks: notifications.yml
+      vars:
+        _arr_name: radarr
+        _arr_host: "{{ servarr_wiring_radarr_host }}"
+        _arr_port: "{{ servarr_wiring_radarr_port }}"
+        _arr_api_key: "{{ servarr_wiring_radarr_api_key }}"

--- a/roles/servarr_wiring/tasks/notifications.yml
+++ b/roles/servarr_wiring/tasks/notifications.yml
@@ -1,0 +1,106 @@
+---
+# Register the Apple-TV Direct-Play audio guard as a *arr "Custom Script" Connect.
+# On import (onDownload) and on upgrade the *arr calls the media_remux script
+# (deployed on the app host by the media_remux role), which remuxes any
+# non-Apple-TV audio codec to AC3 in place.
+#
+# Idempotent: create by name if absent, reconcile in place if the script path
+# drifted, no-op when already correct. The request body is built from the live
+# CustomScript schema so the implementation/configContract match this *arr
+# version exactly (no hardcoded contract strings to rot).
+
+- name: Fetch the notification schema for {{ _arr_name }}
+  ansible.builtin.uri:
+    url: "http://{{ _arr_host }}:{{ _arr_port }}/api/v3/notification/schema"
+    method: GET
+    headers:
+      X-Api-Key: "{{ _arr_api_key }}"
+    status_code: 200
+  register: servarr_wiring_notif_schema
+  changed_when: false
+  no_log: true
+
+- name: List existing notifications for {{ _arr_name }}
+  ansible.builtin.uri:
+    url: "http://{{ _arr_host }}:{{ _arr_port }}/api/v3/notification"
+    method: GET
+    headers:
+      X-Api-Key: "{{ _arr_api_key }}"
+    status_code: 200
+  register: servarr_wiring_notif_list
+  changed_when: false
+  no_log: true
+
+- name: Compute the desired media_remux Custom Script notification for {{ _arr_name }}
+  ansible.builtin.set_fact:
+    # Existing notification with our name (empty dict when absent).
+    servarr_wiring_remux_existing: >-
+      {{ (servarr_wiring_notif_list.json
+          | selectattr('name', 'equalto', servarr_wiring_remux_notif_name)
+          | list | first) | default({}, true) }}
+    # Desired body: the live CustomScript schema + our name/events/script path.
+    servarr_wiring_remux_desired: >-
+      {{ (servarr_wiring_notif_schema.json
+          | selectattr('implementation', 'equalto', 'CustomScript')
+          | list | first | default({}, true))
+         | combine({
+             'name': servarr_wiring_remux_notif_name,
+             'onGrab': false,
+             'onDownload': true,
+             'onUpgrade': true,
+             'onRename': false,
+             'onHealthIssue': false,
+             'onApplicationUpdate': false,
+             'tags': [],
+             'fields': [{'name': 'path', 'value': servarr_wiring_remux_script_path}]
+           }) }}
+
+- name: Fail when the *arr build exposes no CustomScript notification for {{ _arr_name }}
+  ansible.builtin.assert:
+    that:
+      - servarr_wiring_remux_desired.implementation | default('') == 'CustomScript'
+    fail_msg: >-
+      {{ _arr_name }} did not return a CustomScript entry from
+      /api/v3/notification/schema — cannot register the media_remux Connect.
+    quiet: true
+
+- name: Create the media_remux Custom Script notification for {{ _arr_name }}
+  ansible.builtin.uri:
+    url: "http://{{ _arr_host }}:{{ _arr_port }}/api/v3/notification"
+    method: POST
+    headers:
+      X-Api-Key: "{{ _arr_api_key }}"
+    body_format: json
+    body: "{{ servarr_wiring_remux_desired }}"
+    status_code: [200, 201]
+  register: servarr_wiring_remux_post
+  changed_when: true
+  no_log: true
+  when: servarr_wiring_remux_existing | length == 0
+
+- name: Reconcile the media_remux notification (path/event drift) for {{ _arr_name }}
+  ansible.builtin.uri:
+    url: >-
+      http://{{ _arr_host }}:{{ _arr_port }}/api/v3/notification/{{
+      servarr_wiring_remux_existing.id }}
+    method: PUT
+    headers:
+      X-Api-Key: "{{ _arr_api_key }}"
+    body_format: json
+    # Keep the existing id, overlay the desired schema-derived body.
+    body: >-
+      {{ servarr_wiring_remux_existing
+         | combine(servarr_wiring_remux_desired)
+         | combine({'id': servarr_wiring_remux_existing.id}) }}
+    status_code: [200, 202]
+  register: servarr_wiring_remux_put
+  changed_when: true
+  no_log: true
+  when:
+    - servarr_wiring_remux_existing | length > 0
+    - >-
+      (servarr_wiring_remux_existing.fields | default([])
+       | selectattr('name', 'equalto', 'path')
+       | map(attribute='value') | first | default('')) != servarr_wiring_remux_script_path
+      or not (servarr_wiring_remux_existing.onDownload | default(false))
+      or not (servarr_wiring_remux_existing.onUpgrade | default(false))


### PR DESCRIPTION
## What

Adds an import-time **Apple-TV Direct-Play audio guard** so a non-AC3/AAC grab is
auto-remuxed to AC3 5.1 the moment Sonarr/Radarr import it — the durable backstop
to the grab-time codec policy in #823.

## How

- **New `media_remux` role** (on the Sonarr/Radarr hosts): installs `ffmpeg` and
  deploys one universal remux script. On import/upgrade the script probes the
  primary audio codec; if it is not Apple-TV direct-play friendly (anything but
  `ac3`/`aac` — `eac3`, `dts`, `truehd`, `flac`, …) it remuxes the primary audio
  to AC3 5.1 in place, stream-copying video + subtitles and preserving the
  original container/extension (so the *arr DB path never changes).
- **`servarr_wiring/notifications.yml`**: registers the script as a `CustomScript`
  Connect (`onDownload` + `onUpgrade`) via each app's API, built from the live
  notification schema (no hardcoded contract strings to rot).

## Safety / idempotency

- Script runs **detached** (never blocks the import pipeline), takes a per-file
  lock, verifies codec + duration before an atomic same-path replace, and alerts
  ntfy on failure. Already-compatible files are a no-op.
- API wiring is create-by-name / reconcile-on-drift (idempotent).

## Testing

- `ansible-lint` (production profile) passes: 0 failures on 238 files.
- `bash -n` on the rendered script passes.
- Live converge + an EAC3→AC3 import verification to follow.

Refs #825 (strategy S1). Complements #823.
