### PR TITLE
feat(openbao): flow-lock AppRole and nautobot seed grant (#832)

### DIFF
--- a/roles/openbao/README.md
+++ b/roles/openbao/README.md
@@ -174,6 +174,7 @@ secret/infra/      proxmox/ aws/ network/   # IaC kernel — terraform-apply wri
 secret/platform/   dns/ traefik/ terrakube/ splunk/ cribl/ object-storage/ compute/
 secret/apps/       media/ monitoring/ home-automation/
 secret/ai/         hermes/ agents/          # LLM stack + AI-agent creds
+secret/locks/      global                   # cross-repo apply lock state
 secret/public/     domain/ ...              # non-secret, non-exploitable facts
 secret/ci/         github/ doppler-sync/
 ```
@@ -185,7 +186,8 @@ plans):
 
 | AppRole | Reads | Writes | Notes |
 | --- | --- | --- | --- |
-| `terraform-apply` | `secret/infra/*`, `secret/platform/{dns,traefik}`, legacy `homelab/*` | same | Human-triggered IaC apply |
+| `terraform-apply` | `secret/infra/*`, `secret/platform/{dns,traefik}`, `secret/apps/nautobot/*`, legacy `homelab/*` | `secret/infra/*`, `secret/platform/{dns,traefik}`, `secret/apps/nautobot/*`, legacy `homelab/*` | Human-triggered IaC apply; Nautobot grant is narrow seed-only for P1 secrets |
+| `flow-lock` | `secret/locks/global`, `secret/infra/*` | `secret/locks/global` | Cross-repo apply lock holder; can release the global lock via metadata delete |
 | `terrakube-plan` | `secret/platform/terrakube` only | — | Terrakube VCS-driven runs; deliberately walled off from `secret/infra/*` |
 | `ansible-converge` | `secret/platform/*`, `secret/apps/*` | — | Config-management pulls |
 | `observability` | `secret/platform/{splunk,cribl}` | — | Ingest pipeline (shared HEC tokens) |
@@ -254,16 +256,16 @@ shred -u <playbook_dir>/.openbao-approle-*-<host>.json
   `apt` skips re-install when the version is present.
 - `tasks/init.yml` runs **only on the bootstrap host**. The very first
   `bao operator init` happens once (`initialized == false`); the KV mount,
-  each policy, the AppRole auth method, and each AppRole are guarded by
-  existence checks, so re-runs are no-ops for anything already present.
+  each policy, the AppRole auth method, and each AppRole are guarded so re-runs
+  are no-ops for anything already present and unchanged.
 - **Growing the RBAC surface on an already-live cluster is supported**: set
   `openbao_admin_token` (env `BAO_TOKEN`) to a privileged token so the role can
   authenticate without a fresh init; add rows to `openbao_policies` /
-  `openbao_approles`; re-run. Only the genuinely new policies/AppRoles are
-  created, and `role_id`/`secret_id` are surfaced **only for those** — existing
-  identities and their credentials are never touched or re-emitted, so a
-  routine converge without `BAO_TOKEN` set stays a complete no-op for this
-  section.
+  `openbao_approles`; re-run. Missing or changed policies are written, only
+  genuinely new AppRoles are created, and `role_id`/`secret_id` are surfaced
+  **only for those** — existing identities and their credentials are never
+  touched or re-emitted, so a routine converge without `BAO_TOKEN` set stays a
+  complete no-op for this section.
 
 ## Seal-key rotation
 

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -5,9 +5,10 @@
 # upstream .deb (checksum-verified), renders a Raft HA + on-prem
 # static-key auto-unseal config, runs it under systemd, and (in init.yml)
 # bootstraps the cluster, the secret hierarchy, the RBAC policies, and the
-# AppRoles — one per resource-domain identity (terraform-apply / terrakube-plan
-# / ansible-converge / observability / local-cloud / monitoring / media /
-# local-llm / hermes / hermes-write / public / ai-readonly / ai-elevated / snapshot).
+# AppRoles — one per resource-domain identity (terraform-apply / flow-lock /
+# terrakube-plan / ansible-converge / observability / local-cloud / monitoring /
+# media / local-llm / hermes / hermes-write / public / ai-readonly /
+# ai-elevated / snapshot).
 
 # --- Version ----------------------------------------------------------------
 # Pinned to a known-good upstream release. Version bumps follow the repo's
@@ -118,7 +119,11 @@ openbao_homelab_path: homelab
 # Policy + AppRole names, one per RBAC identity (see docs/SECRETS_HIERARCHY.md
 # for the full rationale). Split by resource domain, least-privilege:
 #   terraform-apply  — human-triggered IaC apply (was "terraform"); read+write
-#                      secret/infra/*, secret/platform/{dns,traefik}
+#                      secret/infra/*, secret/platform/{dns,traefik}, plus
+#                      narrow secret/apps/nautobot/* seed grant for Nautobot P1
+#   flow-lock        — cross-repo apply lock holder; read/write only the global
+#                      lock record, metadata-delete for release, and read-only
+#                      secret/infra/* context for lock decisions
 #   terrakube-plan   — Terrakube VCS-driven plan/apply runs; read-only,
 #                      secret/platform/terrakube ONLY — deliberately walled off
 #                      from secret/infra/* (untrusted-plan surface)
@@ -153,6 +158,8 @@ openbao_homelab_path: homelab
 #   ai-readonly / ai-elevated / snapshot — unchanged, kept as-is
 openbao_terraform_apply_policy_name: terraform-apply
 openbao_terraform_apply_approle_name: terraform-apply
+openbao_flow_lock_policy_name: flow-lock
+openbao_flow_lock_approle_name: flow-lock
 openbao_terrakube_plan_policy_name: terrakube-plan
 openbao_terrakube_plan_approle_name: terrakube-plan
 openbao_ansible_converge_policy_name: ansible-converge
@@ -191,6 +198,8 @@ openbao_snapshot_approle_name: snapshot
 openbao_approles:
   - name: "{{ openbao_terraform_apply_approle_name }}"
     policy: "{{ openbao_terraform_apply_policy_name }}"
+  - name: "{{ openbao_flow_lock_approle_name }}"
+    policy: "{{ openbao_flow_lock_policy_name }}"
   - name: "{{ openbao_terrakube_plan_approle_name }}"
     policy: "{{ openbao_terrakube_plan_policy_name }}"
   - name: "{{ openbao_ansible_converge_approle_name }}"
@@ -229,6 +238,8 @@ openbao_approles:
 openbao_policies:
   - name: "{{ openbao_terraform_apply_policy_name }}"
     template: terraform-apply-policy.hcl.j2
+  - name: "{{ openbao_flow_lock_policy_name }}"
+    template: flow-lock-policy.hcl.j2
   - name: "{{ openbao_terrakube_plan_policy_name }}"
     template: terrakube-plan-policy.hcl.j2
   - name: "{{ openbao_ansible_converge_policy_name }}"

--- a/roles/openbao/tasks/init.yml
+++ b/roles/openbao/tasks/init.yml
@@ -187,7 +187,7 @@
     - openbao_bootstrap_token is defined
     - (openbao_kv_mount ~ '/') not in (openbao_mounts_raw.stdout | from_json).keys()
 
-# --- RBAC policies (write-if-missing) ---------------------------------------
+# --- RBAC policies (write-if-missing-or-changed) ----------------------------
 # Rendered on the TARGET: `bao policy write` below executes there and reads
 # the file from its local filesystem (a controller-side render is unreachable
 # from the target). Policy HCL is non-secret — it comes from the committed
@@ -216,7 +216,59 @@
   changed_when: false
   when: openbao_bootstrap_token is defined
 
-- name: Write the RBAC policies that are missing
+- name: Read rendered RBAC policy contents from the target
+  ansible.builtin.slurp:
+    src: "{{ openbao_config_dir }}/.policy-{{ item.name }}.hcl"
+  loop: "{{ openbao_policies }}"
+  loop_control:
+    label: "{{ item.name }}"
+  register: openbao_rendered_policy_reads
+  changed_when: false
+  when: openbao_bootstrap_token is defined
+
+- name: Build the rendered RBAC policy content map
+  ansible.builtin.set_fact:
+    openbao_rendered_policy_map: >-
+      {{ openbao_rendered_policy_map | default({})
+         | combine({ item.item.name: (item.content | b64decode) }) }}
+  loop: "{{ openbao_rendered_policy_reads.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  when:
+    - openbao_bootstrap_token is defined
+    - not (item.skipped | default(false))
+
+- name: Read existing RBAC policy contents
+  ansible.builtin.command:
+    cmd: "bao policy read -format=json {{ item.name }}"
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  loop: "{{ openbao_policies }}"
+  loop_control:
+    label: "{{ item.name }}"
+  register: openbao_existing_policy_reads
+  no_log: true
+  changed_when: false
+  when:
+    - openbao_bootstrap_token is defined
+    - item.name in (openbao_policies_raw.stdout | from_json)
+
+- name: Build the existing RBAC policy content map
+  ansible.builtin.set_fact:
+    openbao_existing_policy_map: >-
+      {{ openbao_existing_policy_map | default({})
+         | combine({ item.item.name: ((item.stdout | from_json).data.policy | default('')) }) }}
+  loop: "{{ openbao_existing_policy_reads.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  no_log: true
+  when:
+    - openbao_bootstrap_token is defined
+    - not (item.skipped | default(false))
+    - (item.rc | default(1)) == 0
+
+- name: Write the RBAC policies that are missing or changed
   ansible.builtin.command:
     cmd: >-
       bao policy write {{ item.name }}
@@ -231,7 +283,12 @@
   changed_when: true
   when:
     - openbao_bootstrap_token is defined
-    - item.name not in (openbao_policies_raw.stdout | from_json)
+    - >-
+      item.name not in (openbao_policies_raw.stdout | from_json)
+      or
+      (openbao_existing_policy_map | default({})).get(item.name, '')
+      !=
+      (openbao_rendered_policy_map | default({})).get(item.name, '')
 
 - name: Remove the rendered policies from the target
   ansible.builtin.file:

--- a/roles/openbao/tasks/init.yml
+++ b/roles/openbao/tasks/init.yml
@@ -230,7 +230,7 @@
   ansible.builtin.set_fact:
     openbao_rendered_policy_map: >-
       {{ openbao_rendered_policy_map | default({})
-         | combine({ item.item.name: (item.content | b64decode) }) }}
+         | combine({ item.item.name: (item.content | default('') | b64decode) }) }}
   loop: "{{ openbao_rendered_policy_reads.results | default([]) }}"
   loop_control:
     label: "{{ item.item.name }}"
@@ -258,7 +258,7 @@
   ansible.builtin.set_fact:
     openbao_existing_policy_map: >-
       {{ openbao_existing_policy_map | default({})
-         | combine({ item.item.name: ((item.stdout | from_json).data.policy | default('')) }) }}
+         | combine({ item.item.name: ((item.stdout | default('{}') | from_json).data.policy | default('')) }) }}
   loop: "{{ openbao_existing_policy_reads.results | default([]) }}"
   loop_control:
     label: "{{ item.item.name }}"

--- a/roles/openbao/templates/flow-lock-policy.hcl.j2
+++ b/roles/openbao/templates/flow-lock-policy.hcl.j2
@@ -1,0 +1,21 @@
+{{ ansible_managed | comment }}
+# OpenBao policy for the flow-lock AppRole — the cross-repo apply lock holder.
+# It can create/update/read the single global lock record, delete that lock's
+# metadata to release it, and read infra context for lock decisions. No broad
+# metadata delete, no app/platform/ai access.
+
+path "{{ openbao_kv_mount }}/data/locks/global" {
+  capabilities = ["create", "update", "read"]
+}
+
+path "{{ openbao_kv_mount }}/metadata/locks/global" {
+  capabilities = ["delete"]
+}
+
+path "{{ openbao_kv_mount }}/data/infra/*" {
+  capabilities = ["read"]
+}
+
+path "{{ openbao_kv_mount }}/metadata/infra/*" {
+  capabilities = ["read", "list"]
+}

--- a/roles/openbao/templates/terraform-apply-policy.hcl.j2
+++ b/roles/openbao/templates/terraform-apply-policy.hcl.j2
@@ -28,3 +28,11 @@ path "{{ openbao_kv_mount }}/metadata/platform/{{ sub }}/*" {
 }
 
 {% endfor %}
+# Seeding grant for the Nautobot P1 secrets, dryvist/docs-starlight#138.
+path "{{ openbao_kv_mount }}/data/apps/nautobot/*" {
+  capabilities = ["create", "update", "read"]
+}
+
+path "{{ openbao_kv_mount }}/metadata/apps/nautobot/*" {
+  capabilities = ["read", "list"]
+}


### PR DESCRIPTION
## Summary
- Add a `flow-lock` OpenBao policy/AppRole for the global cross-repo apply lock.
- Extend `terraform-apply` with a narrow Nautobot P1 seed grant for `secret/apps/nautobot/*`.
- Update OpenBao policy provisioning so privileged converges write missing or changed policies without recreating existing AppRole credentials.

## Live converge note
Converging this against the LIVE cluster requires an operator-supplied privileged `BAO_TOKEN` (`openbao_admin_token`). Exact command:

```sh
env BAO_TOKEN=<privileged-openbao-token> doppler run -- ansible-playbook -i inventory/hosts.yml playbooks/site.yml --tags openbao --limit openbao_group,localhost
```

## Validation
- `nix develop github:JacobPEvans/nix-devenv#ansible-apps -c ansible-lint`
- `nix develop github:JacobPEvans/nix-devenv#ansible-apps -c ansible-playbook -i inventory/hosts.yml playbooks/site.yml --tags openbao --syntax-check`
- `TOFU_INVENTORY_PATH=tests/inventory_load/tofu_inventory.json nix develop github:JacobPEvans/nix-devenv#ansible-apps -c ansible-playbook -i inventory/hosts.yml playbooks/site.yml --tags openbao --syntax-check`

Fixes #832.
Refs dryvist/docs-starlight#138.