### PR TITLE
feat(llm_router): cluster brain in the large phase with solo fallback

### DIFF
--- a/docs/BRAIN_ROTATION.md
+++ b/docs/BRAIN_ROTATION.md
@@ -125,9 +125,9 @@ drops to on-demand and idle-unloads. Auto-discovery is force-disabled fleet-wide
 explicitly.
 
 **The large phase (`Qwen3-Next-80B-A3B-Thinking-4bit`) does NOT fit the swap
-tier alongside both residents** — the original estimate here (58.6 GB residents
-+ ~42 GB weights + 4 GB cache ≈ 104.6 GB, under the ~109 GB trip) budgeted only
-weights + configured cache. The first live large phase (2026-07-09 00:00 UTC)
+tier alongside both residents** — the original estimate here (58.6 GB
+residents + ~42 GB weights + 4 GB cache ≈ 104.6 GB, under the ~109 GB trip)
+budgeted only weights + configured cache. The first live large phase (2026-07-09 00:00 UTC)
 measured Next-80B's real per-process peak at **51.5 GB** (scheduler
 `[Metal memory] ... peak=51.5GB` — activations and paged-cache overshoot on top
 of ~46 GB), putting the composition at ~109.5 GB ≥ the trip: all three backends
@@ -253,3 +253,26 @@ health-checks those orphans "ready" while unable to manage them. Always
 3. **Per-guest rotation (3 routers, 3 timers) vs a single owner?** This design
    rotates per router guest (idempotent, resilient, no elected owner). All three
    bounce `litellm` within `AccuracySec` at the mark.
+
+## Night cluster (large phase only)
+
+With `ai_night_brain_enabled: true` (group_vars), the LARGE phase config gains
+a second shape (docs on the serving side: nix-darwin `docs/NIGHT_CLUSTER.md`):
+
+- `ai-default` becomes a deployment on the serving host's **night-cluster
+  endpoint** — the two-Mac pipeline-parallel brain the Thunderbolt cable
+  creates — gated on its own port by the same bearer token.
+- The solo large brain (the phase model, today Qwen3-Next-80B) moves to
+  **`ai-default-solo`**, and `router_settings.fallbacks` chains
+  `ai-default → ai-default-solo`.
+- Presence detection needs no plumbing: cluster absent or unhealthy means the
+  night attempt fails fast, the request falls back to the solo brain, and
+  `allowed_fails` + `cooldown_time` drain traffic there — byte-identical
+  behavior to today's large phase.
+- The optimized phase never changes. Timers, stagger, and the actuator are
+  untouched.
+
+Inputs (all group_vars; defaults render the flag off and the block inert):
+`ai_night_brain_enabled`, `ai_night_model` (physical id the night rank
+serves), `ai_night_context_window` (SERVING window, same rule as every other
+entry), plus the `llm_night_api` port constant in the tofu ports registry.

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -278,3 +278,23 @@ llm_router_rotation_pause_sentinel: "{{ llm_router_config_dir }}/rotation-paused
 llm_router_rotation_warm_roles:
   - coding
   - tool-calling
+
+# --- Night-cluster brain (docs/BRAIN_ROTATION.md "Night cluster") ------------
+# When enabled, ONLY the large-phase config changes shape: the rotation alias
+# becomes a deployment on the serving host's night-cluster endpoint (the
+# two-Mac pipeline-parallel brain, gated on its own port by the same bearer
+# token), the solo large brain moves to `<alias>-solo`, and LiteLLM fallbacks
+# chain them. Presence detection is free: cluster absent/unhealthy -> the
+# night attempt fails fast, the request falls back to the solo brain, and
+# allowed_fails + cooldown_time drain traffic there — exactly today's
+# behavior. No new trigger plumbing, no timer changes. Off by default; flip
+# ai_night_brain_enabled (group_vars) on the first plug night per the runbook.
+llm_router_night_enabled: "{{ ai_night_brain_enabled | default(false) | bool }}"
+# Physical id the night rank serves (mlx-lm rank 0; single night model).
+llm_router_night_model: "{{ ai_night_model | default('') }}"
+# SERVING window of the night brain (apps#814 rule: never the native window).
+llm_router_night_context: "{{ ai_night_context_window | default(32768) }}"
+# Night endpoint port from the tofu ports registry (fails loud when enabled
+# without the constant; lazy Jinja keeps the disabled default render clean).
+llm_router_night_port: "{{ tofu_data.constants.service_ports.llm_night_api }}"
+llm_router_night_base_url: "https://{{ llm_router_llm_large_fqdn }}:{{ llm_router_night_port }}/v1"

--- a/roles/llm_router/tasks/rotation.yml
+++ b/roles/llm_router/tasks/rotation.yml
@@ -45,6 +45,9 @@
     _alias_entry: "{{ llm_router_large_models | selectattr('alias', 'equalto', item.value.model) | first }}"
     llm_router_rotation_active_backend: "{{ _alias_entry.backend }}"
     llm_router_rotation_active_context: "{{ _alias_entry.context_window }}"
+    # Phase name reaches the template so the night-cluster deployment (and its
+    # fallback chain) renders into the LARGE phase config only.
+    llm_router_rotation_phase: "{{ item.key }}"
   notify: Restart litellm
 
 - name: Determine the current rotation phase from the guest's UTC hour

--- a/roles/llm_router/templates/config.yaml.j2
+++ b/roles/llm_router/templates/config.yaml.j2
@@ -45,13 +45,32 @@ model_list:
 {% endfor %}
 {% endfor %}
 {% if llm_router_rotation_active_backend is defined and llm_router_rotation_active_backend %}
+{% set _night_live = llm_router_night_enabled | default(false) | bool
+     and llm_router_rotation_phase | default('') == 'large'
+     and (llm_router_night_model | default('')) | length > 0 %}
   # --- daily brain rotation: the one stable alias consumers point at ---
   # (docs/BRAIN_ROTATION.md). Hermes + Open WebUI address `{{ llm_router_rotation_alias }}`
   # forever; the systemd rotate timers swap which per-phase config.yaml symlink
   # is live, so this entry's backend flips 00:00/12:00 UTC without touching any
   # consumer. Context is the live phase model's real window (never null — a null
   # max_input_tokens is the compress-to-death trap the aliased entries avoid).
+{% if _night_live %}
+  # Night cluster live: the alias serves on the two-Mac night brain; the solo
+  # phase brain moves to `{{ llm_router_rotation_alias }}-solo` and the
+  # fallbacks entry under router_settings chains them. Cluster absent ->
+  # fail-fast + fallback (allowed_fails/cooldown_time drain the dead endpoint).
   - model_name: {{ llm_router_rotation_alias }}
+    litellm_params:
+      model: openai/{{ llm_router_night_model }}
+      api_base: {{ llm_router_night_base_url }}
+      api_key: os.environ/LLM_LARGE_BEARER_TOKEN
+    model_info:
+      max_input_tokens: {{ llm_router_night_context }}
+      max_tokens: {{ llm_router_night_context }}
+  - model_name: {{ llm_router_rotation_alias }}-solo
+{% else %}
+  - model_name: {{ llm_router_rotation_alias }}
+{% endif %}
     litellm_params:
       model: openai/{{ llm_router_rotation_active_backend }}
       api_base: {{ llm_router_llm_large_base_url }}
@@ -104,6 +123,13 @@ router_settings:
   routing_strategy: {{ llm_router_routing_strategy }}
   allowed_fails: {{ llm_router_allowed_fails }}
   cooldown_time: {{ llm_router_cooldown_time }}
+{% if llm_router_night_enabled | default(false) | bool
+     and llm_router_rotation_phase | default('') == 'large'
+     and (llm_router_night_model | default('')) | length > 0 %}
+  # Night-cluster fallback chain: alias -> solo phase brain (see model_list).
+  fallbacks:
+    - {{ llm_router_rotation_alias }}: ["{{ llm_router_rotation_alias }}-solo"]
+{% endif %}
   # Pre-call context-window checks so an over-long request is not routed to a model
   # that cannot serve it (no cross-tier fallback masks the error).
   enable_pre_call_checks: true


### PR DESCRIPTION
## Summary

Router half of the cluster design (companion: dryvist/nix-ai#1173 + the nix-darwin host PR): when the brain-enable flag is set (group_vars, **default off — this PR is inert until then**), the LARGE phase config gains the cluster endpoint as the `ai-default` deployment with the solo large brain as automatic fallback.

- `ai-default` → cluster endpoint (own gated port on the serving host, same bearer token), serving window from the cluster context-window group_var.
- Solo phase brain → `ai-default-solo`; `router_settings.fallbacks` chains `ai-default → ai-default-solo`.
- Presence detection is fallbacks + `allowed_fails`/`cooldown_time` — cluster absent means fail-fast + fallback, i.e. exactly today's behavior. No new trigger plumbing; optimized phase, timers, stagger, actuator untouched.
- `docs/BRAIN_ROTATION.md` gains the cluster section (plus a reflow fixing that file's two pre-existing markdownlint errors).

## Enablement (runbook-sequenced, not this PR)

The brain-enable flag + the model and context-window keys in group_vars (named in `docs/BRAIN_ROTATION.md`), and the cluster API port constant added to the tofu ports registry (lazy Jinja — required only once the flag is on).

## Verification

- `ansible-lint` production profile: 0 failures.
- Template rendered for (large, flag on), (large, flag off), (optimized, flag on): the cluster deployment, `-solo` rename, and `fallbacks` appear only in the first; the other renders are byte-identical to today's shape.
- markdownlint: 0 errors on the touched doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLeWAhEN9MsTchNU4n1nGY
