### PR TITLE
fix(nautobot): resolve fixed-ips reservations against the live shape (#138)

### DIFF
--- a/roles/nautobot/defaults/main.yml
+++ b/roles/nautobot/defaults/main.yml
@@ -136,10 +136,9 @@ nautobot_seed_networks: "{{ (lookup('env', 'NAUTOBOT_SEED_NETWORKS') | default('
 nautobot_seed_racks:
   - name: homelab-rack-1
     site: homelab
-# Source-shape assumptions (WS-E confirms at cutover):
-#   fixed-ips.json is a list; map its keys to the reservation schema.
-nautobot_seed_fixed_ips_query: >-
-  [].{address: ip, dns_name: dns_name, hostname: name, mac: mac, vlan_vid: vlan_id}
+# fixed-ips.json reservation resolution is handled in seed_bundle.yml (confirmed
+# live shape: {value: {<name>: {cidr_key, host, hostname}}}, no literal IP —
+# address = cidrhost(network_cidrs[cidr_key], host)). No json_query var needed.
 #   hosts.yml groups the pve hypervisors under this key.
 nautobot_seed_hosts_group: proxmox
 

--- a/roles/nautobot/tasks/seed_bundle.yml
+++ b/roles/nautobot/tasks/seed_bundle.yml
@@ -86,13 +86,35 @@
              service_tag: value.service_tag, mgmt_ip: value.mgmt_ip}') }}
   no_log: true
 
-# Reservations from fixed-ips.json. ASSUMPTION: a list of objects each carrying
-# an address plus optional name/mac (WS-E adjusts the key names at cutover).
+# Reservations from fixed-ips.json. Confirmed live shape (WS-E cutover): the file
+# is {fixed_ips: {<name>: {cidr_key, host, hostname, mac, ...}}} and carries
+# NO literal IP — the address is cidrhost(NETWORK_CIDR_<cidr_key>, host),
+# resolved downstream in terragrunt. We reproduce that resolution here from the
+# network CIDRs the caller already supplies (nautobot_seed_networks), so the
+# committed sources still hold zero IP literals. dns_name is the hostname up to
+# the first space (some entries append a parenthetical label).
+- name: Build the VLAN-name to CIDR lookup for reservation resolution
+  ansible.builtin.set_fact:
+    nautobot_seed_network_cidrs: >-
+      {{ dict(nautobot_seed_networks | map(attribute='name')
+              | zip(nautobot_seed_networks | map(attribute='cidr'))) }}
+
 - name: Build reservations from the fixed-IP source
   ansible.builtin.set_fact:
     nautobot_seed_reservations: >-
-      {{ nautobot_seed_fixed_ips
-         | community.general.json_query(nautobot_seed_fixed_ips_query) }}
+      {{ nautobot_seed_reservations | default([]) + [{
+           'address': nautobot_seed_network_cidrs[item.value.cidr_key]
+                      | ansible.utils.ipaddr(item.value.host)
+                      | ansible.utils.ipaddr('address'),
+           'dns_name': item.value.hostname | default('') | regex_replace(' .*$', '')
+         }] }}
+  loop: "{{ (nautobot_seed_fixed_ips.fixed_ips | default({})) | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when:
+    - item.value.cidr_key is defined
+    - item.value.host is defined
+    - nautobot_seed_network_cidrs[item.value.cidr_key | default('')] is defined
   no_log: true
 
 # Nodes from hosts.yml. ASSUMPTION: the pve hypervisors are the host keys under


### PR DESCRIPTION
The seed bundle's `fixed_ips` reservation transform assumed a flat list with a literal `ip` field. The live `tofu-unifi` `fixed-ips.json` is `{fixed_ips: {<name>: {cidr_key, host, hostname, mac}}}` and carries **no literal IP** — the address is `cidrhost(NETWORK_CIDR_<cidr_key>, host)`, resolved downstream in terragrunt. The old `json_query` therefore silently produced **zero reservations**.

This reproduces the `cidrhost` resolution in-Ansible via `ansible.utils.ipaddr`, keyed off the network CIDRs the caller already supplies (`nautobot_seed_networks`), so the committed sources still hold zero IP literals. `dns_name` is the hostname up to the first space (some entries append a label, e.g. `idrac-r410 (R410 BMC)`).

## Verification

- Ran the transform against the **live** fixed-ips file with placeholder CIDRs: **35 reservations** resolve, with clean DNS names (`pve4`, `idrac-r410`, `idrac-r710`, `nautobot`, …).
- ansible-lint (production profile): 0 failures.
- Molecule unaffected (seed build gated `nautobot_build_seed=false`).

Removes the now-unused `nautobot_seed_fixed_ips_query` default.

Refs #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrBt9kMzgRZZXCxyrmkdiF