### PR TITLE
fix(agentgateway): path-scope each MCP target on its own route

### DIFF
--- a/inventory/group_vars/prometheus_group.yml
+++ b/inventory/group_vars/prometheus_group.yml
@@ -43,9 +43,11 @@ prometheus_stack_extra_scrape_configs: |
     static_configs:
       - targets: {{ pve_node_exporter_scrape_targets | to_json }}
   - job_name: agentgateway
+    # The agentgateway DNS name is a Traefik ingress alias, so scrape the
+    # guest by its inventory-derived reserved address (no literal IP).
     static_configs:
-      - targets: ["agentgateway.{{ hostvars['localhost']['tofu_data']['domain'] }}:{{
-          hostvars['localhost']['tofu_data']['constants']['service_ports']['agentgateway_admin'] }}"]
+      - targets: ["{{ hostvars['localhost']['tofu_data']['containers']['agentgateway']['reserved_ip'] }}:{{
+          hostvars['localhost']['tofu_data']['constants']['service_ports']['agentgateway_metrics'] }}"]
 
 # Forward blackbox + smokeping metrics to Cribl Stream → Splunk (index=netmon_metrics).
 # Points at cribl-stream-01 directly (no HAProxy — WAL provides delivery durability).

--- a/roles/agentgateway_docker/defaults/main.yml
+++ b/roles/agentgateway_docker/defaults/main.yml
@@ -26,8 +26,10 @@ agentgateway_docker_data_dir: /opt/agentgateway
 
 # =============================================================================
 # Ports — pulled from the OpenTofu pipeline_constants (DRY: no port literals).
-# proxy  = MCP/LLM/A2A traffic port callers dial
-# admin  = admin UI / xDS / Prometheus metrics (Traefik-fronted, internal-only)
+# proxy   = MCP/LLM/A2A traffic port callers dial (Traefik-fronted as
+#           https://mcp.<domain>)
+# admin   = admin UI / xDS config dump (Traefik-fronted, internal-only)
+# metrics = stats server Prometheus /metrics (scraped directly, internal-only)
 # =============================================================================
 _agentgateway_docker_port_err: >-
   tofu_data.constants.service_ports.agentgateway_* missing —
@@ -40,6 +42,10 @@ agentgateway_docker_proxy_port: >-
 agentgateway_docker_admin_port: >-
   {{ hostvars['localhost']['tofu_data']
      ['constants']['service_ports']['agentgateway_admin']
+     | mandatory(_agentgateway_docker_port_err) }}
+agentgateway_docker_metrics_port: >-
+  {{ hostvars['localhost']['tofu_data']
+     ['constants']['service_ports']['agentgateway_metrics']
      | mandatory(_agentgateway_docker_port_err) }}
 
 # =============================================================================

--- a/roles/agentgateway_docker/defaults/main.yml
+++ b/roles/agentgateway_docker/defaults/main.yml
@@ -43,15 +43,16 @@ agentgateway_docker_admin_port: >-
      | mandatory(_agentgateway_docker_port_err) }}
 
 # =============================================================================
-# MCP targets — the tool servers the gateway multiplexes on the proxy port.
-# Every runtime (Claude Code, Codex, Hermes, ...) dials the gateway once and
-# sees the union of these targets' tools.
+# MCP targets — the tool servers the gateway serves on the proxy port. Each
+# target gets its own path-scoped route (/<name>/mcp), so every runtime
+# (Claude Code, Codex, Hermes, ...) configures one MCP server entry per path.
 #
-# Auth: passthrough. The gateway forwards the caller's Authorization header to
-# the backend, so the Splunk MCP target keeps its own token contract (tokens
-# minted by Splunk's GET /services/mcp_token, aud=mcp). A gateway-held
-# backendAuth key (from OpenBao) is a planned follow-up so callers need no
-# per-backend credential.
+# Auth: passthrough, and per-target routes keep it safe — the caller's
+# Authorization header only ever reaches the one backend behind its path.
+# The Splunk MCP target keeps its own token contract (tokens minted by
+# Splunk's GET /services/mcp_token, aud=mcp). A gateway-held backendAuth key
+# (from OpenBao) is a planned follow-up so callers need no per-backend
+# credential.
 #
 # tls_insecure skips backend certificate verification — required for the
 # Splunk management port's self-signed cert; never set it for public targets.

--- a/roles/agentgateway_docker/tasks/main.yml
+++ b/roles/agentgateway_docker/tasks/main.yml
@@ -58,9 +58,9 @@
     port: "{{ agentgateway_docker_proxy_port | int }}"
     timeout: 120
 
-- name: Verify agentgateway admin metrics endpoint responds
+- name: Verify agentgateway stats metrics endpoint responds
   ansible.builtin.uri:
-    url: "http://127.0.0.1:{{ agentgateway_docker_admin_port }}/metrics"
+    url: "http://127.0.0.1:{{ agentgateway_docker_metrics_port }}/metrics"
     method: GET
     status_code: 200
   register: agentgateway_docker_health

--- a/roles/agentgateway_docker/templates/config.yaml.j2
+++ b/roles/agentgateway_docker/templates/config.yaml.j2
@@ -8,6 +8,11 @@
 # the Splunk token to external targets. Path isolation keeps each credential
 # on its own backend; clients configure one MCP server entry per path.
 config:
+  # Bind the admin UI (Traefik-fronted) and the stats server (Prometheus
+  # /metrics) on all interfaces so the LXC can publish them; the guest
+  # firewall scopes both internal-only. Ports are DRY from pipeline_constants.
+  adminAddr: "0.0.0.0:{{ agentgateway_docker_admin_port }}"
+  statsAddr: "0.0.0.0:{{ agentgateway_docker_metrics_port }}"
   tracing:
     # OTLP/HTTP to the shared Cribl Edge receiver; Cribl forks to
     # Langfuse + Splunk (no direct exporters — telemetry always via Cribl).

--- a/roles/agentgateway_docker/templates/config.yaml.j2
+++ b/roles/agentgateway_docker/templates/config.yaml.j2
@@ -1,6 +1,12 @@
 # {{ ansible_managed }}
 # agentgateway static config — regenerated on every converge (config as code).
 # Schema: https://agentgateway.dev/schema/config
+#
+# One route PER target (path-scoped, e.g. /splunk/mcp) instead of one
+# multiplexed route: auth is passthrough, and a shared route would forward a
+# caller's Authorization header to EVERY backend a tool resolves to — leaking
+# the Splunk token to external targets. Path isolation keeps each credential
+# on its own backend; clients configure one MCP server entry per path.
 config:
   tracing:
     # OTLP/HTTP to the shared Cribl Edge receiver; Cribl forks to
@@ -13,10 +19,13 @@ binds:
 - port: {{ agentgateway_docker_proxy_port }}
   listeners:
   - routes:
-    - backends:
+{% for target in agentgateway_docker_mcp_targets %}
+    - matches:
+      - path:
+          exact: /{{ target.name }}/mcp
+      backends:
       - mcp:
           targets:
-{% for target in agentgateway_docker_mcp_targets %}
           - name: {{ target.name }}
             mcp:
               host: {{ target.host }}

--- a/roles/agentgateway_docker/templates/docker-compose.yml.j2
+++ b/roles/agentgateway_docker/templates/docker-compose.yml.j2
@@ -5,12 +5,9 @@ services:
     container_name: {{ agentgateway_docker_container_name }}
     restart: {{ agentgateway_docker_restart_policy }}
     command: ["-f", "/config.yaml"]
-    environment:
-      # Bind the admin UI/xDS/metrics port on all interfaces so the LXC can
-      # publish it (Traefik fronts it; the guest firewall scopes it internal).
-      ADMIN_ADDR: "0.0.0.0:{{ agentgateway_docker_admin_port }}"
     ports:
       - "{{ agentgateway_docker_proxy_port }}:{{ agentgateway_docker_proxy_port }}"
       - "{{ agentgateway_docker_admin_port }}:{{ agentgateway_docker_admin_port }}"
+      - "{{ agentgateway_docker_metrics_port }}:{{ agentgateway_docker_metrics_port }}"
     volumes:
       - "{{ agentgateway_docker_data_dir }}/config.yaml:/config.yaml:ro"

--- a/roles/service_deadman/defaults/main.yml
+++ b/roles/service_deadman/defaults/main.yml
@@ -57,12 +57,12 @@ service_deadman_group_checks:
   agentgateway_group:
     # The shared MCP tool plane — every agent runtime dials it, so a silent
     # failure breaks tools for the whole fleet. The image is distroless, so
-    # probe from the LXC: docker up + admin metrics endpoint serving.
+    # probe from the LXC: docker up + stats /metrics endpoint serving.
     - name: agentgateway
       probe_command: >-
         systemctl is-active --quiet docker &&
         curl -fsS -m 5 http://127.0.0.1:{{
-        tofu_data.constants.service_ports.agentgateway_admin }}/metrics
+        tofu_data.constants.service_ports.agentgateway_metrics }}/metrics
         >/dev/null 2>&1
       healthcheck_url: "{{ lookup('env', 'DEADMAN_HC_URL_AGENTGATEWAY') | default('', true) }}"
   openbao_group:


### PR DESCRIPTION
## Summary

Follow-up to #833. With **passthrough auth**, a single multiplexed MCP route would forward the caller's `Authorization` header to every backend a tool call resolves to — sending the Splunk aud=mcp token to external targets. This restructures the gateway config so each MCP target gets its own **exact-path route** (`/splunk/mcp`, `/context7/mcp`): a credential only ever reaches the backend behind its own path.

Client contract: one MCP server entry per path (e.g. `http://agentgateway.<domain>:8080/splunk/mcp` with the Splunk token; `/context7/mcp` keyless).

## Verification
- `ansible-lint` (production profile) passes.
- Route-match syntax cross-checked against the upstream v1.3.1 `mcp-authentication` example (`matches: [{path: {exact: ...}}]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MktvVScwVZZZj84gH7bknt