### PR TITLE
feat(openbao): seed vikunja MCP tokens into secret/apps/vikunja

### DIFF
--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -116,6 +116,20 @@ openbao_kv_mount: secret
 # writable by the terraform-apply policy so that read/write proof keeps working.
 openbao_homelab_path: homelab
 
+# App secrets promoted into secret/apps/vikunja so OpenBao is their canonical
+# home. Maps each KV key to the converge-env var that carries its value (the
+# vikunja role mints these and stores them in SOPS; a converge run under
+# `sops exec-env` exposes them). The seed step (init.yml) runs only on the
+# bootstrap host under the admin token, writes only when a value differs from
+# what is already stored, and skips any key whose env var is empty — so a
+# converge without the SOPS values (or with unchanged values) writes nothing.
+openbao_vikunja_secrets:
+  token_ro: VIKUNJA_MCP_TOKEN_RO
+  token_rw: VIKUNJA_MCP_TOKEN_RW
+  token_admin: VIKUNJA_MCP_TOKEN_ADMIN
+  svc_mcp_ro_password: VIKUNJA_SVC_MCP_RO_PASSWORD
+  svc_mcp_rw_password: VIKUNJA_SVC_MCP_RW_PASSWORD
+
 # Policy + AppRole names, one per RBAC identity (see docs/SECRETS_HIERARCHY.md
 # for the full rationale). Split by resource domain, least-privilege:
 #   terraform-apply  — human-triggered IaC apply (was "terraform"); read+write

--- a/roles/openbao/tasks/init.yml
+++ b/roles/openbao/tasks/init.yml
@@ -187,6 +187,58 @@
     - openbao_bootstrap_token is defined
     - (openbao_kv_mount ~ '/') not in (openbao_mounts_raw.stdout | from_json).keys()
 
+# --- App-secret seeding (write-if-changed) ----------------------------------
+# Promote Vikunja MCP service credentials (minted by the vikunja role, stored
+# in SOPS) into secret/apps/vikunja so OpenBao is their canonical home. Values
+# come from the converge environment (SOPS via `sops exec-env`), mapped by
+# openbao_vikunja_secrets. Runs only on the bootstrap host under the admin
+# token; writes only when a value differs from what is already stored.
+- name: Assemble the desired vikunja app-secret map from the converge environment
+  ansible.builtin.set_fact:
+    openbao_vikunja_desired: >-
+      {{ openbao_vikunja_desired | default({})
+         | combine({ item.key: lookup('env', item.value) }) }}
+  loop: "{{ openbao_vikunja_secrets | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  no_log: true
+  when:
+    - openbao_bootstrap_token is defined
+    - lookup('env', item.value) | length > 0
+
+- name: Read the current vikunja app secrets from OpenBao
+  ansible.builtin.command:
+    cmd: "bao kv get -format=json {{ openbao_kv_mount }}/apps/vikunja"
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  register: openbao_vikunja_current
+  failed_when: false
+  changed_when: false
+  no_log: true
+  when:
+    - openbao_bootstrap_token is defined
+    - (openbao_vikunja_desired | default({})) | length > 0
+
+- name: Seed or update the vikunja app secrets in OpenBao (write-if-changed)
+  ansible.builtin.command:
+    argv: >-
+      {{ ['bao', 'kv', 'put', openbao_kv_mount ~ '/apps/vikunja']
+         + (openbao_vikunja_desired.keys() | zip(openbao_vikunja_desired.values())
+            | map('join', '=') | list) }}
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  no_log: true
+  changed_when: true
+  when:
+    - openbao_bootstrap_token is defined
+    - (openbao_vikunja_desired | default({})) | length > 0
+    - >-
+      (openbao_vikunja_current.rc | default(1)) != 0
+      or (openbao_vikunja_current.stdout | default('{}') | from_json).data.data | default({})
+         != (openbao_vikunja_desired | default({}))
+
 # --- RBAC policies (write-if-missing-or-changed) ----------------------------
 # Rendered on the TARGET: `bao policy write` below executes there and reads
 # the file from its local filesystem (a controller-side render is unreachable


### PR DESCRIPTION
## What

Adds a **write-if-changed** seed step to the `openbao` role that promotes the
Vikunja MCP service credentials into OpenBao at `secret/apps/vikunja`, making
OpenBao their canonical home now that a second consumer (the MCP server) needs
them.

- `roles/openbao/defaults/main.yml` — `openbao_vikunja_secrets` maps each KV
  key to the env var that carries its value (RO/RW/ADMIN tokens + the
  `svc-mcp-ro`/`svc-mcp-rw` passwords, all already minted by the `vikunja` role
  and stored in SOPS).
- `roles/openbao/tasks/init.yml` — three guarded tasks: assemble the desired
  map from the converge environment, read the current KV value, and `bao kv put`
  **only when a value differs**. Runs on the bootstrap host under the admin
  token, alongside the existing policy/AppRole provisioning.

## Why

The tokens were generated at their source (the `vikunja` role → SOPS) per the
generate-at-source rule. A second consumer now reads them, so they graduate to
the shared engine rather than being seeded there speculatively.

## Idempotency / safety

- Skips cleanly when no privileged `BAO_TOKEN` is supplied (a routine converge
  that isn't promoting secrets stays a no-op).
- `write-if-changed`: re-running with unchanged values reports `ok`, not
  `changed`.
- `no_log: true` on every task that touches secret material.

## Validation

- `ansible-lint roles/openbao` → **0 failures / 0 warnings**, profile
  `production`.
- Jinja `argv` builder asserted end-to-end: it produces
  `['bao', 'kv', 'put', 'secret/apps/vikunja', '<key>=<val>', ...]`.

## One-time operator step to actually promote

The promotion converge needs the admin `BAO_TOKEN` (Bitwarden-locked; not
self-fetchable by automation) **and** the SOPS-provided token env, e.g.:

```
sops exec-env secrets.enc.yaml 'BAO_TOKEN=<admin> ansible-playbook ... --tags openbao'
```

Merging this PR wires the capability; the values land in OpenBao on the next
admin-token converge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)