### PR TITLE
fix(agentgateway): resolve Splunk MCP backend in the subdomain DNS zone

### DIFF
--- a/roles/agentgateway_docker/defaults/main.yml
+++ b/roles/agentgateway_docker/defaults/main.yml
@@ -63,9 +63,12 @@ agentgateway_docker_metrics_port: >-
 # tls_insecure skips backend certificate verification — required for the
 # Splunk management port's self-signed cert; never set it for public targets.
 # =============================================================================
+# The Splunk VM's A record lives in the PROXMOX_SUBDOMAIN zone (the DNS zone
+# Technitium is authoritative for), not the apex domain — same derivation as
+# every other role (cribl_edge, hermes_agent, ...).
 agentgateway_docker_splunk_mcp_host: >-
   https://{{ hostvars['localhost']['tofu_data']['splunk_vm']['splunk']['hostname'] }}.{{
-  hostvars['localhost']['tofu_data']['domain'] }}:{{
+  lookup('env', 'PROXMOX_SUBDOMAIN') | mandatory('PROXMOX_SUBDOMAIN required (Doppler)') }}:{{
   hostvars['localhost']['tofu_data']['constants']['service_ports']['splunk_mgmt']
   }}/services/mcp
 


### PR DESCRIPTION
The gateway's splunk MCP target was built as `<hostname>.<apex domain>`, which has no A record — backend DNS resolution failed with "backends required DNS resolution which failed" on every `/splunk/mcp` call. The Splunk VM's record lives in the internal subdomain zone, so derive the FQDN from `PROXMOX_SUBDOMAIN` (same pattern as cribl_edge / hermes_agent).

Verified live: context7 target already serves end-to-end through Traefik; splunk target fails only on this resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131dH1tK6vH7Em9JSJGRixu