### PR TITLE
feat(nautobot): run SSoT seed jobs (+ optional export) in the converge (#138)

### DIFF
--- a/roles/nautobot/defaults/main.yml
+++ b/roles/nautobot/defaults/main.yml
@@ -148,3 +148,9 @@ nautobot_seed_hosts_group: proxmox
 # layer without a multi-minute install + live DB; live app validation is the
 # cutover gate (issue #138 "Done when"). Same idea as keepalived_manage_services.
 nautobot_manage_app: true
+
+# Run the additive SSoT seed jobs (load nautobot_seed.json into Nautobot) once
+# during the converge — off by default, enabled at cutover after the seed bundle
+# is placed. nautobot_run_export additionally runs the export Job that same pass.
+nautobot_run_seed_jobs: false
+nautobot_run_export: false

--- a/roles/nautobot/files/run_seed_jobs.py
+++ b/roles/nautobot/files/run_seed_jobs.py
@@ -1,0 +1,66 @@
+"""Run the SSoT seed jobs (and optionally the export) once, synchronously.
+
+Run via ``nautobot-server shell --interface python`` (same mechanism as
+superuser_bootstrap.py / schedule_export.py). For each seed job: enable it,
+enqueue it to the running worker, then poll its JobResult to a terminal state.
+The worker executes with the units' EnvironmentFile (nautobot.env), so it has
+the seed-file path and export S3 credentials without this script passing them.
+
+Ordering matters: VLANs/Prefixes first (IP reservations attach under a parent
+prefix), then IPs, DCIM, nodes, and virtualization last.
+
+Version-defensive like schedule_export.py: prints a per-job marker and never
+raises, so one job's quirk cannot abort the converge. Markers:
+``JOB_DONE <name> <status>`` / ``JOB_SKIPPED <name> <reason>`` /
+``JOB_ERROR <name> <detail>`` / ``JOB_TIMEOUT <name>``.
+"""
+import os
+import time
+
+from django.contrib.auth import get_user_model
+from nautobot.extras.models import Job, JobResult
+
+SEED_JOBS = [
+    "Seed VLANs and Prefixes",
+    "Seed IP Addresses and Reservations",
+    "Seed DCIM Racks and Devices",
+    "Seed Proxmox Node Facts",
+    "SSoT: Virtualization (Proxmox guests)",
+]
+if os.environ.get("NAUTOBOT_RUN_EXPORT", "").lower() in ("1", "true", "yes"):
+    SEED_JOBS.append("Export Nautobot Inventory to S3")
+
+# Celery terminal states (Nautobot JobResult.status mirrors these).
+TERMINAL = {"SUCCESS", "FAILURE", "REVOKED"}
+TIMEOUT = int(os.environ.get("NAUTOBOT_JOB_TIMEOUT", "300"))
+
+approver = get_user_model().objects.filter(is_superuser=True).order_by("pk").first()
+
+
+def run_one(name):
+    """Enable, enqueue, and poll a single job by display name."""
+    job = Job.objects.filter(name=name).first()
+    if job is None:
+        print("JOB_SKIPPED", name, "not-registered")
+        return
+    if not job.enabled:
+        job.enabled = True
+        job.save()
+    try:
+        result = JobResult.enqueue_job(job, approver)
+    except Exception as exc:  # noqa: BLE001 - enqueue signature is version-sensitive
+        print("JOB_ERROR", name, "enqueue:%s" % exc)
+        return
+    deadline = time.time() + TIMEOUT
+    while time.time() < deadline:
+        result.refresh_from_db()
+        status = str(getattr(result, "status", "")).upper()
+        if status in TERMINAL:
+            print("JOB_DONE", name, status)
+            return
+        time.sleep(3)
+    print("JOB_TIMEOUT", name)
+
+
+for job_name in SEED_JOBS:
+    run_one(job_name)

--- a/roles/nautobot/tasks/main.yml
+++ b/roles/nautobot/tasks/main.yml
@@ -323,3 +323,22 @@
       retries: 20
       delay: 6
       changed_when: false
+
+    # Load the seed bundle into Nautobot by running the additive SSoT DiffSync
+    # jobs (and, when NAUTOBOT_RUN_EXPORT is set, the export) once. Off by
+    # default — enable at cutover with -e nautobot_run_seed_jobs=true after the
+    # seed bundle is placed (nautobot_build_seed=true). The jobs are additive
+    # (create/update only), so re-running is safe and idempotent. The worker
+    # executes them with the units' EnvironmentFile, so it already holds the
+    # seed-file path + export S3 credentials.
+    - name: Run the SSoT seed jobs (and optional export) once
+      ansible.builtin.command:
+        cmd: "{{ nautobot_root }}/bin/nautobot-server shell --interface python"
+        stdin: "{{ lookup('ansible.builtin.file', 'run_seed_jobs.py') }}"
+      environment: >-
+        {{ nautobot_env | combine({'NAUTOBOT_RUN_EXPORT': nautobot_run_export | string}) }}
+      register: nautobot_run_seed
+      changed_when: "'JOB_DONE' in nautobot_run_seed.stdout"
+      become: true
+      become_user: "{{ nautobot_user }}"
+      when: nautobot_run_seed_jobs | bool


### PR DESCRIPTION
The converge placed `nautobot_seed.json` and installed the SSoT jobs, but nothing ever **ran** them — so the seed data never loaded into Nautobot, and the DCIM/IPAM/virtualization records stayed empty.

Adds `run_seed_jobs.py` (the same `nautobot-server shell --interface python` mechanism the role already uses for `superuser_bootstrap` and `schedule_export`): for each additive SSoT job it enables the job, enqueues it to the running worker, and polls its `JobResult` to a terminal state — in dependency order (VLANs/Prefixes → IPs → DCIM → nodes → virtualization), optionally the export job last (`nautobot_run_export`). The worker executes with the units' `EnvironmentFile`, so it already holds the seed-file path + export S3 creds.

Gated by `nautobot_run_seed_jobs` (default **false**) — enabled at cutover alongside `nautobot_build_seed=true`. The jobs are additive (create/update only), so re-runs are idempotent. Version-defensive like `schedule_export.py`: each job prints a `JOB_DONE/SKIPPED/ERROR/TIMEOUT` marker and never raises, so one job's quirk can't abort the converge.

## Verification

- Python syntax check + ansible-lint (production profile): 0 failures.
- Molecule unaffected (gated false; `nautobot_manage_app` false in molecule).
- Live seed load + count reconciliation runs at cutover converge (reported on #138).

Refs #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrBt9kMzgRZZXCxyrmkdiF