### PR TITLE
feat(nautobot): SOPS-bootstrap secrets + converge (#138)

### DIFF
--- a/inventory/group_vars/nautobot_group.yml
+++ b/inventory/group_vars/nautobot_group.yml
@@ -40,20 +40,3 @@ nautobot_superuser_password: >-
 # secret store.
 nautobot_export_s3_bucket: >-
   {{ lookup('env', 'NAUTOBOT_EXPORT_S3_BUCKET') | default('', true) }}
-
-# Single source of truth for the Nautobot runtime environment. Rendered into the
-# root-only (0600) EnvironmentFile for the systemd units AND passed via each
-# management task's `environment:` — so no shell `. nautobot.env` ever evaluates
-# a secret value as code (addresses the #840 security review). Keep in lockstep
-# with nautobot.env.j2 (which renders from this dict).
-nautobot_env:
-  NAUTOBOT_ROOT: "{{ nautobot_root }}"
-  NAUTOBOT_SECRET_KEY: "{{ nautobot_effective_secret_key }}"
-  NAUTOBOT_DB_PASSWORD: "{{ nautobot_db_password }}"
-  NAUTOBOT_SUPERUSER_NAME: "{{ nautobot_superuser_name }}"
-  NAUTOBOT_SUPERUSER_EMAIL: "{{ nautobot_superuser_email }}"
-  NAUTOBOT_SUPERUSER_PASSWORD: "{{ nautobot_superuser_password }}"
-  NAUTOBOT_SEED_FILE: "{{ nautobot_seed_file }}"
-  NAUTOBOT_EXPORT_S3_BUCKET: "{{ nautobot_export_s3_bucket }}"
-  NAUTOBOT_EXPORT_S3_KEY: "{{ nautobot_export_s3_key }}"
-  NAUTOBOT_EXPORT_SCHEMA: "{{ nautobot_export_schema_file }}"

--- a/inventory/group_vars/nautobot_group.yml
+++ b/inventory/group_vars/nautobot_group.yml
@@ -20,7 +20,12 @@ nautobot_db_password: >-
 # Public UI FQDN (Traefik-fronted): nautobot.<ingress subdomain>, matching the
 # Traefik router base domain and wildcard certificate from PROXMOX_SUBDOMAIN.
 # The guest zone stays available for east-west service discovery only.
-nautobot_ui_fqdn: "nautobot.{{ lookup('env', 'PROXMOX_SUBDOMAIN') | mandatory('PROXMOX_SUBDOMAIN required') }}"
+# `lookup('env', …)` returns "" (not undefined) when unset, and `| mandatory`
+# does NOT fire on an empty string — so `or undef()` (empty string is falsy)
+# is what actually fails the play when PROXMOX_SUBDOMAIN is missing (#840 review).
+nautobot_ui_fqdn: >-
+  nautobot.{{ lookup('env', 'PROXMOX_SUBDOMAIN')
+     or undef('PROXMOX_SUBDOMAIN is required for the Nautobot UI FQDN') }}
 
 # SECRET_KEY + superuser password bao-first (secret/apps/nautobot), env fallback.
 nautobot_secret_key: >-
@@ -35,3 +40,20 @@ nautobot_superuser_password: >-
 # secret store.
 nautobot_export_s3_bucket: >-
   {{ lookup('env', 'NAUTOBOT_EXPORT_S3_BUCKET') | default('', true) }}
+
+# Single source of truth for the Nautobot runtime environment. Rendered into the
+# root-only (0600) EnvironmentFile for the systemd units AND passed via each
+# management task's `environment:` — so no shell `. nautobot.env` ever evaluates
+# a secret value as code (addresses the #840 security review). Keep in lockstep
+# with nautobot.env.j2 (which renders from this dict).
+nautobot_env:
+  NAUTOBOT_ROOT: "{{ nautobot_root }}"
+  NAUTOBOT_SECRET_KEY: "{{ nautobot_effective_secret_key }}"
+  NAUTOBOT_DB_PASSWORD: "{{ nautobot_db_password }}"
+  NAUTOBOT_SUPERUSER_NAME: "{{ nautobot_superuser_name }}"
+  NAUTOBOT_SUPERUSER_EMAIL: "{{ nautobot_superuser_email }}"
+  NAUTOBOT_SUPERUSER_PASSWORD: "{{ nautobot_superuser_password }}"
+  NAUTOBOT_SEED_FILE: "{{ nautobot_seed_file }}"
+  NAUTOBOT_EXPORT_S3_BUCKET: "{{ nautobot_export_s3_bucket }}"
+  NAUTOBOT_EXPORT_S3_KEY: "{{ nautobot_export_s3_key }}"
+  NAUTOBOT_EXPORT_SCHEMA: "{{ nautobot_export_schema_file }}"

--- a/inventory/group_vars/nautobot_group.yml
+++ b/inventory/group_vars/nautobot_group.yml
@@ -17,10 +17,10 @@ nautobot_db_password: >-
   {{ bao_apps_secrets.db_password
      | default(lookup('env', 'NAUTOBOT_DB_PASSWORD'), true) }}
 
-# Public UI FQDN (Traefik-fronted): nautobot.<guest zone>, the same name
-# technitium/ingress publishes. ALLOWED_HOSTS + CSRF_TRUSTED_ORIGINS derive
-# from it.
-nautobot_ui_fqdn: "nautobot.{{ hostvars['localhost']['tofu_data']['domain'] }}"
+# Public UI FQDN (Traefik-fronted): nautobot.<ingress subdomain>, matching the
+# Traefik router base domain and wildcard certificate from PROXMOX_SUBDOMAIN.
+# The guest zone stays available for east-west service discovery only.
+nautobot_ui_fqdn: "nautobot.{{ lookup('env', 'PROXMOX_SUBDOMAIN') | mandatory('PROXMOX_SUBDOMAIN required') }}"
 
 # SECRET_KEY + superuser password bao-first (secret/apps/nautobot), env fallback.
 nautobot_secret_key: >-

--- a/roles/nautobot/defaults/main.yml
+++ b/roles/nautobot/defaults/main.yml
@@ -13,11 +13,13 @@ nautobot_system_packages:
   - python3
   - python3-venv
   - python3-dev
+  - python3-packaging
   - build-essential
   - libpq-dev
   - redis-server
   - git
   - openssl
+  - sudo
 
 # Python packages installed into the venv (latest stable). The pip
 # distribution names differ from the Django app/plugin names used in PLUGINS:
@@ -27,6 +29,8 @@ nautobot_pip_packages:
   - nautobot
   - nautobot-ssot
   - nautobot-device-onboarding
+  - boto3
+  - jsonschema
 nautobot_plugins:
   - nautobot_ssot
   - nautobot_device_onboarding

--- a/roles/nautobot/defaults/main.yml
+++ b/roles/nautobot/defaults/main.yml
@@ -89,6 +89,24 @@ nautobot_export_schema_file: "{{ nautobot_export_schema_dir }}/nautobot-export-v
 nautobot_export_schedule_hour: 6
 nautobot_export_schedule_minute: 17
 
+# Single source of truth for the Nautobot runtime environment. Rendered into the
+# root-only (0600) EnvironmentFile for the systemd units AND passed via each
+# management task's `environment:` — so no shell `. nautobot.env` ever evaluates
+# a secret value as code (#840 security review). Lives in role defaults (not
+# inventory group_vars) so it resolves under molecule too. Keep in lockstep with
+# templates/nautobot.env.j2, which renders from this dict.
+nautobot_env:
+  NAUTOBOT_ROOT: "{{ nautobot_root }}"
+  NAUTOBOT_SECRET_KEY: "{{ nautobot_effective_secret_key }}"
+  NAUTOBOT_DB_PASSWORD: "{{ nautobot_db_password }}"
+  NAUTOBOT_SUPERUSER_NAME: "{{ nautobot_superuser_name }}"
+  NAUTOBOT_SUPERUSER_EMAIL: "{{ nautobot_superuser_email }}"
+  NAUTOBOT_SUPERUSER_PASSWORD: "{{ nautobot_superuser_password }}"
+  NAUTOBOT_SEED_FILE: "{{ nautobot_seed_file }}"
+  NAUTOBOT_EXPORT_S3_BUCKET: "{{ nautobot_export_s3_bucket }}"
+  NAUTOBOT_EXPORT_S3_KEY: "{{ nautobot_export_s3_key }}"
+  NAUTOBOT_EXPORT_SCHEMA: "{{ nautobot_export_schema_file }}"
+
 # Seed-bundle assembly (tasks/seed_bundle.yml). Off by default — the four
 # sources live in sibling repos the controller only has at cutover (WS-E). Paths
 # and the network definitions come from the runtime environment.

--- a/roles/nautobot/handlers/main.yml
+++ b/roles/nautobot/handlers/main.yml
@@ -1,15 +1,15 @@
 ---
-- name: Restart redis
-  ansible.builtin.systemd:
-    name: redis-server
-    state: restarted
-
 # Reload only when a unit file changed (notified by the unit templates), so an
 # unchanged converge stays idempotent. Applied before the services start via a
 # flush_handlers in the managed-app block.
 - name: Reload systemd daemon
   ansible.builtin.systemd:
     daemon_reload: true
+
+- name: Restart redis
+  ansible.builtin.systemd:
+    name: redis-server
+    state: restarted
 
 # Only meaningful once the app layer is managed (services exist and are
 # started). When nautobot_manage_app is false (molecule) the units are deployed

--- a/roles/nautobot/tasks/main.yml
+++ b/roles/nautobot/tasks/main.yml
@@ -61,6 +61,33 @@
     state: present
   notify: Restart redis
 
+- name: Create Redis systemd override directory
+  ansible.builtin.file:
+    path: /etc/systemd/system/redis-server.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Deploy Redis unprivileged-LXC systemd override
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/redis-server.service.d/lxc-override.conf
+    content: |
+      # Managed by Ansible (nautobot role).
+      # Debian's Redis unit enables PrivateUsers, which requires user namespace
+      # setup that unprivileged Proxmox LXCs deny.
+      [Service]
+      PrivateUsers=no
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - Reload systemd daemon
+    - Restart redis
+
+- name: Apply Redis systemd override before starting Redis
+  ansible.builtin.meta: flush_handlers
+
 - name: Enable and start Redis
   ansible.builtin.systemd:
     name: redis-server
@@ -230,35 +257,46 @@
 - name: Bring up the Nautobot application
   when: nautobot_manage_app | bool
   become: true
-  become_user: "{{ nautobot_user }}"
-  environment:
-    NAUTOBOT_ROOT: "{{ nautobot_root }}"
-    NAUTOBOT_SECRET_KEY: "{{ nautobot_effective_secret_key }}"
-    NAUTOBOT_DB_PASSWORD: "{{ nautobot_db_password }}"
-    NAUTOBOT_SUPERUSER_NAME: "{{ nautobot_superuser_name }}"
-    NAUTOBOT_SUPERUSER_EMAIL: "{{ nautobot_superuser_email }}"
-    NAUTOBOT_SUPERUSER_PASSWORD: "{{ nautobot_superuser_password }}"
-    NAUTOBOT_EXPORT_S3_BUCKET: "{{ nautobot_export_s3_bucket }}"
-    NAUTOBOT_EXPORT_S3_KEY: "{{ nautobot_export_s3_key }}"
   block:
     - name: Apply database migrations
-      ansible.builtin.command:
-        cmd: "{{ nautobot_root }}/bin/nautobot-server migrate"
+      ansible.builtin.shell:
+        cmd: >-
+          set -a &&
+          . {{ nautobot_root }}/nautobot.env &&
+          set +a &&
+          {{ nautobot_root }}/bin/nautobot-server migrate
+        executable: /bin/bash
       register: nautobot_migrate
       changed_when: "'No migrations to apply' not in nautobot_migrate.stdout"
+      become: true
+      become_user: "{{ nautobot_user }}"
 
     - name: Collect static files
-      ansible.builtin.command:
-        cmd: "{{ nautobot_root }}/bin/nautobot-server collectstatic --no-input"
+      ansible.builtin.shell:
+        cmd: >-
+          set -a &&
+          . {{ nautobot_root }}/nautobot.env &&
+          set +a &&
+          {{ nautobot_root }}/bin/nautobot-server collectstatic --no-input
+        executable: /bin/bash
       register: nautobot_collectstatic
       changed_when: "'0 static files copied' not in nautobot_collectstatic.stdout"
+      become: true
+      become_user: "{{ nautobot_user }}"
 
     - name: Ensure the Nautobot superuser exists
-      ansible.builtin.command:
-        cmd: "{{ nautobot_root }}/bin/nautobot-server shell --interface python"
+      ansible.builtin.shell:
+        cmd: >-
+          set -a &&
+          . {{ nautobot_root }}/nautobot.env &&
+          set +a &&
+          {{ nautobot_root }}/bin/nautobot-server shell --interface python
+        executable: /bin/bash
         stdin: "{{ lookup('ansible.builtin.file', 'superuser_bootstrap.py') }}"
       register: nautobot_superuser
       changed_when: "'SUPERUSER_CHANGED' in nautobot_superuser.stdout"
+      become: true
+      become_user: "{{ nautobot_user }}"
       no_log: true
 
     - name: Apply pending systemd reload before starting services
@@ -275,14 +313,20 @@
         - nautobot-scheduler
 
     - name: Schedule the export Job via celery beat
-      ansible.builtin.command:
-        cmd: "{{ nautobot_root }}/bin/nautobot-server shell --interface python"
+      ansible.builtin.shell:
+        cmd: >-
+          set -a &&
+          . {{ nautobot_root }}/nautobot.env &&
+          set +a &&
+          NAUTOBOT_EXPORT_SCHEDULE_HOUR={{ nautobot_export_schedule_hour }}
+          NAUTOBOT_EXPORT_SCHEDULE_MINUTE={{ nautobot_export_schedule_minute }}
+          {{ nautobot_root }}/bin/nautobot-server shell --interface python
+        executable: /bin/bash
         stdin: "{{ lookup('ansible.builtin.file', 'schedule_export.py') }}"
-      environment:
-        NAUTOBOT_EXPORT_SCHEDULE_HOUR: "{{ nautobot_export_schedule_hour }}"
-        NAUTOBOT_EXPORT_SCHEDULE_MINUTE: "{{ nautobot_export_schedule_minute }}"
       register: nautobot_schedule
       changed_when: "'SCHEDULE_CREATED' in nautobot_schedule.stdout"
+      become: true
+      become_user: "{{ nautobot_user }}"
 
     - name: Wait for the Nautobot web UI to answer
       ansible.builtin.uri:

--- a/roles/nautobot/tasks/main.yml
+++ b/roles/nautobot/tasks/main.yml
@@ -259,40 +259,28 @@
   become: true
   block:
     - name: Apply database migrations
-      ansible.builtin.shell:
-        cmd: >-
-          set -a &&
-          . {{ nautobot_root }}/nautobot.env &&
-          set +a &&
-          {{ nautobot_root }}/bin/nautobot-server migrate
-        executable: /bin/bash
+      ansible.builtin.command:
+        cmd: "{{ nautobot_root }}/bin/nautobot-server migrate"
+      environment: "{{ nautobot_env }}"
       register: nautobot_migrate
       changed_when: "'No migrations to apply' not in nautobot_migrate.stdout"
       become: true
       become_user: "{{ nautobot_user }}"
 
     - name: Collect static files
-      ansible.builtin.shell:
-        cmd: >-
-          set -a &&
-          . {{ nautobot_root }}/nautobot.env &&
-          set +a &&
-          {{ nautobot_root }}/bin/nautobot-server collectstatic --no-input
-        executable: /bin/bash
+      ansible.builtin.command:
+        cmd: "{{ nautobot_root }}/bin/nautobot-server collectstatic --no-input"
+      environment: "{{ nautobot_env }}"
       register: nautobot_collectstatic
       changed_when: "'0 static files copied' not in nautobot_collectstatic.stdout"
       become: true
       become_user: "{{ nautobot_user }}"
 
     - name: Ensure the Nautobot superuser exists
-      ansible.builtin.shell:
-        cmd: >-
-          set -a &&
-          . {{ nautobot_root }}/nautobot.env &&
-          set +a &&
-          {{ nautobot_root }}/bin/nautobot-server shell --interface python
-        executable: /bin/bash
+      ansible.builtin.command:
+        cmd: "{{ nautobot_root }}/bin/nautobot-server shell --interface python"
         stdin: "{{ lookup('ansible.builtin.file', 'superuser_bootstrap.py') }}"
+      environment: "{{ nautobot_env }}"
       register: nautobot_superuser
       changed_when: "'SUPERUSER_CHANGED' in nautobot_superuser.stdout"
       become: true
@@ -313,16 +301,13 @@
         - nautobot-scheduler
 
     - name: Schedule the export Job via celery beat
-      ansible.builtin.shell:
-        cmd: >-
-          set -a &&
-          . {{ nautobot_root }}/nautobot.env &&
-          set +a &&
-          NAUTOBOT_EXPORT_SCHEDULE_HOUR={{ nautobot_export_schedule_hour }}
-          NAUTOBOT_EXPORT_SCHEDULE_MINUTE={{ nautobot_export_schedule_minute }}
-          {{ nautobot_root }}/bin/nautobot-server shell --interface python
-        executable: /bin/bash
+      ansible.builtin.command:
+        cmd: "{{ nautobot_root }}/bin/nautobot-server shell --interface python"
         stdin: "{{ lookup('ansible.builtin.file', 'schedule_export.py') }}"
+      environment: >-
+        {{ nautobot_env | combine({
+             'NAUTOBOT_EXPORT_SCHEDULE_HOUR': nautobot_export_schedule_hour | string,
+             'NAUTOBOT_EXPORT_SCHEDULE_MINUTE': nautobot_export_schedule_minute | string}) }}
       register: nautobot_schedule
       changed_when: "'SCHEDULE_CREATED' in nautobot_schedule.stdout"
       become: true

--- a/roles/nautobot/templates/nautobot.env.j2
+++ b/roles/nautobot/templates/nautobot.env.j2
@@ -2,13 +2,8 @@
 # Root-only (0600) EnvironmentFile for the Nautobot systemd units and management
 # commands. Holds the runtime secrets that nautobot_config.py reads from the
 # environment, plus the export Job's S3 target. Never world-readable.
-NAUTOBOT_ROOT={{ nautobot_root }}
-NAUTOBOT_SECRET_KEY={{ nautobot_effective_secret_key }}
-NAUTOBOT_DB_PASSWORD={{ nautobot_db_password }}
-NAUTOBOT_SUPERUSER_NAME={{ nautobot_superuser_name }}
-NAUTOBOT_SUPERUSER_EMAIL={{ nautobot_superuser_email }}
-NAUTOBOT_SUPERUSER_PASSWORD={{ nautobot_superuser_password }}
-NAUTOBOT_SEED_FILE={{ nautobot_seed_file }}
-NAUTOBOT_EXPORT_S3_BUCKET={{ nautobot_export_s3_bucket }}
-NAUTOBOT_EXPORT_S3_KEY={{ nautobot_export_s3_key }}
-NAUTOBOT_EXPORT_SCHEMA={{ nautobot_export_schema_file }}
+# Rendered from the `nautobot_env` dict (group_vars) — the single source of truth
+# shared with the tasks' `environment:` so no shell `source` evaluates a value.
+{% for key, value in nautobot_env.items() %}
+{{ key }}={{ value }}
+{% endfor %}

--- a/roles/nautobot/templates/nautobot_config.py.j2
+++ b/roles/nautobot/templates/nautobot_config.py.j2
@@ -5,6 +5,8 @@
 # into this world-readable file.
 import os
 
+from nautobot.core.settings import *  # noqa: F403 - inherit Nautobot defaults, then override below
+
 #
 # Core
 #

--- a/roles/nautobot/templates/uwsgi.ini.j2
+++ b/roles/nautobot/templates/uwsgi.ini.j2
@@ -6,6 +6,7 @@ chdir = {{ nautobot_root }}
 module = nautobot.core.wsgi:application
 env = NAUTOBOT_ROOT={{ nautobot_root }}
 http = {{ nautobot_web_bind }}:{{ nautobot_web_port }}
+master = true
 processes = {{ nautobot_uwsgi_processes }}
 threads = {{ nautobot_uwsgi_threads }}
 vacuum = true

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -206,22 +206,14 @@
 
 # =============================================================================
 # Phase 4: Roles, databases, and host-based auth
-# Credentials are generate-if-absent: a role's password is set only when the
-# role does not yet exist, which keeps the run idempotent under scram (whose
-# salted verifier cannot be recomputed for comparison) and matches the
-# workspace "generate at the source, idempotent" secrets convention.
+# Credentials come from the source secret store; apply them on each run so an
+# app cutover can rotate from bootstrap SOPS values without manual SQL.
 # =============================================================================
 - name: Provision managed roles and databases
   become: true
   become_user: postgres
   block:
-    - name: List existing login roles
-      community.postgresql.postgresql_query:
-        query: "SELECT rolname FROM pg_roles"
-      register: postgres_existing_roles
-      changed_when: false
-
-    - name: Create the login role for each managed database (password set once)
+    - name: Ensure each managed login role exists with the source password
       community.postgresql.postgresql_user:
         name: "{{ item.user }}"
         password: "{{ item.password }}"
@@ -231,18 +223,6 @@
       loop_control:
         label: "{{ item.user }}"
       no_log: true
-      when: >-
-        item.user not in
-        (postgres_existing_roles.query_result | map(attribute='rolname') | list)
-
-    - name: Ensure each managed login role exists (no password change)
-      community.postgresql.postgresql_user:
-        name: "{{ item.user }}"
-        role_attr_flags: LOGIN
-        state: present
-      loop: "{{ postgres_managed_databases }}"
-      loop_control:
-        label: "{{ item.user }}"
 
     - name: Create each managed database owned by its role
       community.postgresql.postgresql_db:
@@ -259,6 +239,7 @@
       loop: "{{ postgres_managed_databases }}"
       loop_control:
         label: "{{ item.name }}"
+      no_log: true
 
     - name: Grant the owning role all privileges on its database
       community.postgresql.postgresql_privs:
@@ -270,6 +251,7 @@
       loop: "{{ postgres_managed_databases }}"
       loop_control:
         label: "{{ item.name }}"
+      no_log: true
 
     - name: Allow each managed user to connect from its client CIDR (scram)
       community.postgresql.postgresql_pg_hba:
@@ -283,6 +265,7 @@
       loop: "{{ postgres_managed_databases }}"
       loop_control:
         label: "{{ item.name }} <- {{ item.client_cidr }}"
+      no_log: true
       notify: Reload postgresql
 
 - name: Apply pending pg_hba reload

--- a/secrets.enc.yaml
+++ b/secrets.enc.yaml
@@ -26,7 +26,9 @@ N8N_OWNER_PASSWORD: ENC[AES256_GCM,data:p0XLJdXcuthcatYT+zPeueyRqYTEuaa9,iv:ihKe
 VIKUNJA_DB_PASSWORD: ENC[AES256_GCM,data:Jy+qiC6wvgTI2QBCkb4o5oh4vM9+FS70OiT6M7dhvPrw64Ddep65lPQBJKcb2/5d,iv:0HHDfT+Q35DncvnZle1rNAueSWFtdLBPs0mfMmF3NfM=,tag:Lfcquhtg6DHK5+qKLzf6yw==,type:str]
 VIKUNJA_JWT_SECRET: ENC[AES256_GCM,data:5H/XM4Q4hiLYe1dnwlC+Kw0Au2CsAYZSAq2L7jGSc8wAvPFW5sAvWrVwxxwrLubM34iRToAy2KGfnHv6Biexhw==,iv:REWG0SXVgIy0Pd6BmW+ZrV6COqxbcUcON0Yt+Aewi7k=,tag:qe3GTgSYbU8480Gda1pItw==,type:str]
 VIKUNJA_ADMIN_PASSWORD: ENC[AES256_GCM,data:oE14RtfkbF+NswJehLee5KkJeyOOH8i3XQolGuS8qVwqZ7zRYiiJ0HNCR5h8PItQ,iv:WgSwZpPSuBNf5aGNhfEoGQr3DpP3iUfm1cyfh+I4pPA=,tag:40aLFbhvcgpygU1AlGQrqw==,type:str]
-NAUTOBOT_DB_PASSWORD: ENC[AES256_GCM,data:T2zoWBvDSh152O8FGdRZovkms0uzUsldPV8SaS4pLP0Gg+k2BefauhVwimHf3nQ8,iv:SFNy5yZWofOPaunogR2CpcCevGWamb0X4u+fHOu0yQ8=,tag:6VMarf7pe/Ei1kcIeTTXqQ==,type:str]
+NAUTOBOT_DB_PASSWORD: ENC[AES256_GCM,data:+IhPP4X91RF+DRk7aC/A1xJezo4DY1h/SchLgEKoT5XSQu6udbmSbH6T,iv:d0Zbsy1NnD77VU7UEd8nrNBu29zT9PTcsuxmr668fDk=,tag:XTCmCA6pJkMmIzpJbuFKwQ==,type:str]
+NAUTOBOT_SECRET_KEY: ENC[AES256_GCM,data:EfxwknjptH5aBGzPAqWG6g2xK49mbipZCaC3L/sc2Ew/p7pfM91N71VXwLrToYW/WyVTVYxLOhjjW+4iJWDPOaai9vXDlEvUBlkhR50ll50iQsN/caQ=,iv:fVrUBDuWvQ+9UicWyENd8pvUnadjzne06FcpHU+GvJw=,tag:3XgLQoC322qp71/Wgn6MCQ==,type:str]
+NAUTOBOT_SUPERUSER_PASSWORD: ENC[AES256_GCM,data:mWlG6NEp431iCTDAzYQkLELzF4YIQcyDHU+q1/eozGIzIhqwatXYpxs=,iv:64rf0Es1yN19uJaTIchI4WnTEASXot7uVzjWmOWPQw0=,tag:pVtbEAVqZR7JI/5qM7N3kA==,type:str]
 sops:
     age:
         - enc: |
@@ -38,7 +40,7 @@ sops:
             fSSlce/LFPv5+Qzn6bu04aEOlLuM2azDds00cyhyIj4ur0zXxedvSQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
-    lastmodified: "2026-07-10T11:33:31Z"
-    mac: ENC[AES256_GCM,data:uQPUL8B/2iKeupPv4oOXmZnX/8Iq39fEcpkec862kmU7uaWrRl0XWAI5LBJuHOYERlM96WdSB8KD268pSGqaOH/QVevupSH89qAh9+PHf+fYffMMU3r+3SeCqlYnLVopAKdWRKQpQTJNIDib0LrfozOxUE+Q2L5nlHtEfmRpMsw=,iv:KRJW3MQKNG3uh4ymLZzHzvUbh5iY1T7WlL8cx03v+iE=,tag:ZTCUv+9zraVr0sUlsAlZSg==,type:str]
+    lastmodified: "2026-07-10T14:24:10Z"
+    mac: ENC[AES256_GCM,data:JTQ1B5j0BQXq1axMo6uvAsvWu3Ch1h1MTDCmsYQoLCI7hvBa6OgmOq+fFZZM0XElj7ngQgOE6wt8lva8sEsxXfm9NMJhElduOqncjs+4gNz/YVDa8ABBOnk+ursuhRgc8vZoczDY1atKznLF0vEwtBrM3ShlL6rpbXbrUaYmrJQ=,iv:VjHD4cwSTvUfZSP3CIhSONQy3dUOvyUrfCSxt5+C3IM=,tag:eqbAwdhrbp+LfXMl3dzA7w==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.1


### PR DESCRIPTION
## Summary
- Add SOPS-bootstrap Nautobot secret keys for the live cutover.
- Harden Nautobot native converge for unprivileged LXC, secret-safe management commands, uWSGI, and public Traefik FQDN trust.
- Keep Postgres managed role/database convergence compatible with SOPS-bootstrap password rotation.

Refs #138

## Validation
- ansible-lint
- live converge: postgres + Nautobot + ingress
- HTTPS check: Nautobot login returns 200 with certificate verification success

## Not merged
Merge remains human-gated.