### PR TITLE
feat(nautobot): fold tofu inventory into seed + SSoT virtualization job (#138)

### DIFF
--- a/roles/nautobot/files/jobs/ssot_common.py
+++ b/roles/nautobot/files/jobs/ssot_common.py
@@ -49,6 +49,7 @@ _EMPTY_BUNDLE: dict[str, list] = {
     "racks": [],
     "devices": [],
     "nodes": [],
+    "virtual_machines": [],
 }
 
 

--- a/roles/nautobot/files/jobs/ssot_virtualization.py
+++ b/roles/nautobot/files/jobs/ssot_virtualization.py
@@ -1,0 +1,178 @@
+"""SSoT seed job: Proxmox VE guests as Virtualization objects (issue #138).
+
+Source of truth: the ``virtual_machines`` array of the seed bundle (folded from
+the resolved tofu inventory — every LXC container, VM, docker VM, and the Splunk
+VM). DiffSyncs each guest into a Nautobot VirtualMachine (role Active, cluster =
+its Proxmox node, role = its first tag) additively. A ClusterType ``Proxmox`` and
+one Cluster per distinct node are ensured via the ORM before the DiffSync run,
+mirroring how the DCIM/node jobs ensure their DeviceType/Role scaffolding.
+
+After the additive VM sync, each guest carrying a numeric address gets an
+``eth0`` VMInterface, an IPAddress assigned to it, and that IP set as the VM's
+``primary_ip4`` — done in an ORM phase (not DiffSync) because the interface
+assignment and primary-IP FK are the generic-FK path the sibling jobs already
+defer out of DiffSync. IPAddress creation reuses the reservation job's approach
+(a /32 under an existing parent Prefix); a guest whose address has no parent
+Prefix (run the VLANs/Prefixes seed first) is skipped, never fatal.
+
+Live-validation notes: exact Nautobot 2.x field names on VirtualMachine /
+VMInterface / IPAddressToInterface target current 2.x.
+"""
+from __future__ import annotations
+
+from diffsync import Adapter
+from nautobot.apps.jobs import register_jobs
+from nautobot.virtualization.models import VirtualMachine
+from nautobot_ssot.contrib import NautobotAdapter
+from nautobot_ssot.jobs.base import DataSource
+
+from ssot_common import (
+    STATUS_ACTIVE,
+    AdditiveNautobotModel,
+    ensure_location,
+    ensure_role,
+    load_seed,
+)
+
+CLUSTER_TYPE = "Proxmox"
+DEFAULT_CLUSTER = "unknown"
+DEFAULT_ROLE = "vm"
+INTERFACE_NAME = "eth0"
+
+
+def _active_status():
+    """Return the shipped ``Active`` Status object."""
+    from nautobot.extras.models import Status
+
+    return Status.objects.get(name=STATUS_ACTIVE)
+
+
+def ensure_cluster(name: str):
+    """Idempotently ensure the ``Proxmox`` ClusterType and a Cluster (by node)."""
+    from nautobot.virtualization.models import Cluster, ClusterType
+
+    cluster_type, _ = ClusterType.objects.get_or_create(name=CLUSTER_TYPE)
+    cluster, _ = Cluster.objects.get_or_create(
+        name=name, defaults={"cluster_type": cluster_type}
+    )
+    return cluster
+
+
+class VirtualMachineModel(AdditiveNautobotModel):
+    """DiffSync model mirroring a Nautobot VirtualMachine."""
+
+    _model = VirtualMachine
+    _modelname = "virtual_machine"
+    _identifiers = ("name",)
+    _attributes = ("cluster__name", "status__name", "role__name")
+
+    name: str
+    cluster__name: str
+    status__name: str
+    role__name: str
+
+
+class VirtualizationNautobotAdapter(NautobotAdapter):
+    """Target adapter: loads existing VirtualMachines from the Nautobot ORM."""
+
+    top_level = ("virtual_machine",)
+    virtual_machine = VirtualMachineModel
+
+
+class VirtualizationSourceAdapter(Adapter):
+    """Source adapter: builds VirtualMachine models from the seed bundle."""
+
+    top_level = ("virtual_machine",)
+    virtual_machine = VirtualMachineModel
+
+    def __init__(self, *args, job=None, **kwargs):
+        """Store the owning Job for logging."""
+        super().__init__(*args, **kwargs)
+        self.job = job
+
+    def load(self) -> None:
+        """Populate VirtualMachine models from the seed bundle (guests only)."""
+        seed = load_seed()
+        for guest in seed["virtual_machines"]:
+            name = str(guest.get("name") or "")
+            if not name:
+                continue
+            cluster = str(guest.get("cluster") or DEFAULT_CLUSTER)
+            role = str(guest.get("role") or DEFAULT_ROLE)
+            ensure_cluster(cluster)
+            ensure_role(role, VirtualMachine)
+            self.add(
+                self.virtual_machine(
+                    name=name,
+                    cluster__name=cluster,
+                    status__name=STATUS_ACTIVE,
+                    role__name=role,
+                )
+            )
+
+
+class SeedVirtualization(DataSource):
+    """Seed Nautobot with the Proxmox VE guests as Virtualization objects."""
+
+    class Meta:
+        """Job metadata."""
+
+        name = "SSoT: Virtualization (Proxmox guests)"
+        description = "DiffSync Proxmox guests into Nautobot VirtualMachines from the seed bundle."
+        has_sensitive_variables = False
+
+    def load_source_adapter(self) -> None:
+        """Ensure org scaffolding, then load the seed source adapter."""
+        ensure_location()
+        self.source_adapter = VirtualizationSourceAdapter(job=self)
+        self.source_adapter.load()
+
+    def load_target_adapter(self) -> None:
+        """Load the Nautobot target adapter."""
+        self.target_adapter = VirtualizationNautobotAdapter(job=self)
+        self.target_adapter.load()
+
+    def run(self, *args, **kwargs):  # noqa: D102 - see _bind_primary_ips
+        """Run the additive VM sync, then bind eth0 + primary IP in the ORM."""
+        super().run(*args, **kwargs)
+        self._bind_primary_ips()
+
+    def _bind_primary_ips(self) -> None:
+        """Ensure eth0 + an assigned IPAddress + primary_ip4 for each guest.
+
+        ORM (not DiffSync): the interface assignment and primary-IP FK are the
+        generic-FK path the sibling jobs defer. Additive and per-guest defensive
+        — a guest whose IP has no parent Prefix (VLANs/Prefixes seed not yet run)
+        or whose ``ip`` is not numeric (a stray FQDN) is skipped, never fatal.
+        """
+        from nautobot.ipam.models import IPAddress, IPAddressToInterface
+        from nautobot.virtualization.models import VMInterface
+
+        status = _active_status()
+        for guest in load_seed()["virtual_machines"]:
+            name = str(guest.get("name") or "")
+            host = str(guest.get("ip") or "").split("/", 1)[0]
+            if not name or not host:
+                continue
+            vm = VirtualMachine.objects.filter(name=name).first()
+            if vm is None:  # not created (e.g. dry run) — nothing to bind
+                continue
+            try:
+                ip_address, _ = IPAddress.objects.get_or_create(
+                    host=host, defaults={"mask_length": 32, "status": status}
+                )
+            except Exception as exc:  # noqa: BLE001 - stay additive on any IP error
+                self.logger.warning("Skipped IP for VM %s: %s", name, exc)
+                continue
+            interface, _ = VMInterface.objects.get_or_create(
+                virtual_machine=vm, name=INTERFACE_NAME, defaults={"status": status}
+            )
+            IPAddressToInterface.objects.get_or_create(
+                ip_address=ip_address, vm_interface=interface
+            )
+            if vm.primary_ip4_id != ip_address.id:
+                vm.primary_ip4 = ip_address
+                vm.validated_save()
+
+
+register_jobs(SeedVirtualization)

--- a/roles/nautobot/tasks/seed_bundle.yml
+++ b/roles/nautobot/tasks/seed_bundle.yml
@@ -105,6 +105,41 @@
              mgmt_ip: value.ansible_host, commissioned: `true`}') }}
   no_log: true
 
+# Virtual machines from the resolved tofu inventory (issue #138): every guest
+# (containers + vms + docker_vms + splunk_vm) folded into one additive list. The
+# tofu inventory is resolved onto localhost by inventory/load_tofu.yml; default
+# to an empty map so the bundle build stays green when it is absent (molecule /
+# tests). The numeric address is reserved_ip when the guest is DHCP-first (its
+# `ip` then carries an FQDN) else the static `ip`; role is the guest's first tag.
+- name: Merge every guest kind into one map
+  vars:
+    nautobot_seed_tofu: "{{ hostvars['localhost'].tofu_data | default({}) }}"
+  ansible.builtin.set_fact:
+    nautobot_seed_virtual_machines: []
+    nautobot_seed_guests: >-
+      {{ (nautobot_seed_tofu.containers | default({}))
+         | combine(nautobot_seed_tofu.vms | default({}))
+         | combine(nautobot_seed_tofu.docker_vms | default({}))
+         | combine(nautobot_seed_tofu.splunk_vm | default({})) }}
+
+- name: Fold the tofu inventory guests into virtual_machines
+  ansible.builtin.set_fact:
+    nautobot_seed_virtual_machines: >-
+      {{ nautobot_seed_virtual_machines | default([]) + [{
+           'name': item.value.hostname,
+           'vmid': item.value.vmid | default(''),
+           'cluster': item.value.node | default('unknown'),
+           'role': (item.value.tags | default([]) | first)
+                   if (item.value.tags | default([]) | length) > 0 else 'vm',
+           'ip': item.value.reserved_ip | default('', true) or (item.value.ip | default('')),
+           'mac': item.value.mac | default('')
+         }] }}
+  loop: "{{ nautobot_seed_guests | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when: item.value.hostname | default('')
+  no_log: true
+
 - name: Assemble the seed bundle
   ansible.builtin.set_fact:
     nautobot_seed_bundle:
@@ -116,6 +151,7 @@
       racks: "{{ nautobot_seed_racks }}"
       devices: "{{ nautobot_seed_devices }}"
       nodes: "{{ nautobot_seed_nodes }}"
+      virtual_machines: "{{ nautobot_seed_virtual_machines }}"
   no_log: true
 
 # --- Write the bundle onto the Nautobot LXC ---------------------------------


### PR DESCRIPTION
## What

Feed the **full published tofu inventory** into Nautobot as Virtualization objects, additively. Two parts.

### Part 1 — seed bundle (`roles/nautobot/tasks/seed_bundle.yml`)

Adds a `virtual_machines` array to `nautobot_seed_bundle`, folded from the localhost-resolved tofu inventory (`hostvars['localhost'].tofu_data`): every LXC container, VM, docker VM, and the Splunk VM. Per-entry field mapping (source key -> seed key):

| source (tofu guest) | seed entry |
| --- | --- |
| `hostname` | `name` (entry skipped when absent) |
| `vmid` | `vmid` |
| `node` | `cluster` (default `unknown`) |
| `tags[0]` | `role` (default `vm`) |
| `reserved_ip` or `ip` | `ip` (numeric address; DHCP-first guests carry an FQDN in `ip` and the address in `reserved_ip`) |
| `mac` | `mac` |

Every field is `| default`-guarded, so a missing key never fails the build. The build initializes the array to `[]` and stays green when `tofu_data` is absent (molecule/tests). `ssot_common` adds `virtual_machines: []` to the empty-bundle template so `load_seed` tolerates its absence.

### Part 2 — new SSoT job (`roles/nautobot/files/jobs/ssot_virtualization.py`)

Mirrors the sibling seed jobs exactly:
- Ensures a `Proxmox` ClusterType and one Cluster per distinct node via the ORM (`get_or_create`).
- DiffSyncs VirtualMachines additively (`AdditiveNautobotModel`, `delete` no-op; identifier `name`; attributes cluster/status/role), ensuring a Role for the VirtualMachine content-type via `ensure_role`.
- After the sync, an ORM phase binds an `eth0` VMInterface, an IPAddress, and `primary_ip4` per guest — the generic-FK path the sibling DCIM/IP jobs deliberately defer out of DiffSync. Reuses the reservation job's `/32`-under-parent-prefix approach; a guest whose IP has no parent prefix (run the VLANs/Prefixes seed first) or a stray non-numeric `ip` is skipped, never fatal.
- Registered via `register_jobs`; installed by the existing wholesale `jobs/` copy. Operator-run at cutover like the other seed jobs (no enable-list to update).

## Verification

- `ansible-lint roles/nautobot` (production profile) passes: `0 failure(s), 0 warning(s) on 23 files. Profile 'production' was required, and it passed.`
- `python3 -m py_compile` clean on the new job + `ssot_common`.
- Fold-logic self-check against the cached tofu inventory: 58 guests folded, all carry name/cluster/role, all `ip` values resolve to numeric IPv4 (the `reserved_ip`-or-`ip` coalesce leaves 0 non-numeric).
- No molecule scenario exists for the nautobot role, and the export contract does not assert on `virtual_machines` — nothing to break.

## Notes / assumptions

- Guest field shapes confirmed against the published inventory: containers/vms/docker_vms carry `hostname, ip, mac, node, reserved_ip, tags, vmid`; `splunk_vm` carries `hostname, ip, node, vmid` (no mac/reserved_ip/tags — all `default`-guarded).
- `primary_ip4` binding is ORM (post-sync), not DiffSync, matching how the sibling jobs keep DiffSync models free of the generic-FK path.
- Does **not** converge anything live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrBt9kMzgRZZXCxyrmkdiF