### PR TITLE
fix(media_monitor): enable timers (drop double .timer suffix)

### DIFF
--- a/roles/media_monitor/tasks/main.yml
+++ b/roles/media_monitor/tasks/main.yml
@@ -64,6 +64,6 @@
     enabled: true
     daemon_reload: true
   loop:
-    - plex-session-probe.timer
-    - plex-codec-audit.timer
+    - plex-session-probe
+    - plex-codec-audit
   when: media_monitor_manage | bool


### PR DESCRIPTION
## What
The `media_monitor` timer enable/start task looped over unit names already ending in `.timer` **and** templated `name: "{{ item }}.timer"`, yielding `plex-session-probe.timer.timer`. systemd could not find that unit, so the task failed and the timers were deployed to `/etc/systemd/system` but never enabled/started.

## Fix
Loop over the bare basenames (`plex-session-probe`, `plex-codec-audit`) — matching the deploy tasks directly above — so `name: "{{ item }}.timer"` resolves correctly.

## Verification
Converged `--tags plex` against the live Plex host: `Enable + start the media monitor timers` now succeeds, both timers active. PLAY RECAP `plex ok=30 changed=3 failed=0`.

Refs #825 (S2 monitoring). Follow-up to #830.