### PR TITLE
feat(postgres): standby pull trust + dr_restore path (DB DR Standard)

### DIFF
--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -67,3 +67,17 @@ postgres_backup_dir: "{{ postgres_data_root }}/backups"
 postgres_backup_on_calendar: "*-*-* 02:30:00"
 postgres_backup_randomized_delay_sec: 900
 postgres_backup_retention_days: 14
+
+# SSH public key(s) the standby node's puller (ansible-proxmox
+# roles/postgres_standby) uses to rsync the backup directory. One key per
+# line; env-sourced (a public key, not a secret — but node-identifying, so
+# never a committed literal). Empty -> no trust installed.
+postgres_standby_pull_pubkeys: "{{ lookup('env', 'POSTGRES_STANDBY_SSH_PUBKEYS') | default('', true) }}"
+
+# DR restore inputs (docs/DATABASE_DR_STANDARD.md in ansible-proxmox; tagged
+# `never,dr_restore` — runs only on explicit invocation). `_dump` is a
+# CONTROLLER-side path (fetched from the replicated archive or the Tier-2
+# cloud copy); `_db` is the database to restore into — point it at a scratch
+# database for the mandatory restore drill.
+postgres_dr_restore_db: ""
+postgres_dr_restore_dump: ""

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -316,6 +316,65 @@
         enabled: true
         daemon_reload: true
 
+# Trust the standby node's puller so ansible-proxmox roles/postgres_standby can
+# rsync the backup directory into the replicated archive (Tier 1 of the
+# Database DR Standard). Env-gated: no key supplied, no trust installed.
+- name: Authorize the standby puller's SSH key(s) for root
+  ansible.posix.authorized_key:
+    user: root
+    key: "{{ postgres_standby_pull_pubkeys }}"
+  when: postgres_standby_pull_pubkeys | length > 0
+
+# =============================================================================
+# DR restore (explicit invocation only — the Database DR Standard's per-engine
+# restore path). Runs a controller-fetched dump into the named database:
+#   ansible-playbook ... --tags dr_restore \
+#     -e postgres_dr_restore_db=<db> -e postgres_dr_restore_dump=<local path>
+# Point _db at a scratch database for the mandatory restore drill.
+# =============================================================================
+- name: DR restore from a logical dump
+  tags:
+    - never
+    - dr_restore
+  block:
+    - name: Require the restore inputs
+      ansible.builtin.assert:
+        that:
+          - postgres_dr_restore_db | length > 0
+          - postgres_dr_restore_dump | length > 0
+        fail_msg: >-
+          dr_restore needs -e postgres_dr_restore_db=<db> and
+          -e postgres_dr_restore_dump=<controller-side dump path>
+
+    - name: Stage the dump on the guest
+      ansible.builtin.copy:
+        src: "{{ postgres_dr_restore_dump }}"
+        dest: /tmp/pg-dr-restore.dump
+        owner: postgres
+        group: postgres
+        mode: "0600"
+
+    - name: Ensure the restore target database exists
+      become: true
+      become_user: postgres
+      community.postgresql.postgresql_db:
+        name: "{{ postgres_dr_restore_db }}"
+        state: present
+
+    - name: Restore the dump (clean, if-exists)
+      become: true
+      become_user: postgres
+      ansible.builtin.command:
+        cmd: >-
+          pg_restore --clean --if-exists
+          --dbname={{ postgres_dr_restore_db }} /tmp/pg-dr-restore.dump
+      changed_when: true
+
+    - name: Remove the staged dump
+      ansible.builtin.file:
+        path: /tmp/pg-dr-restore.dump
+        state: absent
+
 # =============================================================================
 # Phase 6: Health check
 # =============================================================================


### PR DESCRIPTION
Guest side of the Database DR Standard (dryvist/ansible-proxmox#399 is the standby side).

## What

- **Standby pull trust** — `ansible.posix.authorized_key` for root from the
  env-sourced `POSTGRES_STANDBY_SSH_PUBKEYS` (public keys, node-identifying, so
  env-wired rather than committed; inert when unset). Lets the standby node's
  `postgres_standby` role rsync `postgres_backup_dir` into the replicated
  `bulk/databases/<instance>` archive.
- **`dr_restore`** (`tags: never,dr_restore` — explicit invocation only):
  asserts inputs, stages a controller-fetched dump, ensures the target database
  exists, `pg_restore --clean --if-exists` into it, removes the staged dump.
  Ownership is restored faithfully (managed roles already exist on the
  cluster). Pointing `postgres_dr_restore_db` at a scratch database is exactly
  the mandatory restore-drill flow.

## Verification

- `ansible-lint` (production profile): 0 failures.
- Molecule-safe: both additions are inert in CI (no env key; `never` tag).
- The restore drill itself (scratch DB, row-count diff = 0) runs live after
  merge + converge and will be reported on the tracking issue.

Refs #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrBt9kMzgRZZXCxyrmkdiF