### PR TITLE
feat(nautobot): native shared-postgres and nautobot roles with SSoT seed + export (#138)

### DIFF
--- a/.github/workflows/_molecule.yml
+++ b/.github/workflows/_molecule.yml
@@ -35,6 +35,8 @@ jobs:
           - immich
           - openbao
           - keepalived
+          - postgres
+          - nautobot
 
     steps:
       - name: Checkout code

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -136,3 +136,6 @@ bao_observability_secrets: {}
 bao_local_cloud_secrets: {}
 bao_monitoring_secrets: {}
 bao_media_secrets: {}
+# `apps` domain — shared-Postgres app secrets (Nautobot #138: db_password,
+# secret_key, superuser_password under secret/apps/nautobot).
+bao_apps_secrets: {}

--- a/inventory/group_vars/nautobot_group.yml
+++ b/inventory/group_vars/nautobot_group.yml
@@ -1,0 +1,37 @@
+---
+# Nautobot IPAM/DCIM (issue #138). tofu-derived FQDNs/ports plus bao-first
+# secrets (apps domain). The heavy app layer stays enabled here; molecule
+# disables it separately.
+
+# Web port from the published constants (WS-C adds service_ports.nautobot_web,
+# 8080). Falls back to 8080 when the cache predates that key.
+nautobot_web_port: >-
+  {{ (hostvars['localhost']['tofu_data']['constants']['service_ports']['nautobot_web'])
+     | default(8080) }}
+
+# Postgres has no ingress; reach it by its guest FQDN on the data VLAN. The
+# guest DNS zone is tofu_data.domain and the hostname is fixed at `postgres`
+# by the container (a stable service identifier, not a hard-coded address).
+nautobot_db_host: "postgres.{{ hostvars['localhost']['tofu_data']['domain'] }}"
+nautobot_db_password: >-
+  {{ bao_apps_secrets.db_password
+     | default(lookup('env', 'NAUTOBOT_DB_PASSWORD'), true) }}
+
+# Public UI FQDN (Traefik-fronted): nautobot.<guest zone>, the same name
+# technitium/ingress publishes. ALLOWED_HOSTS + CSRF_TRUSTED_ORIGINS derive
+# from it.
+nautobot_ui_fqdn: "nautobot.{{ hostvars['localhost']['tofu_data']['domain'] }}"
+
+# SECRET_KEY + superuser password bao-first (secret/apps/nautobot), env fallback.
+nautobot_secret_key: >-
+  {{ bao_apps_secrets.secret_key
+     | default(lookup('env', 'NAUTOBOT_SECRET_KEY'), true) }}
+nautobot_superuser_password: >-
+  {{ bao_apps_secrets.superuser_password
+     | default(lookup('env', 'NAUTOBOT_SUPERUSER_PASSWORD'), true) }}
+
+# Export artifact target — the same S3 state bucket the ansible inventory
+# artifact uses (terraform-proxmox-state-useast2-<account>), from the runtime
+# secret store.
+nautobot_export_s3_bucket: >-
+  {{ lookup('env', 'NAUTOBOT_EXPORT_S3_BUCKET') | default('', true) }}

--- a/inventory/group_vars/postgres_group.yml
+++ b/inventory/group_vars/postgres_group.yml
@@ -1,0 +1,26 @@
+---
+# Shared native PostgreSQL (issue #138) — backs Nautobot now, Vikunja/EspoCRM
+# later. Secrets resolve bao-first (apps domain) with an env fallback; the
+# listener is narrowed to the data-VLAN reservation address.
+
+# Narrow the listener to the guest's own data-VLAN reservation address (derived
+# from the tofu inventory, never a literal). Falls back to the permissive role
+# default only when the reservation fact is absent (e.g. a molecule run, which
+# sets its own value anyway).
+postgres_listen_addresses: >-
+  {{ ('localhost,' ~ container_reserved_ip)
+     if (container_reserved_ip | default('', true) | length > 0)
+     else '*' }}
+
+# Databases on this shared cluster. Each password is bao-first
+# (secret/apps/<app>) with an env fallback; each client_cidr is the app LXC's
+# subnet sourced from the runtime secret store (NETWORK_CIDR_APPS) — the only
+# place a CIDR literal is legitimate (pg_hba cannot take an FQDN) and even then
+# it is env-derived, not hard-coded.
+postgres_managed_databases:
+  - name: nautobot
+    user: nautobot
+    password: >-
+      {{ bao_apps_secrets.db_password
+         | default(lookup('env', 'NAUTOBOT_DB_PASSWORD'), true) }}
+    client_cidr: "{{ lookup('env', 'NETWORK_CIDR_APPS') | default('', true) }}"

--- a/inventory/load_tofu.yml
+++ b/inventory/load_tofu.yml
@@ -89,6 +89,9 @@
         - tofu_data.docker_vms is defined
         - tofu_data.docker_vms | length > 0
 
+    # NOTE (issue #138): postgres_group is keyed on the SPECIFIC `postgres` tag,
+    # not the generic `database` tag (which already selects mssql_group) — so the
+    # postgres guest must NOT carry `database`, or mssql_docker would run on it.
     - name: Add LXC containers to inventory (proxmox_pct_remote connection)
       ansible.builtin.add_host:
         name: "{{ item.key }}"
@@ -130,6 +133,16 @@
             (
               ['mssql_group']
               if 'database' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
+              ['postgres_group']
+              if 'postgres' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
+              ['nautobot_group']
+              if 'nautobot' in (item.value.tags | default([]))
               else []
             ) +
             (

--- a/molecule/nautobot/converge.yml
+++ b/molecule/nautobot/converge.yml
@@ -1,0 +1,21 @@
+---
+# Converge the nautobot role with the live app layer disabled. Secrets are left
+# empty to exercise the SECRET_KEY generate-once path; the DB password is a
+# placeholder (no DB is contacted with nautobot_manage_app=false). These vars
+# stand in for what group_vars/nautobot_group.yml supplies live.
+- name: Converge
+  hosts: all
+  become: true
+  gather_facts: true
+
+  vars:
+    nautobot_manage_app: false
+    nautobot_db_host: postgres.example.test
+    nautobot_db_password: molecule-db-pw
+    nautobot_ui_fqdn: nautobot.example.test
+    nautobot_superuser_password: molecule-super-pw
+
+  tasks:
+    - name: Include nautobot role
+      ansible.builtin.include_role:
+        name: nautobot

--- a/molecule/nautobot/molecule.yml
+++ b/molecule/nautobot/molecule.yml
@@ -1,0 +1,57 @@
+---
+# Molecule scenario for the native nautobot role. Runs with
+# nautobot_manage_app=false: it exercises the deterministic layer (system deps,
+# nautobot user, Redis bound to loopback, SECRET_KEY generate-once, rendered
+# config/uWSGI/env, systemd units, deployed SSoT/export jobs) WITHOUT the
+# multi-minute Nautobot pip install + live database. The live application layer
+# (migrate, superuser, service start, HTTP 200/302) is validated at cutover
+# (issue #138 "Done when"), mirroring keepalived_manage_services.
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: nautobot-test
+    image: geerlingguy/docker-debian12-ansible:latest
+    privileged: true
+    command: ""
+    pre_build_image: true
+    tmpfs:
+      - /run
+      - /tmp
+      - /run/lock
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    groups:
+      - nautobot_group
+      - lxc_containers
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
+
+verifier:
+  name: ansible
+
+scenario:
+  name: nautobot
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - cleanup
+    - destroy

--- a/molecule/nautobot/prepare.yml
+++ b/molecule/nautobot/prepare.yml
@@ -1,0 +1,14 @@
+---
+# Bring the test container to a ready state before converge.
+- name: Prepare
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Wait for container to be ready
+      ansible.builtin.wait_for_connection:
+        timeout: 30
+
+    - name: Gather facts
+      ansible.builtin.setup:

--- a/molecule/nautobot/verify.yml
+++ b/molecule/nautobot/verify.yml
@@ -1,0 +1,133 @@
+---
+# Verify the deterministic layer the role renders with nautobot_manage_app=false:
+# rendered config + env + uWSGI, the three systemd units, Redis bound to
+# loopback, the persisted SECRET_KEY, and the deployed SSoT/export jobs.
+- name: Verify
+  hosts: all
+  become: true
+  gather_facts: false
+
+  vars:
+    nautobot_root: /opt/nautobot
+
+  tasks:
+    - name: Read the rendered nautobot_config.py
+      ansible.builtin.slurp:
+        src: "{{ nautobot_root }}/nautobot_config.py"
+      register: nautobot_config
+
+    - name: Assert the config carries the UI host, plugins, and DB host
+      ansible.builtin.assert:
+        that:
+          - "'nautobot.example.test' in config"
+          - "'nautobot_ssot' in config"
+          - "'nautobot_device_onboarding' in config"
+          - "'postgres.example.test' in config"
+          - "'NAUTOBOT_SECRET_KEY' in config"
+        fail_msg: "nautobot_config.py is missing expected content"
+      vars:
+        config: "{{ nautobot_config.content | b64decode }}"
+
+    - name: Stat the environment file
+      ansible.builtin.stat:
+        path: "{{ nautobot_root }}/nautobot.env"
+      register: nautobot_env
+
+    - name: Assert the env file is present and root-only
+      ansible.builtin.assert:
+        that:
+          - nautobot_env.stat.exists
+          - nautobot_env.stat.mode == '0600'
+        fail_msg: "nautobot.env missing or not 0600"
+
+    - name: Stat the persisted SECRET_KEY
+      ansible.builtin.stat:
+        path: "{{ nautobot_root }}/.secret_key"
+      register: nautobot_secret_key
+
+    - name: Assert the SECRET_KEY was generated and is root-only
+      ansible.builtin.assert:
+        that:
+          - nautobot_secret_key.stat.exists
+          - nautobot_secret_key.stat.mode == '0600'
+          - nautobot_secret_key.stat.size > 0
+        fail_msg: "SECRET_KEY was not generated/persisted at 0600"
+
+    - name: Read the uWSGI config
+      ansible.builtin.slurp:
+        src: "{{ nautobot_root }}/uwsgi.ini"
+      register: nautobot_uwsgi
+
+    - name: Assert uWSGI binds the web port and serves static
+      ansible.builtin.assert:
+        that:
+          - "'8080' in uwsgi"
+          - "'static-map' in uwsgi"
+        fail_msg: "uwsgi.ini missing http bind or static-map"
+      vars:
+        uwsgi: "{{ nautobot_uwsgi.content | b64decode }}"
+
+    - name: Stat the systemd units
+      ansible.builtin.stat:
+        path: "/etc/systemd/system/{{ item }}"
+      register: nautobot_units
+      loop:
+        - nautobot-server.service
+        - nautobot-worker.service
+        - nautobot-scheduler.service
+
+    - name: Assert all three units are installed
+      ansible.builtin.assert:
+        that:
+          - item.stat.exists
+        fail_msg: "systemd unit {{ item.item }} not installed"
+      loop: "{{ nautobot_units.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+
+    - name: Read redis.conf
+      ansible.builtin.slurp:
+        src: /etc/redis/redis.conf
+      register: nautobot_redis_conf
+
+    - name: Assert Redis is bound to loopback
+      ansible.builtin.assert:
+        that:
+          - "'bind 127.0.0.1' in redis_conf"
+        fail_msg: "redis.conf is not bound to loopback"
+      vars:
+        redis_conf: "{{ nautobot_redis_conf.content | b64decode }}"
+
+    - name: Assert Redis is running
+      ansible.builtin.systemd:
+        name: redis-server
+      register: nautobot_redis_state
+      changed_when: false
+
+    - name: Assert redis-server is active
+      ansible.builtin.assert:
+        that:
+          - nautobot_redis_state.status.ActiveState == 'active'
+        fail_msg: "redis-server is not active"
+
+    - name: Stat the deployed SSoT/export jobs
+      ansible.builtin.stat:
+        path: "{{ nautobot_root }}/jobs/{{ item }}"
+      register: nautobot_jobs
+      loop:
+        - ssot_common.py
+        - ssot_vlans_prefixes.py
+        - ssot_ip_addresses.py
+        - ssot_dcim.py
+        - ssot_nodes.py
+        - export_nautobot.py
+        - device_onboarding_setup.py
+
+    - name: Assert every job file was deployed
+      ansible.builtin.assert:
+        that:
+          - item.stat.exists
+        fail_msg: "job {{ item.item }} was not deployed to JOBS_ROOT"
+      loop: "{{ nautobot_jobs.results }}"
+      loop_control:
+        label: "{{ item.item }}"

--- a/molecule/nautobot/verify.yml
+++ b/molecule/nautobot/verify.yml
@@ -40,6 +40,19 @@
           - nautobot_env.stat.mode == '0600'
         fail_msg: "nautobot.env missing or not 0600"
 
+    - name: Stat the installed export schema contract
+      ansible.builtin.stat:
+        path: "{{ nautobot_root }}/contracts/nautobot-export-v1.json"
+      register: nautobot_export_schema
+
+    - name: Assert the export schema contract was deployed
+      ansible.builtin.assert:
+        that:
+          - nautobot_export_schema.stat.exists
+          - nautobot_export_schema.stat.mode == '0644'
+          - nautobot_export_schema.stat.size > 0
+        fail_msg: "nautobot-export-v1 schema was not deployed"
+
     - name: Stat the persisted SECRET_KEY
       ansible.builtin.stat:
         path: "{{ nautobot_root }}/.secret_key"

--- a/molecule/postgres/converge.yml
+++ b/molecule/postgres/converge.yml
@@ -1,0 +1,23 @@
+---
+# Converge the postgres role with a local-only listener and a single managed
+# database (nautobot). The client CIDR is loopback so the verify play can prove
+# scram auth over TCP without a second host. These vars stand in for what
+# group_vars/postgres_group.yml supplies live (bao password, data-VLAN address,
+# apps-subnet CIDR).
+- name: Converge
+  hosts: all
+  become: true
+  gather_facts: true
+
+  vars:
+    postgres_listen_addresses: localhost
+    postgres_managed_databases:
+      - name: nautobot
+        user: nautobot
+        password: molecule-nautobot-pw
+        client_cidr: 127.0.0.1/32
+
+  tasks:
+    - name: Include postgres role
+      ansible.builtin.include_role:
+        name: postgres

--- a/molecule/postgres/molecule.yml
+++ b/molecule/postgres/molecule.yml
@@ -1,0 +1,55 @@
+---
+# Molecule scenario for the native postgres role. A single privileged systemd
+# container installs PostgreSQL from PGDG, creates the nautobot role+db, and the
+# verify play connects as that role over TCP with scram to prove pg_hba + the
+# password path work end to end. The idempotence step guards the "generate
+# password only when the role is absent" design.
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: postgres-test
+    image: geerlingguy/docker-debian12-ansible:latest
+    privileged: true
+    command: ""
+    pre_build_image: true
+    tmpfs:
+      - /run
+      - /tmp
+      - /run/lock
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    groups:
+      - postgres_group
+      - lxc_containers
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
+
+verifier:
+  name: ansible
+
+scenario:
+  name: postgres
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - cleanup
+    - destroy

--- a/molecule/postgres/prepare.yml
+++ b/molecule/postgres/prepare.yml
@@ -1,0 +1,14 @@
+---
+# Bring the test container to a ready state before converge.
+- name: Prepare
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Wait for container to be ready
+      ansible.builtin.wait_for_connection:
+        timeout: 30
+
+    - name: Gather facts
+      ansible.builtin.setup:

--- a/molecule/postgres/verify.yml
+++ b/molecule/postgres/verify.yml
@@ -1,0 +1,68 @@
+---
+# Verify the cluster is up, the nautobot role can authenticate over TCP with
+# scram from its allowed CIDR, the database exists and is owned correctly, and
+# the backup timer is scheduled.
+- name: Verify
+  hosts: all
+  become: true
+  gather_facts: false
+
+  vars:
+    nautobot_db_password: molecule-nautobot-pw
+
+  tasks:
+    - name: Ping the cluster as the postgres superuser
+      become: true
+      become_user: postgres
+      community.postgresql.postgresql_ping:
+        db: postgres
+      register: postgres_ping
+      changed_when: false
+
+    - name: Assert the cluster answered
+      ansible.builtin.assert:
+        that:
+          - postgres_ping.is_available | bool
+        fail_msg: "PostgreSQL did not answer postgresql_ping"
+
+    - name: Connect as the nautobot role over TCP with scram
+      community.postgresql.postgresql_query:
+        login_host: 127.0.0.1
+        login_user: nautobot
+        login_password: "{{ nautobot_db_password }}"
+        db: nautobot
+        query: "SELECT current_user AS who, current_database() AS db"
+      register: nautobot_conn
+      changed_when: false
+
+    - name: Assert the nautobot role reached its own database
+      ansible.builtin.assert:
+        that:
+          - nautobot_conn.query_result[0].who == 'nautobot'
+          - nautobot_conn.query_result[0].db == 'nautobot'
+        fail_msg: "nautobot role could not authenticate to the nautobot database over TCP"
+
+    - name: Read pg_hba.conf
+      ansible.builtin.slurp:
+        src: "{{ postgres_conf_dir }}/pg_hba.conf"
+      register: pg_hba
+
+    - name: Assert pg_hba carries the scram rule for nautobot
+      ansible.builtin.assert:
+        that:
+          - "'nautobot' in hba"
+          - "'scram-sha-256' in hba"
+        fail_msg: "pg_hba.conf is missing the scram host rule for nautobot"
+      vars:
+        hba: "{{ pg_hba.content | b64decode }}"
+
+    - name: Stat the backup timer unit
+      ansible.builtin.stat:
+        path: /etc/systemd/system/pg-backup.timer
+      register: pg_backup_timer
+
+    - name: Assert the backup timer is installed
+      ansible.builtin.assert:
+        that:
+          - pg_backup_timer.stat.exists
+        fail_msg: "pg-backup.timer was not installed"

--- a/molecule/postgres/verify.yml
+++ b/molecule/postgres/verify.yml
@@ -9,8 +9,24 @@
 
   vars:
     nautobot_db_password: molecule-nautobot-pw
+    postgres_cluster_name: main
 
   tasks:
+    - name: Discover installed PostgreSQL major
+      ansible.builtin.command:
+        argv:
+          - psql
+          - --version
+      register: postgres_psql_version
+      changed_when: false
+
+    - name: Set PostgreSQL config directory
+      ansible.builtin.set_fact:
+        postgres_conf_dir: >-
+          /etc/postgresql/{{
+            postgres_psql_version.stdout | regex_search('[0-9]+')
+          }}/{{ postgres_cluster_name }}
+
     - name: Ping the cluster as the postgres superuser
       become: true
       become_user: postgres

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -25,6 +25,7 @@
     cribl_stream_group:cribl_edge:
     object_storage_group:
     netmon_group:prometheus_group:unifi_metrics_group:
+    postgres_group:nautobot_group:
     sonarr_group:radarr_group:plex_group:seerr_group:sortarr_group:download_vpn_group:immich_group
   gather_facts: false
   tags:
@@ -47,6 +48,7 @@
         bao_monitoring_secrets: "{{ openbao_secrets_by_domain['monitoring'] | default({}) }}"
         bao_media_secrets: "{{ openbao_secrets_by_domain['media'] | default({}) }}"
         bao_local_llm_secrets: "{{ openbao_secrets_by_domain['local-llm'] | default({}) }}"
+        bao_apps_secrets: "{{ openbao_secrets_by_domain['apps'] | default({}) }}"
       vars:
         openbao_secrets_by_domain: "{{ hostvars['localhost'].openbao_secrets_by_domain | default({}) }}"
       no_log: true
@@ -534,6 +536,33 @@
     - database
   roles:
     - role: mssql_docker
+
+# =============================================================================
+# Phase 5b: Shared PostgreSQL + Nautobot IPAM/DCIM (issue #138)
+# Postgres (the shared native DB backend) must converge before Nautobot, which
+# connects to it by FQDN on the data VLAN. Both read their secrets from the
+# openbao_secrets pre-play (apps domain) with an env fallback. gather_facts is
+# on: the postgres role derives the PGDG apt repo from ansible_distribution_release.
+# =============================================================================
+
+- name: Configure shared PostgreSQL
+  hosts: postgres_group
+  become: true
+  gather_facts: true
+  tags:
+    - postgres
+    - database
+  roles:
+    - role: postgres
+
+- name: Configure Nautobot IPAM/DCIM
+  hosts: nautobot_group
+  become: true
+  gather_facts: true
+  tags:
+    - nautobot
+  roles:
+    - role: nautobot
 
 # =============================================================================
 # Phase 6: Qdrant Vector Database

--- a/requirements.yml
+++ b/requirements.yml
@@ -26,6 +26,9 @@ collections:
   - name: community.hashi_vault
     version: ">=6.0.0"  # openbao_secrets role: vault_login (approle) + vault_kv2_get (needs python hvac)
 
+  - name: community.postgresql
+    version: ">=3.4.0"  # postgres role: postgresql_user/_db/_privs idempotent role+db creation
+
 roles:
   # Shared inventory resolver consumed by inventory/load_tofu.yml — replaces the
   # per-repo resolution-tier copy-paste. Pinned to the release that first ships

--- a/roles/nautobot/defaults/main.yml
+++ b/roles/nautobot/defaults/main.yml
@@ -1,0 +1,114 @@
+---
+# Native Nautobot (issue #138): a Python venv running uWSGI (web) + celery
+# worker + celery beat scheduler, with Redis colocated on loopback. Role
+# defaults carry only non-secret, molecule-safe values; group_vars supplies the
+# tofu-derived FQDNs/ports and the bao-first secrets.
+
+nautobot_root: /opt/nautobot
+nautobot_user: nautobot
+nautobot_group: nautobot
+
+# System packages: python build chain, libpq for psycopg, redis, git.
+nautobot_system_packages:
+  - python3
+  - python3-venv
+  - python3-dev
+  - build-essential
+  - libpq-dev
+  - redis-server
+  - git
+  - openssl
+
+# Python packages installed into the venv (latest stable). The pip
+# distribution names differ from the Django app/plugin names used in PLUGINS:
+#   nautobot-ssot              -> nautobot_ssot
+#   nautobot-device-onboarding -> nautobot_device_onboarding
+nautobot_pip_packages:
+  - nautobot
+  - nautobot-ssot
+  - nautobot-device-onboarding
+nautobot_plugins:
+  - nautobot_ssot
+  - nautobot_device_onboarding
+
+# Web listener. Traefik fronts Nautobot on this port; uWSGI serves HTTP on it
+# directly (no nginx) and serves collected static files via a static-map.
+nautobot_web_port: 8080
+nautobot_web_bind: "0.0.0.0"
+# uWSGI worker/process sizing — small, a homelab single node.
+nautobot_uwsgi_processes: 3
+nautobot_uwsgi_threads: 2
+
+# Database (shared native postgres). group_vars overrides host+password.
+nautobot_db_host: "127.0.0.1"
+nautobot_db_port: 5432
+nautobot_db_name: nautobot
+nautobot_db_user: nautobot
+nautobot_db_password: ""
+
+# Redis, colocated and bound to loopback (no ingress).
+nautobot_redis_host: "127.0.0.1"
+nautobot_redis_port: 6379
+
+# Identity / CSRF. group_vars overrides with the real Traefik-fronted UI FQDN.
+nautobot_ui_fqdn: "localhost"
+nautobot_allowed_hosts:
+  - "{{ nautobot_ui_fqdn }}"
+  - localhost
+  - 127.0.0.1
+# Traefik terminates TLS and forwards one hop; trust its X-Forwarded-Proto.
+nautobot_trust_proxy_ssl_header: true
+
+# SECRET_KEY: bao-first in group_vars; when unset the role generates one once
+# and persists it to nautobot_secret_key_file (generate-if-absent), so the
+# rendered env stays stable across runs.
+nautobot_secret_key: ""
+nautobot_secret_key_file: "{{ nautobot_root }}/.secret_key"
+
+# Superuser (idempotent create-or-update). Password bao-first in group_vars.
+nautobot_superuser_name: admin
+nautobot_superuser_email: "admin@{{ nautobot_ui_fqdn }}"
+nautobot_superuser_password: ""
+
+# Jobs. The SSoT seed jobs, export job, and onboarding setup ship in
+# files/jobs and are copied into JOBS_ROOT.
+nautobot_jobs_root: "{{ nautobot_root }}/jobs"
+nautobot_seed_file: "{{ nautobot_root }}/nautobot_seed.json"
+
+# Export Job → S3 (mirrors terraform-proxmox/inventory_publish.tf: same bucket,
+# a new key; ambient creds). group_vars/env supplies the bucket.
+nautobot_export_s3_bucket: ""
+nautobot_export_s3_key: "nautobot/nautobot_export.json"
+nautobot_export_schema_dir: "{{ nautobot_root }}/contracts"
+nautobot_export_schema_file: "{{ nautobot_export_schema_dir }}/nautobot-export-v1.json"
+# Export runs on a schedule via celery beat; this is the beat crontab (UTC).
+nautobot_export_schedule_hour: 6
+nautobot_export_schedule_minute: 17
+
+# Seed-bundle assembly (tasks/seed_bundle.yml). Off by default — the four
+# sources live in sibling repos the controller only has at cutover (WS-E). Paths
+# and the network definitions come from the runtime environment.
+nautobot_build_seed: false
+nautobot_seed_sops_path: "{{ lookup('env', 'TERRAFORM_PROXMOX_SOPS') | default('', true) }}"
+nautobot_seed_fixed_ips_path: "{{ lookup('env', 'TOFU_UNIFI_FIXED_IPS') | default('', true) }}"
+nautobot_seed_hosts_yml_path: "{{ lookup('env', 'ANSIBLE_PROXMOX_HOSTS') | default('', true) }}"
+# VLAN/prefix definitions (list of {vid, name, cidr}) from Doppler / terraform
+# output, supplied as a JSON string.
+nautobot_seed_networks: "{{ (lookup('env', 'NAUTOBOT_SEED_NETWORKS') | default('[]', true)) | from_json }}"
+# Rack topology is not carried by rack_servers; default to one homelab rack.
+nautobot_seed_racks:
+  - name: homelab-rack-1
+    site: homelab
+# Source-shape assumptions (WS-E confirms at cutover):
+#   fixed-ips.json is a list; map its keys to the reservation schema.
+nautobot_seed_fixed_ips_query: >-
+  [].{address: ip, dns_name: dns_name, hostname: name, mac: mac, vlan_vid: vlan_id}
+#   hosts.yml groups the pve hypervisors under this key.
+nautobot_seed_hosts_group: proxmox
+
+# Gate the heavy live application layer: pip install of Nautobot + apps,
+# post_upgrade (migrate/collectstatic), superuser, service start, HTTP health.
+# Molecule sets this false to validate the deterministic config/unit/redis/jobs
+# layer without a multi-minute install + live DB; live app validation is the
+# cutover gate (issue #138 "Done when"). Same idea as keepalived_manage_services.
+nautobot_manage_app: true

--- a/roles/nautobot/files/contracts/nautobot-export-v1.json
+++ b/roles/nautobot/files/contracts/nautobot-export-v1.json
@@ -1,0 +1,215 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/dryvist/homelab-contracts/schemas/nautobot-export-v1.json",
+  "$comment": "Vendored from homelab-contracts nautobot-export-v1 v1.0.0.",
+  "title": "dryvist homelab nautobot_export contract (v1)",
+  "description": "schema_version 1.0.0. Shape of the nautobot_export.json artifact published to the S3 artifact bucket by the Nautobot GraphQL export job (issue #138). Consumers read this artifact, never live Nautobot, so a full rebuild works with Nautobot down — the same pattern as ansible_inventory.json. Self-contained: every cross-reference resolves within this document (prefixes[].vlan -> vlans[].vid, devices[].rack -> racks[].name, interfaces[].device -> devices[].name, ip_addresses[].assigned_interface -> interfaces[].{device,name}). Breaking changes bump the major and add a versions/v<X.Y.Z>/ snapshot.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "vlans",
+    "prefixes",
+    "ip_addresses",
+    "devices",
+    "racks",
+    "interfaces"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "description": "Semantic version of this contract. Consumers fail-fast when the major differs.",
+      "type": "string",
+      "pattern": "^1\\.\\d+\\.\\d+$",
+      "examples": ["1.0.0"]
+    },
+    "vlans": {
+      "description": "Layer-2 VLANs (Nautobot VLAN objects).",
+      "type": "array",
+      "items": { "$ref": "#/$defs/vlan" }
+    },
+    "prefixes": {
+      "description": "IP prefixes (Nautobot Prefix objects). Each may reference a VLAN by vid.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/prefix" }
+    },
+    "ip_addresses": {
+      "description": "Assigned IP addresses / reservations (Nautobot IPAddress objects). Each may bind to an interface.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/ipAddress" }
+    },
+    "devices": {
+      "description": "Physical/virtual devices (Nautobot Device objects): Proxmox nodes, iDRACs, UniFi gear, LXC/VM guests.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/device" }
+    },
+    "racks": {
+      "description": "Racks (Nautobot Rack objects), each within a site.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/rack" }
+    },
+    "interfaces": {
+      "description": "Device interfaces (Nautobot Interface objects). Each belongs to a device.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/interface" }
+    }
+  },
+  "$defs": {
+    "mac": {
+      "type": ["string", "null"],
+      "description": "IEEE 802 MAC address (colon-separated hex, either case); null when the object carries no MAC.",
+      "pattern": "^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$"
+    },
+    "ipv4": {
+      "type": "string",
+      "pattern": "^(\\d{1,3}\\.){3}\\d{1,3}$"
+    },
+    "ipv4Cidr": {
+      "type": "string",
+      "pattern": "^(\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2}$"
+    },
+    "ipv4OrHostname": {
+      "type": "string",
+      "anyOf": [
+        { "pattern": "^(\\d{1,3}\\.){3}\\d{1,3}$" },
+        { "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$" }
+      ]
+    },
+    "vlan": {
+      "type": "object",
+      "required": ["vid", "name", "group"],
+      "additionalProperties": false,
+      "properties": {
+        "vid": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 4094,
+          "description": "802.1Q VLAN ID."
+        },
+        "name": { "type": "string", "minLength": 1 },
+        "group": {
+          "type": ["string", "null"],
+          "minLength": 1,
+          "description": "VLAN group name; null when the VLAN is ungrouped."
+        }
+      }
+    },
+    "prefix": {
+      "type": "object",
+      "required": ["cidr", "vlan", "role"],
+      "additionalProperties": false,
+      "properties": {
+        "cidr": { "$ref": "#/$defs/ipv4Cidr" },
+        "vlan": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 4094,
+          "description": "vid of the associated VLAN (resolves to vlans[].vid); null when unassociated."
+        },
+        "role": {
+          "type": ["string", "null"],
+          "minLength": 1,
+          "description": "Prefix role (e.g. mgmt, servers, dhcp-pool); null when unset."
+        }
+      }
+    },
+    "ipAddress": {
+      "type": "object",
+      "required": ["address", "dns_name", "mac", "assigned_interface"],
+      "additionalProperties": false,
+      "properties": {
+        "address": {
+          "description": "IPv4 host address, with or without prefix length (Nautobot IPAddress.address).",
+          "type": "string",
+          "anyOf": [
+            { "$ref": "#/$defs/ipv4" },
+            { "$ref": "#/$defs/ipv4Cidr" }
+          ]
+        },
+        "dns_name": {
+          "type": ["string", "null"],
+          "description": "Forward DNS name for this address; null when unset."
+        },
+        "mac": { "$ref": "#/$defs/mac" },
+        "assigned_interface": {
+          "description": "The interface this address is bound to (resolves to interfaces[] by device+name); null when unassigned.",
+          "anyOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "required": ["device", "name"],
+              "additionalProperties": false,
+              "properties": {
+                "device": { "type": "string", "minLength": 1 },
+                "name": { "type": "string", "minLength": 1 }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "device": {
+      "type": "object",
+      "required": ["name", "role", "rack", "bmc"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "role": {
+          "type": ["string", "null"],
+          "minLength": 1,
+          "description": "Device role (e.g. proxmox_node, idrac, switch); null when unset."
+        },
+        "rack": {
+          "type": ["string", "null"],
+          "minLength": 1,
+          "description": "Rack name this device sits in (resolves to racks[].name); null when unracked."
+        },
+        "bmc": {
+          "description": "Baseboard management controller (iDRAC/IPMI) reachability; null when the device has no BMC.",
+          "anyOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "required": ["address"],
+              "additionalProperties": false,
+              "properties": {
+                "address": { "$ref": "#/$defs/ipv4OrHostname" },
+                "mac": { "$ref": "#/$defs/mac" }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "rack": {
+      "type": "object",
+      "required": ["name", "site"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "site": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Site/location name the rack belongs to."
+        }
+      }
+    },
+    "interface": {
+      "type": "object",
+      "required": ["name", "device", "mac", "mgmt_only"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "device": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Owning device name (resolves to devices[].name)."
+        },
+        "mac": { "$ref": "#/$defs/mac" },
+        "mgmt_only": {
+          "type": "boolean",
+          "description": "true = management-only interface (excluded from data-plane assignment)."
+        }
+      }
+    }
+  }
+}

--- a/roles/nautobot/files/jobs/device_onboarding_setup.py
+++ b/roles/nautobot/files/jobs/device_onboarding_setup.py
@@ -1,0 +1,75 @@
+"""Nautobot Job: configure Device Onboarding targets (issue #138).
+
+Device Onboarding is the live half of the source-of-truth pipeline: it logs into
+the real Proxmox VE nodes and iDRAC/BMC (and UniFi gear) to register them. This
+Job derives the onboarding target IPs from the seed bundle, ensures a
+SecretsGroup wired to the OpenBao-sourced credentials (read from the
+environment, never hardcoded), and logs the target list. Live onboarding runs
+at cutover, so the Job is self-guarding — it never fails the converge if the
+onboarding app is not fully ready.
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from nautobot.apps.jobs import Job, register_jobs
+
+from ssot_common import load_seed
+
+
+def _onboarding_targets() -> list[dict]:
+    """Derive {ip, kind} onboarding targets from the seed bundle."""
+    seed = load_seed()
+    targets: list[dict] = []
+    for node in seed["nodes"]:
+        if node.get("commissioned", True) and node.get("mgmt_ip"):
+            targets.append({"ip": node["mgmt_ip"], "kind": "proxmox-node"})
+    for device in seed["devices"]:
+        if device.get("bmc_ip"):
+            targets.append({"ip": device["bmc_ip"], "kind": "bmc"})
+    return targets
+
+
+def _ensure_secrets_group() -> Optional[str]:
+    """Best-effort: ensure a SecretsGroup for onboarding credentials exists.
+
+    Credentials themselves come from OpenBao via the environment; this only wires
+    the Nautobot SecretsGroup that the onboarding job references. Returns the
+    group name, or None when the surface is unavailable.
+    """
+    group_name = os.environ.get("ONBOARDING_SECRETS_GROUP", "device-onboarding")
+    try:
+        from nautobot.extras.models import SecretsGroup
+
+        SecretsGroup.objects.get_or_create(name=group_name)
+        return group_name
+    except Exception as exc:  # noqa: BLE001 - best-effort scaffolding
+        return f"unavailable ({type(exc).__name__})"
+
+
+class ConfigureDeviceOnboarding(Job):
+    """Derive and log the Device Onboarding target set."""
+
+    class Meta:
+        """Job metadata."""
+
+        name = "Configure Device Onboarding Targets"
+        description = "Derive onboarding targets from the seed and wire the SecretsGroup."
+        has_sensitive_variables = False
+
+    def run(self) -> None:  # noqa: D102 - Nautobot Job entrypoint
+        targets = _onboarding_targets()
+        group = _ensure_secrets_group()
+        self.logger.info("Onboarding SecretsGroup: %s", group)
+        self.logger.info("Derived %d onboarding targets:", len(targets))
+        for target in targets:
+            self.logger.info("  %s (%s)", target["ip"], target["kind"])
+        if not os.environ.get("ONBOARDING_USERNAME"):
+            self.logger.warning(
+                "ONBOARDING_USERNAME/ONBOARDING_PASSWORD not set — live onboarding "
+                "will be run at cutover with OpenBao-sourced credentials."
+            )
+
+
+register_jobs(ConfigureDeviceOnboarding)

--- a/roles/nautobot/files/jobs/export_nautobot.py
+++ b/roles/nautobot/files/jobs/export_nautobot.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import json
 import os
-from datetime import datetime, timezone
 from typing import Any, Optional
 
 import boto3
@@ -32,6 +31,73 @@ def _name(obj: Any, attr: str) -> Optional[str]:
     return related.name if related is not None else None
 
 
+def _all(related: Any) -> list[Any]:
+    """Return a concrete list from a Django related manager or plain iterable."""
+    if related is None:
+        return []
+    if hasattr(related, "all"):
+        return list(related.all())
+    return list(related)
+
+
+def _address(value: Any, *, host_only: bool = False) -> Optional[str]:
+    """Return a string IP address, optionally without its prefix length."""
+    if value is None:
+        return None
+    rendered = str(getattr(value, "address", value))
+    if host_only:
+        return rendered.split("/", 1)[0]
+    return rendered
+
+
+def _interface_for_ip(ip: Any) -> Optional[Any]:
+    """Find the first interface assigned to a Nautobot IPAddress."""
+    for attr in ("interfaces", "assigned_object", "interface"):
+        candidate = getattr(ip, attr, None)
+        if candidate is None:
+            continue
+        if attr == "interfaces":
+            interfaces = _all(candidate)
+            if interfaces:
+                return interfaces[0]
+            continue
+        if getattr(candidate, "device", None) is not None:
+            return candidate
+    return None
+
+
+def _assigned_interface(ip: Any) -> Optional[dict]:
+    """Return the contract's assigned_interface object for an IPAddress."""
+    interface = _interface_for_ip(ip)
+    if interface is None:
+        return None
+    return {"device": interface.device.name, "name": interface.name}
+
+
+def _interface_mac(interface: Any) -> Optional[str]:
+    """Return an interface MAC address as a string when present."""
+    mac = getattr(interface, "mac_address", None)
+    return str(mac) if mac else None
+
+
+def _bmc_for_device(device: Any) -> Optional[dict]:
+    """Return the contract's BMC object from a device's management interface."""
+    for interface in _all(getattr(device, "interfaces", None)):
+        if not (
+            getattr(interface, "mgmt_only", False)
+            or str(getattr(interface, "name", "")).lower() in {"bmc", "idrac", "ipmi"}
+        ):
+            continue
+        addresses = _all(getattr(interface, "ip_addresses", None))
+        if not addresses:
+            continue
+        return {
+            "address": _address(addresses[0], host_only=True),
+            "mac": _interface_mac(interface),
+        }
+    return None
+
+
 def build_export() -> dict:
     """Shape Nautobot's current contents into the export document.
 
@@ -39,25 +105,23 @@ def build_export() -> dict:
     the homelab-contracts schema.
     """
     vlans = [
-        {"vid": v.vid, "name": v.name, "status": _name(v, "status")}
+        {"vid": v.vid, "name": v.name, "group": _name(v, "vlan_group") or _name(v, "group")}
         for v in VLAN.objects.all()
     ]
     prefixes = [
         {
-            "prefix": str(p.prefix),
-            "vlan_vid": p.vlan.vid if p.vlan_id else None,
+            "cidr": str(p.prefix),
+            "vlan": p.vlan.vid if p.vlan_id else None,
             "role": _name(p, "role"),
-            "status": _name(p, "status"),
         }
         for p in Prefix.objects.all()
     ]
-    reservations = [
+    ip_addresses = [
         {
-            "address": ip.host,
+            "address": _address(getattr(ip, "address", getattr(ip, "host", None))),
             "dns_name": ip.dns_name or None,
-            "device": None,
-            "interface": None,
-            "status": _name(ip, "status"),
+            "mac": _interface_mac(_interface_for_ip(ip)),
+            "assigned_interface": _assigned_interface(ip),
         }
         for ip in IPAddress.objects.all()
     ]
@@ -65,26 +129,20 @@ def build_export() -> dict:
         {
             "name": d.name,
             "role": _name(d, "role"),
-            "status": _name(d, "status"),
             "rack": _name(d, "rack"),
-            "position": d.position,
-            "primary_ip": str(d.primary_ip.address) if d.primary_ip else None,
-            "manufacturer": d.device_type.manufacturer.name,
-            "model": d.device_type.model,
-            "serial": d.serial or None,
+            "bmc": _bmc_for_device(d),
         }
         for d in Device.objects.all()
     ]
     racks = [
-        {"name": r.name, "site": _name(r, "location"), "u_height": r.u_height}
+        {"name": r.name, "site": _name(r, "location") or ""}
         for r in Rack.objects.all()
     ]
     interfaces = [
         {
-            "device": i.device.name,
             "name": i.name,
+            "device": i.device.name,
             "mac": str(i.mac_address) if i.mac_address else None,
-            "type": i.type,
             "mgmt_only": i.mgmt_only,
         }
         for i in Interface.objects.all()
@@ -92,11 +150,9 @@ def build_export() -> dict:
 
     return {
         "schema_version": SCHEMA_VERSION,
-        "generated_at": datetime.now(timezone.utc).isoformat(),
-        "source": "nautobot",
         "vlans": vlans,
         "prefixes": prefixes,
-        "reservations": reservations,
+        "ip_addresses": ip_addresses,
         "devices": devices,
         "racks": racks,
         "interfaces": interfaces,
@@ -143,11 +199,11 @@ class ExportNautobotToS3(Job):
     def run(self) -> None:  # noqa: D102 - Nautobot Job entrypoint
         document = build_export()
         self.logger.info(
-            "Built export: %d vlans, %d prefixes, %d reservations, %d devices, "
+            "Built export: %d vlans, %d prefixes, %d ip_addresses, %d devices, "
             "%d racks, %d interfaces",
             len(document["vlans"]),
             len(document["prefixes"]),
-            len(document["reservations"]),
+            len(document["ip_addresses"]),
             len(document["devices"]),
             len(document["racks"]),
             len(document["interfaces"]),

--- a/roles/nautobot/files/jobs/export_nautobot.py
+++ b/roles/nautobot/files/jobs/export_nautobot.py
@@ -1,0 +1,159 @@
+"""Nautobot Job: export the inventory to the S3 artifact bucket (issue #138).
+
+Celery-beat scheduled. Gathers Nautobot's IPAM/DCIM contents via the ORM, shapes
+them into the homelab-contracts ``nautobot-export-v1`` document, validates
+against that schema when present, and uploads the JSON to the S3 state bucket
+with ambient credentials — mirroring ``terraform-proxmox/inventory_publish.tf``
+so every consumer reads the artifact, never live Nautobot, and a full rebuild
+works with Nautobot down.
+
+``build_export()`` is the single place the output is shaped, so aligning field
+names with the finalized schema is a one-function change.
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import boto3
+from nautobot.apps.jobs import Job, register_jobs
+from nautobot.dcim.models import Device, Interface, Rack
+from nautobot.ipam.models import VLAN, IPAddress, Prefix
+
+SCHEMA_VERSION = "1.0.0"
+DEFAULT_KEY = "nautobot/nautobot_export.json"
+
+
+def _name(obj: Any, attr: str) -> Optional[str]:
+    """Return ``obj.<attr>.name`` when the related object is set, else None."""
+    related = getattr(obj, attr, None)
+    return related.name if related is not None else None
+
+
+def build_export() -> dict:
+    """Shape Nautobot's current contents into the export document.
+
+    Single source of truth for the artifact's field names — adjust here to track
+    the homelab-contracts schema.
+    """
+    vlans = [
+        {"vid": v.vid, "name": v.name, "status": _name(v, "status")}
+        for v in VLAN.objects.all()
+    ]
+    prefixes = [
+        {
+            "prefix": str(p.prefix),
+            "vlan_vid": p.vlan.vid if p.vlan_id else None,
+            "role": _name(p, "role"),
+            "status": _name(p, "status"),
+        }
+        for p in Prefix.objects.all()
+    ]
+    reservations = [
+        {
+            "address": ip.host,
+            "dns_name": ip.dns_name or None,
+            "device": None,
+            "interface": None,
+            "status": _name(ip, "status"),
+        }
+        for ip in IPAddress.objects.all()
+    ]
+    devices = [
+        {
+            "name": d.name,
+            "role": _name(d, "role"),
+            "status": _name(d, "status"),
+            "rack": _name(d, "rack"),
+            "position": d.position,
+            "primary_ip": str(d.primary_ip.address) if d.primary_ip else None,
+            "manufacturer": d.device_type.manufacturer.name,
+            "model": d.device_type.model,
+            "serial": d.serial or None,
+        }
+        for d in Device.objects.all()
+    ]
+    racks = [
+        {"name": r.name, "site": _name(r, "location"), "u_height": r.u_height}
+        for r in Rack.objects.all()
+    ]
+    interfaces = [
+        {
+            "device": i.device.name,
+            "name": i.name,
+            "mac": str(i.mac_address) if i.mac_address else None,
+            "type": i.type,
+            "mgmt_only": i.mgmt_only,
+        }
+        for i in Interface.objects.all()
+    ]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "source": "nautobot",
+        "vlans": vlans,
+        "prefixes": prefixes,
+        "reservations": reservations,
+        "devices": devices,
+        "racks": racks,
+        "interfaces": interfaces,
+    }
+
+
+class ExportNautobotToS3(Job):
+    """Export the Nautobot inventory artifact to S3."""
+
+    class Meta:
+        """Job metadata."""
+
+        name = "Export Nautobot Inventory to S3"
+        description = "Publish the nautobot-export-v1 artifact to the S3 state bucket."
+        has_sensitive_variables = False
+
+    def _validate(self, document: dict) -> None:
+        """Validate against the homelab-contracts schema when it is present."""
+        schema_path = os.environ.get("NAUTOBOT_EXPORT_SCHEMA", "")
+        if not schema_path or not os.path.isfile(schema_path):
+            self.logger.warning(
+                "Export schema %s not found — skipping validation", schema_path or "(unset)"
+            )
+            return
+        import jsonschema  # local import: only needed on the validation path
+
+        with open(schema_path, encoding="utf-8") as handle:
+            schema = json.load(handle)
+        jsonschema.validate(instance=document, schema=schema)
+        self.logger.info("Export validated against %s", schema_path)
+
+    def _upload(self, document: dict) -> None:
+        """Upload the document to S3 with ambient credentials."""
+        bucket = os.environ.get("NAUTOBOT_EXPORT_S3_BUCKET", "")
+        if not bucket:
+            raise ValueError("NAUTOBOT_EXPORT_S3_BUCKET is not set — cannot publish export")
+        key = os.environ.get("NAUTOBOT_EXPORT_S3_KEY", DEFAULT_KEY)
+        body = json.dumps(document, indent=2, sort_keys=True).encode("utf-8")
+        boto3.client("s3").put_object(
+            Bucket=bucket, Key=key, Body=body, ContentType="application/json"
+        )
+        self.logger.info("Published %d bytes to s3://%s/%s", len(body), bucket, key)
+
+    def run(self) -> None:  # noqa: D102 - Nautobot Job entrypoint
+        document = build_export()
+        self.logger.info(
+            "Built export: %d vlans, %d prefixes, %d reservations, %d devices, "
+            "%d racks, %d interfaces",
+            len(document["vlans"]),
+            len(document["prefixes"]),
+            len(document["reservations"]),
+            len(document["devices"]),
+            len(document["racks"]),
+            len(document["interfaces"]),
+        )
+        self._validate(document)
+        self._upload(document)
+
+
+register_jobs(ExportNautobotToS3)

--- a/roles/nautobot/files/jobs/ssot_common.py
+++ b/roles/nautobot/files/jobs/ssot_common.py
@@ -1,0 +1,131 @@
+"""Shared helpers and constants for the homelab SSoT seed jobs (issue #138).
+
+Every seed job reads one resolved JSON bundle (``nautobot_seed.json``, assembled
+on the Ansible controller from the four hand-maintained sources) and DiffSyncs
+its leaf data into Nautobot. The fixed scaffolding that Nautobot 2.x requires as
+foreign keys — Status, LocationType, Location, Manufacturer, DeviceType, Role —
+is created here idempotently via the ORM (``get_or_create``) rather than through
+DiffSync, so the DiffSync models stay simple and never have to model m2m
+``content_types``. Nautobot ORM imports are done lazily inside the helpers so the
+module is importable in any context.
+
+Live-validation notes (verify at cutover): exact Nautobot 2.x field names on a
+few models (``Prefix.type``, ``IPAddress`` mask handling, Role ``content_types``
+API) can shift between minor versions; the helpers below target current 2.x.
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from nautobot_ssot.contrib import NautobotModel
+
+# Names of the shared prerequisite objects, referenced by every seed job.
+STATUS_ACTIVE = "Active"
+LOCATION_NAME = "homelab"
+LOCATION_TYPE = "Site"
+MANUFACTURER = "Generic"
+
+
+class AdditiveNautobotModel(NautobotModel):
+    """A NautobotModel whose ``delete`` is a no-op.
+
+    The seed jobs are additive (create/update only): re-running a seed must
+    never remove objects that a different seed job, Device Onboarding, or a
+    human added — and because each job's target adapter loads the whole table
+    for its model, a destructive sync would otherwise delete objects owned by
+    another job. Suppressing delete makes every seed job idempotent and safe to
+    re-run in any order.
+    """
+
+    def delete(self):  # noqa: D102 - see class docstring
+        return self
+
+_EMPTY_BUNDLE: dict[str, list] = {
+    "vlans": [],
+    "prefixes": [],
+    "reservations": [],
+    "racks": [],
+    "devices": [],
+    "nodes": [],
+}
+
+
+def seed_path() -> str:
+    """Return the resolved seed-bundle path from the environment."""
+    root = os.environ.get("NAUTOBOT_ROOT", "/opt/nautobot")
+    return os.environ.get("NAUTOBOT_SEED_FILE", os.path.join(root, "nautobot_seed.json"))
+
+
+def load_seed() -> dict[str, Any]:
+    """Load the seed bundle, tolerating a missing file (returns empty arrays)."""
+    path = seed_path()
+    if not os.path.isfile(path):
+        return dict(_EMPTY_BUNDLE)
+    with open(path, encoding="utf-8") as handle:
+        data = json.load(handle)
+    merged = dict(_EMPTY_BUNDLE)
+    merged.update({key: (data.get(key) or []) for key in _EMPTY_BUNDLE})
+    return merged
+
+
+def _active_status():
+    """Return the shipped ``Active`` Status object."""
+    from nautobot.extras.models import Status
+
+    return Status.objects.get(name=STATUS_ACTIVE)
+
+
+def ensure_location():
+    """Idempotently ensure the ``Site`` LocationType and ``homelab`` Location exist.
+
+    The LocationType is granted the content types the seed jobs place in it
+    (device, rack, prefix, vlan, ip address) so those objects can be located.
+    """
+    from django.contrib.contenttypes.models import ContentType
+    from nautobot.dcim.models import Device, Location, LocationType, Rack
+    from nautobot.ipam.models import VLAN, IPAddress, Prefix
+
+    location_type, _ = LocationType.objects.get_or_create(name=LOCATION_TYPE)
+    content_types = [
+        ContentType.objects.get_for_model(model)
+        for model in (Device, Rack, Prefix, VLAN, IPAddress)
+    ]
+    location_type.content_types.add(*content_types)
+
+    location, _ = Location.objects.get_or_create(
+        name=LOCATION_NAME,
+        defaults={"location_type": location_type, "status": _active_status()},
+    )
+    return location
+
+
+def ensure_manufacturer():
+    """Idempotently ensure the ``Generic`` Manufacturer exists."""
+    from nautobot.dcim.models import Manufacturer
+
+    manufacturer, _ = Manufacturer.objects.get_or_create(name=MANUFACTURER)
+    return manufacturer
+
+
+def ensure_device_type(model_name: str):
+    """Idempotently ensure a DeviceType (by model) under the Generic manufacturer."""
+    from nautobot.dcim.models import DeviceType
+
+    device_type, _ = DeviceType.objects.get_or_create(
+        model=model_name, manufacturer=ensure_manufacturer()
+    )
+    return device_type
+
+
+def ensure_role(name: str, *models) -> None:
+    """Idempotently ensure a Role exists and covers the given content-type models."""
+    from django.contrib.contenttypes.models import ContentType
+    from nautobot.extras.models import Role
+
+    role, _ = Role.objects.get_or_create(name=name)
+    if models:
+        role.content_types.add(
+            *[ContentType.objects.get_for_model(model) for model in models]
+        )

--- a/roles/nautobot/files/jobs/ssot_dcim.py
+++ b/roles/nautobot/files/jobs/ssot_dcim.py
@@ -1,0 +1,189 @@
+"""SSoT seed job: DCIM racks and devices (issue #138).
+
+Source of truth: the ``racks`` and ``devices`` arrays of the seed bundle (from
+``terraform-proxmox`` SOPS ``rack_servers``). DiffSyncs Racks, Devices (with a
+DeviceType per distinct chassis under the Generic manufacturer, a Role, the
+homelab Location, optional rack/position, serial = service_tag) and a mgmt-only
+``BMC`` Interface per device.
+
+Live-validation notes: DeviceTypes/Roles are ensured via the ORM before the
+DiffSync run; binding the BMC IP address to the BMC interface is deferred to
+Device Onboarding to avoid the generic-FK path here.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from diffsync import Adapter
+from nautobot.apps.jobs import register_jobs
+from nautobot.dcim.models import Device, Interface, Rack
+from nautobot_ssot.contrib import NautobotAdapter
+from nautobot_ssot.jobs.base import DataSource
+
+from ssot_common import (
+    STATUS_ACTIVE,
+    AdditiveNautobotModel,
+    ensure_device_type,
+    ensure_location,
+    ensure_role,
+    load_seed,
+)
+
+BMC_INTERFACE_NAME = "BMC"
+SERVER_ROLE = "server"
+
+
+class RackModel(AdditiveNautobotModel):
+    """DiffSync model mirroring a Nautobot Rack."""
+
+    _model = Rack
+    _modelname = "rack"
+    _identifiers = ("name",)
+    _attributes = ("location__name", "status__name")
+
+    name: str
+    location__name: str
+    status__name: str
+
+
+class DeviceModel(AdditiveNautobotModel):
+    """DiffSync model mirroring a Nautobot Device."""
+
+    _model = Device
+    _modelname = "device"
+    _identifiers = ("name",)
+    _attributes = (
+        "role__name",
+        "device_type__model",
+        "location__name",
+        "status__name",
+        "rack__name",
+        "position",
+        "serial",
+    )
+
+    name: str
+    role__name: str
+    device_type__model: str
+    location__name: str
+    status__name: str
+    rack__name: Optional[str] = None
+    position: Optional[int] = None
+    serial: str = ""
+
+    @classmethod
+    def get_queryset(cls):
+        """Exclude pve nodes — the node seed job owns those devices."""
+        return Device.objects.exclude(role__name="pve-node")
+
+
+class InterfaceModel(AdditiveNautobotModel):
+    """DiffSync model mirroring a Nautobot Interface (the BMC port)."""
+
+    _model = Interface
+    _modelname = "interface"
+    _identifiers = ("device__name", "name")
+    _attributes = ("type", "mgmt_only", "status__name")
+
+    device__name: str
+    name: str
+    type: str
+    mgmt_only: bool
+    status__name: str
+
+    @classmethod
+    def get_queryset(cls):
+        """Manage only BMC interfaces so other interfaces are never diffed."""
+        return Interface.objects.filter(name=BMC_INTERFACE_NAME)
+
+
+class DcimNautobotAdapter(NautobotAdapter):
+    """Target adapter: loads existing Racks/Devices/Interfaces from Nautobot."""
+
+    top_level = ("rack", "device", "interface")
+    rack = RackModel
+    device = DeviceModel
+    interface = InterfaceModel
+
+
+class DcimSourceAdapter(Adapter):
+    """Source adapter: builds Rack/Device/Interface models from the seed."""
+
+    top_level = ("rack", "device", "interface")
+    rack = RackModel
+    device = DeviceModel
+    interface = InterfaceModel
+
+    def __init__(self, *args, job=None, **kwargs):
+        """Store the owning Job for logging."""
+        super().__init__(*args, **kwargs)
+        self.job = job
+
+    def load(self) -> None:
+        """Populate Rack/Device/Interface models from the seed bundle."""
+        seed = load_seed()
+
+        for rack in seed["racks"]:
+            self.add(
+                self.rack(
+                    name=str(rack["name"]),
+                    location__name=str(rack.get("site") or "homelab"),
+                    status__name=STATUS_ACTIVE,
+                )
+            )
+
+        for device in seed["devices"]:
+            chassis = str(device.get("chassis") or "unknown")
+            role = str(device.get("role") or SERVER_ROLE)
+            ensure_device_type(chassis)
+            ensure_role(role, Device)
+
+            position = device.get("position")
+            self.add(
+                self.device(
+                    name=str(device["name"]),
+                    role__name=role,
+                    device_type__model=chassis,
+                    location__name="homelab",
+                    status__name=STATUS_ACTIVE,
+                    rack__name=str(device["rack"]) if device.get("rack") else None,
+                    position=int(position) if position is not None else None,
+                    serial=str(device.get("service_tag") or ""),
+                )
+            )
+
+            if device.get("bmc_ip") or device.get("bmc_mac"):
+                self.add(
+                    self.interface(
+                        device__name=str(device["name"]),
+                        name=BMC_INTERFACE_NAME,
+                        type="other",
+                        mgmt_only=True,
+                        status__name=STATUS_ACTIVE,
+                    )
+                )
+
+
+class SeedDcim(DataSource):
+    """Seed Nautobot DCIM racks and devices from the rack-server source."""
+
+    class Meta:
+        """Job metadata."""
+
+        name = "Seed DCIM Racks and Devices"
+        description = "DiffSync racks, devices, and BMC interfaces from the seed bundle."
+        has_sensitive_variables = False
+
+    def load_source_adapter(self) -> None:
+        """Ensure org scaffolding, then load the seed source adapter."""
+        ensure_location()
+        self.source_adapter = DcimSourceAdapter(job=self)
+        self.source_adapter.load()
+
+    def load_target_adapter(self) -> None:
+        """Load the Nautobot target adapter."""
+        self.target_adapter = DcimNautobotAdapter(job=self)
+        self.target_adapter.load()
+
+
+register_jobs(SeedDcim)

--- a/roles/nautobot/files/jobs/ssot_ip_addresses.py
+++ b/roles/nautobot/files/jobs/ssot_ip_addresses.py
@@ -1,0 +1,101 @@
+"""SSoT seed job: IP addresses and reservations (issue #138).
+
+Source of truth: the ``reservations`` array of the seed bundle (from
+``tofu-unifi`` ``fixed-ips.json``). DiffSyncs each reservation into a Nautobot
+IPAddress (host + dns_name), idempotently.
+
+Live-validation notes: Nautobot 2.x requires each IPAddress to fall inside an
+existing parent Prefix in its Namespace (default ``Global``). Run the VLANs and
+Prefixes seed job first so those parents exist; reservations are created with a
+/32 mask under the containing prefix. IP-to-interface binding is deferred to
+Device Onboarding.
+"""
+from __future__ import annotations
+
+from diffsync import Adapter
+from nautobot.apps.jobs import register_jobs
+from nautobot.ipam.models import IPAddress
+from nautobot_ssot.contrib import NautobotAdapter
+from nautobot_ssot.jobs.base import DataSource
+
+from ssot_common import (
+    STATUS_ACTIVE,
+    AdditiveNautobotModel,
+    ensure_location,
+    load_seed,
+)
+
+
+class IPAddressModel(AdditiveNautobotModel):
+    """DiffSync model mirroring a Nautobot IPAddress."""
+
+    _model = IPAddress
+    _modelname = "ip_address"
+    _identifiers = ("host",)
+    _attributes = ("mask_length", "status__name", "dns_name")
+
+    host: str
+    mask_length: int
+    status__name: str
+    dns_name: str = ""
+
+
+class IPAddressNautobotAdapter(NautobotAdapter):
+    """Target adapter: loads existing IP addresses from the Nautobot ORM."""
+
+    top_level = ("ip_address",)
+    ip_address = IPAddressModel
+
+
+class IPAddressSourceAdapter(Adapter):
+    """Source adapter: builds IPAddress models from the seed reservations."""
+
+    top_level = ("ip_address",)
+    ip_address = IPAddressModel
+
+    def __init__(self, *args, job=None, **kwargs):
+        """Store the owning Job for logging."""
+        super().__init__(*args, **kwargs)
+        self.job = job
+
+    def load(self) -> None:
+        """Populate IPAddress models from the seed reservations."""
+        seed = load_seed()
+        for reservation in seed["reservations"]:
+            address = reservation.get("address")
+            if not address:
+                continue
+            host = str(address).split("/", 1)[0]
+            self.add(
+                self.ip_address(
+                    host=host,
+                    mask_length=32,
+                    status__name=STATUS_ACTIVE,
+                    dns_name=str(reservation.get("dns_name") or ""),
+                )
+            )
+
+
+class SeedIPAddresses(DataSource):
+    """Seed Nautobot IP addresses from the hand-maintained reservations."""
+
+    class Meta:
+        """Job metadata."""
+
+        name = "Seed IP Addresses and Reservations"
+        description = "DiffSync IP address reservations from the resolved seed bundle."
+        has_sensitive_variables = False
+
+    def load_source_adapter(self) -> None:
+        """Ensure org scaffolding, then load the seed source adapter."""
+        ensure_location()
+        self.source_adapter = IPAddressSourceAdapter(job=self)
+        self.source_adapter.load()
+
+    def load_target_adapter(self) -> None:
+        """Load the Nautobot target adapter."""
+        self.target_adapter = IPAddressNautobotAdapter(job=self)
+        self.target_adapter.load()
+
+
+register_jobs(SeedIPAddresses)

--- a/roles/nautobot/files/jobs/ssot_nodes.py
+++ b/roles/nautobot/files/jobs/ssot_nodes.py
@@ -1,0 +1,120 @@
+"""SSoT seed job: Proxmox VE node facts (issue #138).
+
+Source of truth: the ``nodes`` array of the seed bundle (from ``ansible-proxmox``
+``hosts.yml``). DiffSyncs the commissioned pve nodes into Nautobot Devices with
+role ``pve-node`` and a ``pve-node`` DeviceType under the Generic manufacturer.
+Uncommissioned nodes are skipped.
+
+Live-validation notes: like the DCIM job, DeviceType/Role are ensured via the
+ORM before the DiffSync run; mgmt-IP-to-interface binding is deferred to Device
+Onboarding.
+"""
+from __future__ import annotations
+
+from diffsync import Adapter
+from nautobot.apps.jobs import register_jobs
+from nautobot.dcim.models import Device
+from nautobot_ssot.contrib import NautobotAdapter
+from nautobot_ssot.jobs.base import DataSource
+
+from ssot_common import (
+    STATUS_ACTIVE,
+    AdditiveNautobotModel,
+    ensure_device_type,
+    ensure_location,
+    ensure_role,
+    load_seed,
+)
+
+NODE_ROLE = "pve-node"
+NODE_DEVICE_TYPE = "pve-node"
+
+
+class NodeDeviceModel(AdditiveNautobotModel):
+    """DiffSync model mirroring a Nautobot Device for a Proxmox node.
+
+    Scoped to node-role devices so the target adapter only ever loads (and thus
+    only ever updates) the pve nodes — the DCIM seed job owns the other devices.
+    """
+
+    @classmethod
+    def get_queryset(cls):
+        """Load only pve-node-role devices into the target adapter."""
+        return Device.objects.filter(role__name=NODE_ROLE)
+
+    _model = Device
+    _modelname = "device"
+    _identifiers = ("name",)
+    _attributes = ("role__name", "device_type__model", "location__name", "status__name")
+
+    name: str
+    role__name: str
+    device_type__model: str
+    location__name: str
+    status__name: str
+
+
+class NodesNautobotAdapter(NautobotAdapter):
+    """Target adapter: loads existing node Devices from the Nautobot ORM.
+
+    Scoping lives on ``NodeDeviceModel.get_queryset`` (node-role only), so this
+    adapter only diffs pve nodes.
+    """
+
+    top_level = ("device",)
+    device = NodeDeviceModel
+
+
+class NodesSourceAdapter(Adapter):
+    """Source adapter: builds node Device models from the seed bundle."""
+
+    top_level = ("device",)
+    device = NodeDeviceModel
+
+    def __init__(self, *args, job=None, **kwargs):
+        """Store the owning Job for logging."""
+        super().__init__(*args, **kwargs)
+        self.job = job
+
+    def load(self) -> None:
+        """Populate node Device models from the seed bundle (commissioned only)."""
+        seed = load_seed()
+        ensure_device_type(NODE_DEVICE_TYPE)
+        ensure_role(NODE_ROLE, Device)
+        for node in seed["nodes"]:
+            if not node.get("commissioned", True):
+                continue
+            self.add(
+                self.device(
+                    name=str(node["name"]),
+                    role__name=NODE_ROLE,
+                    device_type__model=NODE_DEVICE_TYPE,
+                    location__name="homelab",
+                    status__name=STATUS_ACTIVE,
+                )
+            )
+
+
+class SeedNodes(DataSource):
+    """Seed Nautobot with the Proxmox VE node inventory."""
+
+    class Meta:
+        """Job metadata."""
+
+        name = "Seed Proxmox Node Facts"
+        description = "DiffSync commissioned Proxmox nodes from the seed bundle."
+        has_sensitive_variables = False
+
+    def load_source_adapter(self) -> None:
+        """Ensure org scaffolding, then load the seed source adapter."""
+        ensure_location()
+        self.source_adapter = NodesSourceAdapter(job=self)
+        self.source_adapter.load()
+
+    def load_target_adapter(self) -> None:
+        """Load the Nautobot target adapter."""
+        self.target_adapter = NodesNautobotAdapter(job=self)
+        self.target_adapter.load()
+
+
+register_jobs(SeedNodes)

--- a/roles/nautobot/files/jobs/ssot_vlans_prefixes.py
+++ b/roles/nautobot/files/jobs/ssot_vlans_prefixes.py
@@ -1,0 +1,131 @@
+"""SSoT seed job: VLANs and Prefixes (issue #138).
+
+Source of truth: the ``vlans`` (from ``vlan_ids``) and ``prefixes`` (from
+``network_cidrs``) arrays of the resolved seed bundle. DiffSyncs them into
+Nautobot VLAN + Prefix objects idempotently via the SSoT ``contrib`` framework.
+
+Live-validation notes: Prefix in Nautobot 2.x is scoped by a Namespace
+(defaults to ``Global``) and has a required ``type`` (defaults to ``network``);
+both defaults are relied on here. VLANs are created global (no VLANGroup), keyed
+by ``vid`` — the homelab's vids are unique.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from diffsync import Adapter
+from nautobot.apps.jobs import register_jobs
+from nautobot.ipam.models import VLAN, Prefix
+from nautobot_ssot.contrib import NautobotAdapter
+from nautobot_ssot.jobs.base import DataSource
+
+from ssot_common import (
+    STATUS_ACTIVE,
+    AdditiveNautobotModel,
+    ensure_location,
+    ensure_role,
+    load_seed,
+)
+
+
+class VLANModel(AdditiveNautobotModel):
+    """DiffSync model mirroring a Nautobot VLAN."""
+
+    _model = VLAN
+    _modelname = "vlan"
+    _identifiers = ("vid",)
+    _attributes = ("name", "status__name")
+
+    vid: int
+    name: str
+    status__name: str
+
+
+class PrefixModel(AdditiveNautobotModel):
+    """DiffSync model mirroring a Nautobot Prefix, optionally tied to a VLAN."""
+
+    _model = Prefix
+    _modelname = "prefix"
+    _identifiers = ("network", "prefix_length")
+    _attributes = ("status__name", "vlan__vid", "role__name")
+
+    network: str
+    prefix_length: int
+    status__name: str
+    vlan__vid: Optional[int] = None
+    role__name: Optional[str] = None
+
+
+class VlanPrefixNautobotAdapter(NautobotAdapter):
+    """Target adapter: loads existing VLANs/Prefixes from the Nautobot ORM."""
+
+    top_level = ("vlan", "prefix")
+    vlan = VLANModel
+    prefix = PrefixModel
+
+
+class VlanPrefixSourceAdapter(Adapter):
+    """Source adapter: builds VLAN/Prefix models from the seed bundle."""
+
+    top_level = ("vlan", "prefix")
+    vlan = VLANModel
+    prefix = PrefixModel
+
+    def __init__(self, *args, job=None, **kwargs):
+        """Store the owning Job for logging."""
+        super().__init__(*args, **kwargs)
+        self.job = job
+
+    def load(self) -> None:
+        """Populate VLAN and Prefix models from the seed bundle."""
+        seed = load_seed()
+
+        for vlan in seed["vlans"]:
+            self.add(
+                self.vlan(
+                    vid=int(vlan["vid"]),
+                    name=str(vlan["name"]),
+                    status__name=STATUS_ACTIVE,
+                )
+            )
+
+        for prefix in seed["prefixes"]:
+            network, _, length = str(prefix["prefix"]).partition("/")
+            role = prefix.get("role")
+            if role:
+                ensure_role(role, Prefix)
+            vlan_vid = prefix.get("vlan_vid")
+            self.add(
+                self.prefix(
+                    network=network,
+                    prefix_length=int(length),
+                    status__name=STATUS_ACTIVE,
+                    vlan__vid=int(vlan_vid) if vlan_vid is not None else None,
+                    role__name=role,
+                )
+            )
+
+
+class SeedVlansPrefixes(DataSource):
+    """Seed Nautobot VLANs and Prefixes from the hand-maintained network sources."""
+
+    class Meta:
+        """Job metadata."""
+
+        name = "Seed VLANs and Prefixes"
+        description = "DiffSync VLANs and Prefixes from the resolved seed bundle."
+        has_sensitive_variables = False
+
+    def load_source_adapter(self) -> None:
+        """Ensure org scaffolding, then load the seed source adapter."""
+        ensure_location()
+        self.source_adapter = VlanPrefixSourceAdapter(job=self)
+        self.source_adapter.load()
+
+    def load_target_adapter(self) -> None:
+        """Load the Nautobot target adapter."""
+        self.target_adapter = VlanPrefixNautobotAdapter(job=self)
+        self.target_adapter.load()
+
+
+register_jobs(SeedVlansPrefixes)

--- a/roles/nautobot/files/schedule_export.py
+++ b/roles/nautobot/files/schedule_export.py
@@ -1,0 +1,52 @@
+"""Idempotently schedule the S3 export Job on celery beat.
+
+Run via ``nautobot-server shell --interface python``. Creates a daily
+``ScheduledJob`` bound to the export Job at the hour/minute given in the
+environment. Best-effort and self-guarding: the ScheduledJob ORM surface is
+version-sensitive, so any failure prints a ``SCHEDULE_SKIPPED`` marker with the
+reason rather than aborting the converge — the schedule can be finalized in the
+UI at cutover. Prints ``SCHEDULE_CREATED`` / ``SCHEDULE_EXISTS`` on success.
+"""
+import os
+
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+JOB_NAME = "Export Nautobot Inventory to S3"
+SCHEDULE_NAME = "export-nautobot-daily"
+
+hour = int(os.environ.get("NAUTOBOT_EXPORT_SCHEDULE_HOUR", "6"))
+minute = int(os.environ.get("NAUTOBOT_EXPORT_SCHEDULE_MINUTE", "17"))
+
+try:
+    from nautobot.extras.choices import JobExecutionType
+    from nautobot.extras.models import Job, ScheduledJob
+
+    job = Job.objects.filter(name=JOB_NAME).first()
+    if job is None:
+        print("SCHEDULE_SKIPPED job-not-registered")
+    else:
+        if not job.enabled:
+            job.enabled = True
+            job.save()
+
+        approver = get_user_model().objects.filter(is_superuser=True).order_by("pk").first()
+        if approver is None:
+            print("SCHEDULE_SKIPPED no-superuser")
+        else:
+            obj, created = ScheduledJob.objects.get_or_create(
+                name=SCHEDULE_NAME,
+                defaults={
+                    "job_model": job,
+                    "task": job.class_path,
+                    "interval": JobExecutionType.TYPE_CUSTOM,
+                    "crontab": f"{minute} {hour} * * *",
+                    "user": approver,
+                    "start_time": timezone.now(),
+                    "enabled": True,
+                    "approval_required": False,
+                },
+            )
+            print("SCHEDULE_CREATED" if created else "SCHEDULE_EXISTS")
+except Exception as exc:  # noqa: BLE001 - best-effort; never fail the converge
+    print(f"SCHEDULE_SKIPPED {type(exc).__name__}: {exc}")

--- a/roles/nautobot/files/superuser_bootstrap.py
+++ b/roles/nautobot/files/superuser_bootstrap.py
@@ -2,8 +2,8 @@
 
 Run via ``nautobot-server shell --interface python`` with the superuser name,
 email, and password supplied in the environment (never on argv). Prints
-``SUPERUSER_CREATED`` on first creation and ``SUPERUSER_UPDATED`` thereafter so
-the calling Ansible task can report change accurately.
+``SUPERUSER_CHANGED`` only when the database row changed, so the calling
+Ansible task can report change accurately.
 """
 import os
 
@@ -16,11 +16,21 @@ email = os.environ.get("NAUTOBOT_SUPERUSER_EMAIL", "")
 password = os.environ["NAUTOBOT_SUPERUSER_PASSWORD"]
 
 user, created = User.objects.get_or_create(username=name, defaults={"email": email})
-user.is_superuser = True
-user.is_staff = True
-if email:
-    user.email = email
-user.set_password(password)
-user.save()
+changed = created
 
-print("SUPERUSER_CREATED" if created else "SUPERUSER_UPDATED")
+if not user.is_superuser:
+    user.is_superuser = True
+    changed = True
+if not user.is_staff:
+    user.is_staff = True
+    changed = True
+if email and user.email != email:
+    user.email = email
+    changed = True
+if created or not user.check_password(password):
+    user.set_password(password)
+    changed = True
+if changed:
+    user.save()
+
+print("SUPERUSER_CHANGED" if changed else "SUPERUSER_UNCHANGED")

--- a/roles/nautobot/files/superuser_bootstrap.py
+++ b/roles/nautobot/files/superuser_bootstrap.py
@@ -1,0 +1,26 @@
+"""Idempotently ensure the Nautobot superuser exists.
+
+Run via ``nautobot-server shell --interface python`` with the superuser name,
+email, and password supplied in the environment (never on argv). Prints
+``SUPERUSER_CREATED`` on first creation and ``SUPERUSER_UPDATED`` thereafter so
+the calling Ansible task can report change accurately.
+"""
+import os
+
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+name = os.environ["NAUTOBOT_SUPERUSER_NAME"]
+email = os.environ.get("NAUTOBOT_SUPERUSER_EMAIL", "")
+password = os.environ["NAUTOBOT_SUPERUSER_PASSWORD"]
+
+user, created = User.objects.get_or_create(username=name, defaults={"email": email})
+user.is_superuser = True
+user.is_staff = True
+if email:
+    user.email = email
+user.set_password(password)
+user.save()
+
+print("SUPERUSER_CREATED" if created else "SUPERUSER_UPDATED")

--- a/roles/nautobot/handlers/main.yml
+++ b/roles/nautobot/handlers/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Restart redis
+  ansible.builtin.systemd:
+    name: redis-server
+    state: restarted
+
+# Reload only when a unit file changed (notified by the unit templates), so an
+# unchanged converge stays idempotent. Applied before the services start via a
+# flush_handlers in the managed-app block.
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+# Only meaningful once the app layer is managed (services exist and are
+# started). When nautobot_manage_app is false (molecule) the units are deployed
+# but not started, so a restart would fail — skip it.
+- name: Restart nautobot services
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    state: restarted
+    daemon_reload: true
+  loop:
+    - nautobot-server
+    - nautobot-worker
+    - nautobot-scheduler
+  when: nautobot_manage_app | bool

--- a/roles/nautobot/meta/main.yml
+++ b/roles/nautobot/meta/main.yml
@@ -1,0 +1,20 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: >-
+    Native Nautobot (venv + uWSGI + celery worker/scheduler) as the homelab
+    IPAM/DCIM source of truth (issue #138). Redis colocated; SSoT DiffSync jobs
+    seed from the hand-maintained sources; an export Job publishes the inventory
+    artifact to S3.
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+  galaxy_tags:
+    - nautobot
+    - ipam
+    - dcim
+dependencies: []

--- a/roles/nautobot/tasks/main.yml
+++ b/roles/nautobot/tasks/main.yml
@@ -190,6 +190,15 @@
     mode: "0644"
   notify: Restart nautobot services
 
+- name: Deploy the Nautobot export schema contract
+  ansible.builtin.copy:
+    src: contracts/nautobot-export-v1.json
+    dest: "{{ nautobot_export_schema_file }}"
+    owner: "{{ nautobot_user }}"
+    group: "{{ nautobot_group }}"
+    mode: "0644"
+  notify: Restart nautobot services
+
 # =============================================================================
 # Phase 6: systemd units (always deployed; started only when managing the app)
 # =============================================================================
@@ -249,7 +258,7 @@
         cmd: "{{ nautobot_root }}/bin/nautobot-server shell --interface python"
         stdin: "{{ lookup('ansible.builtin.file', 'superuser_bootstrap.py') }}"
       register: nautobot_superuser
-      changed_when: "'SUPERUSER_CREATED' in nautobot_superuser.stdout"
+      changed_when: "'SUPERUSER_CHANGED' in nautobot_superuser.stdout"
       no_log: true
 
     - name: Apply pending systemd reload before starting services

--- a/roles/nautobot/tasks/main.yml
+++ b/roles/nautobot/tasks/main.yml
@@ -1,0 +1,287 @@
+---
+# Native Nautobot (issue #138). Two layers:
+#   * always: system deps, user/dirs, Redis, SECRET_KEY, config + env + uWSGI +
+#     jobs + systemd units. Deterministic, molecule-tested.
+#   * nautobot_manage_app (default true): venv + pip install of Nautobot and
+#     apps, migrate/collectstatic, superuser, service start, export schedule,
+#     HTTP health. Skipped by molecule; validated live at cutover.
+
+# =============================================================================
+# Phase 1: System packages + user + directories
+# =============================================================================
+- name: Install Nautobot system packages
+  ansible.builtin.apt:
+    name: "{{ nautobot_system_packages }}"
+    state: present
+    update_cache: true
+
+- name: Create the nautobot system group
+  ansible.builtin.group:
+    name: "{{ nautobot_group }}"
+    system: true
+
+- name: Create the nautobot system user
+  ansible.builtin.user:
+    name: "{{ nautobot_user }}"
+    group: "{{ nautobot_group }}"
+    system: true
+    shell: /usr/sbin/nologin
+    home: "{{ nautobot_root }}"
+    create_home: true
+
+- name: Create Nautobot directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ nautobot_user }}"
+    group: "{{ nautobot_group }}"
+    mode: "0755"
+  loop:
+    - "{{ nautobot_root }}"
+    - "{{ nautobot_jobs_root }}"
+    - "{{ nautobot_export_schema_dir }}"
+    - "{{ nautobot_root }}/static"
+
+# =============================================================================
+# Phase 2: Redis — colocated, loopback only
+# =============================================================================
+- name: Bind Redis to loopback only
+  ansible.builtin.lineinfile:
+    path: /etc/redis/redis.conf
+    regexp: "^bind "
+    line: "bind {{ nautobot_redis_host }} -::1"
+    state: present
+  notify: Restart redis
+
+- name: Enforce Redis protected-mode
+  ansible.builtin.lineinfile:
+    path: /etc/redis/redis.conf
+    regexp: "^protected-mode "
+    line: "protected-mode yes"
+    state: present
+  notify: Restart redis
+
+- name: Enable and start Redis
+  ansible.builtin.systemd:
+    name: redis-server
+    state: started
+    enabled: true
+
+# =============================================================================
+# Phase 3: SECRET_KEY — bao-first, else generate-once and persist
+# =============================================================================
+- name: Decide whether a SECRET_KEY was supplied (bao/env)
+  ansible.builtin.set_fact:
+    nautobot_secret_key_supplied: "{{ (nautobot_secret_key | default('', true) | length) > 0 }}"
+
+- name: Persist the supplied SECRET_KEY
+  ansible.builtin.copy:
+    content: "{{ nautobot_secret_key }}"
+    dest: "{{ nautobot_secret_key_file }}"
+    owner: "{{ nautobot_user }}"
+    group: "{{ nautobot_group }}"
+    mode: "0600"
+  no_log: true
+  when: nautobot_secret_key_supplied
+
+- name: Stat the persisted SECRET_KEY
+  ansible.builtin.stat:
+    path: "{{ nautobot_secret_key_file }}"
+  register: nautobot_secret_key_stat
+
+- name: Generate a SECRET_KEY once when none supplied and none persisted
+  ansible.builtin.copy:
+    content: "{{ lookup('community.general.random_string', length=64, special=false) }}"
+    dest: "{{ nautobot_secret_key_file }}"
+    owner: "{{ nautobot_user }}"
+    group: "{{ nautobot_group }}"
+    mode: "0600"
+  no_log: true
+  when:
+    - not nautobot_secret_key_supplied
+    - not nautobot_secret_key_stat.stat.exists
+
+- name: Read the effective SECRET_KEY
+  ansible.builtin.slurp:
+    src: "{{ nautobot_secret_key_file }}"
+  register: nautobot_secret_key_slurp
+  no_log: true
+
+- name: Publish the effective SECRET_KEY fact
+  ansible.builtin.set_fact:
+    nautobot_effective_secret_key: "{{ nautobot_secret_key_slurp.content | b64decode | trim }}"
+  no_log: true
+
+# =============================================================================
+# Phase 4: Python venv + Nautobot install (heavy — gated)
+# =============================================================================
+- name: Create the Nautobot virtualenv
+  ansible.builtin.command:
+    cmd: "python3 -m venv {{ nautobot_root }}"
+    creates: "{{ nautobot_root }}/bin/python"
+  become: true
+  become_user: "{{ nautobot_user }}"
+
+- name: Install/upgrade pip tooling in the venv
+  ansible.builtin.pip:
+    name:
+      - pip
+      - wheel
+    state: latest  # noqa package-latest - pip/wheel bootstrap, not app pinning
+    virtualenv: "{{ nautobot_root }}"
+  become: true
+  become_user: "{{ nautobot_user }}"
+  when: nautobot_manage_app | bool
+
+- name: Install Nautobot and apps into the venv
+  ansible.builtin.pip:
+    name: "{{ nautobot_pip_packages }}"
+    state: present
+    virtualenv: "{{ nautobot_root }}"
+  become: true
+  become_user: "{{ nautobot_user }}"
+  when: nautobot_manage_app | bool
+
+- name: Pin the app packages in local_requirements for future upgrades
+  ansible.builtin.copy:
+    content: "{{ nautobot_pip_packages | join('\n') }}\n"
+    dest: "{{ nautobot_root }}/local_requirements.txt"
+    owner: "{{ nautobot_user }}"
+    group: "{{ nautobot_group }}"
+    mode: "0644"
+
+# =============================================================================
+# Phase 5: Configuration, environment, uWSGI, jobs (always)
+# =============================================================================
+- name: Render nautobot_config.py
+  ansible.builtin.template:
+    src: nautobot_config.py.j2
+    dest: "{{ nautobot_root }}/nautobot_config.py"
+    owner: "{{ nautobot_user }}"
+    group: "{{ nautobot_group }}"
+    mode: "0644"
+  notify: Restart nautobot services
+
+- name: Render the root-only environment file
+  ansible.builtin.template:
+    src: nautobot.env.j2
+    dest: "{{ nautobot_root }}/nautobot.env"
+    owner: "{{ nautobot_user }}"
+    group: "{{ nautobot_group }}"
+    mode: "0600"
+  no_log: true
+  notify: Restart nautobot services
+
+- name: Render the uWSGI config
+  ansible.builtin.template:
+    src: uwsgi.ini.j2
+    dest: "{{ nautobot_root }}/uwsgi.ini"
+    owner: "{{ nautobot_user }}"
+    group: "{{ nautobot_group }}"
+    mode: "0644"
+  notify: Restart nautobot services
+
+- name: Deploy the SSoT/export/onboarding jobs into JOBS_ROOT
+  ansible.builtin.copy:
+    src: jobs/
+    dest: "{{ nautobot_jobs_root }}/"
+    owner: "{{ nautobot_user }}"
+    group: "{{ nautobot_group }}"
+    mode: "0644"
+  notify: Restart nautobot services
+
+# =============================================================================
+# Phase 6: systemd units (always deployed; started only when managing the app)
+# =============================================================================
+- name: Deploy the Nautobot systemd units
+  ansible.builtin.template:
+    src: "{{ item }}.j2"
+    dest: "/etc/systemd/system/{{ item }}"
+    owner: root
+    group: root
+    mode: "0644"
+  loop:
+    - nautobot-server.service
+    - nautobot-worker.service
+    - nautobot-scheduler.service
+  notify:
+    - Reload systemd daemon
+    - Restart nautobot services
+
+# =============================================================================
+# Phase 6b: Seed-bundle assembly (cutover-gated)
+# =============================================================================
+- name: Assemble and place the seed bundle
+  ansible.builtin.include_tasks: seed_bundle.yml
+  when: nautobot_build_seed | bool
+
+# =============================================================================
+# Phase 7: Live application bring-up (gated)
+# =============================================================================
+- name: Bring up the Nautobot application
+  when: nautobot_manage_app | bool
+  become: true
+  become_user: "{{ nautobot_user }}"
+  environment:
+    NAUTOBOT_ROOT: "{{ nautobot_root }}"
+    NAUTOBOT_SECRET_KEY: "{{ nautobot_effective_secret_key }}"
+    NAUTOBOT_DB_PASSWORD: "{{ nautobot_db_password }}"
+    NAUTOBOT_SUPERUSER_NAME: "{{ nautobot_superuser_name }}"
+    NAUTOBOT_SUPERUSER_EMAIL: "{{ nautobot_superuser_email }}"
+    NAUTOBOT_SUPERUSER_PASSWORD: "{{ nautobot_superuser_password }}"
+    NAUTOBOT_EXPORT_S3_BUCKET: "{{ nautobot_export_s3_bucket }}"
+    NAUTOBOT_EXPORT_S3_KEY: "{{ nautobot_export_s3_key }}"
+  block:
+    - name: Apply database migrations
+      ansible.builtin.command:
+        cmd: "{{ nautobot_root }}/bin/nautobot-server migrate"
+      register: nautobot_migrate
+      changed_when: "'No migrations to apply' not in nautobot_migrate.stdout"
+
+    - name: Collect static files
+      ansible.builtin.command:
+        cmd: "{{ nautobot_root }}/bin/nautobot-server collectstatic --no-input"
+      register: nautobot_collectstatic
+      changed_when: "'0 static files copied' not in nautobot_collectstatic.stdout"
+
+    - name: Ensure the Nautobot superuser exists
+      ansible.builtin.command:
+        cmd: "{{ nautobot_root }}/bin/nautobot-server shell --interface python"
+        stdin: "{{ lookup('ansible.builtin.file', 'superuser_bootstrap.py') }}"
+      register: nautobot_superuser
+      changed_when: "'SUPERUSER_CREATED' in nautobot_superuser.stdout"
+      no_log: true
+
+    - name: Apply pending systemd reload before starting services
+      ansible.builtin.meta: flush_handlers
+
+    - name: Enable and start the Nautobot services
+      ansible.builtin.systemd:
+        name: "{{ item }}"
+        state: started
+        enabled: true
+      loop:
+        - nautobot-server
+        - nautobot-worker
+        - nautobot-scheduler
+
+    - name: Schedule the export Job via celery beat
+      ansible.builtin.command:
+        cmd: "{{ nautobot_root }}/bin/nautobot-server shell --interface python"
+        stdin: "{{ lookup('ansible.builtin.file', 'schedule_export.py') }}"
+      environment:
+        NAUTOBOT_EXPORT_SCHEDULE_HOUR: "{{ nautobot_export_schedule_hour }}"
+        NAUTOBOT_EXPORT_SCHEDULE_MINUTE: "{{ nautobot_export_schedule_minute }}"
+      register: nautobot_schedule
+      changed_when: "'SCHEDULE_CREATED' in nautobot_schedule.stdout"
+
+    - name: Wait for the Nautobot web UI to answer
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ nautobot_web_port }}/"
+        status_code: [200, 302]
+        follow_redirects: none
+      register: nautobot_health
+      until: nautobot_health.status in [200, 302]
+      retries: 20
+      delay: 6
+      changed_when: false

--- a/roles/nautobot/tasks/seed_bundle.yml
+++ b/roles/nautobot/tasks/seed_bundle.yml
@@ -1,0 +1,129 @@
+---
+# Controller-side seed-bundle assembly (issue #138). Reads the four
+# hand-maintained sources, transforms each into the nautobot_seed.json schema,
+# and writes the bundle onto the Nautobot LXC (0600, never committed). Gated by
+# nautobot_build_seed (default false): the sources live in sibling repos the
+# controller only has at cutover. The SSoT seed jobs then DiffSync this bundle
+# into Nautobot.
+#
+# Source shapes: rack_servers (SOPS-encrypted in terraform-proxmox) is known —
+# chassis/bmc_ip/bmc_mac/service_tag/mgmt_ip, keyed by node name. VLAN/prefix
+# definitions come from a provided JSON var (Doppler / terraform output). The
+# fixed-ips.json (tofu-unifi) and hosts.yml (ansible-proxmox) mappings below are
+# documented ASSUMPTIONS about those shapes; WS-E confirms/adjusts the field
+# names against the live sources at cutover — the mappings are isolated here so
+# that is a one-place edit.
+
+- name: Assert seed sources are provided when building the seed
+  ansible.builtin.assert:
+    that:
+      - nautobot_seed_sops_path | length > 0
+      - nautobot_seed_fixed_ips_path | length > 0
+      - nautobot_seed_hosts_yml_path | length > 0
+    fail_msg: >-
+      nautobot_build_seed is true but a source path is unset. Set
+      TERRAFORM_PROXMOX_SOPS, TOFU_UNIFI_FIXED_IPS, and ANSIBLE_PROXMOX_HOSTS
+      (or the matching nautobot_seed_*_path vars) to the sibling-repo files.
+
+# --- Read + decrypt the sources on the controller --------------------------
+- name: Decrypt rack_servers from the terraform-proxmox SOPS file
+  ansible.builtin.command:
+    cmd: "sops -d {{ nautobot_seed_sops_path }}"
+  delegate_to: localhost
+  become: false
+  vars:
+    ansible_become: false
+  changed_when: false
+  register: nautobot_seed_sops_raw
+  no_log: true
+
+- name: Read the tofu-unifi fixed-IP reservations
+  ansible.builtin.slurp:
+    src: "{{ nautobot_seed_fixed_ips_path }}"
+  delegate_to: localhost
+  become: false
+  vars:
+    ansible_become: false
+  register: nautobot_seed_fixed_ips_raw
+
+- name: Read the ansible-proxmox hosts inventory
+  ansible.builtin.slurp:
+    src: "{{ nautobot_seed_hosts_yml_path }}"
+  delegate_to: localhost
+  become: false
+  vars:
+    ansible_become: false
+  register: nautobot_seed_hosts_raw
+
+- name: Parse the sources
+  ansible.builtin.set_fact:
+    nautobot_seed_rack_servers: >-
+      {{ (nautobot_seed_sops_raw.stdout | from_json).rack_servers | default({}) }}
+    nautobot_seed_fixed_ips: "{{ nautobot_seed_fixed_ips_raw.content | b64decode | from_json }}"
+    nautobot_seed_hosts: "{{ nautobot_seed_hosts_raw.content | b64decode | from_yaml }}"
+  no_log: true
+
+# --- Transform into the nautobot_seed.json schema ---------------------------
+# VLANs + prefixes from the provided network definitions (list of {vid,name,cidr}).
+- name: Build VLANs and prefixes from the network definitions
+  ansible.builtin.set_fact:
+    nautobot_seed_vlans: >-
+      {{ nautobot_seed_networks
+         | map('community.general.json_query', '{vid: vid, name: name, cidr: cidr}')
+         | list }}
+    nautobot_seed_prefixes: >-
+      {{ nautobot_seed_networks
+         | map('community.general.json_query', '{prefix: cidr, vlan_vid: vid, role: name}')
+         | list }}
+
+# Devices from the decrypted rack_servers (known shape).
+- name: Build devices from the decrypted rack_servers
+  ansible.builtin.set_fact:
+    nautobot_seed_devices: >-
+      {{ nautobot_seed_rack_servers | dict2items
+         | community.general.json_query('[].{name: key, chassis: value.chassis,
+             bmc_ip: value.bmc_ip, bmc_mac: value.bmc_mac,
+             service_tag: value.service_tag, mgmt_ip: value.mgmt_ip}') }}
+  no_log: true
+
+# Reservations from fixed-ips.json. ASSUMPTION: a list of objects each carrying
+# an address plus optional name/mac (WS-E adjusts the key names at cutover).
+- name: Build reservations from the fixed-IP source
+  ansible.builtin.set_fact:
+    nautobot_seed_reservations: >-
+      {{ nautobot_seed_fixed_ips
+         | community.general.json_query(nautobot_seed_fixed_ips_query) }}
+  no_log: true
+
+# Nodes from hosts.yml. ASSUMPTION: the pve hypervisors are the host keys under
+# nautobot_seed_hosts_group (default proxmox); WS-E adjusts the path at cutover.
+- name: Build nodes from the hosts inventory
+  ansible.builtin.set_fact:
+    nautobot_seed_nodes: >-
+      {{ (nautobot_seed_hosts[nautobot_seed_hosts_group].hosts | default({}) | dict2items)
+         | community.general.json_query('[].{name: key, role: `pve-node`,
+             mgmt_ip: value.ansible_host, commissioned: `true`}') }}
+  no_log: true
+
+- name: Assemble the seed bundle
+  ansible.builtin.set_fact:
+    nautobot_seed_bundle:
+      schema_version: "1.0.0"
+      generated_at: "{{ '%Y-%m-%dT%H:%M:%SZ' | strftime }}"
+      vlans: "{{ nautobot_seed_vlans }}"
+      prefixes: "{{ nautobot_seed_prefixes }}"
+      reservations: "{{ nautobot_seed_reservations }}"
+      racks: "{{ nautobot_seed_racks }}"
+      devices: "{{ nautobot_seed_devices }}"
+      nodes: "{{ nautobot_seed_nodes }}"
+  no_log: true
+
+# --- Write the bundle onto the Nautobot LXC ---------------------------------
+- name: Write nautobot_seed.json onto the Nautobot LXC (0600)
+  ansible.builtin.copy:
+    content: "{{ nautobot_seed_bundle | to_nice_json }}\n"
+    dest: "{{ nautobot_seed_file }}"
+    owner: "{{ nautobot_user }}"
+    group: "{{ nautobot_group }}"
+    mode: "0600"
+  no_log: true

--- a/roles/nautobot/templates/nautobot-scheduler.service.j2
+++ b/roles/nautobot/templates/nautobot-scheduler.service.j2
@@ -1,0 +1,19 @@
+[Unit]
+# {{ ansible_managed }}
+Description=Nautobot Celery Beat Scheduler
+After=network-online.target redis-server.service nautobot-server.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ nautobot_user }}
+Group={{ nautobot_group }}
+WorkingDirectory={{ nautobot_root }}
+EnvironmentFile={{ nautobot_root }}/nautobot.env
+Environment=NAUTOBOT_ROOT={{ nautobot_root }}
+ExecStart={{ nautobot_root }}/bin/nautobot-server celery beat --loglevel INFO
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/nautobot/templates/nautobot-server.service.j2
+++ b/roles/nautobot/templates/nautobot-server.service.j2
@@ -1,0 +1,19 @@
+[Unit]
+# {{ ansible_managed }}
+Description=Nautobot WSGI Service (uWSGI)
+After=network-online.target redis-server.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ nautobot_user }}
+Group={{ nautobot_group }}
+WorkingDirectory={{ nautobot_root }}
+EnvironmentFile={{ nautobot_root }}/nautobot.env
+Environment=NAUTOBOT_ROOT={{ nautobot_root }}
+ExecStart={{ nautobot_root }}/bin/nautobot-server start --ini {{ nautobot_root }}/uwsgi.ini
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/nautobot/templates/nautobot-worker.service.j2
+++ b/roles/nautobot/templates/nautobot-worker.service.j2
@@ -1,0 +1,19 @@
+[Unit]
+# {{ ansible_managed }}
+Description=Nautobot Celery Worker
+After=network-online.target redis-server.service nautobot-server.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ nautobot_user }}
+Group={{ nautobot_group }}
+WorkingDirectory={{ nautobot_root }}
+EnvironmentFile={{ nautobot_root }}/nautobot.env
+Environment=NAUTOBOT_ROOT={{ nautobot_root }}
+ExecStart={{ nautobot_root }}/bin/nautobot-server celery worker --loglevel INFO --concurrency 2
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/nautobot/templates/nautobot.env.j2
+++ b/roles/nautobot/templates/nautobot.env.j2
@@ -1,0 +1,14 @@
+# {{ ansible_managed }}
+# Root-only (0600) EnvironmentFile for the Nautobot systemd units and management
+# commands. Holds the runtime secrets that nautobot_config.py reads from the
+# environment, plus the export Job's S3 target. Never world-readable.
+NAUTOBOT_ROOT={{ nautobot_root }}
+NAUTOBOT_SECRET_KEY={{ nautobot_effective_secret_key }}
+NAUTOBOT_DB_PASSWORD={{ nautobot_db_password }}
+NAUTOBOT_SUPERUSER_NAME={{ nautobot_superuser_name }}
+NAUTOBOT_SUPERUSER_EMAIL={{ nautobot_superuser_email }}
+NAUTOBOT_SUPERUSER_PASSWORD={{ nautobot_superuser_password }}
+NAUTOBOT_SEED_FILE={{ nautobot_seed_file }}
+NAUTOBOT_EXPORT_S3_BUCKET={{ nautobot_export_s3_bucket }}
+NAUTOBOT_EXPORT_S3_KEY={{ nautobot_export_s3_key }}
+NAUTOBOT_EXPORT_SCHEMA={{ nautobot_export_schema_file }}

--- a/roles/nautobot/templates/nautobot_config.py.j2
+++ b/roles/nautobot/templates/nautobot_config.py.j2
@@ -1,0 +1,75 @@
+# {{ ansible_managed }}
+# Nautobot configuration (issue #138). Non-secret values are rendered here;
+# every secret (SECRET_KEY, DB password) is read from the environment supplied
+# by the systemd EnvironmentFile (nautobot.env, 0600), so no secret is written
+# into this world-readable file.
+import os
+
+#
+# Core
+#
+ALLOWED_HOSTS = {{ nautobot_allowed_hosts | to_json }}
+
+SECRET_KEY = os.environ["NAUTOBOT_SECRET_KEY"]
+
+#
+# Database — the shared native PostgreSQL cluster (no ingress; reached by FQDN).
+#
+DATABASES = {
+    "default": {
+        "NAME": "{{ nautobot_db_name }}",
+        "USER": "{{ nautobot_db_user }}",
+        "PASSWORD": os.environ["NAUTOBOT_DB_PASSWORD"],
+        "HOST": "{{ nautobot_db_host }}",
+        "PORT": "{{ nautobot_db_port }}",
+        "CONN_MAX_AGE": 300,
+        "ENGINE": "django.db.backends.postgresql",
+    }
+}
+
+#
+# Redis — colocated, loopback only. DB 0 = celery broker, DB 1 = cache.
+#
+REDIS_HOST = "{{ nautobot_redis_host }}"
+REDIS_PORT = {{ nautobot_redis_port }}
+
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}/1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        },
+    }
+}
+
+CELERY_BROKER_URL = f"redis://{REDIS_HOST}:{REDIS_PORT}/0"
+
+#
+# Proxy / CSRF — Traefik terminates TLS and forwards one hop.
+#
+CSRF_TRUSTED_ORIGINS = [
+{% for host in nautobot_allowed_hosts if host not in ['localhost', '127.0.0.1'] %}
+    "https://{{ host }}",
+{% endfor %}
+]
+{% if nautobot_trust_proxy_ssl_header %}
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+USE_X_FORWARDED_HOST = True
+{% endif %}
+
+#
+# Jobs + Apps (plugins)
+#
+JOBS_ROOT = "{{ nautobot_jobs_root }}"
+
+PLUGINS = {{ nautobot_plugins | to_json }}
+
+PLUGINS_CONFIG = {
+    "nautobot_ssot": {
+        "hide_example_jobs": True,
+    },
+    "nautobot_device_onboarding": {},
+}
+
+INSTALLATION_METRICS_ENABLED = False

--- a/roles/nautobot/templates/uwsgi.ini.j2
+++ b/roles/nautobot/templates/uwsgi.ini.j2
@@ -1,0 +1,14 @@
+# {{ ansible_managed }}
+# uWSGI serves Nautobot's WSGI app over HTTP directly (Traefik fronts it, no
+# nginx) and serves collected static files via static-map after collectstatic.
+[uwsgi]
+chdir = {{ nautobot_root }}
+module = nautobot.core.wsgi:application
+env = NAUTOBOT_ROOT={{ nautobot_root }}
+http = {{ nautobot_web_bind }}:{{ nautobot_web_port }}
+processes = {{ nautobot_uwsgi_processes }}
+threads = {{ nautobot_uwsgi_threads }}
+vacuum = true
+max-requests = 5000
+buffer-size = 65535
+static-map = /static={{ nautobot_root }}/static

--- a/roles/openbao_secrets/defaults/main.yml
+++ b/roles/openbao_secrets/defaults/main.yml
@@ -64,6 +64,18 @@ openbao_secrets_domains:
     secret_id_env: MEDIA_VAULT_SECRET_ID
     paths:
       - apps/media
+  - name: apps
+    role_id_env: APPS_VAULT_ROLE_ID
+    secret_id_env: APPS_VAULT_SECRET_ID
+    paths:
+      # Nautobot IPAM/DCIM (issue #138). The apps/nautobot KV path carries the
+      # fields db_password, secret_key, superuser_password (the #138 secret
+      # contract WS-C seeds), merged flat into bao_apps_secrets. Future apps
+      # sharing the Postgres instance (Vikunja P3, EspoCRM P4) add their own
+      # `apps/<app>` path here; because the merge is flat, their fields MUST be
+      # app-namespaced (e.g. vikunja_db_password) or given a separate domain,
+      # so they never collide with Nautobot's bare field names.
+      - apps/nautobot
   - name: local-llm
     role_id_env: LOCAL_LLM_VAULT_ROLE_ID
     secret_id_env: LOCAL_LLM_VAULT_SECRET_ID

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -1,0 +1,65 @@
+---
+# Native PostgreSQL role defaults (issue #138). Installs the PGDG apt build so
+# the homelab tracks a current major independent of the Debian base, and keeps
+# all persistent state (cluster + pg_dump backups) on the container's ZFS bind
+# mount so a ChaosMonkey rebuild reconstructs everything from Ansible while the
+# data survives.
+
+# PGDG package. The unversioned metapackage tracks PGDG's current stable major;
+# set postgres_version only for tests or emergency pinning.
+postgres_version: ""
+postgres_package: >-
+  {{ ('postgresql-' ~ postgres_version)
+     if (postgres_version | string | length > 0)
+     else 'postgresql' }}
+postgres_cluster_name: main
+
+# Persistent state root. The LXC bind-mounts a ZFS dataset here (provided by
+# terraform-proxmox), so the PGDG-default cluster path AND the backup dir below
+# both land on persistent storage without moving PGDATA off the packaged
+# location. WS-C must bind-mount the dataset at this exact path.
+postgres_data_root: /var/lib/postgresql
+postgres_data_dir: >-
+  {{ postgres_data_root }}/{{ postgres_cluster_version | default(postgres_version) }}/{{ postgres_cluster_name }}
+postgres_conf_dir: >-
+  /etc/postgresql/{{ postgres_cluster_version | default(postgres_version) }}/{{ postgres_cluster_name }}
+
+# Listener. Role default is permissive because access is gated by pg_hba
+# (scram, per-CIDR) + the host firewall, NOT by the bind address. group_vars
+# narrows this to the data-VLAN address in production. Port is standard 5432.
+postgres_port: 5432
+postgres_listen_addresses: "*"
+# scram-sha-256 for every stored password (no md5). Applied cluster-wide via
+# postgresql_set; each managed role is created with the scram hash.
+postgres_password_encryption: scram-sha-256
+
+# PGDG apt repository. Key is dearmored into a dedicated keyring and referenced
+# with signed-by so the repo is trusted narrowly (no global apt-key).
+postgres_pgdg_key_url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
+# ASCII-armored key stored directly; apt signed-by accepts a .asc keyring, so no
+# non-idempotent gpg --dearmor step is needed.
+postgres_pgdg_keyring: /usr/share/keyrings/pgdg.asc
+postgres_pgdg_repo: >-
+  deb [signed-by={{ postgres_pgdg_keyring }}]
+  https://apt.postgresql.org/pub/repos/apt {{ ansible_distribution_release }}-pgdg main
+
+# Managed databases. One entry per app sharing this cluster; extensible so
+# Vikunja (P3) / EspoCRM (P4) append here without a new role. Populated by
+# inventory/group_vars/postgres_group.yml (bao-first password, apps-subnet
+# client_cidr). Each entry:
+#   name        - database name (owner is a role of the same name)
+#   user        - login role that owns the db and connects remotely
+#   password    - bao-first with env fallback (never a literal here)
+#   client_cidr - CIDR the user may connect from (the app's LXC subnet); the
+#                 ONLY place an IP literal is legitimate (pg_hba needs a CIDR,
+#                 not an FQDN), and even then it is env-derived, not hard-coded.
+postgres_managed_databases: []
+
+# pg_dump backups via a systemd timer, written to the persistent mount.
+postgres_backup_enabled: true
+postgres_backup_dir: "{{ postgres_data_root }}/backups"
+# Daily at 02:30 with a small randomized delay (set on the timer) to avoid a
+# thundering herd if more timers land on the same minute.
+postgres_backup_on_calendar: "*-*-* 02:30:00"
+postgres_backup_randomized_delay_sec: 900
+postgres_backup_retention_days: 14

--- a/roles/postgres/handlers/main.yml
+++ b/roles/postgres/handlers/main.yml
@@ -1,0 +1,14 @@
+---
+# A config change that only needs the running server to re-read it (pg_hba,
+# most GUCs) triggers a reload; listen_addresses/port changes need a full
+# restart. postgresql_set reports restart_required, so the tasks notify the
+# right handler explicitly rather than restarting on every reload.
+- name: Reload postgresql
+  ansible.builtin.systemd:
+    name: "postgresql@{{ postgres_cluster_version }}-{{ postgres_cluster_name }}"
+    state: reloaded
+
+- name: Restart postgresql
+  ansible.builtin.systemd:
+    name: "postgresql@{{ postgres_cluster_version }}-{{ postgres_cluster_name }}"
+    state: restarted

--- a/roles/postgres/meta/main.yml
+++ b/roles/postgres/meta/main.yml
@@ -1,0 +1,20 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: >-
+    Native PostgreSQL (PGDG apt) as the shared homelab database backend —
+    Nautobot first (issue #138), later Vikunja/EspoCRM. Data + pg_dump backups
+    live on the container's persistent ZFS bind mount so a full rebuild keeps
+    the data.
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+  galaxy_tags:
+    - postgres
+    - postgresql
+    - database
+dependencies: []

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -33,9 +33,10 @@
 
 # =============================================================================
 # Phase 2: Install PostgreSQL
-# The postgresql-common postinst creates the `postgres` user and auto-creates
-# the default PGDG main cluster. With the ZFS dataset bind-mounted at
-# postgres_data_root, that cluster is created ON the persistent mount.
+# The postgresql-common postinst creates the `postgres` user. On normal LXCs it
+# also auto-creates the default PGDG main cluster on postgres_data_root, but
+# containers can skip that path (create_main_cluster/policy-rc.d), so the role
+# explicitly creates the cluster when discovery finds nothing.
 # =============================================================================
 - name: Install PostgreSQL from PGDG
   ansible.builtin.apt:
@@ -43,19 +44,148 @@
     state: present
     update_cache: true
 
-- name: Discover the installed PostgreSQL main cluster
+- name: Discover PostgreSQL clusters
   ansible.builtin.command:
     cmd: pg_lsclusters --no-header
   register: postgres_clusters
   changed_when: false
 
+- name: Select matching PostgreSQL cluster lines
+  ansible.builtin.set_fact:
+    postgres_matching_clusters: >-
+      {{ postgres_clusters.stdout_lines
+         | select('search', '^[0-9]+\\s+' ~ postgres_cluster_name ~ '\\s+')
+         | list }}
+
+- name: Create the PostgreSQL cluster when postinst did not
+  when: postgres_matching_clusters | length == 0
+  block:
+    - name: Discover installed PostgreSQL server versions
+      ansible.builtin.command:
+        argv:
+          - find
+          - /usr/lib/postgresql
+          - -mindepth
+          - "1"
+          - -maxdepth
+          - "1"
+          - -type
+          - d
+          - -printf
+          - "%f\n"
+      register: postgres_installed_versions
+      changed_when: false
+      failed_when: false
+
+    - name: Set the PostgreSQL cluster version to create
+      ansible.builtin.set_fact:
+        postgres_cluster_version: >-
+          {{ postgres_version
+             if (postgres_version | string | length > 0)
+             else (postgres_installed_versions.stdout_lines | sort | last | default('')) }}
+
+    - name: Fail when no PostgreSQL server version is installed
+      ansible.builtin.fail:
+        msg: >-
+          PostgreSQL package {{ postgres_package }} installed, but no server
+          version directories were found under /usr/lib/postgresql. Cannot
+          create cluster {{ postgres_cluster_name }}.
+      when: postgres_cluster_version | string | length == 0
+
+    - name: Check whether the persistent data directory already has a cluster
+      ansible.builtin.stat:
+        path: "{{ postgres_data_dir }}/PG_VERSION"
+      register: postgres_existing_data_version
+
+    - name: Read the persistent data directory version
+      ansible.builtin.slurp:
+        src: "{{ postgres_data_dir }}/PG_VERSION"
+      register: postgres_existing_data_pg_version
+      when: postgres_existing_data_version.stat.exists
+
+    - name: Fail when persistent data belongs to a different PostgreSQL major
+      ansible.builtin.fail:
+        msg: >-
+          Existing PostgreSQL data directory {{ postgres_data_dir }} belongs to
+          major version {{ postgres_existing_data_pg_version.content | b64decode | trim }},
+          but the installed server version selected for cluster
+          {{ postgres_cluster_name }} is {{ postgres_cluster_version }}. Pin
+          postgres_version or perform a controlled PostgreSQL upgrade before
+          recreating the postgresql-common cluster config.
+      when:
+        - postgres_existing_data_version.stat.exists
+        - (postgres_existing_data_pg_version.content | b64decode | trim) !=
+          (postgres_cluster_version | string)
+
+    - name: Set pg_createcluster data directory
+      ansible.builtin.set_fact:
+        postgres_createcluster_data_dir: >-
+          {{ postgres_data_root ~ '/.ansible-pg-createcluster-' ~
+             postgres_cluster_version ~ '-' ~ postgres_cluster_name
+             if postgres_existing_data_version.stat.exists
+             else postgres_data_dir }}
+
+    - name: Remove stale temporary pg_createcluster data directory
+      ansible.builtin.file:
+        path: "{{ postgres_createcluster_data_dir }}"
+        state: absent
+      when: postgres_existing_data_version.stat.exists
+
+    - name: Ensure the PostgreSQL version data root exists
+      ansible.builtin.file:
+        path: "{{ postgres_data_root }}/{{ postgres_cluster_version }}"
+        state: directory
+        owner: postgres
+        group: postgres
+        mode: "0750"
+
+    - name: Create the PostgreSQL cluster
+      ansible.builtin.command:
+        argv:
+          - pg_createcluster
+          - --datadir
+          - "{{ postgres_createcluster_data_dir }}"
+          - "{{ postgres_cluster_version }}"
+          - "{{ postgres_cluster_name }}"
+      changed_when: true
+
+    - name: Point recreated cluster config at existing persistent data
+      ansible.builtin.lineinfile:
+        path: "{{ postgres_conf_dir }}/postgresql.conf"
+        regexp: "^data_directory\\s*="
+        line: "data_directory = '{{ postgres_data_dir }}'"
+      when: postgres_existing_data_version.stat.exists
+
+    - name: Remove temporary pg_createcluster data directory
+      ansible.builtin.file:
+        path: "{{ postgres_createcluster_data_dir }}"
+        state: absent
+      when: postgres_existing_data_version.stat.exists
+
+    - name: Re-discover PostgreSQL clusters after explicit creation
+      ansible.builtin.command:
+        cmd: pg_lsclusters --no-header
+      register: postgres_clusters
+      changed_when: false
+
+    - name: Re-select matching PostgreSQL cluster lines
+      ansible.builtin.set_fact:
+        postgres_matching_clusters: >-
+          {{ postgres_clusters.stdout_lines
+             | select('search', '^[0-9]+\\s+' ~ postgres_cluster_name ~ '\\s+')
+             | list }}
+
+- name: Fail when the PostgreSQL cluster is still missing
+  ansible.builtin.fail:
+    msg: >-
+      PostgreSQL cluster {{ postgres_cluster_name }} was not found after
+      package install and explicit pg_createcluster. pg_lsclusters output:
+      {{ postgres_clusters.stdout | default('') | trim | default('<empty>', true) }}
+  when: postgres_matching_clusters | length == 0
+
 - name: Set the PostgreSQL cluster version fact
   ansible.builtin.set_fact:
-    postgres_cluster_version: >-
-      {{ (postgres_clusters.stdout_lines
-          | select('search', '^[0-9]+\\s+' ~ postgres_cluster_name ~ '\\s+')
-          | first
-          | split)[0] }}
+    postgres_cluster_version: "{{ (postgres_matching_clusters | first | split)[0] }}"
 
 - name: Ensure the PostgreSQL cluster service is started and enabled
   ansible.builtin.systemd:

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -33,10 +33,9 @@
 
 # =============================================================================
 # Phase 2: Install PostgreSQL
-# The postgresql-common postinst creates the `postgres` user. On normal LXCs it
-# also auto-creates the default PGDG main cluster on postgres_data_root, but
-# containers can skip that path (create_main_cluster/policy-rc.d), so the role
-# explicitly creates the cluster when discovery finds nothing.
+# The postgresql-common postinst creates the `postgres` user and usually creates
+# the default cluster. Use the config directory as the existence test because
+# pg_createcluster refuses to run when /etc/postgresql/<major>/<name> exists.
 # =============================================================================
 - name: Install PostgreSQL from PGDG
   ansible.builtin.apt:
@@ -44,148 +43,108 @@
     state: present
     update_cache: true
 
-- name: Discover PostgreSQL clusters
+- name: Discover installed PostgreSQL major
   ansible.builtin.command:
-    cmd: pg_lsclusters --no-header
-  register: postgres_clusters
+    argv:
+      - psql
+      - --version
+  register: postgres_psql_version
   changed_when: false
-
-- name: Select matching PostgreSQL cluster lines
-  ansible.builtin.set_fact:
-    postgres_matching_clusters: >-
-      {{ postgres_clusters.stdout_lines
-         | select('search', '^[0-9]+\\s+' ~ postgres_cluster_name ~ '\\s+')
-         | list }}
-
-- name: Create the PostgreSQL cluster when postinst did not
-  when: postgres_matching_clusters | length == 0
-  block:
-    - name: Discover installed PostgreSQL server versions
-      ansible.builtin.command:
-        argv:
-          - find
-          - /usr/lib/postgresql
-          - -mindepth
-          - "1"
-          - -maxdepth
-          - "1"
-          - -type
-          - d
-          - -printf
-          - "%f\n"
-      register: postgres_installed_versions
-      changed_when: false
-      failed_when: false
-
-    - name: Set the PostgreSQL cluster version to create
-      ansible.builtin.set_fact:
-        postgres_cluster_version: >-
-          {{ postgres_version
-             if (postgres_version | string | length > 0)
-             else (postgres_installed_versions.stdout_lines | sort | last | default('')) }}
-
-    - name: Fail when no PostgreSQL server version is installed
-      ansible.builtin.fail:
-        msg: >-
-          PostgreSQL package {{ postgres_package }} installed, but no server
-          version directories were found under /usr/lib/postgresql. Cannot
-          create cluster {{ postgres_cluster_name }}.
-      when: postgres_cluster_version | string | length == 0
-
-    - name: Check whether the persistent data directory already has a cluster
-      ansible.builtin.stat:
-        path: "{{ postgres_data_dir }}/PG_VERSION"
-      register: postgres_existing_data_version
-
-    - name: Read the persistent data directory version
-      ansible.builtin.slurp:
-        src: "{{ postgres_data_dir }}/PG_VERSION"
-      register: postgres_existing_data_pg_version
-      when: postgres_existing_data_version.stat.exists
-
-    - name: Fail when persistent data belongs to a different PostgreSQL major
-      ansible.builtin.fail:
-        msg: >-
-          Existing PostgreSQL data directory {{ postgres_data_dir }} belongs to
-          major version {{ postgres_existing_data_pg_version.content | b64decode | trim }},
-          but the installed server version selected for cluster
-          {{ postgres_cluster_name }} is {{ postgres_cluster_version }}. Pin
-          postgres_version or perform a controlled PostgreSQL upgrade before
-          recreating the postgresql-common cluster config.
-      when:
-        - postgres_existing_data_version.stat.exists
-        - (postgres_existing_data_pg_version.content | b64decode | trim) !=
-          (postgres_cluster_version | string)
-
-    - name: Set pg_createcluster data directory
-      ansible.builtin.set_fact:
-        postgres_createcluster_data_dir: >-
-          {{ postgres_data_root ~ '/.ansible-pg-createcluster-' ~
-             postgres_cluster_version ~ '-' ~ postgres_cluster_name
-             if postgres_existing_data_version.stat.exists
-             else postgres_data_dir }}
-
-    - name: Remove stale temporary pg_createcluster data directory
-      ansible.builtin.file:
-        path: "{{ postgres_createcluster_data_dir }}"
-        state: absent
-      when: postgres_existing_data_version.stat.exists
-
-    - name: Ensure the PostgreSQL version data root exists
-      ansible.builtin.file:
-        path: "{{ postgres_data_root }}/{{ postgres_cluster_version }}"
-        state: directory
-        owner: postgres
-        group: postgres
-        mode: "0750"
-
-    - name: Create the PostgreSQL cluster
-      ansible.builtin.command:
-        argv:
-          - pg_createcluster
-          - --datadir
-          - "{{ postgres_createcluster_data_dir }}"
-          - "{{ postgres_cluster_version }}"
-          - "{{ postgres_cluster_name }}"
-      changed_when: true
-
-    - name: Point recreated cluster config at existing persistent data
-      ansible.builtin.lineinfile:
-        path: "{{ postgres_conf_dir }}/postgresql.conf"
-        regexp: "^data_directory\\s*="
-        line: "data_directory = '{{ postgres_data_dir }}'"
-      when: postgres_existing_data_version.stat.exists
-
-    - name: Remove temporary pg_createcluster data directory
-      ansible.builtin.file:
-        path: "{{ postgres_createcluster_data_dir }}"
-        state: absent
-      when: postgres_existing_data_version.stat.exists
-
-    - name: Re-discover PostgreSQL clusters after explicit creation
-      ansible.builtin.command:
-        cmd: pg_lsclusters --no-header
-      register: postgres_clusters
-      changed_when: false
-
-    - name: Re-select matching PostgreSQL cluster lines
-      ansible.builtin.set_fact:
-        postgres_matching_clusters: >-
-          {{ postgres_clusters.stdout_lines
-             | select('search', '^[0-9]+\\s+' ~ postgres_cluster_name ~ '\\s+')
-             | list }}
-
-- name: Fail when the PostgreSQL cluster is still missing
-  ansible.builtin.fail:
-    msg: >-
-      PostgreSQL cluster {{ postgres_cluster_name }} was not found after
-      package install and explicit pg_createcluster. pg_lsclusters output:
-      {{ postgres_clusters.stdout | default('') | trim | default('<empty>', true) }}
-  when: postgres_matching_clusters | length == 0
 
 - name: Set the PostgreSQL cluster version fact
   ansible.builtin.set_fact:
-    postgres_cluster_version: "{{ (postgres_matching_clusters | first | split)[0] }}"
+    postgres_cluster_version: >-
+      {{ postgres_version
+         if (postgres_version | string | length > 0)
+         else (postgres_psql_version.stdout | regex_search('[0-9]+')) }}
+
+- name: Fail when PostgreSQL major discovery failed
+  ansible.builtin.fail:
+    msg: >-
+      PostgreSQL package {{ postgres_package }} installed, but psql --version
+      did not expose a server major version: {{ postgres_psql_version.stdout }}
+  when: postgres_cluster_version | string | length == 0
+
+- name: Check whether the PostgreSQL cluster config exists
+  ansible.builtin.stat:
+    path: "{{ postgres_conf_dir }}"
+  register: postgres_cluster_config
+
+- name: Check whether the persistent data directory already has a cluster
+  ansible.builtin.stat:
+    path: "{{ postgres_data_dir }}/PG_VERSION"
+  register: postgres_existing_data_version
+
+- name: Read the persistent data directory version
+  ansible.builtin.slurp:
+    src: "{{ postgres_data_dir }}/PG_VERSION"
+  register: postgres_existing_data_pg_version
+  when: postgres_existing_data_version.stat.exists
+
+- name: Fail when persistent data belongs to a different PostgreSQL major
+  ansible.builtin.fail:
+    msg: >-
+      Existing PostgreSQL data directory {{ postgres_data_dir }} belongs to
+      major version {{ postgres_existing_data_pg_version.content | b64decode | trim }},
+      but the installed server version selected for cluster
+      {{ postgres_cluster_name }} is {{ postgres_cluster_version }}. Pin
+      postgres_version or perform a controlled PostgreSQL upgrade before
+      recreating the postgresql-common cluster config.
+  when:
+    - postgres_existing_data_version.stat.exists
+    - (postgres_existing_data_pg_version.content | b64decode | trim) !=
+      (postgres_cluster_version | string)
+
+- name: Set pg_createcluster data directory
+  ansible.builtin.set_fact:
+    postgres_createcluster_data_dir: >-
+      {{ postgres_data_root ~ '/.ansible-pg-createcluster-' ~
+         postgres_cluster_version ~ '-' ~ postgres_cluster_name
+         if postgres_existing_data_version.stat.exists
+         else postgres_data_dir }}
+  when: not postgres_cluster_config.stat.exists
+
+- name: Remove stale temporary pg_createcluster data directory
+  ansible.builtin.file:
+    path: "{{ postgres_createcluster_data_dir }}"
+    state: absent
+  when:
+    - not postgres_cluster_config.stat.exists
+    - postgres_existing_data_version.stat.exists
+
+- name: Create the PostgreSQL cluster when config is absent
+  ansible.builtin.command:
+    argv:
+      - pg_createcluster
+      - --datadir
+      - "{{ postgres_createcluster_data_dir }}"
+      - "{{ postgres_cluster_version }}"
+      - "{{ postgres_cluster_name }}"
+  changed_when: true
+  when: not postgres_cluster_config.stat.exists
+
+- name: Point recreated cluster config at existing persistent data
+  ansible.builtin.lineinfile:
+    path: "{{ postgres_conf_dir }}/postgresql.conf"
+    regexp: "^data_directory\\s*="
+    line: "data_directory = '{{ postgres_data_dir }}'"
+  when:
+    - not postgres_cluster_config.stat.exists
+    - postgres_existing_data_version.stat.exists
+
+- name: Remove temporary pg_createcluster data directory
+  ansible.builtin.file:
+    path: "{{ postgres_createcluster_data_dir }}"
+    state: absent
+  when:
+    - not postgres_cluster_config.stat.exists
+    - postgres_existing_data_version.stat.exists
+
+- name: Ensure the PostgreSQL cluster config exists
+  ansible.builtin.stat:
+    path: "{{ postgres_conf_dir }}/postgresql.conf"
+  register: postgres_cluster_config_file
+  failed_when: not postgres_cluster_config_file.stat.exists
 
 - name: Ensure the PostgreSQL cluster service is started and enabled
   ansible.builtin.systemd:

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -1,0 +1,233 @@
+---
+# Native PostgreSQL (PGDG) for the shared homelab database backend (issue #138).
+# All persistent state lives on the container's ZFS bind mount at
+# postgres_data_root, so a ChaosMonkey rebuild reconstructs the cluster config,
+# roles, and databases from Ansible while the data on the mount survives.
+
+# =============================================================================
+# Phase 1: PGDG apt repository
+# =============================================================================
+- name: Install apt prerequisites
+  ansible.builtin.apt:
+    name:
+      - ca-certificates
+      - python3-psycopg2   # community.postgresql modules connect via psycopg2
+      - acl                # become_user:postgres file ops on unprivileged tmp
+    state: present
+    update_cache: true
+
+- name: Install the PGDG repository signing key
+  ansible.builtin.get_url:
+    url: "{{ postgres_pgdg_key_url }}"
+    dest: "{{ postgres_pgdg_keyring }}"
+    mode: "0644"
+    owner: root
+    group: root
+
+- name: Add the PGDG apt repository
+  ansible.builtin.apt_repository:
+    repo: "{{ postgres_pgdg_repo }}"
+    filename: pgdg
+    state: present
+    update_cache: true
+
+# =============================================================================
+# Phase 2: Install PostgreSQL
+# The postgresql-common postinst creates the `postgres` user and auto-creates
+# the default PGDG main cluster. With the ZFS dataset bind-mounted at
+# postgres_data_root, that cluster is created ON the persistent mount.
+# =============================================================================
+- name: Install PostgreSQL from PGDG
+  ansible.builtin.apt:
+    name: "{{ postgres_package }}"
+    state: present
+    update_cache: true
+
+- name: Discover the installed PostgreSQL main cluster
+  ansible.builtin.command:
+    cmd: pg_lsclusters --no-header
+  register: postgres_clusters
+  changed_when: false
+
+- name: Set the PostgreSQL cluster version fact
+  ansible.builtin.set_fact:
+    postgres_cluster_version: >-
+      {{ (postgres_clusters.stdout_lines
+          | select('search', '^[0-9]+\\s+' ~ postgres_cluster_name ~ '\\s+')
+          | first
+          | split)[0] }}
+
+- name: Ensure the PostgreSQL cluster service is started and enabled
+  ansible.builtin.systemd:
+    name: "postgresql@{{ postgres_cluster_version }}-{{ postgres_cluster_name }}"
+    state: started
+    enabled: true
+
+# =============================================================================
+# Phase 3: Cluster configuration (idempotent GUCs)
+# postgresql_set only writes when the value differs, so the idempotence run is
+# clean. listen_addresses/port need a restart; password_encryption reloads.
+# =============================================================================
+- name: Configure cluster GUCs
+  become: true
+  become_user: postgres
+  vars:
+    ansible_ssh_pipelining: true
+  block:
+    - name: Set listen_addresses
+      community.postgresql.postgresql_set:
+        name: listen_addresses
+        value: "{{ postgres_listen_addresses }}"
+      notify: Restart postgresql
+
+    - name: Set port
+      community.postgresql.postgresql_set:
+        name: port
+        value: "{{ postgres_port }}"
+      notify: Restart postgresql
+
+    - name: Enforce scram-sha-256 password encryption
+      community.postgresql.postgresql_set:
+        name: password_encryption
+        value: "{{ postgres_password_encryption }}"
+      notify: Reload postgresql
+
+# Apply a pending restart NOW so the remote listener + scram are live before we
+# create roles and run the health check (handlers otherwise flush at play end).
+- name: Apply pending PostgreSQL restart/reload
+  ansible.builtin.meta: flush_handlers
+
+# =============================================================================
+# Phase 4: Roles, databases, and host-based auth
+# Credentials are generate-if-absent: a role's password is set only when the
+# role does not yet exist, which keeps the run idempotent under scram (whose
+# salted verifier cannot be recomputed for comparison) and matches the
+# workspace "generate at the source, idempotent" secrets convention.
+# =============================================================================
+- name: Provision managed roles and databases
+  become: true
+  become_user: postgres
+  block:
+    - name: List existing login roles
+      community.postgresql.postgresql_query:
+        query: "SELECT rolname FROM pg_roles"
+      register: postgres_existing_roles
+      changed_when: false
+
+    - name: Create the login role for each managed database (password set once)
+      community.postgresql.postgresql_user:
+        name: "{{ item.user }}"
+        password: "{{ item.password }}"
+        role_attr_flags: LOGIN
+        state: present
+      loop: "{{ postgres_managed_databases }}"
+      loop_control:
+        label: "{{ item.user }}"
+      no_log: true
+      when: >-
+        item.user not in
+        (postgres_existing_roles.query_result | map(attribute='rolname') | list)
+
+    - name: Ensure each managed login role exists (no password change)
+      community.postgresql.postgresql_user:
+        name: "{{ item.user }}"
+        role_attr_flags: LOGIN
+        state: present
+      loop: "{{ postgres_managed_databases }}"
+      loop_control:
+        label: "{{ item.user }}"
+
+    - name: Create each managed database owned by its role
+      community.postgresql.postgresql_db:
+        name: "{{ item.name }}"
+        owner: "{{ item.user }}"
+        encoding: UTF-8
+        state: present
+      loop: "{{ postgres_managed_databases }}"
+      loop_control:
+        label: "{{ item.name }}"
+
+    - name: Grant the owning role all privileges on its database
+      community.postgresql.postgresql_privs:
+        database: "{{ item.name }}"
+        roles: "{{ item.user }}"
+        type: database
+        privs: ALL
+        state: present
+      loop: "{{ postgres_managed_databases }}"
+      loop_control:
+        label: "{{ item.name }}"
+
+    - name: Allow each managed user to connect from its client CIDR (scram)
+      community.postgresql.postgresql_pg_hba:
+        dest: "{{ postgres_conf_dir }}/pg_hba.conf"
+        contype: host
+        databases: "{{ item.name }}"
+        users: "{{ item.user }}"
+        source: "{{ item.client_cidr }}"
+        method: scram-sha-256
+        state: present
+      loop: "{{ postgres_managed_databases }}"
+      loop_control:
+        label: "{{ item.name }} <- {{ item.client_cidr }}"
+      notify: Reload postgresql
+
+- name: Apply pending pg_hba reload
+  ansible.builtin.meta: flush_handlers
+
+# =============================================================================
+# Phase 5: pg_dump backups on the persistent mount, via a systemd timer
+# =============================================================================
+- name: Configure pg_dump backups
+  when: postgres_backup_enabled | bool
+  block:
+    - name: Create the backup directory on the persistent mount
+      ansible.builtin.file:
+        path: "{{ postgres_backup_dir }}"
+        state: directory
+        owner: postgres
+        group: postgres
+        mode: "0750"
+
+    - name: Deploy the pg_dump backup script
+      ansible.builtin.template:
+        src: pg-backup.sh.j2
+        dest: /usr/local/bin/pg-backup.sh
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Deploy the pg_dump backup systemd service
+      ansible.builtin.template:
+        src: pg-backup.service.j2
+        dest: /etc/systemd/system/pg-backup.service
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Deploy the pg_dump backup systemd timer
+      ansible.builtin.template:
+        src: pg-backup.timer.j2
+        dest: /etc/systemd/system/pg-backup.timer
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Enable and start the pg_dump backup timer
+      ansible.builtin.systemd:
+        name: pg-backup.timer
+        state: started
+        enabled: true
+        daemon_reload: true
+
+# =============================================================================
+# Phase 6: Health check
+# =============================================================================
+- name: Verify PostgreSQL answers a trivial query
+  become: true
+  become_user: postgres
+  community.postgresql.postgresql_ping:
+    db: postgres
+  register: postgres_ping
+  failed_when: not postgres_ping.is_available
+  changed_when: false

--- a/roles/postgres/templates/pg-backup.service.j2
+++ b/roles/postgres/templates/pg-backup.service.j2
@@ -1,8 +1,8 @@
 [Unit]
 # {{ ansible_managed }}
 Description=PostgreSQL pg_dump backup to the persistent mount
-After=postgresql@{{ postgres_version }}-main.service
-Wants=postgresql@{{ postgres_version }}-main.service
+After=postgresql@{{ postgres_cluster_version }}-{{ postgres_cluster_name }}.service
+Wants=postgresql@{{ postgres_cluster_version }}-{{ postgres_cluster_name }}.service
 
 [Service]
 Type=oneshot

--- a/roles/postgres/templates/pg-backup.service.j2
+++ b/roles/postgres/templates/pg-backup.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+# {{ ansible_managed }}
+Description=PostgreSQL pg_dump backup to the persistent mount
+After=postgresql@{{ postgres_version }}-main.service
+Wants=postgresql@{{ postgres_version }}-main.service
+
+[Service]
+Type=oneshot
+User=postgres
+Group=postgres
+ExecStart=/usr/local/bin/pg-backup.sh
+# Backups are local disk I/O; never let a slow dump wedge the timer forever.
+TimeoutStartSec=3600

--- a/roles/postgres/templates/pg-backup.sh.j2
+++ b/roles/postgres/templates/pg-backup.sh.j2
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# {{ ansible_managed }}
+# Per-database pg_dump to the persistent ZFS mount, then prune dumps older than
+# the retention window. Runs as the postgres user (see pg-backup.service), so it
+# authenticates to the local cluster over the unix socket (peer auth).
+set -euo pipefail
+
+BACKUP_DIR="{{ postgres_backup_dir }}"
+RETENTION_DAYS="{{ postgres_backup_retention_days }}"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+
+mkdir -p "$BACKUP_DIR"
+
+{% for db in postgres_managed_databases %}
+pg_dump --format=custom --dbname="{{ db.name }}" \
+  --file="${BACKUP_DIR}/{{ db.name }}-${STAMP}.dump"
+{% endfor %}
+
+# Retention: drop dumps older than the window. -mtime +N counts whole days.
+find "$BACKUP_DIR" -maxdepth 1 -type f -name '*.dump' \
+  -mtime "+${RETENTION_DAYS}" -delete

--- a/roles/postgres/templates/pg-backup.timer.j2
+++ b/roles/postgres/templates/pg-backup.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+# {{ ansible_managed }}
+Description=Schedule PostgreSQL pg_dump backups
+
+[Timer]
+OnCalendar={{ postgres_backup_on_calendar }}
+RandomizedDelaySec={{ postgres_backup_randomized_delay_sec }}
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/tests/nautobot_export_shape.py
+++ b/tests/nautobot_export_shape.py
@@ -1,0 +1,178 @@
+"""Fixture check for the Nautobot export contract shape."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPORT_JOB = ROOT / "roles/nautobot/files/jobs/export_nautobot.py"
+SCHEMA = ROOT / "roles/nautobot/files/contracts/nautobot-export-v1.json"
+
+
+class Manager(list):
+    """Tiny stand-in for a Django model manager."""
+
+    def all(self) -> list[Any]:
+        """Return all stored objects."""
+        return list(self)
+
+
+class Related(list):
+    """Tiny stand-in for a Django related manager."""
+
+    def all(self) -> list[Any]:
+        """Return all related objects."""
+        return list(self)
+
+
+class Object:
+    """Simple object with named attributes."""
+
+    def __init__(self, **attrs: Any) -> None:
+        self.__dict__.update(attrs)
+
+
+class VLAN:
+    """Fake Nautobot VLAN model."""
+
+
+class Prefix:
+    """Fake Nautobot Prefix model."""
+
+
+class IPAddress:
+    """Fake Nautobot IPAddress model."""
+
+
+class Device:
+    """Fake Nautobot Device model."""
+
+
+class Interface:
+    """Fake Nautobot Interface model."""
+
+
+class Rack:
+    """Fake Nautobot Rack model."""
+
+
+def install_import_stubs() -> None:
+    """Install enough modules for importing the Nautobot job file."""
+    boto3 = types.ModuleType("boto3")
+    boto3.client = lambda *_args, **_kwargs: None
+    sys.modules["boto3"] = boto3
+
+    jobs = types.ModuleType("nautobot.apps.jobs")
+    jobs.Job = object
+    jobs.register_jobs = lambda *_args, **_kwargs: None
+
+    dcim_models = types.ModuleType("nautobot.dcim.models")
+    dcim_models.Device = Device
+    dcim_models.Interface = Interface
+    dcim_models.Rack = Rack
+
+    ipam_models = types.ModuleType("nautobot.ipam.models")
+    ipam_models.VLAN = VLAN
+    ipam_models.IPAddress = IPAddress
+    ipam_models.Prefix = Prefix
+
+    for name in (
+        "nautobot",
+        "nautobot.apps",
+        "nautobot.dcim",
+        "nautobot.ipam",
+    ):
+        sys.modules[name] = types.ModuleType(name)
+    sys.modules["nautobot.apps.jobs"] = jobs
+    sys.modules["nautobot.dcim.models"] = dcim_models
+    sys.modules["nautobot.ipam.models"] = ipam_models
+
+
+def load_export_module() -> Any:
+    """Import the export job module with fake Nautobot dependencies."""
+    install_import_stubs()
+    spec = importlib.util.spec_from_file_location("export_nautobot", EXPORT_JOB)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> None:
+    """Build a sample export and validate its contract shape."""
+    module = load_export_module()
+
+    vlan_group = Object(name="example-group")
+    VLAN.objects = Manager([Object(vid=10, name="example-mgmt", vlan_group=vlan_group)])
+
+    Prefix.objects = Manager(
+        [Object(prefix="192.0.2.0/24", vlan_id=1, vlan=Object(vid=10), role=Object(name="mgmt"))]
+    )
+
+    rack = Object(name="rack-1", location=Object(name="example-site"), u_height=42)
+    Rack.objects = Manager([rack])
+
+    device = Object(name="example-node-1", role=Object(name="server"), rack=rack)
+    bmc_interface = Object(
+        device=device,
+        name="BMC",
+        mac_address="02:00:00:00:00:60",
+        type="other",
+        mgmt_only=True,
+    )
+    primary_interface = Object(
+        device=device,
+        name="eth0",
+        mac_address="02:00:00:00:00:10",
+        type="1000base-t",
+        mgmt_only=False,
+    )
+    bmc_ip = Object(address="192.0.2.60/24")
+    primary_ip = Object(
+        address="192.0.2.10/24",
+        dns_name="node-1.example.com",
+        interfaces=Related([primary_interface]),
+    )
+    bmc_interface.ip_addresses = Related([bmc_ip])
+    primary_interface.ip_addresses = Related([primary_ip])
+    device.interfaces = Related([bmc_interface, primary_interface])
+
+    Device.objects = Manager([device])
+    Interface.objects = Manager([bmc_interface, primary_interface])
+    IPAddress.objects = Manager([primary_ip])
+
+    document = module.build_export()
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    required = schema["required"]
+
+    assert list(document) == required, list(document)
+    defs_by_collection = {
+        "vlans": "vlan",
+        "prefixes": "prefix",
+        "ip_addresses": "ipAddress",
+        "devices": "device",
+        "racks": "rack",
+        "interfaces": "interface",
+    }
+    for collection in required[1:]:
+        expected_item_keys = schema["$defs"][defs_by_collection[collection]]["required"]
+        assert list(document[collection][0]) == expected_item_keys, document[collection][0]
+
+    jsonschema_status = "skipped"
+    try:
+        import jsonschema
+    except ModuleNotFoundError:
+        pass
+    else:
+        jsonschema.validate(instance=document, schema=schema)
+        jsonschema_status = "validated"
+
+    print("export_shape_ok", ",".join(document.keys()), f"jsonschema={jsonschema_status}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add native PGDG PostgreSQL shared database role with unpinned PGDG stable package, scram pg_hba, managed Nautobot DB/user, and pg_dump timer
- add native Nautobot role with venv install, Redis loopback, bao-first secrets with env fallback, systemd services, SSoT jobs, seed bundle assembly, export job, and onboarding setup scaffold
- wire tofu tags, group vars, OpenBao apps domain, site ordering, community.postgresql dependency, and Molecule CI matrix entries

Refs: dryvist/docs-starlight#138

## Validation
- `nix develop -c ansible-lint` fails in this repo because there is no local flake; documented shell is `.envrc` remote flake `github:JacobPEvans/nix-devenv#ansible-apps`
- `nix develop github:JacobPEvans/nix-devenv#ansible-apps -c ansible-lint` passed: `Passed: 0 failure(s), 0 warning(s) on 735 files`
- `nix develop github:JacobPEvans/nix-devenv#ansible-apps -c molecule test -s postgres` attempted; blocked by local molecule docker plugin failure before create/converge: strict Ansible 2.21 conditional failure in plugin destroy play `when: (lookup('env', 'HOME'))`
- `nix develop github:JacobPEvans/nix-devenv#ansible-apps -c molecule test -s nautobot` attempted; same local molecule docker plugin failure
- fallback syntax checks passed:
  - `ansible-playbook --syntax-check -i localhost, molecule/postgres/converge.yml` -> `postgres-converge-syntax-ok`
  - `ansible-playbook --syntax-check -i localhost, molecule/nautobot/converge.yml` -> `nautobot-converge-syntax-ok`
  - `ansible-playbook --syntax-check -i inventory/hosts.yml playbooks/site.yml` -> `site-syntax-ok`
- Python payload syntax passed: `python -m py_compile ...` -> `py_compile-ok`
- `git diff --check` passed

## Notes
- Nautobot packages are installed by `ansible.builtin.pip` from the public pip resolver; no private index or `extra_args` is configured. Package names match upstream/PyPI docs: `nautobot`, `nautobot-ssot`, `nautobot-device-onboarding`.
- This repo currently does not ruff/pyright/type-check role `files/*.py` payloads. Evidence: `.pre-commit-config.yaml` only configures pre-commit-hooks, yamllint, ansible-lint, and markdownlint; no `pyproject.toml`, `ruff.toml`, `pyrightconfig.json`, `mypy.ini`, or `setup.cfg` exists.
