### PR TITLE
fix(agentgateway): world-readable gateway config for the nonroot image

### DIFF
--- a/roles/agentgateway_docker/tasks/main.yml
+++ b/roles/agentgateway_docker/tasks/main.yml
@@ -20,7 +20,10 @@
     dest: "{{ agentgateway_docker_data_dir }}/config.yaml"
     owner: root
     group: root
-    mode: "0600" # may carry backend auth keys later; locked down from day one
+    # ponytail: 0644 — the distroless image runs nonroot and must read the
+    # ro-mounted config; today it holds no secrets. When backendAuth keys land,
+    # switch to 0640 + the container uid as group (or move keys to env).
+    mode: "0644"
   notify: Restart agentgateway
 
 - name: Deploy agentgateway docker-compose template


### PR DESCRIPTION
## Summary

Follow-up to #833/#834: the distroless `agentgateway` image runs as a **nonroot** user, so the role's root:root `0600` config mount is unreadable inside the container — it crash-loops on `failed to open file /config.yaml: Permission denied` (observed live on the guest). The config carries no secrets today; relax to `0644` with a documented ceiling: move to `0640` + container-uid group (or env-sourced keys) when gateway-held `backendAuth` keys land.

## Verification
- ansible-lint (production profile): clean.
- Post-merge converge on the guest brings the container out of the restart loop (driving session verifies the full MCP handshake E2E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MktvVScwVZZZj84gH7bknt