### PR TITLE
feat: add zammad ITSM role (incident-management system of record)

### DIFF
--- a/inventory/group_vars/postgres_group.yml
+++ b/inventory/group_vars/postgres_group.yml
@@ -33,3 +33,9 @@ postgres_managed_databases:
       {{ bao_apps_secrets.vikunja_db_password
          | default(lookup('env', 'VIKUNJA_DB_PASSWORD'), true) }}
     client_cidr: "{{ lookup('env', 'NETWORK_CIDR_APPS') | default('', true) }}"
+  - name: zammad
+    user: zammad
+    password: >-
+      {{ bao_apps_secrets.zammad_db_password
+         | default(lookup('env', 'ZAMMAD_DB_PASSWORD'), true) }}
+    client_cidr: "{{ lookup('env', 'NETWORK_CIDR_APPS') | default('', true) }}"

--- a/inventory/group_vars/zammad_group.yml
+++ b/inventory/group_vars/zammad_group.yml
@@ -1,0 +1,51 @@
+---
+# Zammad ITSM/ticketing + knowledge base — the incident-management system of
+# record. tofu-derived FQDNs/ports plus bao-first secrets (apps domain), env
+# fallback. Mirrors the nautobot_group.yml shape (shared-Postgres app on the
+# apps VLAN). The heavy app layer stays enabled here; molecule disables it via
+# zammad_manage_app.
+
+# Web port from the published constants (service_ports.zammad_web, 8080 — nginx
+# in-guest). Falls back to 8080 when the cache predates that key.
+zammad_web_port: >-
+  {{ (hostvars['localhost']['tofu_data']['constants']['service_ports']['zammad_web'])
+     | default(8080) }}
+
+# Postgres has no ingress; reach it by its guest FQDN on the data VLAN. The
+# guest DNS zone is tofu_data.domain and the hostname is fixed at `postgres`
+# by the container (a stable service identifier, not a hard-coded address).
+zammad_db_host: "postgres.{{ hostvars['localhost']['tofu_data']['domain'] }}"
+zammad_db_password: >-
+  {{ bao_apps_secrets.zammad_db_password
+     | default(lookup('env', 'ZAMMAD_DB_PASSWORD'), true) }}
+
+# Admin password bao-first (secret/apps/zammad), env fallback.
+zammad_admin_password: >-
+  {{ bao_apps_secrets.zammad_admin_password
+     | default(lookup('env', 'ZAMMAD_ADMIN_PASSWORD'), true) }}
+
+# Public UI FQDN (Traefik-fronted): zammad.<ingress subdomain>, matching the
+# Traefik router base domain and wildcard certificate from PROXMOX_SUBDOMAIN.
+# `lookup('env', …)` returns "" (not undefined) when unset; `or undef()` (empty
+# string is falsy) is what actually fails the play when PROXMOX_SUBDOMAIN is
+# missing, matching the nautobot_group.yml pattern.
+zammad_ui_fqdn: >-
+  zammad.{{ lookup('env', 'PROXMOX_SUBDOMAIN')
+     or undef('PROXMOX_SUBDOMAIN is required for the Zammad UI FQDN') }}
+
+# API token seeded into Zammad for the Hermes agent. Its canonical home is
+# ai/hermes (local-llm domain) so ONE token feeds both the seeding side here
+# and the Hermes skill env — bao-first with env fallback. On hosts where the
+# local-llm domain is not fetched, bao_local_llm_secrets is {} and the env
+# fallback (ZAMMAD_API_TOKEN, from Doppler/SOPS) resolves it.
+zammad_hermes_api_token: >-
+  {{ bao_local_llm_secrets.ZAMMAD_API_TOKEN
+     | default(lookup('env', 'ZAMMAD_API_TOKEN'), true) }}
+
+# Outbound notification email relays through the existing Mailpit LXC (SMTP on
+# notification_ports.mailpit_smtp). Reached by its guest FQDN — no auth, no TLS
+# on the internal relay. Notifications land in the Mailpit web UI, not real mail.
+zammad_smtp_host: "mailpit.{{ hostvars['localhost']['tofu_data']['domain'] }}"
+zammad_smtp_port: >-
+  {{ (hostvars['localhost']['tofu_data']['constants']['notification_ports']['mailpit_smtp'])
+     | default(1025) }}

--- a/inventory/load_tofu.yml
+++ b/inventory/load_tofu.yml
@@ -344,6 +344,11 @@
               ['vikunja_group']
               if 'vikunja' in (item.value.tags | default([]))
               else []
+            ) +
+            (
+              ['zammad_group']
+              if 'zammad' in (item.value.tags | default([]))
+              else []
             )
           }}
         proxmox_vmid: "{{ item.value.vmid }}"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -1055,6 +1055,25 @@
     - role: vikunja
 
 # =============================================================================
+# Phase 8h: Zammad ITSM/ticketing + knowledge base (incident-management SoR)
+# Native packager.io DEB with a colocated Elasticsearch + Redis, state in the
+# shared native Postgres cluster (#138). Requires DNS (Phase 1a/1b) and Postgres
+# (Phase 5b) to have converged first. gather_facts is on: the role derives the
+# packager.io apt repo from ansible_distribution_major_version.
+# =============================================================================
+
+- name: Configure Zammad ITSM
+  hosts: zammad_group
+  become: true
+  gather_facts: true
+  tags:
+    - zammad
+    - itsm
+    - incident
+  roles:
+    - role: zammad
+
+# =============================================================================
 # Phase 8d: HTTPS ingress (Traefik)
 # Fronts every service web UI at https://<name>.<domain> (no ports) with a
 # wildcard Let's Encrypt cert fetched via Route53 DNS-01. On the media VLAN so

--- a/roles/apt_cacher_ng/defaults/main.yml
+++ b/roles/apt_cacher_ng/defaults/main.yml
@@ -72,6 +72,19 @@ apt_cacher_ng_microsoft_passthrough: true
 # with "403 CONNECT denied (ask the admin to allow HTTPS tunnels)".
 apt_cacher_ng_postgresql_passthrough: true
 
+# Zammad (packager.io) repo passthrough. The Zammad DEB repo is served from
+# go.packager.io, which 302-redirects package downloads to dl.packager.io —
+# both HTTPS-only, so apt tunnels them via CONNECT. Allow BOTH hosts (the
+# initial CONNECT and the redirect target) or the zammad role fails at
+# "apt-get update" / package fetch with "403 CONNECT denied".
+apt_cacher_ng_packager_passthrough: true
+
+# Elasticsearch (Elastic) repo passthrough. artifacts.elastic.co (used by the
+# zammad role for Zammad's colocated Elasticsearch full-text search backend)
+# is HTTPS-only and cannot be cached, so apt tunnels it via CONNECT. Without
+# this the zammad role fails installing Elasticsearch with "403 CONNECT denied".
+apt_cacher_ng_elastic_passthrough: true
+
 # Logging
 apt_cacher_ng_verbose_log: 1
 apt_cacher_ng_debug_log: 0

--- a/roles/apt_cacher_ng/templates/acng.conf.j2
+++ b/roles/apt_cacher_ng/templates/acng.conf.j2
@@ -68,6 +68,12 @@ Remap-uburep: file:backends_ubuntu /ubuntu
 {% if apt_cacher_ng_postgresql_passthrough %}
 {% set _ = passthrough_patterns.append('(^|\\.)apt\\.postgresql\\.org:443$') %}
 {% endif %}
+{% if apt_cacher_ng_packager_passthrough %}
+{% set _ = passthrough_patterns.append('(^|\\.)(go|dl)\\.packager\\.io:443$') %}
+{% endif %}
+{% if apt_cacher_ng_elastic_passthrough %}
+{% set _ = passthrough_patterns.append('(^|\\.)artifacts\\.elastic\\.co:443$') %}
+{% endif %}
 {% if passthrough_patterns %}
 PassThroughPattern: {{ passthrough_patterns | join('|') }}
 {% endif %}

--- a/roles/openbao_secrets/defaults/main.yml
+++ b/roles/openbao_secrets/defaults/main.yml
@@ -76,6 +76,12 @@ openbao_secrets_domains:
       # app-namespaced (e.g. vikunja_db_password) or given a separate domain,
       # so they never collide with Nautobot's bare field names.
       - apps/nautobot
+      # Zammad ITSM/ticketing (incident-management system of record). Fields are
+      # app-namespaced (zammad_db_password, zammad_admin_password) so the flat
+      # merge into bao_apps_secrets never collides with Nautobot's bare names.
+      # The Hermes API token is NOT here — it lives in ai/hermes (local-llm
+      # domain) so the one token has a single home shared by both sides.
+      - apps/zammad
   - name: local-llm
     role_id_env: LOCAL_LLM_VAULT_ROLE_ID
     secret_id_env: LOCAL_LLM_VAULT_SECRET_ID

--- a/roles/zammad/defaults/main.yml
+++ b/roles/zammad/defaults/main.yml
@@ -1,0 +1,116 @@
+---
+# Zammad ITSM/ticketing + knowledge base — the homelab's incident-management
+# system of record. Native DEB from the packager.io apt repo (Rails web/worker/
+# websocket) with a colocated Elasticsearch (full-text incident search) and a
+# colocated Redis; state lives in the shared native Postgres cluster (#138).
+#
+# Two layers, mirroring the nautobot role:
+#   * always: apt repos, Elasticsearch, Redis, nginx, systemd wiring —
+#     deterministic, molecule-safe.
+#   * zammad_manage_app (default true): the Zammad DEB install, external-DB
+#     migrate/seed, search-index rebuild, and rails-runner bootstrap. Skipped
+#     by molecule (needs a real package + DB); validated live at converge.
+zammad_manage_app: true
+
+# --- System user / paths ------------------------------------------------------
+# The packager.io DEB creates the zammad user and installs under /opt/zammad
+# (a persistent ZFS bind mount from terraform-proxmox). Attachments live under
+# /opt/zammad/storage; the ES index is derived state on the rootfs.
+zammad_user: zammad
+zammad_group: zammad
+zammad_root: /opt/zammad
+
+# --- Network ------------------------------------------------------------------
+# nginx listens on zammad_web (8080), Traefik-fronted. Port is DERIVED from the
+# published constants, never a literal.
+zammad_web_port: "{{ tofu_data.constants.service_ports.zammad_web }}"
+# Public UI FQDN (Traefik router base domain) — Zammad uses it for the fqdn
+# Setting, generated links, and http_type. group_vars supplies the real value.
+zammad_ui_fqdn: "zammad.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
+
+# --- Database: the shared native Postgres cluster (#138) ----------------------
+# FQDN + port are DERIVED, never literals. The zammad database/role itself is
+# provisioned by roles/postgres's postgres_managed_databases list — this role
+# only connects. pool sized small to fit the shared cluster's default
+# max_connections alongside nautobot + vikunja (see PR notes / open risk #2).
+zammad_db_host: "postgres.{{ tofu_data.domain }}"
+zammad_db_port: "{{ tofu_data.constants.service_ports.postgres_default }}"
+zammad_db_name: zammad
+zammad_db_user: zammad
+# pool is a per-process CEILING (Rails opens lazily up to this), not steady
+# usage — a small instance opens far fewer. 15 keeps the web/worker/websocket
+# processes under a shared max_connections=100 alongside nautobot + vikunja.
+zammad_db_pool: 15
+zammad_db_password: "{{ lookup('env', 'ZAMMAD_DB_PASSWORD') }}"
+
+# --- Redis: colocated, loopback only (nautobot precedent) --------------------
+zammad_redis_host: 127.0.0.1
+zammad_redis_port: 6379
+zammad_redis_url: "redis://{{ zammad_redis_host }}:{{ zammad_redis_port }}"
+
+# --- Elasticsearch: colocated single node, loopback only ---------------------
+# Zammad's full-text search backend (a core reason for choosing Zammad over a
+# task queue). ES 8.x bundles ingest-attachment, so no plugin install. Dev-mode
+# (network.host 127.0.0.1) keeps ES's bootstrap checks as warnings, not errors,
+# in the unprivileged LXC (vm.max_map_count is host-global — see open risk #3).
+zammad_es_apt_channel: "8.x"
+zammad_es_package: elasticsearch
+zammad_es_host: 127.0.0.1
+zammad_es_port: 9200
+zammad_es_url: "http://{{ zammad_es_host }}:{{ zammad_es_port }}"
+zammad_es_heap: 2g
+
+# --- Admin + Hermes API token -------------------------------------------------
+# Admin account seeded once (idempotent create-or-find). The Hermes API token
+# is seeded into a persistent api Token row so the agent can open/update
+# tickets; its value comes from the secret store (group_vars, bao-first).
+zammad_admin_user: admin
+zammad_admin_email: "{{ zammad_admin_user }}@{{ tofu_data.domain }}"
+zammad_admin_firstname: Zammad
+zammad_admin_lastname: Admin
+zammad_admin_password: "{{ lookup('env', 'ZAMMAD_ADMIN_PASSWORD') }}"
+zammad_hermes_api_token: "{{ lookup('env', 'ZAMMAD_API_TOKEN') }}"
+
+# Incident-management groups + severity priorities. Hermes maps its P-levels to
+# these priority ids: P1->4 critical, P2->3 high, P3->2 normal, P4->1 low. The
+# built-in 1/2/3 are kept; only "4 critical" is added.
+zammad_groups:
+  - Incidents
+zammad_extra_priority:
+  id: 4
+  name: 4 critical
+
+# --- Outbound email via the Mailpit relay (no real mail) ---------------------
+zammad_smtp_host: "mailpit.{{ tofu_data.domain }}"
+zammad_smtp_port: "{{ tofu_data.constants.notification_ports.mailpit_smtp }}"
+zammad_notification_sender: "Zammad <zammad@{{ tofu_data.domain }}>"
+
+# --- apt: controller-staged, sha256-pinned signing keys ----------------------
+# LXCs are firewalled outbound-internal-only and reach these HTTPS repos through
+# the apt-cacher-ng proxy (which allows go/dl.packager.io + artifacts.elastic.co
+# via PassThroughPattern). The signing keys are fetched + checksum-verified on
+# the CONTROLLER, then copied to the guest — same pattern as roles/postgres.
+# ASCII-armored keys are stored directly as the keyring; apt signed-by accepts
+# a .asc keyring, so no dearmor step is needed.
+zammad_packager_key_url: "https://go.packager.io/srv/deb/zammad/zammad/gpg-key.asc"
+zammad_packager_key_staging_path: /tmp/zammad-packager-key.asc
+zammad_packager_keyring: /usr/share/keyrings/zammad.asc
+zammad_packager_key_sha256: "a429c0ce1f0e2304fdcced83d0d541ad57a38c9c315e734f6f0927feef521376"
+# packager.io keys the pool by the numeric release (e.g. `12`), not the codename.
+zammad_packager_repo: >-
+  deb [signed-by={{ zammad_packager_keyring }}]
+  https://go.packager.io/srv/deb/zammad/zammad/stable/debian
+  {{ ansible_distribution_major_version }} main
+
+zammad_elastic_key_url: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
+zammad_elastic_key_staging_path: /tmp/zammad-elastic-key.asc
+zammad_elastic_keyring: /usr/share/keyrings/elasticsearch.asc
+zammad_elastic_key_sha256: "db52809c5f6b27f9c2bed45cb43e398c659275f3d35305653c6750a0db90f5eb"
+zammad_elastic_repo: >-
+  deb [signed-by={{ zammad_elastic_keyring }}]
+  https://artifacts.elastic.co/packages/{{ zammad_es_apt_channel }}/apt stable main
+
+# HTTP liveness poll for the nginx front after the app is up.
+zammad_api_timeout: 30
+zammad_health_retries: 30
+zammad_health_delay: 10

--- a/roles/zammad/files/zammad_bootstrap.rb
+++ b/roles/zammad/files/zammad_bootstrap.rb
@@ -1,0 +1,129 @@
+# Idempotent Zammad bootstrap — run via `zammad run rails r zammad_bootstrap.rb`.
+# All inputs arrive as ENV (set by the Ansible task's `environment:`) so nothing
+# secret is ever on a command line. Prints "ZAMMAD_BOOTSTRAP_CHANGED" whenever it
+# mutates state, so the Ansible task can report changed accurately; a re-run with
+# no drift prints nothing and stays idempotent.
+#
+# Essential seeding (settings, admin, API token, Incidents group, severities)
+# fails loudly. The version-sensitive extras (Mailpit notification channel, the
+# knowledge base) are wrapped so a model-API drift warns but never aborts the
+# converge — both have a one-click manual fallback in the UI.
+
+changed = false
+UserInfo.current_user_id = 1 # act as the system user for created_by/updated_by
+
+def env!(key)
+  v = ENV[key]
+  raise "missing required env #{key}" if v.nil? || v.empty?
+  v
+end
+
+fqdn        = env!('ZAMMAD_FQDN')
+es_url      = env!('ZAMMAD_ES_URL')
+admin_email = env!('ZAMMAD_ADMIN_EMAIL')
+admin_pass  = env!('ZAMMAD_ADMIN_PASSWORD')
+api_token   = env!('ZAMMAD_API_TOKEN')
+smtp_host   = env!('ZAMMAD_SMTP_HOST')
+smtp_port   = env!('ZAMMAD_SMTP_PORT').to_i
+sender      = env!('ZAMMAD_NOTIFICATION_SENDER')
+groups      = env!('ZAMMAD_GROUPS').split(',').map(&:strip).reject(&:empty?)
+
+def set_setting(name, value)
+  return false if Setting.get(name) == value
+  Setting.set(name, value)
+  true
+end
+
+# --- Core settings: end the getting-started wizard, https, storage, es -------
+{
+  'system_init_done' => true,
+  'fqdn'             => fqdn,
+  'http_type'       => 'https',
+  'storage_provider' => 'File',
+  'es_url'          => es_url,
+}.each { |k, v| changed = true if set_setting(k, v) }
+
+# --- Admin user (create-or-find; ensure Admin+Agent + active) ----------------
+admin = User.find_by(email: admin_email.downcase)
+roles = Role.where(name: %w[Admin Agent]).to_a
+if admin.nil?
+  admin = User.create!(
+    login: admin_email.downcase, firstname: ENV['ZAMMAD_ADMIN_FIRSTNAME'] || 'Zammad',
+    lastname: ENV['ZAMMAD_ADMIN_LASTNAME'] || 'Admin', email: admin_email.downcase,
+    password: admin_pass, roles: roles, active: true
+  )
+  changed = true
+else
+  missing = roles - admin.roles.to_a
+  unless missing.empty?
+    admin.roles = (admin.roles.to_a + missing).uniq
+    admin.save!
+    changed = true
+  end
+end
+
+# --- Incident groups (create-or-find; make admin a full agent in each) -------
+groups.each do |gname|
+  group = Group.find_by(name: gname)
+  if group.nil?
+    group = Group.create!(name: gname, active: true)
+    changed = true
+  end
+  # Grant the admin full access to the group so it can own/route incidents.
+  unless admin.group_ids_access('full').include?(group.id)
+    admin.group_names_access_map = admin.group_names_access_map.merge(group.name => ['full'])
+    admin.save!
+    changed = true
+  end
+end
+
+# --- Severity: keep built-in 1 low / 2 normal / 3 high, add 4 critical -------
+if Ticket::Priority.find_by(id: 4).nil? && Ticket::Priority.find_by(name: '4 critical').nil?
+  Ticket::Priority.create!(id: 4, name: '4 critical', active: true)
+  changed = true
+end
+
+# --- Hermes API token (persistent api token seeded with the supplied value) --
+if Token.find_by(action: 'api', name: 'hermes').nil?
+  Token.create!(action: 'api', name: 'hermes', persistent: true, user_id: admin.id, token: api_token)
+  changed = true
+end
+
+# --- Outbound email via the Mailpit relay (best-effort; manual UI fallback) --
+begin
+  channel = Channel.find_by(area: 'Email::Notification')
+  desired = {
+    adapter: 'smtp', host: smtp_host, port: smtp_port,
+    ssl: false, start_tls: false, user: '', password: ''
+  }
+  if channel.nil?
+    Channel.create!(
+      area: 'Email::Notification', group_id: Group.first&.id,
+      options: { outbound: { adapter: 'smtp', options: desired } }, active: true
+    )
+    changed = true
+  elsif channel.options.dig('outbound', 'options', 'host') != smtp_host
+    channel.options = { 'outbound' => { 'adapter' => 'smtp', 'options' => desired.transform_keys(&:to_s) } }
+    channel.save!
+    changed = true
+  end
+  changed = true if set_setting('notification_sender', sender)
+rescue => e
+  warn "WARN: Mailpit notification channel not configured automatically (#{e.class}: #{e.message}). Configure it once in the UI."
+end
+
+# --- Knowledge base (best-effort; manual UI fallback) ------------------------
+begin
+  if defined?(KnowledgeBase) && KnowledgeBase.count.zero?
+    kb = KnowledgeBase.create!(
+      iconset: 'FontAwesome', color_highlight: '#38ae6a', color_header: '#f9fafb',
+      homepage_layout: 'grid', category_layout: 'grid', active: true, translations: []
+    )
+    kb.kb_locales.create!(kb_locale: 'en-us', primary: true) if kb.respond_to?(:kb_locales)
+    changed = true
+  end
+rescue => e
+  warn "WARN: knowledge base not created automatically (#{e.class}: #{e.message}). Create it once in the UI."
+end
+
+puts 'ZAMMAD_BOOTSTRAP_CHANGED' if changed

--- a/roles/zammad/handlers/main.yml
+++ b/roles/zammad/handlers/main.yml
@@ -1,0 +1,32 @@
+---
+# Reload only when a unit/config changed, so an unchanged converge stays
+# idempotent. The app-service restart is gated on zammad_manage_app: under
+# molecule the packages are not installed, so the services do not exist and a
+# restart would fail (same pattern as the nautobot role).
+
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: Restart redis
+  ansible.builtin.systemd:
+    name: redis-server
+    state: restarted
+
+- name: Restart elasticsearch
+  ansible.builtin.systemd:
+    name: elasticsearch
+    state: restarted
+  when: zammad_manage_app | bool
+
+- name: Reload nginx
+  ansible.builtin.systemd:
+    name: nginx
+    state: reloaded
+  when: zammad_manage_app | bool
+
+- name: Restart zammad
+  ansible.builtin.systemd:
+    name: zammad
+    state: restarted
+  when: zammad_manage_app | bool

--- a/roles/zammad/meta/main.yml
+++ b/roles/zammad/meta/main.yml
@@ -1,0 +1,24 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: >-
+    Zammad ITSM/ticketing + knowledge base as the homelab's incident-management
+    system of record. Native packager.io DEB (Rails web/worker/websocket) with a
+    colocated Elasticsearch for full-text incident search and a colocated Redis;
+    state in the shared native Postgres. nginx-fronted, Traefik-terminated.
+    Idempotent rails-runner bootstrap seeds the admin, the Hermes API token, the
+    Incidents group, the P1-P4 severities, the knowledge base, and the Mailpit
+    notification channel.
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+  galaxy_tags:
+    - zammad
+    - itsm
+    - ticketing
+    - incident
+dependencies: []

--- a/roles/zammad/tasks/main.yml
+++ b/roles/zammad/tasks/main.yml
@@ -1,0 +1,414 @@
+---
+# Zammad ITSM/ticketing + KB — native packager.io DEB, colocated Elasticsearch +
+# Redis, state in the shared external Postgres (#138). The whole body is gated on
+# zammad_manage_app (default true) so a molecule/dry run can no-op the network +
+# package + DB work; a real converge runs it all.
+#
+# The install is deterministic and avoids a local PostgreSQL despite the .deb's
+# hard `Depends: postgresql`: an equivs dummy satisfies the dependency, then
+# download-only + dpkg --unpack creates /opt/zammad WITHOUT running the postinst,
+# we template database.yml (pointing at the shared cluster), and only then
+# dpkg --configure runs the postinst — which takes its "database.yml exists"
+# branch (migrate against the remote DB) instead of creating a local one.
+
+- name: Configure Zammad
+  when: zammad_manage_app | bool
+  become: true
+  block:
+    # =========================================================================
+    # Phase 1: System packages
+    # =========================================================================
+    - name: Install Zammad system packages
+      ansible.builtin.apt:
+        name:
+          - ca-certificates
+          - gpg          # apt_repository needs a gpg binary on minimal templates
+          - equivs       # builds the dummy package that satisfies Depends: postgresql
+          - nginx        # reverse proxy in front of the puma/websocket servers
+          - redis-server # colocated, loopback only
+          - acl          # become_user file ops on unprivileged tmp
+        state: present
+        update_cache: true
+
+    # =========================================================================
+    # Phase 2: Redis — colocated, loopback only (nautobot precedent)
+    # =========================================================================
+    - name: Bind Redis to loopback only
+      ansible.builtin.lineinfile:
+        path: /etc/redis/redis.conf
+        regexp: "^bind "
+        line: "bind {{ zammad_redis_host }} -::1"
+        state: present
+      notify: Restart redis
+
+    - name: Enforce Redis protected-mode
+      ansible.builtin.lineinfile:
+        path: /etc/redis/redis.conf
+        regexp: "^protected-mode "
+        line: "protected-mode yes"
+        state: present
+      notify: Restart redis
+
+    - name: Create Redis systemd override directory
+      ansible.builtin.file:
+        path: /etc/systemd/system/redis-server.service.d
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Deploy Redis unprivileged-LXC systemd override
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/redis-server.service.d/lxc-override.conf
+        content: |
+          # Managed by Ansible (zammad role).
+          # Debian's Redis unit enables PrivateUsers, which requires user
+          # namespace setup that unprivileged Proxmox LXCs deny.
+          [Service]
+          PrivateUsers=no
+        owner: root
+        group: root
+        mode: "0644"
+      notify:
+        - Reload systemd daemon
+        - Restart redis
+
+    - name: Apply Redis overrides before starting Redis
+      ansible.builtin.meta: flush_handlers
+
+    - name: Enable and start Redis
+      ansible.builtin.systemd:
+        name: redis-server
+        state: started
+        enabled: true
+
+    # =========================================================================
+    # Phase 3: Signing keys — controller-staged, sha256-pinned (postgres pattern)
+    # LXCs are firewalled outbound-internal-only, so the keys are fetched +
+    # checksum-verified on the controller, then copied to the guest. ASCII-armored
+    # keys are stored directly as the keyring (apt signed-by accepts .asc).
+    # =========================================================================
+    - name: Stage the Elasticsearch + Zammad signing keys on the controller
+      ansible.builtin.get_url:
+        url: "{{ item.url }}"
+        dest: "{{ item.staging }}"
+        checksum: "sha256:{{ item.sha256 }}"
+        mode: "0644"
+      delegate_to: localhost
+      connection: local
+      become: false
+      vars:
+        ansible_become: false
+      run_once: true
+      loop:
+        - url: "{{ zammad_elastic_key_url }}"
+          staging: "{{ zammad_elastic_key_staging_path }}"
+          sha256: "{{ zammad_elastic_key_sha256 }}"
+        - url: "{{ zammad_packager_key_url }}"
+          staging: "{{ zammad_packager_key_staging_path }}"
+          sha256: "{{ zammad_packager_key_sha256 }}"
+      loop_control:
+        label: "{{ item.url }}"
+
+    - name: Install the signing keys into dedicated keyrings
+      ansible.builtin.copy:
+        src: "{{ item.staging }}"
+        dest: "{{ item.keyring }}"
+        owner: root
+        group: root
+        mode: "0644"
+      loop:
+        - staging: "{{ zammad_elastic_key_staging_path }}"
+          keyring: "{{ zammad_elastic_keyring }}"
+        - staging: "{{ zammad_packager_key_staging_path }}"
+          keyring: "{{ zammad_packager_keyring }}"
+      loop_control:
+        label: "{{ item.keyring }}"
+
+    # =========================================================================
+    # Phase 4: apt repositories (Elasticsearch + Zammad)
+    # =========================================================================
+    - name: Add the Elasticsearch apt repository
+      ansible.builtin.apt_repository:
+        repo: "{{ zammad_elastic_repo }}"
+        filename: elastic
+        state: present
+        update_cache: true
+
+    - name: Add the Zammad (packager.io) apt repository
+      ansible.builtin.apt_repository:
+        repo: "{{ zammad_packager_repo }}"
+        filename: zammad
+        state: present
+        update_cache: true
+
+    # =========================================================================
+    # Phase 5: Elasticsearch — single node, loopback, before Zammad
+    # =========================================================================
+    - name: Install Elasticsearch
+      ansible.builtin.apt:
+        name: "{{ zammad_es_package }}"
+        state: present
+        update_cache: true
+
+    - name: Configure Elasticsearch (single node, loopback, security off)
+      ansible.builtin.template:
+        src: elasticsearch.yml.j2
+        dest: /etc/elasticsearch/elasticsearch.yml
+        owner: root
+        group: elasticsearch
+        mode: "0660"
+      notify: Restart elasticsearch
+
+    - name: Pin the Elasticsearch heap
+      ansible.builtin.template:
+        src: jvm-heap.options.j2
+        dest: /etc/elasticsearch/jvm.options.d/heap.options
+        owner: root
+        group: elasticsearch
+        mode: "0660"
+      notify: Restart elasticsearch
+
+    - name: Apply Elasticsearch config before starting it
+      ansible.builtin.meta: flush_handlers
+
+    - name: Enable and start Elasticsearch
+      ansible.builtin.systemd:
+        name: elasticsearch
+        state: started
+        enabled: true
+        daemon_reload: true
+
+    - name: Wait for Elasticsearch to answer
+      ansible.builtin.uri:
+        url: "{{ zammad_es_url }}"
+        status_code: [200]
+      register: zammad_es_health
+      until: zammad_es_health.status == 200
+      retries: 30
+      delay: 5
+      changed_when: false
+
+    # =========================================================================
+    # Phase 6: equivs dummy — satisfy `Depends: postgresql` without a local server
+    # =========================================================================
+    - name: Check whether the postgresql-dummy equivs package is installed
+      ansible.builtin.command:
+        cmd: "dpkg-query -W -f='${db:Status-Status}' zammad-postgresql-dummy"
+      register: zammad_pg_dummy
+      failed_when: false
+      changed_when: false
+
+    - name: Build and install the postgresql-dummy equivs package
+      when: zammad_pg_dummy.stdout != 'installed'
+      block:
+        - name: Template the equivs control file
+          ansible.builtin.template:
+            src: zammad-postgresql-dummy.control.j2
+            dest: /tmp/zammad-postgresql-dummy.control
+            owner: root
+            group: root
+            mode: "0644"
+
+        - name: Build the dummy package with equivs
+          ansible.builtin.command:
+            cmd: equivs-build /tmp/zammad-postgresql-dummy.control
+            chdir: /tmp
+            creates: /tmp/zammad-postgresql-dummy_1.0_all.deb
+
+        - name: Install the dummy package (satisfies the postgresql dependency)
+          ansible.builtin.apt:
+            deb: /tmp/zammad-postgresql-dummy_1.0_all.deb
+            state: present
+
+    # =========================================================================
+    # Phase 7: Zammad package — download-only + unpack + template DB + configure
+    # =========================================================================
+    - name: Check whether the zammad package is fully configured
+      ansible.builtin.command:
+        cmd: "dpkg-query -W -f='${db:Status-Status}' zammad"
+      register: zammad_pkg
+      failed_when: false
+      changed_when: false
+
+    - name: Set the zammad-configured fact
+      ansible.builtin.set_fact:
+        zammad_configured: "{{ zammad_pkg.stdout == 'installed' }}"
+
+    - name: Download + unpack the zammad package without running its postinst
+      when: not zammad_configured
+      block:
+        # noqa command-instead-of-module: the ansible.builtin.apt module has no
+        # download-only mode, and installing normally would run the postinst
+        # before database.yml is templated — which takes the create-local-DB
+        # branch and fails (no local Postgres). Download only here, then unpack
+        # + template + configure below.
+        - name: Download the zammad package (and deps) into the apt cache  # noqa: command-instead-of-module
+          ansible.builtin.command: apt-get -y install --download-only zammad
+          register: zammad_download
+          changed_when: "'newly installed' in zammad_download.stdout or 'Get:' in zammad_download.stdout"
+
+        - name: Locate the downloaded zammad .deb
+          ansible.builtin.find:
+            paths: /var/cache/apt/archives
+            patterns: "zammad_*.deb"
+          register: zammad_deb
+
+        - name: Fail if the zammad .deb was not downloaded
+          ansible.builtin.assert:
+            that: zammad_deb.files | length > 0
+            fail_msg: "zammad .deb not found in the apt cache after download-only."
+
+        - name: Unpack zammad (creates /opt/zammad; runs NO postinst)
+          ansible.builtin.command:
+            cmd: "dpkg --unpack {{ (zammad_deb.files | sort(attribute='path') | last).path }}"
+          changed_when: true
+
+    - name: Template Zammad's database.yml (points at the shared external Postgres)
+      ansible.builtin.template:
+        src: database.yml.j2
+        dest: "{{ zammad_root }}/config/database.yml"
+        owner: "{{ zammad_user }}"
+        group: "{{ zammad_group }}"
+        mode: "0600"
+      register: zammad_dbyml
+      no_log: true
+
+    - name: Configure zammad (runs the postinst — migrates against the external DB)
+      ansible.builtin.command: dpkg --configure zammad
+      when: not zammad_configured
+      changed_when: true
+
+    - name: Seed the Zammad database (first configure only; seeds are create-if-missing)
+      ansible.builtin.command:
+        cmd: "zammad run rake db:seed"
+      when: not zammad_configured
+      changed_when: true
+
+    - name: Migrate the Zammad schema after a database.yml change (already-configured hosts)
+      ansible.builtin.command:
+        cmd: "zammad run rake db:migrate"
+      when:
+        - zammad_configured
+        - zammad_dbyml is changed
+      changed_when: true
+      notify: Restart zammad
+
+    # =========================================================================
+    # Phase 8: nginx reverse proxy
+    # =========================================================================
+    - name: Deploy the Zammad nginx vhost
+      ansible.builtin.template:
+        src: zammad.nginx.conf.j2
+        dest: /etc/nginx/sites-available/zammad.conf
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Reload nginx
+
+    - name: Enable the Zammad nginx vhost
+      ansible.builtin.file:
+        src: /etc/nginx/sites-available/zammad.conf
+        dest: /etc/nginx/sites-enabled/zammad.conf
+        state: link
+      notify: Reload nginx
+
+    - name: Remove the default nginx vhost
+      ansible.builtin.file:
+        path: /etc/nginx/sites-enabled/default
+        state: absent
+      notify: Reload nginx
+
+    - name: Apply pending restarts before health checks + bootstrap
+      ansible.builtin.meta: flush_handlers
+
+    - name: Enable and start the Zammad + nginx services
+      ansible.builtin.systemd:
+        name: "{{ item }}"
+        state: started
+        enabled: true
+      loop:
+        - zammad
+        - nginx
+
+    # =========================================================================
+    # Phase 9: Idempotent bootstrap (settings incl. es_url, admin, Hermes token,
+    # Incidents group, P1-P4 severities, Mailpit channel, KB). The ruby prints
+    # ZAMMAD_BOOTSTRAP_CHANGED on drift. Runs BEFORE the search-index rebuild so
+    # es_url is set first.
+    # =========================================================================
+    - name: Validate the bootstrap secrets are present
+      ansible.builtin.assert:
+        that:
+          - zammad_admin_password | length > 0
+          - zammad_hermes_api_token | length > 0
+        fail_msg: >-
+          ZAMMAD_ADMIN_PASSWORD and ZAMMAD_API_TOKEN must be set before the
+          first converge (Doppler/SOPS or OpenBao apps/zammad + ai/hermes).
+        quiet: true
+      no_log: true
+
+    - name: Stage the bootstrap script on the target
+      ansible.builtin.copy:
+        src: zammad_bootstrap.rb
+        dest: "{{ zammad_root }}/ansible_bootstrap.rb"
+        owner: "{{ zammad_user }}"
+        group: "{{ zammad_group }}"
+        mode: "0640"
+
+    - name: Run the idempotent Zammad bootstrap
+      ansible.builtin.command:
+        cmd: "zammad run rails r {{ zammad_root }}/ansible_bootstrap.rb"
+      environment:
+        ZAMMAD_FQDN: "{{ zammad_ui_fqdn }}"
+        ZAMMAD_ES_URL: "{{ zammad_es_url }}"
+        ZAMMAD_ADMIN_EMAIL: "{{ zammad_admin_email }}"
+        ZAMMAD_ADMIN_FIRSTNAME: "{{ zammad_admin_firstname }}"
+        ZAMMAD_ADMIN_LASTNAME: "{{ zammad_admin_lastname }}"
+        ZAMMAD_ADMIN_PASSWORD: "{{ zammad_admin_password }}"
+        ZAMMAD_API_TOKEN: "{{ zammad_hermes_api_token }}"
+        ZAMMAD_SMTP_HOST: "{{ zammad_smtp_host }}"
+        ZAMMAD_SMTP_PORT: "{{ zammad_smtp_port }}"
+        ZAMMAD_NOTIFICATION_SENDER: "{{ zammad_notification_sender }}"
+        ZAMMAD_GROUPS: "{{ zammad_groups | join(',') }}"
+      register: zammad_bootstrap
+      changed_when: "'ZAMMAD_BOOTSTRAP_CHANGED' in zammad_bootstrap.stdout"
+      no_log: true
+
+    # =========================================================================
+    # Phase 10: Search-index rebuild (guarded — expensive, first time only)
+    # es_url was just set by the bootstrap above.
+    # =========================================================================
+    - name: Check whether the search index has already been built
+      ansible.builtin.stat:
+        path: "{{ zammad_root }}/.ansible-searchindex-built"
+      register: zammad_searchindex_marker
+
+    - name: Rebuild the Zammad search index (first time only — it is expensive)
+      ansible.builtin.command:
+        cmd: "zammad run rake zammad:searchindex:rebuild"
+      when: not zammad_searchindex_marker.stat.exists
+      changed_when: true
+
+    - name: Mark the search index as built
+      ansible.builtin.copy:
+        content: "built by the zammad role\n"
+        dest: "{{ zammad_root }}/.ansible-searchindex-built"
+        owner: "{{ zammad_user }}"
+        group: "{{ zammad_group }}"
+        mode: "0644"
+      when: not zammad_searchindex_marker.stat.exists
+
+    # =========================================================================
+    # Phase 11: Health
+    # =========================================================================
+    - name: Wait for the Zammad web UI to answer through nginx
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ zammad_web_port }}/"
+        status_code: [200, 301, 302]
+        follow_redirects: none
+      register: zammad_health
+      until: zammad_health.status in [200, 301, 302]
+      retries: "{{ zammad_health_retries | int }}"
+      delay: "{{ zammad_health_delay | int }}"
+      changed_when: false

--- a/roles/zammad/templates/database.yml.j2
+++ b/roles/zammad/templates/database.yml.j2
@@ -1,0 +1,17 @@
+# {{ ansible_managed }}
+# Zammad points at the SHARED external Postgres cluster (#138). This file is
+# templated BEFORE `dpkg --configure zammad` runs, so the packager postinst
+# takes its "database.yml exists" branch (migrate against this DB) instead of
+# creating a local one. The packager's database.yml has no host key and no
+# DATABASE_URL support, so templating the full production block is the only way
+# to reach a remote host.
+production:
+  adapter: postgresql
+  host: {{ zammad_db_host }}
+  port: {{ zammad_db_port }}
+  database: {{ zammad_db_name }}
+  username: {{ zammad_db_user }}
+  password: "{{ zammad_db_password }}"
+  pool: {{ zammad_db_pool }}
+  encoding: utf8
+  timeout: 5000

--- a/roles/zammad/templates/elasticsearch.yml.j2
+++ b/roles/zammad/templates/elasticsearch.yml.j2
@@ -1,0 +1,13 @@
+# {{ ansible_managed }}
+# Single-node Elasticsearch, loopback only — Zammad's colocated full-text search
+# backend. Bound to 127.0.0.1 so it stays in dev mode: ES's production bootstrap
+# checks (which include the host-global vm.max_map_count that an unprivileged LXC
+# cannot set) become warnings instead of hard failures. Security is disabled
+# because nothing but the local Zammad process ever reaches it.
+cluster.name: zammad
+node.name: zammad-es
+network.host: {{ zammad_es_host }}
+http.port: {{ zammad_es_port }}
+discovery.type: single-node
+xpack.security.enabled: false
+xpack.security.enrollment.enabled: false

--- a/roles/zammad/templates/jvm-heap.options.j2
+++ b/roles/zammad/templates/jvm-heap.options.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+# Pin the Elasticsearch heap (min == max, as ES requires) in a jvm.options.d
+# drop-in so the package's own jvm.options is left untouched. Sized to fit the
+# Zammad LXC alongside Rails + Redis + nginx (see the LXC memory_dedicated).
+-Xms{{ zammad_es_heap }}
+-Xmx{{ zammad_es_heap }}

--- a/roles/zammad/templates/zammad-postgresql-dummy.control.j2
+++ b/roles/zammad/templates/zammad-postgresql-dummy.control.j2
@@ -1,0 +1,11 @@
+Section: database
+Priority: optional
+Standards-Version: 3.9.2
+Package: zammad-postgresql-dummy
+Version: 1.0
+Provides: postgresql
+Description: Satisfy Zammad's postgresql dependency without a local server
+ Zammad uses the shared external PostgreSQL cluster (#138), so no local
+ PostgreSQL server is installed on this guest. This equivs package Provides:
+ postgresql to satisfy the zammad .deb's hard "Depends: postgresql", which
+ would otherwise drag in and start a local cluster the guest never uses.

--- a/roles/zammad/templates/zammad.nginx.conf.j2
+++ b/roles/zammad/templates/zammad.nginx.conf.j2
@@ -1,0 +1,56 @@
+# {{ ansible_managed }}
+# Zammad nginx vhost (the canonical upstream contrib config, parameterised).
+# Traefik terminates TLS and proxies here on {{ zammad_web_port }}; this vhost
+# proxies to the local puma (zammad-web, :3000) and websocket (:6042) servers.
+
+upstream zammad-railsserver {
+    server 127.0.0.1:3000;
+}
+
+upstream zammad-websocket {
+    server 127.0.0.1:6042;
+}
+
+# Honour Traefik's X-Forwarded-Proto (https) when present so Zammad builds https
+# links; fall back to the local scheme on direct access.
+map $http_x_forwarded_proto $zammad_forwarded_proto {
+    default $scheme;
+    "~.+"   $http_x_forwarded_proto;
+}
+
+server {
+    listen {{ zammad_web_port }};
+    server_name {{ zammad_ui_fqdn }};
+
+    root {{ zammad_root }}/public;
+
+    client_max_body_size 50M;
+
+    location ~ ^/(assets/|robots.txt|humans.txt|favicon.ico|apple-touch-icon.png) {
+        expires max;
+    }
+
+    location /ws {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header CLIENT_IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $zammad_forwarded_proto;
+        proxy_read_timeout 86400;
+        proxy_pass http://zammad-websocket;
+    }
+
+    location / {
+        proxy_set_header Host $http_host;
+        proxy_set_header CLIENT_IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $zammad_forwarded_proto;
+        proxy_read_timeout 300;
+        proxy_pass http://zammad-railsserver;
+
+        gzip on;
+        gzip_types text/plain text/xml text/css image/svg+xml application/javascript application/json;
+        gzip_proxied any;
+    }
+}


### PR DESCRIPTION
## Context

The homelab has a project-management stack (Nautobot = network SoT, Vikunja = task queue) but no **incident-management** system. This PR deploys **Zammad** — ITSM/ticketing + knowledge base — as the incident-management system of record. The Hermes agent will open/update tickets from confirmed Splunk anomalies (follow-up PR).

Companions: [terraform-proxmox#624](https://github.com/dryvist/terraform-proxmox/pull/624) (LXC shell) and [tofu-unifi#105](https://github.com/dryvist/tofu-unifi/pull/105) (DHCP reservation). Deploy order: reservation → LXC apply → this converge.

## Architecture

Native packager.io DEB (Rails web/worker/websocket) + colocated **Elasticsearch** (full-text incident search) + colocated **Redis**; state in the shared native Postgres (#138); nginx-fronted, Traefik-terminated. No Docker nesting.

### The external-Postgres install (the tricky part)

The Zammad `.deb` **hard-Depends on `postgresql`** and its postinst branches on whether `/opt/zammad/config/database.yml` exists (migrate-against-it vs create-a-local-DB). To keep **no local Postgres** and use the shared cluster, the role:

1. builds an **equivs dummy** `postgresql` package to satisfy the hard dependency;
2. `apt-get --download-only` + **`dpkg --unpack`** — creates `/opt/zammad` **without** running the postinst;
3. **templates `database.yml`** pointing at `postgres.<domain>`;
4. **`dpkg --configure`** — now the postinst takes the "database.yml exists" branch and migrates against the shared cluster;
5. `db:seed` once; re-converges are idempotent.

(Sourced from the actual packager.io postinst: `contrib/packager.io/functions`, `database.yml.pkgr`.)

## What's in the role

- **ES 8.x** single-node, loopback, security off (dev-mode so the host-global `vm.max_map_count` bootstrap check stays a warning in the unprivileged LXC), 2 GB heap.
- **Redis** loopback + the `PrivateUsers=no` LXC systemd override (nautobot precedent).
- **nginx** canonical Zammad vhost, honours Traefik's `X-Forwarded-Proto`.
- **Idempotent rails-runner bootstrap** (`files/zammad_bootstrap.rb`, prints `ZAMMAD_BOOTSTRAP_CHANGED` on drift): core Settings (ends the wizard, https, fqdn, es_url), admin, **Hermes API token**, **Incidents** group, **P1–P4** severities (adds "4 critical"; Hermes maps P1→4…P4→1), **Mailpit** notification channel, and the knowledge base. The version-sensitive extras (email channel, KB) warn-but-continue with a one-click UI fallback; the essential parts fail loud.
- Guarded **search-index rebuild** (marker file — expensive, first time only).

## Wiring

- `apt_cacher_ng`: passthrough toggles for `go`/`dl.packager.io` + `artifacts.elastic.co` (signing keys controller-staged + sha256-pinned, postgres pattern).
- `postgres_group`: `zammad` database entry on the shared cluster (`pool: 15` ceiling — fits `max_connections=100` alongside nautobot + vikunja).
- `zammad_group`: bao-first (`apps` domain) + env-fallback secrets; tofu-derived FQDNs/ports; the Hermes token is sourced from `ai/hermes` so one token has a single home.
- `openbao_secrets`: `apps/zammad` KV path. `load_tofu` + `site.yml`: `zammad` tag → `zammad_group` → play after Postgres.

## Verification

- `ansible-lint` (production profile): **0 failures, 0 warnings**.
- `ansible-playbook --syntax-check`: passes.
- `roles/zammad/files/zammad_bootstrap.rb`: `ruby -c` → Syntax OK.
- All Jinja templates parse.
- Live end-to-end (post-merge, after secrets seeded): systemd units green, `https://zammad.<domain>` login (no wizard), a ticket POSTed by the Hermes token is found via ES search, Mailpit shows a notification, KB article publishes.

### Secrets (seeded at deploy)

`ZAMMAD_DB_PASSWORD`, `ZAMMAD_ADMIN_PASSWORD` → `secret/apps/zammad` (+ Doppler/SOPS env fallback); `ZAMMAD_API_TOKEN` → single home `secret/ai/hermes` (feeds both the Zammad token seed and the Hermes skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)