### PR TITLE
feat(hermes): dial Context7 through the shared agentgateway MCP plane

### DIFF
--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -321,10 +321,16 @@ hermes_agent_seeded_cron_names: >-
      + (hermes_agent_splunk_cron_jobs | map(attribute='name') | list) }}
 
 # --- Context7 MCP client (current library/framework docs on demand) ---
-# Registers Context7's hosted HTTP MCP server so Hermes can pull up-to-date,
-# version-specific docs mid-task. Bao-first, env fallback (see group_vars); the
-# entry is omitted until the API key is set.
+# Registers Context7 so Hermes can pull up-to-date, version-specific docs
+# mid-task. Bao-first, env fallback (see group_vars); the entry is omitted
+# until the API key is set. Dialed through the shared agentgateway MCP plane
+# (one governed front door per target; the gateway federates outbound HTTPS
+# to Context7) — set the URL back to https://mcp.context7.com/mcp to bypass
+# the gateway.
 hermes_agent_context7_mcp_enabled: true
+hermes_agent_context7_mcp_url: >-
+  https://mcp.{{ lookup('env', 'PROXMOX_SUBDOMAIN')
+  | mandatory('PROXMOX_SUBDOMAIN required (Doppler)') }}/context7/mcp
 hermes_agent_context7_api_key: ""
 
 # --- Escalation (Codex via MCP) ---

--- a/roles/hermes_agent/templates/config.yaml.j2
+++ b/roles/hermes_agent/templates/config.yaml.j2
@@ -106,9 +106,10 @@ mcp_servers:
       Authorization: "Bearer ${SPLUNK_MCP_TOKEN}"
 {% endif %}
 {% if _mcp_context7 %}
-  # Context7 — current, version-specific library/framework docs on demand.
+  # Context7 — current, version-specific library/framework docs on demand,
+  # via the shared agentgateway MCP plane (see defaults).
   context7:
-    url: "https://mcp.context7.com/mcp"
+    url: "{{ hermes_agent_context7_mcp_url }}"
 {% if hermes_agent_context7_api_key | length > 0 %}
     headers:
       CONTEXT7_API_KEY: "${CONTEXT7_API_KEY}"


### PR DESCRIPTION
Routes Hermes' Context7 MCP client through the agentgateway front door (`/context7/mcp`, Traefik-fronted) instead of the hosted endpoint directly — the campaign goal is every agent runtime reaching MCP targets through one governed plane, and the context7 path is verified end-to-end for strict clients (Claude Code connects through it). The Splunk target stays direct until the upstream empty-body-notification bug is fixed (#843).

The URL is a role default derived from `PROXMOX_SUBDOMAIN`; setting it back to the hosted endpoint bypasses the gateway. The API-key header (when set) passes through unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131dH1tK6vH7Em9JSJGRixu