### PR TITLE
feat(agentgateway): add agentgateway_docker role + monitoring/deadman wiring

### DIFF
--- a/inventory/group_vars/agentgateway_group.yml
+++ b/inventory/group_vars/agentgateway_group.yml
@@ -1,0 +1,9 @@
+---
+# agentgateway LXC (tag `agentgateway` → agentgateway_group via load_tofu.yml).
+# Role config lives in roles/agentgateway_docker/defaults; only group-level
+# reliability wiring belongs here.
+
+# Restart the Docker engine on failure (Phase 9 systemd restart policy);
+# the gateway container itself carries restart: unless-stopped in compose.
+systemd_restart_policy_services:
+  - docker

--- a/inventory/group_vars/prometheus_group.yml
+++ b/inventory/group_vars/prometheus_group.yml
@@ -42,6 +42,10 @@ prometheus_stack_extra_scrape_configs: |
     scrape_interval: 60s
     static_configs:
       - targets: {{ pve_node_exporter_scrape_targets | to_json }}
+  - job_name: agentgateway
+    static_configs:
+      - targets: ["agentgateway.{{ hostvars['localhost']['tofu_data']['domain'] }}:{{
+          hostvars['localhost']['tofu_data']['constants']['service_ports']['agentgateway_admin'] }}"]
 
 # Forward blackbox + smokeping metrics to Cribl Stream → Splunk (index=netmon_metrics).
 # Points at cribl-stream-01 directly (no HAProxy — WAL provides delivery durability).

--- a/inventory/load_tofu.yml
+++ b/inventory/load_tofu.yml
@@ -203,6 +203,11 @@
               else []
             ) +
             (
+              ['agentgateway_group']
+              if 'agentgateway' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
               ['apt_cacher_group']
               if 'apt-cache' in (item.value.tags | default([]))
               else []

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -509,7 +509,7 @@
 # =============================================================================
 
 - name: Deploy keystone SPOF deadman watchdog
-  hosts: technitium_dns_group:traefik_group:haproxy_group:openbao_group
+  hosts: technitium_dns_group:traefik_group:haproxy_group:openbao_group:agentgateway_group
   become: true
   gather_facts: false
   tags:
@@ -758,6 +758,16 @@
     - observability
   roles:
     - role: langfuse_docker
+
+- name: Configure agentgateway MCP/LLM/A2A data plane
+  hosts: agentgateway_group
+  become: true
+  gather_facts: true
+  tags:
+    - agentgateway_docker
+    - ai-orchestration
+  roles:
+    - role: agentgateway_docker
 
 # =============================================================================
 # Phase 8b: OpenProject Community Edition

--- a/roles/agentgateway_docker/defaults/main.yml
+++ b/roles/agentgateway_docker/defaults/main.yml
@@ -1,0 +1,82 @@
+---
+# agentgateway — AI-first data plane (agentgateway.dev, AAIF/Linux Foundation).
+# Unifies MCP, LLM, and A2A traffic behind one governed proxy. Deployed as a
+# single-container Docker-Compose-in-LXC stack. MCP-first: only MCP/tool
+# traffic flows through the gateway; agents keep dialing the LiteLLM router
+# directly for inference (LLM routing through the gateway is a later opt-in).
+#
+# The gateway config is fully regenerated from the template on every converge
+# (config as code — no state on the guest worth backing up).
+
+# =============================================================================
+# Container image — pinned. Bump via Renovate or manual review.
+# cr.agentgateway.dev is the upstream-documented registry (mirrors ghcr.io).
+# =============================================================================
+agentgateway_docker_image: "cr.agentgateway.dev/agentgateway:v1.3.1"
+
+agentgateway_docker_container_name: agentgateway
+
+# Restart policy for the gateway service.
+agentgateway_docker_restart_policy: unless-stopped
+
+# =============================================================================
+# Filesystem layout — config only; the gateway itself is stateless.
+# =============================================================================
+agentgateway_docker_data_dir: /opt/agentgateway
+
+# =============================================================================
+# Ports — pulled from the OpenTofu pipeline_constants (DRY: no port literals).
+# proxy  = MCP/LLM/A2A traffic port callers dial
+# admin  = admin UI / xDS / Prometheus metrics (Traefik-fronted, internal-only)
+# =============================================================================
+_agentgateway_docker_port_err: >-
+  tofu_data.constants.service_ports.agentgateway_* missing —
+  regenerate tofu_inventory.json via
+  `terragrunt output -json ansible_inventory`.
+agentgateway_docker_proxy_port: >-
+  {{ hostvars['localhost']['tofu_data']
+     ['constants']['service_ports']['agentgateway_proxy']
+     | mandatory(_agentgateway_docker_port_err) }}
+agentgateway_docker_admin_port: >-
+  {{ hostvars['localhost']['tofu_data']
+     ['constants']['service_ports']['agentgateway_admin']
+     | mandatory(_agentgateway_docker_port_err) }}
+
+# =============================================================================
+# MCP targets — the tool servers the gateway multiplexes on the proxy port.
+# Every runtime (Claude Code, Codex, Hermes, ...) dials the gateway once and
+# sees the union of these targets' tools.
+#
+# Auth: passthrough. The gateway forwards the caller's Authorization header to
+# the backend, so the Splunk MCP target keeps its own token contract (tokens
+# minted by Splunk's GET /services/mcp_token, aud=mcp). A gateway-held
+# backendAuth key (from OpenBao) is a planned follow-up so callers need no
+# per-backend credential.
+#
+# tls_insecure skips backend certificate verification — required for the
+# Splunk management port's self-signed cert; never set it for public targets.
+# =============================================================================
+agentgateway_docker_splunk_mcp_host: >-
+  https://{{ hostvars['localhost']['tofu_data']['splunk_vm']['splunk']['hostname'] }}.{{
+  hostvars['localhost']['tofu_data']['domain'] }}:{{
+  hostvars['localhost']['tofu_data']['constants']['service_ports']['splunk_mgmt']
+  }}/services/mcp
+
+agentgateway_docker_mcp_targets:
+  - name: splunk
+    host: "{{ agentgateway_docker_splunk_mcp_host }}"
+    tls_insecure: true
+  # Context7 (library docs MCP) — proves the outbound-HTTPS federation path.
+  # Keyless tier; add a backendAuth key via OpenBao if rate limits bite.
+  - name: context7
+    host: "https://mcp.context7.com/mcp"
+
+# =============================================================================
+# Tracing — OTLP/HTTP to the shared Cribl Edge receiver (telemetry always via
+# Cribl; Cribl forks to Langfuse + Splunk). Endpoint contract comes from
+# group_vars/all.yml. Sampling: keep everything while traffic is low.
+# =============================================================================
+agentgateway_docker_otlp_endpoint: >-
+  {{ ai_orchestration_otel_endpoint
+     | mandatory('ai_orchestration_otel_endpoint must be set in group_vars (Cribl Edge OTLP receiver URL)') }}
+agentgateway_docker_trace_sampling: "true"

--- a/roles/agentgateway_docker/handlers/main.yml
+++ b/roles/agentgateway_docker/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+# Use state: present with recreate: always so config-only changes (which don't
+# restart healthy containers) trigger a full recreate against the new compose
+# file and freshly-mounted gateway config.
+- name: Restart agentgateway
+  community.docker.docker_compose_v2:
+    project_src: "{{ agentgateway_docker_data_dir }}"
+    state: present
+    recreate: always

--- a/roles/agentgateway_docker/meta/main.yml
+++ b/roles/agentgateway_docker/meta/main.yml
@@ -1,0 +1,29 @@
+---
+galaxy_info:
+  author: Jacob Evans
+  description: >-
+    agentgateway (agentgateway.dev) — AI-first data plane unifying MCP, LLM,
+    and A2A traffic behind one governed proxy, on an LXC container via
+    Docker Compose. MCP-first deployment: multiplexes MCP tool servers to
+    every agent runtime; OTLP traces to the shared Cribl Edge receiver.
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+  galaxy_tags:
+    - ai
+    - mcp
+    - gateway
+    - docker
+
+dependencies:
+  # Shared Docker-in-LXC bootstrap (docker-ce + compose plugin, LXC-conditional
+  # fuse-overlayfs). configure_daemon_json pins the fuse-overlayfs storage
+  # driver (required on ZFS-backed LXC).
+  - role: docker_engine
+    docker_engine_configure_daemon_json: true
+
+collections:
+  - community.docker

--- a/roles/agentgateway_docker/tasks/main.yml
+++ b/roles/agentgateway_docker/tasks/main.yml
@@ -1,0 +1,70 @@
+---
+# agentgateway Docker deployment.
+#
+# Installs Docker + Compose on the target LXC (docker_engine meta dependency),
+# renders the gateway config from vars (config as code — regenerated every
+# converge), and deploys the single agentgateway container via Docker Compose.
+# The gateway is stateless: recovery = re-apply the LXC + re-run this role.
+
+- name: Create agentgateway data directory
+  ansible.builtin.file:
+    path: "{{ agentgateway_docker_data_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Deploy agentgateway config
+  ansible.builtin.template:
+    src: config.yaml.j2
+    dest: "{{ agentgateway_docker_data_dir }}/config.yaml"
+    owner: root
+    group: root
+    mode: "0600" # may carry backend auth keys later; locked down from day one
+  notify: Restart agentgateway
+
+- name: Deploy agentgateway docker-compose template
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ agentgateway_docker_data_dir }}/docker-compose.yml"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart agentgateway
+
+- name: Deploy agentgateway via docker compose
+  community.docker.docker_compose_v2:
+    project_src: "{{ agentgateway_docker_data_dir }}"
+    state: present
+  register: agentgateway_docker_compose_result
+  changed_when: >-
+    (agentgateway_docker_compose_result.actions | default([]))
+    | selectattr('status', 'in', ['Creating', 'Recreating', 'Pulling', 'Building'])
+    | list | length > 0
+
+# Apply any pending config-change restart before health-checking, so the
+# checks validate the NEW config rather than the previous container.
+- name: Flush handlers (restart on config change before health check)
+  ansible.builtin.meta: flush_handlers
+
+# =============================================================================
+# Health check — the image is distroless (no shell), so liveness is verified
+# from the LXC, not via an in-container Docker healthcheck.
+# =============================================================================
+
+- name: Wait for agentgateway proxy port to be ready
+  ansible.builtin.wait_for:
+    host: 127.0.0.1
+    port: "{{ agentgateway_docker_proxy_port | int }}"
+    timeout: 120
+
+- name: Verify agentgateway admin metrics endpoint responds
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ agentgateway_docker_admin_port }}/metrics"
+    method: GET
+    status_code: 200
+  register: agentgateway_docker_health
+  retries: 12
+  delay: 5
+  until: agentgateway_docker_health.status == 200
+  changed_when: false

--- a/roles/agentgateway_docker/templates/config.yaml.j2
+++ b/roles/agentgateway_docker/templates/config.yaml.j2
@@ -1,0 +1,28 @@
+# {{ ansible_managed }}
+# agentgateway static config — regenerated on every converge (config as code).
+# Schema: https://agentgateway.dev/schema/config
+config:
+  tracing:
+    # OTLP/HTTP to the shared Cribl Edge receiver; Cribl forks to
+    # Langfuse + Splunk (no direct exporters — telemetry always via Cribl).
+    otlpEndpoint: "{{ agentgateway_docker_otlp_endpoint }}"
+    otlpProtocol: http
+    randomSampling: {{ agentgateway_docker_trace_sampling }}
+
+binds:
+- port: {{ agentgateway_docker_proxy_port }}
+  listeners:
+  - routes:
+    - backends:
+      - mcp:
+          targets:
+{% for target in agentgateway_docker_mcp_targets %}
+          - name: {{ target.name }}
+            mcp:
+              host: {{ target.host }}
+{% if target.tls_insecure | default(false) %}
+            policies:
+              backendTLS:
+                insecure: true
+{% endif %}
+{% endfor %}

--- a/roles/agentgateway_docker/templates/docker-compose.yml.j2
+++ b/roles/agentgateway_docker/templates/docker-compose.yml.j2
@@ -1,0 +1,16 @@
+# {{ ansible_managed }}
+services:
+  agentgateway:
+    image: {{ agentgateway_docker_image }}
+    container_name: {{ agentgateway_docker_container_name }}
+    restart: {{ agentgateway_docker_restart_policy }}
+    command: ["-f", "/config.yaml"]
+    environment:
+      # Bind the admin UI/xDS/metrics port on all interfaces so the LXC can
+      # publish it (Traefik fronts it; the guest firewall scopes it internal).
+      ADMIN_ADDR: "0.0.0.0:{{ agentgateway_docker_admin_port }}"
+    ports:
+      - "{{ agentgateway_docker_proxy_port }}:{{ agentgateway_docker_proxy_port }}"
+      - "{{ agentgateway_docker_admin_port }}:{{ agentgateway_docker_admin_port }}"
+    volumes:
+      - "{{ agentgateway_docker_data_dir }}/config.yaml:/config.yaml:ro"

--- a/roles/service_deadman/defaults/main.yml
+++ b/roles/service_deadman/defaults/main.yml
@@ -54,6 +54,17 @@ service_deadman_group_checks:
     - name: nginx-syslog-lb
       probe_command: "systemctl is-active --quiet nginx.service"
       healthcheck_url: "{{ lookup('env', 'DEADMAN_HC_URL_NGINX') | default('', true) }}"
+  agentgateway_group:
+    # The shared MCP tool plane — every agent runtime dials it, so a silent
+    # failure breaks tools for the whole fleet. The image is distroless, so
+    # probe from the LXC: docker up + admin metrics endpoint serving.
+    - name: agentgateway
+      probe_command: >-
+        systemctl is-active --quiet docker &&
+        curl -fsS -m 5 http://127.0.0.1:{{
+        tofu_data.constants.service_ports.agentgateway_admin }}/metrics
+        >/dev/null 2>&1
+      healthcheck_url: "{{ lookup('env', 'DEADMAN_HC_URL_AGENTGATEWAY') | default('', true) }}"
   openbao_group:
     # `bao status` exits 0 only when THIS node is unsealed (2 = sealed, 1 =
     # error/unreachable) — a direct seal+liveness probe. Hit the node's own VLAN


### PR DESCRIPTION
## Summary

Deploys **agentgateway** (agentgateway.dev — the AAIF/Linux Foundation MCP/LLM/A2A data plane) on the dedicated LXC that terraform-proxmox #562 defined (now applied). MCP-first scope: the gateway multiplexes MCP tool servers to every agent runtime; inference keeps dialing the LiteLLM router directly.

### New role `agentgateway_docker`
- Single-container compose stack, pinned `cr.agentgateway.dev/agentgateway:v1.3.1` (Renovate-managed), `restart: unless-stopped`, read-only config mount.
- Gateway config is fully templated (config as code, regenerated each converge): MCP targets **splunk** (Splunk MCP, `/services/mcp`, backend TLS verification skipped for the self-signed mgmt cert) and **context7** (external HTTPS federation), ports DRY from the tofu `pipeline_constants`.
- Tracing: OTLP/HTTP to the shared Cribl Edge receiver (`ai_orchestration_otel_endpoint`) — telemetry always via Cribl; Cribl forks to Langfuse + Splunk.
- Health: distroless image (no shell) → role-level `wait_for` + `/metrics` probe instead of an in-container healthcheck.
- Auth: passthrough (callers keep the Splunk aud=mcp token contract). Gateway-held OpenBao-backed `backendAuth` is a documented follow-up.

### Monitoring + reliability wiring
- `load_tofu.yml`: `agentgateway` tag → `agentgateway_group`.
- `site.yml`: converge play; host added to the keystone `service_deadman` play.
- `service_deadman`: group check — docker active + admin `/metrics` serving (`DEADMAN_HC_URL_AGENTGATEWAY` optional ping).
- `prometheus_group`: `agentgateway` scrape job against the admin metrics port by FQDN.
- `systemd_restart_policy`: docker engine restart policy on the guest.

## Verification
- `ansible-lint` (production profile): 0 failures on the role and every edited shared file.
- Converge + live MCP tool-call verification happens post-merge (gated on the DHCP reservation + DNS A record landing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MktvVScwVZZZj84gH7bknt