### PR TITLE
feat(hermes): open + document incidents in Zammad from splunk-monitor

### DIFF
--- a/inventory/group_vars/hermes_agent_group.yml
+++ b/inventory/group_vars/hermes_agent_group.yml
@@ -31,6 +31,17 @@ hermes_agent_context7_api_key: >-
   {{ bao_local_llm_secrets.CONTEXT7_API_KEY
      | default(lookup('env', 'CONTEXT7_API_KEY'), true) }}
 
+# Zammad ITSM client (dryvist/zammad-incidents skill). URL is the Traefik-fronted
+# FQDN (non-secret, derived from PROXMOX_SUBDOMAIN). The API token is bao-first
+# (local-llm domain, secret/ai/hermes — the SAME token the zammad role seeds INTO
+# Zammad, one home for one secret), env fallback; empty until Zammad is deployed.
+hermes_agent_zammad_url: >-
+  https://zammad.{{ lookup('env', 'PROXMOX_SUBDOMAIN')
+     | mandatory('PROXMOX_SUBDOMAIN required for the Zammad URL') }}
+hermes_agent_zammad_api_token: >-
+  {{ bao_local_llm_secrets.ZAMMAD_API_TOKEN
+     | default(lookup('env', 'ZAMMAD_API_TOKEN'), true) }}
+
 # GitHub issues + org projects PAT (read/write Issues in all repos, read/write
 # Projects v2 in the dryvist org). Bao-first (local-llm domain, secret/ai/hermes),
 # env fallback — empty until the token is present. See the dryvist/github-issues

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -210,6 +210,13 @@ hermes_agent_splunk_mcp_enabled: true
 hermes_agent_splunk_mcp_url: ""
 hermes_agent_splunk_mcp_token: ""
 
+# Zammad ITSM client (dryvist/zammad-incidents skill — the incident-management
+# system of record). Bao-first, env fallback (see group_vars). An empty URL or
+# token means the skill simply has nothing to call until Zammad is deployed and
+# its API token is seeded; the agent still starts cleanly.
+hermes_agent_zammad_url: ""
+hermes_agent_zammad_api_token: ""
+
 # --- Splunk monitor: 24/7 self-directed SIEM analyst -----------------------
 # Seeds a small fleet of Hermes cron jobs, each carrying the dryvist/splunk-monitor
 # skill. That skill encodes the HARD query-safety rails (bounded queries only —

--- a/roles/hermes_agent/files/skills/dryvist/splunk-monitor/SKILL.md
+++ b/roles/hermes_agent/files/skills/dryvist/splunk-monitor/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   hermes:
     category: research
     tags: [splunk, siem, monitoring, observability, dryvist]
-    related_skills: [research/llm-wiki, dryvist/github-issues]
+    related_skills: [research/llm-wiki, dryvist/github-issues, dryvist/zammad-incidents]
 ---
 
 # dryvist splunk-monitor
@@ -144,13 +144,25 @@ Record baselines even on quiet runs — a quiet run that refreshes "index X is n
 
 ### 2.6 Decide delivery
 
-- **Genuinely off** → deliver a **concise alert**: one concern per message, plain
-  language, and include the **bounded query** you ran and the **numbers** that make it
-  actionable. No walls of text, no raw events.
+- **Genuinely off** → this is a confirmed incident. Do BOTH, in this order:
+  1. **Record it in Zammad** (the system of record) via the `dryvist/zammad-incidents`
+     skill. **Dedupe first**: search open tickets for this problem's fingerprint. If one
+     exists, **append** your new finding as an article on that ticket; if not, **open** a
+     new ticket in the `Incidents` group at the mapped priority (P1→critical … P4→low).
+     Keep it numbers-backed — the same bounded query + figures you would put in an alert.
+  2. **Then DM the operator on Slack** — a **concise alert**, one concern per message,
+     plain language, with the **bounded query** and the **numbers**, **and the Zammad
+     ticket URL** (`$ZAMMAD_URL/#ticket/zoom/<id>`) so they can jump straight to it. Every
+     confirmed anomaly still pages Slack, exactly as before — Zammad adds the durable
+     record, it does not replace the notification. No walls of text, no raw events.
+
+  If Zammad is unreachable or its token is unset, do not drop the alert: send the Slack
+  DM anyway and note in it that the ticket could not be filed.
 - **Nothing notable** → reply with **exactly `[SILENT]`** and nothing else. The cron
   system suppresses delivery entirely when your final response contains `[SILENT]`, so
   a normal run costs the user zero notifications. Use it liberally — silence when all is
-  well is the whole point.
+  well is the whole point. (No ticket for a non-finding — Zammad is for confirmed
+  incidents only.)
 
 Do not pad an alert to seem busy, and do not stay silent about something real to avoid
 bothering the user. Signal, not noise, in both directions.

--- a/roles/hermes_agent/files/skills/dryvist/zammad-incidents/SKILL.md
+++ b/roles/hermes_agent/files/skills/dryvist/zammad-incidents/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: dryvist-zammad-incidents
+description: Open, update, dedupe, resolve, and document homelab incidents in Zammad (the ITSM system of record) via its REST API — the durable ticket + knowledge-base layer behind the splunk-monitor alerts
+version: 1.0.0
+author: dryvist homelab
+license: MIT
+platforms: [linux]
+metadata:
+  hermes:
+    category: research
+    tags: [zammad, itsm, incident, ticketing, dryvist]
+    related_skills: [dryvist/splunk-monitor, dryvist/github-issues]
+---
+
+# dryvist zammad-incidents
+
+Zammad is the homelab's **incident-management system of record**. When you
+confirm something is genuinely wrong, the durable record lives here as a
+**ticket** with a threaded narrative; when you resolve it, the runbook/RCA lives
+here as a **knowledge-base article**. Slack is only the notification surface —
+Zammad is the truth.
+
+You reach Zammad over its REST API with `curl`. Two environment variables are
+already in your process (from the systemd EnvironmentFile), so never print them:
+
+- `ZAMMAD_URL` — base URL, e.g. `https://zammad.<subdomain>`
+- `ZAMMAD_API_TOKEN` — your API token
+
+Every request carries `Authorization: Token token=$ZAMMAD_API_TOKEN`. Standard
+call shape:
+
+```bash
+curl -sS -H "Authorization: Token token=$ZAMMAD_API_TOKEN" \
+  -H 'Content-Type: application/json' "$ZAMMAD_URL/api/v1/<path>"
+```
+
+---
+
+## 1. The one rule: dedupe BEFORE you create
+
+An incident that is already open must be **appended to**, never re-opened as a
+duplicate. Before creating anything, search for an open ticket that matches the
+same underlying problem.
+
+Give every incident a stable **fingerprint** — a short, deterministic tag for
+"this exact problem" (e.g. `fp:splunk-ingest-stalled:index=firewall`), and put
+it in the ticket title. Then a search finds prior occurrences:
+
+```bash
+# state.name:(new OR open) keeps it to LIVE incidents; the fingerprint pins the problem.
+curl -sS -G -H "Authorization: Token token=$ZAMMAD_API_TOKEN" \
+  --data-urlencode 'query=state.name:(new OR open) AND title:"fp:splunk-ingest-stalled*"' \
+  --data-urlencode 'limit=5' --data-urlencode 'expand=false' \
+  "$ZAMMAD_URL/api/v1/tickets/search"
+```
+
+Keep results bounded (`limit` small, `expand=false`) — do NOT pull full ticket
+bodies or article lists into your context. If the search returns a match →
+**append** (Section 3). If not → **create** (Section 2).
+
+---
+
+## 2. Create an incident
+
+```bash
+curl -sS -X POST -H "Authorization: Token token=$ZAMMAD_API_TOKEN" \
+  -H 'Content-Type: application/json' "$ZAMMAD_URL/api/v1/tickets" -d '{
+    "title": "fp:<fingerprint> — <human summary>",
+    "group": "Incidents",
+    "priority_id": <P>,
+    "article": {
+      "subject": "<short>",
+      "body": "<what you observed, the bounded query, the numbers>",
+      "type": "note",
+      "internal": true
+    }
+  }'
+```
+
+**Severity mapping** — your P-level maps to Zammad `priority_id`:
+
+| You call it | `priority_id` | Zammad name |
+| --- | --- | --- |
+| P1 (server/service down, security) | `4` | 4 critical |
+| P2 (major degradation) | `3` | 3 high |
+| P3 (minor / single-source) | `2` | 2 normal |
+| P4 (cosmetic / low) | `1` | 1 low |
+
+Always file into the **`Incidents`** group. Keep the article factual and
+numbers-backed — same discipline as a splunk-monitor alert, no walls of text,
+no raw events.
+
+---
+
+## 3. Append to an existing incident (the narrative)
+
+Investigation notes, new readings, and status changes go on the **existing
+ticket's thread** — never a new ticket. Add an article:
+
+```bash
+curl -sS -X POST -H "Authorization: Token token=$ZAMMAD_API_TOKEN" \
+  -H 'Content-Type: application/json' "$ZAMMAD_URL/api/v1/ticket_articles" -d '{
+    "ticket_id": <id>,
+    "subject": "triage update",
+    "body": "<new finding + the bounded query + numbers>",
+    "type": "note", "internal": true
+  }'
+```
+
+Escalate or de-escalate by updating the ticket's priority/state:
+
+```bash
+curl -sS -X PUT -H "Authorization: Token token=$ZAMMAD_API_TOKEN" \
+  -H 'Content-Type: application/json' "$ZAMMAD_URL/api/v1/tickets/<id>" \
+  -d '{"priority_id": 3}'
+```
+
+---
+
+## 4. Resolve — close the ticket AND capture the knowledge
+
+When the problem is **confirmed recovered** (verified with a bounded query, not
+just "it went quiet"):
+
+1. Close the ticket (`state_id` 4 = closed on a default Zammad install; confirm
+   via `GET /api/v1/ticket_states` if unsure):
+
+   ```bash
+   curl -sS -X PUT -H "Authorization: Token token=$ZAMMAD_API_TOKEN" \
+     -H 'Content-Type: application/json' "$ZAMMAD_URL/api/v1/tickets/<id>" \
+     -d '{"state_id": 4, "article": {"body": "recovered — <verifying query + numbers>", "type": "note", "internal": true}}'
+   ```
+
+2. If the incident taught something reusable (a root cause, a fix, a runbook),
+   publish a **knowledge-base article** so the next occurrence is faster. Fetch
+   the KB + a category id first, then create the answer:
+
+   ```bash
+   curl -sS -H "Authorization: Token token=$ZAMMAD_API_TOKEN" "$ZAMMAD_URL/api/v1/knowledge_bases"   # ids
+   curl -sS -X POST -H "Authorization: Token token=$ZAMMAD_API_TOKEN" \
+     -H 'Content-Type: application/json' \
+     "$ZAMMAD_URL/api/v1/knowledge_bases/<kb_id>/answers" -d '{
+       "category_id": <cat_id>,
+       "translations": [{"title": "<what broke> — <fix>", "body": "<RCA + runbook>", "kb_locale_id": <locale_id>}]
+     }'
+   ```
+
+   If the KB API shape has drifted (Zammad versions vary here), record the RCA
+   as an internal article on the closed ticket instead and note that the KB
+   article is still to be written — never drop the knowledge.
+
+---
+
+## 5. Guardrails
+
+1. **Dedupe first, always.** Search open tickets by fingerprint before creating.
+   One incident = one ticket; everything else is an article on that ticket.
+2. **Bounded reads.** `limit` small, `expand=false`, never pull full ticket or
+   article lists into context — same anti-context-spam contract as splunk-monitor.
+3. **Numbers, not prose.** Every article carries the bounded query and the
+   figures that justify it.
+4. **Never print `$ZAMMAD_API_TOKEN`** (or any secret) into a ticket, article,
+   KB page, log, or Slack message.
+5. **Confirm recovery before closing.** A quiet signal is not a recovered one —
+   verify with a query.
+6. **Zammad is the record; Slack is the notification.** After you open or update
+   a ticket, the splunk-monitor delivery step still DMs the operator — include
+   the ticket URL (`$ZAMMAD_URL/#ticket/zoom/<id>`) so they can jump straight to it.

--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -389,6 +389,18 @@
     mode: "0640"
     directory_mode: "0750"
 
+# The incident-management system of record. Materialized BEFORE splunk-monitor
+# so its delivery step can reference dryvist/zammad-incidents to open/append
+# tickets for confirmed anomalies.
+- name: Deploy the dryvist zammad-incidents skill
+  ansible.builtin.copy:
+    src: skills/dryvist/zammad-incidents/
+    dest: "{{ hermes_agent_hermes_home }}/skills/dryvist/zammad-incidents/"
+    owner: "{{ hermes_agent_user }}"
+    group: "{{ hermes_agent_user }}"
+    mode: "0640"
+    directory_mode: "0750"
+
 # --- Splunk monitor: skill + self-directed 24/7 SIEM analyst cron fleet ------
 # The skill encodes the hard query-safety rails (bounded queries only) + the
 # self-directed investigative method. It must be materialized BEFORE the cron

--- a/roles/hermes_agent/templates/hermes-env.j2
+++ b/roles/hermes_agent/templates/hermes-env.j2
@@ -56,3 +56,9 @@ SPLUNK_MCP_TOKEN={{ hermes_agent_splunk_mcp_token }}
 
 # Context7 MCP client — config.yaml's mcp_servers.context7 resolves this ${VAR}.
 CONTEXT7_API_KEY={{ hermes_agent_context7_api_key }}
+
+# Zammad ITSM client — the dryvist/zammad-incidents skill reads these from .env
+# at use time (Authorization: Token token=$ZAMMAD_API_TOKEN). Empty until Zammad
+# is deployed and its API token is seeded.
+ZAMMAD_URL={{ hermes_agent_zammad_url }}
+ZAMMAD_API_TOKEN={{ hermes_agent_zammad_api_token }}


### PR DESCRIPTION
## Context

Follow-up to [#852](https://github.com/dryvist/ansible-proxmox-apps/pull/852) (the Zammad role). This wires the **Hermes agent** into Zammad — the incident-management system of record — so confirmed Splunk anomalies become durable, deduped **tickets** with a threaded narrative and a **knowledge-base** trail. Slack stays exactly the notification surface it is today.

## What this adds

- **New skill `dryvist/zammad-incidents`** — curl against the Zammad REST API with `$ZAMMAD_URL` / `$ZAMMAD_API_TOKEN` (read from `.env` at use time, same pattern as the `GH_PAT_WRITE_PROJECT_ISSUES` github-issues skill). It teaches Hermes to:
  - **dedupe first** — search open tickets by a stable fingerprint before creating; append to a live ticket instead of opening a duplicate;
  - **create / append / escalate / close-on-recovery**;
  - **publish KB articles** for reusable RCAs/runbooks (with a graceful fallback to an internal ticket note if the KB API shape has drifted).
  - Severity: P1→`priority_id` 4 (critical) … P4→1 (low). Bounded reads (`limit` + `expand=false`) keep it inside the same anti-context-spam contract as splunk-monitor.

- **`splunk-monitor` rewire (§2.6)** — on a **confirmed** anomaly, Hermes now:
  1. records it in Zammad (dedupe → open or append), then
  2. **DMs the operator on Slack with the ticket URL**.

  Every confirmed anomaly still pages Slack, unchanged — Zammad adds the record, it does not replace the page. `[SILENT]` non-findings file no ticket. If Zammad is unreachable, the Slack DM still goes out (with a note that the ticket could not be filed).

- **Role wiring** — `ZAMMAD_URL` (Traefik FQDN, derived from `PROXMOX_SUBDOMAIN`) + `ZAMMAD_API_TOKEN` (bao-first from `ai/hermes` — the **same** token the zammad role seeds *into* Zammad, so one secret has one home) added to `defaults`, `hermes_agent_group.yml`, and `hermes-env.j2`. The skill is materialized before the splunk-monitor cron fleet so its delivery step can reference it.

## Verification

- `ansible-lint` (production profile): **0 failures, 0 warnings**.
- `markdownlint` (repo `.markdownlint.json`): **0 errors** on both SKILL.md files.
- Live (post-merge, after the token is seeded): ask Hermes via Slack to open a test incident → ticket appears in `Incidents` at the right priority; repeat the same fingerprint → it appends (no duplicate); the Slack DM carries the ticket link. A synthetic splunk-monitor anomaly produces the same.

Depends on #852 (the token + FQDN exist once Zammad is deployed; until then the skill simply has nothing to call and the agent starts cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)