### PR TITLE
feat(media): Plex playback monitor + weekly codec audit

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -867,6 +867,9 @@
     - media
   roles:
     - role: plex
+    # Playback visibility: a session probe that alerts on forced transcode
+    # (the audio-dropout signature) + a weekly library codec audit.
+    - role: media_monitor
 
 # Seerr request UI (Docker in LXC). Registers Sonarr/Radarr/Plex via its settings
 # API — depends only on those apps being up (from the plays above), not on the

--- a/roles/media_monitor/defaults/main.yml
+++ b/roles/media_monitor/defaults/main.yml
@@ -1,0 +1,50 @@
+---
+# media_monitor — visibility for the media stack, deployed on the Plex host.
+# Two systemd timers:
+#   1. plex-session-probe: polls Plex /status/sessions and alerts ntfy when a
+#      client is forced to TRANSCODE (especially audio) instead of Direct Play —
+#      the live signature of the Apple-TV audio dropout this program set out to
+#      fix.
+#   2. plex-codec-audit: a weekly ffprobe sweep of the library flagging any
+#      primary-audio codec that is not Apple-TV direct-play friendly, catching
+#      files that slipped past the grab-time policy (#823) and the import-time
+#      remux (media_remux).
+
+media_monitor_manage: true
+
+media_monitor_plex_api_port: 32400
+# Preferences.xml holds PlexOnlineToken; the probe reads it at runtime (no baked
+# secret). Matches the plex role's plex_preferences_path.
+media_monitor_preferences_path: >-
+  /var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Preferences.xml
+
+# Library roots swept by the weekly codec audit (the plex role's scaffolded roots).
+media_monitor_library_roots:
+  - /data/media/movies
+  - /data/media/tv
+
+# Codecs an Apple-TV AVR passes through reliably; everything else is "needs
+# remux". Kept identical to media_remux_compatible_codecs_re so the audit and
+# the import guard agree on what counts as compatible.
+media_monitor_compatible_codecs_re: '^(ac3|aac)$'
+
+# Session probe cadence + de-dupe cooldown (a long transcode must not spam).
+media_monitor_probe_interval: "120s"
+media_monitor_alert_cooldown: 1800
+
+# Weekly audit schedule (systemd OnCalendar). Off-hours, off-minute; low-priority
+# ntfy when clean, high when files need remux.
+media_monitor_audit_oncalendar: "Sun *-*-* 04:17:00"
+media_monitor_audit_ok_priority: "low"
+
+# Working paths.
+media_monitor_bin_dir: /usr/local/bin
+media_monitor_state_dir: /var/lib/media-playback-monitor
+media_monitor_probe_state_dir: "{{ media_monitor_state_dir }}"
+media_monitor_audit_log: "{{ media_monitor_state_dir }}/codec-audit.log"
+
+# ntfy alert target. Reuses the repo ntfy LXC + notification-port convention.
+media_monitor_ntfy_topic: media
+media_monitor_ntfy_url: >-
+  http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
+  tofu_data.constants.notification_ports.ntfy_http }}/{{ media_monitor_ntfy_topic }}

--- a/roles/media_monitor/handlers/main.yml
+++ b/roles/media_monitor/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Reload systemd for media monitor
+  ansible.builtin.systemd:
+    daemon_reload: true

--- a/roles/media_monitor/meta/main.yml
+++ b/roles/media_monitor/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: media_monitor
+  author: JacobPEvans
+  description: Plex playback probe (alert on forced transcode) + weekly library codec audit
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+
+  galaxy_tags:
+    - media
+    - plex
+    - monitoring
+    - observability
+    - resiliency
+
+dependencies: []

--- a/roles/media_monitor/tasks/main.yml
+++ b/roles/media_monitor/tasks/main.yml
@@ -1,0 +1,69 @@
+---
+# Deploy the media playback monitor (session probe + weekly codec audit) on the
+# Plex host: two scripts driven by systemd timers, alerting ntfy.
+
+- name: Install ffmpeg (ffprobe for the weekly codec audit)
+  ansible.builtin.apt:
+    name: ffmpeg
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  when: media_monitor_manage | bool
+
+- name: Ensure the monitor state directory exists
+  ansible.builtin.file:
+    path: "{{ media_monitor_state_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: media_monitor_manage | bool
+
+- name: Deploy the media monitor scripts
+  ansible.builtin.template:
+    src: "{{ item }}.j2"
+    dest: "{{ media_monitor_bin_dir }}/{{ item }}"
+    owner: root
+    group: root
+    mode: "0755"
+  loop:
+    - plex-session-probe.sh
+    - plex-codec-audit.sh
+  when: media_monitor_manage | bool
+
+- name: Deploy the media monitor systemd service units
+  ansible.builtin.template:
+    src: "{{ item }}.service.j2"
+    dest: "/etc/systemd/system/{{ item }}.service"
+    owner: root
+    group: root
+    mode: "0644"
+  loop:
+    - plex-session-probe
+    - plex-codec-audit
+  notify: Reload systemd for media monitor
+  when: media_monitor_manage | bool
+
+- name: Deploy the media monitor systemd timer units
+  ansible.builtin.template:
+    src: "{{ item }}.timer.j2"
+    dest: "/etc/systemd/system/{{ item }}.timer"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd for media monitor
+  loop:
+    - plex-session-probe
+    - plex-codec-audit
+  when: media_monitor_manage | bool
+
+- name: Enable + start the media monitor timers
+  ansible.builtin.systemd:
+    name: "{{ item }}.timer"
+    state: started
+    enabled: true
+    daemon_reload: true
+  loop:
+    - plex-session-probe.timer
+    - plex-codec-audit.timer
+  when: media_monitor_manage | bool

--- a/roles/media_monitor/templates/plex-codec-audit.service.j2
+++ b/roles/media_monitor/templates/plex-codec-audit.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Plex weekly library codec audit (flag non-AppleTV audio)
+Documentation=https://github.com/JacobPEvans/ansible-proxmox-apps
+After=network-online.target
+
+[Service]
+Type=oneshot
+# Read-only ffprobe sweep — nice + idle IO so it never competes with live
+# playback on a shared node.
+Nice=15
+IOSchedulingClass=idle
+ExecStart={{ media_monitor_bin_dir }}/plex-codec-audit.sh

--- a/roles/media_monitor/templates/plex-codec-audit.sh.j2
+++ b/roles/media_monitor/templates/plex-codec-audit.sh.j2
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# {{ ansible_managed }}
+# Weekly library codec audit. Scans the media library for primary-audio codecs
+# that are NOT Apple-TV direct-play friendly (anything but ac3/aac) and reports
+# the count to ntfy. Complements the import-time media_remux guard: catches
+# files that arrived out-of-band (manual copy, pre-existing library, a failed
+# remux). Read-only (ffprobe) and niced/idle-scheduled by the unit so it never
+# hurts live playback on a shared node.
+set -uo pipefail
+
+NTFY_URL="{{ media_monitor_ntfy_url }}"
+COMPAT_RE='{{ media_monitor_compatible_codecs_re }}'
+LOG="{{ media_monitor_audit_log }}"
+OK_PRIORITY="{{ media_monitor_audit_ok_priority }}"
+roots=({% for r in media_monitor_library_roots %}"{{ r }}" {% endfor %})
+
+: >"$LOG" 2>/dev/null || true
+bad=0; total=0
+for root in "${roots[@]}"; do
+  [ -d "$root" ] || continue
+  while IFS= read -r -d '' f; do
+    total=$((total + 1))
+    codec="$(ffprobe -v error -select_streams a:0 -show_entries stream=codec_name -of default=nw=1:nk=1 "$f" 2>/dev/null)"
+    if ! printf '%s' "$codec" | grep -qE "$COMPAT_RE"; then
+      bad=$((bad + 1)); printf '%s\t%s\n' "${codec:-unknown}" "$f" >>"$LOG"
+    fi
+  done < <(find "$root" -type f \( -iname '*.mkv' -o -iname '*.mp4' -o -iname '*.m4v' -o -iname '*.avi' \) -print0)
+done
+
+prio="$OK_PRIORITY"; tags="white_check_mark"
+if [ "$bad" -gt 0 ]; then prio="high"; tags="rotating_light"; fi
+
+if [ -n "$NTFY_URL" ]; then
+  curl -fsS -m 20 \
+    -H "Title: Plex codec audit — $bad/$total non-AppleTV" \
+    -H "Priority: $prio" -H "Tags: $tags" \
+    -d "{{ inventory_hostname }}: $bad of $total files have non-AppleTV audio (need remux). Detail: $LOG" \
+    "$NTFY_URL" >/dev/null 2>&1 || true
+fi

--- a/roles/media_monitor/templates/plex-codec-audit.timer.j2
+++ b/roles/media_monitor/templates/plex-codec-audit.timer.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Weekly Plex library codec audit
+
+[Timer]
+OnCalendar={{ media_monitor_audit_oncalendar }}
+AccuracySec=1h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/roles/media_monitor/templates/plex-session-probe.service.j2
+++ b/roles/media_monitor/templates/plex-session-probe.service.j2
@@ -1,0 +1,8 @@
+[Unit]
+Description=Plex Direct-Play session probe (alert on forced transcode)
+Documentation=https://github.com/JacobPEvans/ansible-proxmox-apps
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart={{ media_monitor_bin_dir }}/plex-session-probe.sh

--- a/roles/media_monitor/templates/plex-session-probe.sh.j2
+++ b/roles/media_monitor/templates/plex-session-probe.sh.j2
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# {{ ansible_managed }}
+# Plex Direct-Play session probe. Polls Plex /status/sessions and alerts ntfy
+# when a client is being forced to TRANSCODE (especially audio) instead of
+# Direct Play — the live signature of the Apple-TV audio dropout this program
+# set out to fix. Reads the server token from Preferences.xml at runtime (no
+# baked-in secret). Best-effort and quiet on the happy path.
+set -uo pipefail
+
+PREFS="{{ media_monitor_preferences_path }}"
+API="http://127.0.0.1:{{ media_monitor_plex_api_port }}"
+NTFY_URL="{{ media_monitor_ntfy_url }}"
+STAMP="{{ media_monitor_probe_state_dir }}/last-transcode-alert"
+COOLDOWN={{ media_monitor_alert_cooldown }}
+
+# PlexOnlineToken is present once the server is claimed; an unclaimed server
+# accepts unauthenticated loopback requests, so an empty token is fine.
+token="$(grep -o 'PlexOnlineToken="[^"]*"' "$PREFS" 2>/dev/null | head -1 | cut -d'"' -f2)"
+
+sessions="$(curl -fsS -m 10 "$API/status/sessions${token:+?X-Plex-Token=$token}" 2>/dev/null)" || exit 0
+
+# No TranscodeSession element => every stream is Direct Play/Stream => nothing to do.
+printf '%s' "$sessions" | grep -q '<TranscodeSession' || exit 0
+
+audio_xcode="$(printf '%s' "$sessions" | grep -o 'audioDecision="transcode"' | wc -l | tr -d ' ')"
+video_xcode="$(printf '%s' "$sessions" | grep -o 'videoDecision="transcode"' | wc -l | tr -d ' ')"
+audio_xcode="${audio_xcode:-0}"; video_xcode="${video_xcode:-0}"
+
+if [ "$audio_xcode" -eq 0 ] && [ "$video_xcode" -eq 0 ]; then exit 0; fi
+
+# De-dupe: alert at most once per cooldown so a long transcode does not spam.
+now="$(date +%s)"
+if [ -f "$STAMP" ]; then
+  last="$(cat "$STAMP" 2>/dev/null || echo 0)"
+  if [ $(( now - last )) -lt "$COOLDOWN" ]; then exit 0; fi
+fi
+
+if [ -n "$NTFY_URL" ]; then
+  curl -fsS -m 15 \
+    -H "Title: Plex is transcoding (not Direct Play)" \
+    -H "Priority: high" -H "Tags: warning,tv" \
+    -d "Forced transcode on {{ inventory_hostname }}: audio=$audio_xcode video=$video_xcode. A client is NOT Direct Playing — check its audio-passthrough setting or the file's audio codec." \
+    "$NTFY_URL" >/dev/null 2>&1 || true
+fi
+echo "$now" >"$STAMP" 2>/dev/null || true

--- a/roles/media_monitor/templates/plex-session-probe.timer.j2
+++ b/roles/media_monitor/templates/plex-session-probe.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run the Plex session probe every {{ media_monitor_probe_interval }}
+
+[Timer]
+OnBootSec=120s
+OnUnitActiveSec={{ media_monitor_probe_interval }}
+AccuracySec=15s
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## What

A `media_monitor` role on the Plex host with two systemd timers, giving the media stack the visibility it lacked when the Apple-TV audio dropouts went unnoticed.

## How

- **plex-session-probe** (every 2m): polls Plex `/status/sessions` and alerts ntfy when a client is forced to **transcode** (esp. audio) instead of Direct Play — the live signature of the dropout. Reads the server token from Preferences.xml at runtime; de-duped by a cooldown.
- **plex-codec-audit** (weekly): ffprobe sweep flagging any primary-audio codec that is not Apple-TV direct-play friendly (non `ac3`/`aac`); niced + idle-IO so it never competes with playback. ntfy low when clean, high when files need remux.

Compatible-codec set kept identical to the `media_remux` import guard (#829) so the two agree.

## Testing

- `ansible-lint` (production profile): 0 failures on 241 files.
- `bash -n` on both rendered scripts passes.

Refs #825 (strategy S2).