### PR TITLE
feat(vikunja): tiered service accounts for API automation

### DIFF
--- a/inventory/group_vars/postgres_group.yml
+++ b/inventory/group_vars/postgres_group.yml
@@ -7,8 +7,11 @@
 # from the tofu inventory, never a literal). Falls back to the permissive role
 # default only when the reservation fact is absent (e.g. a molecule run, which
 # sets its own value anyway).
+# NB the space after the comma: postgres normalizes list GUCs to ", " — a
+# space-less value never matches SHOW output, so postgresql_set re-applies and
+# restarts the cluster on every converge.
 postgres_listen_addresses: >-
-  {{ ('localhost,' ~ container_reserved_ip)
+  {{ ('localhost, ' ~ container_reserved_ip)
      if (container_reserved_ip | default('', true) | length > 0)
      else '*' }}
 

--- a/roles/vikunja/defaults/main.yml
+++ b/roles/vikunja/defaults/main.yml
@@ -53,4 +53,13 @@ vikunja_admin_user: admin
 vikunja_admin_email: "{{ vikunja_admin_user }}@{{ tofu_data.domain }}"
 vikunja_admin_password: "{{ lookup('env', 'VIKUNJA_ADMIN_PASSWORD') }}"
 
+# Tiered service accounts for API automation (vikunja-mcp et al.). Created
+# idempotently like the admin; project shares + scoped API tokens are minted
+# against these accounts (read-only vs read-write tiers; admin token = admin).
+vikunja_service_users:
+  - username: svc-mcp-ro
+    password: "{{ lookup('env', 'VIKUNJA_SVC_MCP_RO_PASSWORD') }}"
+  - username: svc-mcp-rw
+    password: "{{ lookup('env', 'VIKUNJA_SVC_MCP_RW_PASSWORD') }}"
+
 vikunja_api_timeout: 30

--- a/roles/vikunja/tasks/main.yml
+++ b/roles/vikunja/tasks/main.yml
@@ -154,11 +154,14 @@
       - "--username={{ vikunja_admin_user }}"
       - "--email={{ vikunja_admin_email }}"
       - "--password={{ vikunja_admin_password }}"
-  # Word-boundary match — a bare substring test would false-positive on user
-  # names or emails that merely contain the admin name (e.g. "sysadmin").
-  # NB: '\\b' — a single '\b' in a Jinja string literal is a backspace char,
-  # which silently never matches and re-runs the create on every converge.
-  when: not (vikunja_user_list.stdout | default('') | regex_search('\\b' ~ vikunja_admin_user ~ '\\b'))
+  # Match the exact username as a whole table cell in `vikunja user list`
+  # output. A `\b` word boundary is wrong here: `-` is a non-word char, so
+  # `\badmin\b` would match "admin" inside "admin-helper". Anchor on
+  # start/whitespace/pipe (the table delimiters) instead. `default('', true)`
+  # guards against an undefined stdout when the list task is skipped.
+  when: >-
+    not (vikunja_user_list.stdout | default('', true)
+         | regex_search('(?:^|\\s|\\|)' ~ vikunja_admin_user ~ '(?:\\s|\\||$)'))
   changed_when: true
   no_log: true
 
@@ -174,8 +177,13 @@
   loop: "{{ vikunja_service_users }}"
   loop_control:
     label: "{{ item.username }}"
+  # Whole-cell match (see the admin task above): a `\b` boundary would let
+  # `svc-mcp-ro` false-match inside a hypothetical `svc-mcp-ro-x` and skip
+  # a real creation.
   when:
     - item.password | length > 0
-    - not (vikunja_user_list.stdout | default('') | regex_search('\\b' ~ item.username ~ '\\b'))
+    - >-
+      not (vikunja_user_list.stdout | default('', true)
+           | regex_search('(?:^|\\s|\\|)' ~ item.username ~ '(?:\\s|\\||$)'))
   changed_when: true
   no_log: true

--- a/roles/vikunja/tasks/main.yml
+++ b/roles/vikunja/tasks/main.yml
@@ -72,6 +72,9 @@
     remote_src: true
     include:
       - "{{ vikunja_binary_name }}"
+    # unarchive re-extracts (and reports changed) every run without this guard;
+    # the zip is checksum-pinned, so an existing extract is always current.
+    creates: "/tmp/{{ vikunja_binary_name }}"
   delegate_to: localhost
   connection: local
   become: false

--- a/roles/vikunja/tasks/main.yml
+++ b/roles/vikunja/tasks/main.yml
@@ -161,3 +161,21 @@
   when: not (vikunja_user_list.stdout | default('') | regex_search('\\b' ~ vikunja_admin_user ~ '\\b'))
   changed_when: true
   no_log: true
+
+- name: Create Vikunja service users (idempotent — skipped if already present)
+  ansible.builtin.command:
+    argv:
+      - "{{ vikunja_binary_path }}"
+      - user
+      - create
+      - "--username={{ item.username }}"
+      - "--email={{ item.username }}@{{ tofu_data.domain }}"
+      - "--password={{ item.password }}"
+  loop: "{{ vikunja_service_users }}"
+  loop_control:
+    label: "{{ item.username }}"
+  when:
+    - item.password | length > 0
+    - not (vikunja_user_list.stdout | default('') | regex_search('\\b' ~ item.username ~ '\\b'))
+  changed_when: true
+  no_log: true

--- a/roles/vikunja/tasks/main.yml
+++ b/roles/vikunja/tasks/main.yml
@@ -153,6 +153,8 @@
       - "--password={{ vikunja_admin_password }}"
   # Word-boundary match — a bare substring test would false-positive on user
   # names or emails that merely contain the admin name (e.g. "sysadmin").
-  when: not (vikunja_user_list.stdout | default('') | regex_search('\b' ~ vikunja_admin_user ~ '\b'))
+  # NB: '\\b' — a single '\b' in a Jinja string literal is a backspace char,
+  # which silently never matches and re-runs the create on every converge.
+  when: not (vikunja_user_list.stdout | default('') | regex_search('\\b' ~ vikunja_admin_user ~ '\\b'))
   changed_when: true
   no_log: true

--- a/secrets.enc.yaml
+++ b/secrets.enc.yaml
@@ -27,6 +27,8 @@ VIKUNJA_DB_PASSWORD: ENC[AES256_GCM,data:Jy+qiC6wvgTI2QBCkb4o5oh4vM9+FS70OiT6M7d
 VIKUNJA_JWT_SECRET: ENC[AES256_GCM,data:5H/XM4Q4hiLYe1dnwlC+Kw0Au2CsAYZSAq2L7jGSc8wAvPFW5sAvWrVwxxwrLubM34iRToAy2KGfnHv6Biexhw==,iv:REWG0SXVgIy0Pd6BmW+ZrV6COqxbcUcON0Yt+Aewi7k=,tag:qe3GTgSYbU8480Gda1pItw==,type:str]
 VIKUNJA_ADMIN_PASSWORD: ENC[AES256_GCM,data:oE14RtfkbF+NswJehLee5KkJeyOOH8i3XQolGuS8qVwqZ7zRYiiJ0HNCR5h8PItQ,iv:WgSwZpPSuBNf5aGNhfEoGQr3DpP3iUfm1cyfh+I4pPA=,tag:40aLFbhvcgpygU1AlGQrqw==,type:str]
 NAUTOBOT_DB_PASSWORD: ENC[AES256_GCM,data:T2zoWBvDSh152O8FGdRZovkms0uzUsldPV8SaS4pLP0Gg+k2BefauhVwimHf3nQ8,iv:SFNy5yZWofOPaunogR2CpcCevGWamb0X4u+fHOu0yQ8=,tag:6VMarf7pe/Ei1kcIeTTXqQ==,type:str]
+VIKUNJA_SVC_MCP_RO_PASSWORD: ENC[AES256_GCM,data:J/CN8uK4KV9uh2G7ZxHI+9tCYaVho7Zz52Jmf9JhjReJxFdjfka57v5Ev9Qu+kGJ,iv:jCgR4C3iic6T1GpkbH04pYS6smytLOAYefQZWsls+zU=,tag:g/Cs/YWlA6dhDUTO4ceaDg==,type:str]
+VIKUNJA_SVC_MCP_RW_PASSWORD: ENC[AES256_GCM,data:bxbBMeGFxp7fFu1vV0+nezpkD0lpjLx8viiQxoIv8mQtciLXPbXzteLMdHp8hC7u,iv:sajpKY4Y+J247gldd0fiVYM7DijKqEuo4hKgroDj1w4=,tag:c7xnWzHtSiTl9r/ZTLWuPw==,type:str]
 sops:
     age:
         - enc: |
@@ -38,7 +40,7 @@ sops:
             fSSlce/LFPv5+Qzn6bu04aEOlLuM2azDds00cyhyIj4ur0zXxedvSQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
-    lastmodified: "2026-07-10T11:33:31Z"
-    mac: ENC[AES256_GCM,data:uQPUL8B/2iKeupPv4oOXmZnX/8Iq39fEcpkec862kmU7uaWrRl0XWAI5LBJuHOYERlM96WdSB8KD268pSGqaOH/QVevupSH89qAh9+PHf+fYffMMU3r+3SeCqlYnLVopAKdWRKQpQTJNIDib0LrfozOxUE+Q2L5nlHtEfmRpMsw=,iv:KRJW3MQKNG3uh4ymLZzHzvUbh5iY1T7WlL8cx03v+iE=,tag:ZTCUv+9zraVr0sUlsAlZSg==,type:str]
+    lastmodified: "2026-07-10T15:27:41Z"
+    mac: ENC[AES256_GCM,data:UkTIyoOEIdRHqtN2bMi2fj3ZQIORlCmlNHuzygyuqxegPbCP+PTw7NLGsmW3W7kUKSH8EQxrBSF2FNQrk0l/AinkYbISBa8usovjYuK1DqqKjebBOe1UTVgjXq/GuDZjVJBj5AOmA9Cl+0JOaC/dmAkDRhA1YiGSa4TuLfGgq5s=,iv:Lj0Yxu2RsbP4c7Q3X5C+q27mcRnrdoGf7Q5oFqVgC5A=,tag:5L9d9ggPNtYoaDbK69uf6A==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.1

--- a/secrets.enc.yaml
+++ b/secrets.enc.yaml
@@ -29,6 +29,9 @@ VIKUNJA_ADMIN_PASSWORD: ENC[AES256_GCM,data:oE14RtfkbF+NswJehLee5KkJeyOOH8i3XQol
 NAUTOBOT_DB_PASSWORD: ENC[AES256_GCM,data:T2zoWBvDSh152O8FGdRZovkms0uzUsldPV8SaS4pLP0Gg+k2BefauhVwimHf3nQ8,iv:SFNy5yZWofOPaunogR2CpcCevGWamb0X4u+fHOu0yQ8=,tag:6VMarf7pe/Ei1kcIeTTXqQ==,type:str]
 VIKUNJA_SVC_MCP_RO_PASSWORD: ENC[AES256_GCM,data:J/CN8uK4KV9uh2G7ZxHI+9tCYaVho7Zz52Jmf9JhjReJxFdjfka57v5Ev9Qu+kGJ,iv:jCgR4C3iic6T1GpkbH04pYS6smytLOAYefQZWsls+zU=,tag:g/Cs/YWlA6dhDUTO4ceaDg==,type:str]
 VIKUNJA_SVC_MCP_RW_PASSWORD: ENC[AES256_GCM,data:bxbBMeGFxp7fFu1vV0+nezpkD0lpjLx8viiQxoIv8mQtciLXPbXzteLMdHp8hC7u,iv:sajpKY4Y+J247gldd0fiVYM7DijKqEuo4hKgroDj1w4=,tag:c7xnWzHtSiTl9r/ZTLWuPw==,type:str]
+VIKUNJA_MCP_TOKEN_RO: ENC[AES256_GCM,data:UkHke3+uwUvgMLJ4fA+b55Tx7vSBjulqDRBuN4R9oCewLuKf8UUtArt9IQ==,iv:wFzAQK4CdC+yb4H/kDFkxbxVpMgQ0gPC9+eD6aubmpI=,tag:6OvCwit/n6CLsm68IjM8WA==,type:str]
+VIKUNJA_MCP_TOKEN_RW: ENC[AES256_GCM,data:hl/D967ifpFz0lSB7LF093hnx5lq/l56bRmKV9M+Z7M+fHD2in80w7P+IQ==,iv:uyGouFToZpRLk5+7nonRc+RpZxBihG5yf9dImh0KSIA=,tag:kj+7yrmfF1tjWdyY1UlMfg==,type:str]
+VIKUNJA_MCP_TOKEN_ADMIN: ENC[AES256_GCM,data:xRHMSJ9OksjHyXpRb6Aa0MdEwk1Ws83gXJfqu897mTM4FYzkZYK79rhxew==,iv:O1cdp1hkNkbUvgN5Gq+nlfblrI8dWfS9oH0MfOBacTU=,tag:XU//P0nPJj6Pcdvl4DIbtQ==,type:str]
 sops:
     age:
         - enc: |
@@ -40,7 +43,7 @@ sops:
             fSSlce/LFPv5+Qzn6bu04aEOlLuM2azDds00cyhyIj4ur0zXxedvSQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
-    lastmodified: "2026-07-10T15:27:41Z"
-    mac: ENC[AES256_GCM,data:UkTIyoOEIdRHqtN2bMi2fj3ZQIORlCmlNHuzygyuqxegPbCP+PTw7NLGsmW3W7kUKSH8EQxrBSF2FNQrk0l/AinkYbISBa8usovjYuK1DqqKjebBOe1UTVgjXq/GuDZjVJBj5AOmA9Cl+0JOaC/dmAkDRhA1YiGSa4TuLfGgq5s=,iv:Lj0Yxu2RsbP4c7Q3X5C+q27mcRnrdoGf7Q5oFqVgC5A=,tag:5L9d9ggPNtYoaDbK69uf6A==,type:str]
+    lastmodified: "2026-07-10T15:40:28Z"
+    mac: ENC[AES256_GCM,data:ko+PcYiU3bhLgradWnQifC8adFLOWnj/OQDDb1gjWaPKGatlqYA4g8R+DmrE/Yr0GkXdH2/K+uuqdGiBqMcVgFA+RnzYva8AdnTi+h/Gzxh8G7lpAvfmOWdHPP0I+y4SlSBWnbNFu62oCVyb4O3FU+1TdQz9OttBeMnQlgLpVko=,iv:/3epB4vk9BGhtooJaqU90aeosvMCh7h0ABvECIVbytg=,tag:hqE5nl2ZnvE0tQbN4rpqZw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.1


### PR DESCRIPTION
Adds `svc-mcp-ro` / `svc-mcp-rw` service users to the vikunja role (created idempotently like the admin; passwords generated-at-source into SOPS). These back the least-privilege API-token tiers for vikunja-mcp and other agents — read-only and read-write project shares + scoped tokens, with the admin token reserved for admin operations.

Also carries two commits that missed the #835 squash window: the Jinja `\b` regex escape fix and the converge-idempotency pair.

Verification: ansible-lint production profile passes on the changed files; live converge + token minting evidence to follow on this PR.

Refs dryvist/docs-starlight#141

🤖 Generated with [Claude Code](https://claude.com/claude-code)