### PR TITLE
fix(nautobot): seed load completeness — nodes path, dryrun, worker env, S3 path-style (#138)

### DIFF
--- a/roles/nautobot/files/jobs/export_nautobot.py
+++ b/roles/nautobot/files/jobs/export_nautobot.py
@@ -185,13 +185,26 @@ class ExportNautobotToS3(Job):
         self.logger.info("Export validated against %s", schema_path)
 
     def _upload(self, document: dict) -> None:
-        """Upload the document to S3 with ambient credentials."""
+        """Upload the document to S3 (ambient creds, optional custom endpoint).
+
+        When a non-AWS endpoint is configured (AWS_ENDPOINT_URL_S3, e.g. an
+        on-prem RustFS/MinIO store), force path-style addressing — those stores
+        do not serve the virtual-hosted ``<bucket>.<host>`` form boto3 defaults
+        to. A default region keeps the SigV4 signer happy when none is set.
+        """
         bucket = os.environ.get("NAUTOBOT_EXPORT_S3_BUCKET", "")
         if not bucket:
             raise ValueError("NAUTOBOT_EXPORT_S3_BUCKET is not set — cannot publish export")
         key = os.environ.get("NAUTOBOT_EXPORT_S3_KEY", DEFAULT_KEY)
         body = json.dumps(document, indent=2, sort_keys=True).encode("utf-8")
-        boto3.client("s3").put_object(
+        client_kwargs: dict[str, Any] = {
+            "region_name": os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
+        }
+        if os.environ.get("AWS_ENDPOINT_URL_S3"):
+            from botocore.config import Config
+
+            client_kwargs["config"] = Config(s3={"addressing_style": "path"})
+        boto3.client("s3", **client_kwargs).put_object(
             Bucket=bucket, Key=key, Body=body, ContentType="application/json"
         )
         self.logger.info("Published %d bytes to s3://%s/%s", len(body), bucket, key)

--- a/roles/nautobot/files/run_seed_jobs.py
+++ b/roles/nautobot/files/run_seed_jobs.py
@@ -38,7 +38,12 @@ approver = get_user_model().objects.filter(is_superuser=True).order_by("pk").fir
 
 
 def run_one(name):
-    """Enable, enqueue, and poll a single job by display name."""
+    """Enable, enqueue, and poll a single job by display name.
+
+    SSoT DataSource jobs default to a dry run (compute diffs, commit nothing);
+    pass ``dryrun=False`` so the additive sync actually persists. The export
+    Job has no such var, so it is enqueued without job kwargs.
+    """
     job = Job.objects.filter(name=name).first()
     if job is None:
         print("JOB_SKIPPED", name, "not-registered")
@@ -46,8 +51,9 @@ def run_one(name):
     if not job.enabled:
         job.enabled = True
         job.save()
+    kwargs = {} if "Export" in name else {"dryrun": False}
     try:
-        result = JobResult.enqueue_job(job, approver)
+        result = JobResult.enqueue_job(job, approver, **kwargs)
     except Exception as exc:  # noqa: BLE001 - enqueue signature is version-sensitive
         print("JOB_ERROR", name, "enqueue:%s" % exc)
         return

--- a/roles/nautobot/tasks/main.yml
+++ b/roles/nautobot/tasks/main.yml
@@ -324,6 +324,14 @@
       delay: 6
       changed_when: false
 
+    # The seed jobs enqueue to the worker, which executes them with its
+    # EnvironmentFile. Flush the restart handler now so a worker started this
+    # converge already carries the fresh nautobot.env (seed-file path + export
+    # S3 credentials) before any job is enqueued — otherwise the export runs on
+    # a stale worker and fails "NAUTOBOT_EXPORT_S3_BUCKET is not set".
+    - name: Restart nautobot services before enqueuing jobs
+      ansible.builtin.meta: flush_handlers
+
     # Load the seed bundle into Nautobot by running the additive SSoT DiffSync
     # jobs (and, when NAUTOBOT_RUN_EXPORT is set, the export) once. Off by
     # default — enable at cutover with -e nautobot_run_seed_jobs=true after the

--- a/roles/nautobot/tasks/seed_bundle.yml
+++ b/roles/nautobot/tasks/seed_bundle.yml
@@ -117,12 +117,16 @@
     - nautobot_seed_network_cidrs[item.value.cidr_key | default('')] is defined
   no_log: true
 
-# Nodes from hosts.yml. ASSUMPTION: the pve hypervisors are the host keys under
-# nautobot_seed_hosts_group (default proxmox); WS-E adjusts the path at cutover.
+# Nodes from hosts.yml. Confirmed live shape (WS-E cutover): the pve hypervisors
+# are the host keys under all.children.<group>.hosts (not a top-level <group>
+# key), so read that nested path. mgmt_ip carries ansible_host verbatim (a
+# lookup template when DHCP-first); ssot_nodes does not key on it (Device
+# Onboarding binds the real management IP), so it is informational only.
 - name: Build nodes from the hosts inventory
   ansible.builtin.set_fact:
     nautobot_seed_nodes: >-
-      {{ (nautobot_seed_hosts[nautobot_seed_hosts_group].hosts | default({}) | dict2items)
+      {{ (((nautobot_seed_hosts.all | default({})).children | default({}))[nautobot_seed_hosts_group]
+          | default({})).hosts | default({}) | dict2items
          | community.general.json_query('[].{name: key, role: `pve-node`,
              mgmt_ip: value.ansible_host, commissioned: `true`}') }}
   no_log: true


### PR DESCRIPTION
The first live seed converge loaded **58 VirtualMachines, 13 VLANs, 13 prefixes, 63 IP addresses** — but exposed four defects that left nodes and the export incomplete:

1. **Dry-run** — the SSoT `DataSource` jobs default to a dry run (compute diffs, commit nothing). Only the `ensure_*` ORM scaffolding (ClusterType + Clusters) persisted; the DiffSynced objects didn't until `dryrun=False` was passed. `run_seed_jobs.py` now enqueues SSoT jobs with `dryrun=False` (the export Job has no such var, so it's enqueued plain).
2. **Nodes path** — the seed read pve hypervisors from a top-level `<group>` key, but `hosts.yml` nests them under `all.children.<group>.hosts` → **0 node Devices**. Fixed to the real path (verified: `pve1..pve4`).
3. **Worker env ordering** — the export runs on the worker, which loads `nautobot.env` at start. The restart handler flushed at end-of-play, *after* the jobs enqueued, so the export ran on a stale worker and failed `NAUTOBOT_EXPORT_S3_BUCKET is not set`. Now `flush_handlers` runs **before** enqueuing.
4. **S3 addressing** — `boto3.client("s3")` defaults to virtual-hosted addressing, which an on-prem RustFS/MinIO store doesn't serve. Force path-style + a default region when a custom `AWS_ENDPOINT_URL_S3` is set.

## Verification

- Live seed load already confirmed 58 VMs / 13 VLANs / 13 prefixes / 63 IPs.
- Nodes-path transform verified against the live `hosts.yml`: `pve1..pve4`.
- ansible-lint (production profile): 0 failures.
- Full node + export verification runs on the post-merge converge (reported on #138).

Refs #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrBt9kMzgRZZXCxyrmkdiF