### PR TITLE
feat(nautobot): real device-onboarding wiring — SecretsGroup, sync schedule (#138)

### DIFF
--- a/roles/nautobot/defaults/main.yml
+++ b/roles/nautobot/defaults/main.yml
@@ -109,7 +109,10 @@ nautobot_env: >-
                if nautobot_export_s3_endpoint | length > 0 else {})
      | combine({'AWS_ACCESS_KEY_ID': nautobot_export_s3_access_key,
                 'AWS_SECRET_ACCESS_KEY': nautobot_export_s3_secret_key}
-               if nautobot_export_s3_access_key | length > 0 else {}) }}
+               if nautobot_export_s3_access_key | length > 0 else {})
+     | combine({'NAUTOBOT_ONBOARD_USERNAME': nautobot_onboard_username,
+                'NAUTOBOT_ONBOARD_PASSWORD': nautobot_onboard_password}
+               if nautobot_onboard_username | length > 0 else {}) }}
 nautobot_env_base:
   NAUTOBOT_ROOT: "{{ nautobot_root }}"
   NAUTOBOT_SECRET_KEY: "{{ nautobot_effective_secret_key }}"
@@ -154,3 +157,30 @@ nautobot_manage_app: true
 # is placed. nautobot_run_export additionally runs the export Job that same pass.
 nautobot_run_seed_jobs: false
 nautobot_run_export: false
+
+# --- Automated discovery (nautobot-device-onboarding) -----------------------
+# One shared discovery credential (env-sourced, never a literal). Folded into
+# nautobot.env only when set, then bound to Nautobot Secret objects (provider
+# `environment-variable`) inside the `device-onboarding` SecretsGroup by
+# device_onboarding_setup.py. The nautobot-device-onboarding "Sync Devices From
+# Network" job (SSOTSyncDevices) drives SSH-CLI discovery for netmiko platforms.
+#
+# SCOPE NOTE: that plugin onboards SSH-CLI *network* devices (switches/routers).
+# Proxmox VE nodes (Linux), iDRAC/BMC (IPMI/Redfish), and the UniFi controller
+# (HTTP API) are NOT netmiko platforms — full discovery of those needs their
+# native APIs and is tracked as a follow-up (see roles/nautobot/README). This
+# wiring makes the SSH-CLI path real and leaves the discovery run inert until
+# real SSH targets + a platform are configured.
+nautobot_onboard_username: "{{ lookup('env', 'NAUTOBOT_ONBOARD_USERNAME') | default('', true) }}"
+nautobot_onboard_password: "{{ lookup('env', 'NAUTOBOT_ONBOARD_PASSWORD') | default('', true) }}"
+# Run + schedule the SSOTSyncDevices discovery — off by default; the run is
+# inert unless discovery targets are supplied (empty ip list -> nothing swept).
+nautobot_run_discovery: false
+# Comma-separated target IPs/CIDRs for the SSH-CLI sweep (env-sourced; the only
+# place an IP literal is legitimate, and even then env-derived, not committed).
+nautobot_onboard_targets: "{{ lookup('env', 'NAUTOBOT_ONBOARD_TARGETS') | default('', true) }}"
+nautobot_onboard_platform: "{{ lookup('env', 'NAUTOBOT_ONBOARD_PLATFORM') | default('', true) }}"
+nautobot_onboard_location: "{{ lookup('env', 'NAUTOBOT_ONBOARD_LOCATION') | default('homelab', true) }}"
+nautobot_onboard_port: 22
+nautobot_discovery_schedule_hour: 5
+nautobot_discovery_schedule_minute: 43

--- a/roles/nautobot/files/jobs/device_onboarding_setup.py
+++ b/roles/nautobot/files/jobs/device_onboarding_setup.py
@@ -1,75 +1,126 @@
-"""Nautobot Job: configure Device Onboarding targets (issue #138).
+"""Nautobot Job: wire the Device Onboarding SecretsGroup (issue #138).
 
-Device Onboarding is the live half of the source-of-truth pipeline: it logs into
-the real Proxmox VE nodes and iDRAC/BMC (and UniFi gear) to register them. This
-Job derives the onboarding target IPs from the seed bundle, ensures a
-SecretsGroup wired to the OpenBao-sourced credentials (read from the
-environment, never hardcoded), and logs the target list. Live onboarding runs
-at cutover, so the Job is self-guarding — it never fails the converge if the
-onboarding app is not fully ready.
+Creates (idempotently) the ``device-onboarding`` SecretsGroup and binds two
+``environment-variable`` Secret objects — username + password — as the Generic
+access-type username/password the nautobot-device-onboarding "Sync Devices From
+Network" job (``SSOTSyncDevices``) expects. The credential VALUES never touch
+Nautobot's database: the ``environment-variable`` provider resolves them at run
+time from the worker's environment (NAUTOBOT_ONBOARD_USERNAME / _PASSWORD in
+nautobot.env), so this only wires the indirection.
+
+Scope: SSOTSyncDevices drives SSH-CLI (netmiko) discovery of *network* devices.
+Proxmox VE nodes, iDRAC/BMC, and the UniFi controller are not netmiko platforms
+— their discovery needs native APIs and is a tracked follow-up. This Job just
+makes the SecretsGroup real and logs the seed-derived target set; the actual
+sweep is driven by schedule_discovery.py only when real SSH targets exist.
+
+Self-guarding like the other seed jobs: prints markers, never raises.
 """
 from __future__ import annotations
 
 import os
-from typing import Optional
 
 from nautobot.apps.jobs import Job, register_jobs
 
 from ssot_common import load_seed
+
+GROUP_NAME = os.environ.get("ONBOARDING_SECRETS_GROUP", "device-onboarding")
+USERNAME_ENV = "NAUTOBOT_ONBOARD_USERNAME"
+PASSWORD_ENV = "NAUTOBOT_ONBOARD_PASSWORD"
 
 
 def _onboarding_targets() -> list[dict]:
     """Derive {ip, kind} onboarding targets from the seed bundle."""
     seed = load_seed()
     targets: list[dict] = []
-    for node in seed["nodes"]:
+    for node in seed.get("nodes", []):
         if node.get("commissioned", True) and node.get("mgmt_ip"):
             targets.append({"ip": node["mgmt_ip"], "kind": "proxmox-node"})
-    for device in seed["devices"]:
+    for device in seed.get("devices", []):
         if device.get("bmc_ip"):
             targets.append({"ip": device["bmc_ip"], "kind": "bmc"})
     return targets
 
 
-def _ensure_secrets_group() -> Optional[str]:
-    """Best-effort: ensure a SecretsGroup for onboarding credentials exists.
+def _ensure_env_secret(name: str, variable: str):
+    """Idempotently ensure an environment-variable-backed Secret object."""
+    from nautobot.extras.models import Secret
 
-    Credentials themselves come from OpenBao via the environment; this only wires
-    the Nautobot SecretsGroup that the onboarding job references. Returns the
-    group name, or None when the surface is unavailable.
-    """
-    group_name = os.environ.get("ONBOARDING_SECRETS_GROUP", "device-onboarding")
-    try:
-        from nautobot.extras.models import SecretsGroup
+    secret, _ = Secret.objects.get_or_create(
+        name=name,
+        defaults={
+            "provider": "environment-variable",
+            "parameters": {"variable": variable},
+        },
+    )
+    # Reconcile drift on re-run without clobbering unrelated fields.
+    changed = False
+    if secret.provider != "environment-variable":
+        secret.provider = "environment-variable"
+        changed = True
+    if secret.parameters != {"variable": variable}:
+        secret.parameters = {"variable": variable}
+        changed = True
+    if changed:
+        secret.validated_save()
+    return secret
 
-        SecretsGroup.objects.get_or_create(name=group_name)
-        return group_name
-    except Exception as exc:  # noqa: BLE001 - best-effort scaffolding
-        return f"unavailable ({type(exc).__name__})"
+
+def _wire_secrets_group():
+    """Ensure the SecretsGroup + Generic username/password associations."""
+    from nautobot.extras.choices import (
+        SecretsGroupAccessTypeChoices,
+        SecretsGroupSecretTypeChoices,
+    )
+    from nautobot.extras.models import SecretsGroup, SecretsGroupAssociation
+
+    group, _ = SecretsGroup.objects.get_or_create(name=GROUP_NAME)
+    pairs = (
+        (SecretsGroupSecretTypeChoices.TYPE_USERNAME, "onboarding-username", USERNAME_ENV),
+        (SecretsGroupSecretTypeChoices.TYPE_PASSWORD, "onboarding-password", PASSWORD_ENV),
+    )
+    for secret_type, secret_name, variable in pairs:
+        secret = _ensure_env_secret(secret_name, variable)
+        SecretsGroupAssociation.objects.update_or_create(
+            secrets_group=group,
+            access_type=SecretsGroupAccessTypeChoices.TYPE_GENERIC,
+            secret_type=secret_type,
+            defaults={"secret": secret},
+        )
+    return group
 
 
 class ConfigureDeviceOnboarding(Job):
-    """Derive and log the Device Onboarding target set."""
+    """Wire the Device Onboarding SecretsGroup and log the target set."""
 
     class Meta:
         """Job metadata."""
 
         name = "Configure Device Onboarding Targets"
-        description = "Derive onboarding targets from the seed and wire the SecretsGroup."
+        description = "Wire the device-onboarding SecretsGroup and log discovery targets."
         has_sensitive_variables = False
 
     def run(self) -> None:  # noqa: D102 - Nautobot Job entrypoint
+        if not os.environ.get(USERNAME_ENV):
+            self.logger.warning(
+                "%s not set — discovery credentials are not configured; the "
+                "SecretsGroup is wired but the sweep stays inert.",
+                USERNAME_ENV,
+            )
+        try:
+            group = _wire_secrets_group()
+            self.logger.info("Onboarding SecretsGroup wired: %s", group.name)
+        except Exception as exc:  # noqa: BLE001 - self-guarding scaffolding
+            self.logger.warning("SecretsGroup wiring unavailable: %s", exc)
+
         targets = _onboarding_targets()
-        group = _ensure_secrets_group()
-        self.logger.info("Onboarding SecretsGroup: %s", group)
-        self.logger.info("Derived %d onboarding targets:", len(targets))
+        self.logger.info("Derived %d seed onboarding targets:", len(targets))
         for target in targets:
             self.logger.info("  %s (%s)", target["ip"], target["kind"])
-        if not os.environ.get("ONBOARDING_USERNAME"):
-            self.logger.warning(
-                "ONBOARDING_USERNAME/ONBOARDING_PASSWORD not set — live onboarding "
-                "will be run at cutover with OpenBao-sourced credentials."
-            )
+        self.logger.info(
+            "SSOTSyncDevices sweeps SSH-CLI network platforms only; Proxmox / "
+            "iDRAC / UniFi discovery via native APIs is a tracked follow-up."
+        )
 
 
 register_jobs(ConfigureDeviceOnboarding)

--- a/roles/nautobot/files/run_seed_jobs.py
+++ b/roles/nautobot/files/run_seed_jobs.py
@@ -20,13 +20,18 @@ import time
 from django.contrib.auth import get_user_model
 from nautobot.extras.models import Job, JobResult
 
-SEED_JOBS = [
+# SSoT DataSource jobs default to a dry run — they need dryrun=False to commit.
+SSOT_JOBS = [
     "Seed VLANs and Prefixes",
     "Seed IP Addresses and Reservations",
     "Seed DCIM Racks and Devices",
     "Seed Proxmox Node Facts",
     "SSoT: Virtualization (Proxmox guests)",
 ]
+# Plain Jobs (no dryrun var) — enqueued without job kwargs.
+PLAIN_JOBS = ["Configure Device Onboarding Targets"]
+
+SEED_JOBS = SSOT_JOBS + PLAIN_JOBS
 if os.environ.get("NAUTOBOT_RUN_EXPORT", "").lower() in ("1", "true", "yes"):
     SEED_JOBS.append("Export Nautobot Inventory to S3")
 
@@ -41,8 +46,8 @@ def run_one(name):
     """Enable, enqueue, and poll a single job by display name.
 
     SSoT DataSource jobs default to a dry run (compute diffs, commit nothing);
-    pass ``dryrun=False`` so the additive sync actually persists. The export
-    Job has no such var, so it is enqueued without job kwargs.
+    pass ``dryrun=False`` so the additive sync actually persists. Plain Jobs
+    (export, onboarding setup) have no such var, so they get no job kwargs.
     """
     job = Job.objects.filter(name=name).first()
     if job is None:
@@ -51,7 +56,7 @@ def run_one(name):
     if not job.enabled:
         job.enabled = True
         job.save()
-    kwargs = {} if "Export" in name else {"dryrun": False}
+    kwargs = {"dryrun": False} if name in SSOT_JOBS else {}
     try:
         result = JobResult.enqueue_job(job, approver, **kwargs)
     except Exception as exc:  # noqa: BLE001 - enqueue signature is version-sensitive

--- a/roles/nautobot/files/schedule_discovery.py
+++ b/roles/nautobot/files/schedule_discovery.py
@@ -90,7 +90,6 @@ try:
             "user": approver,
             "start_time": timezone.now(),
             "enabled": True,
-            "approval_required": False,
             "kwargs": job_kwargs,
         },
     )

--- a/roles/nautobot/files/schedule_discovery.py
+++ b/roles/nautobot/files/schedule_discovery.py
@@ -1,0 +1,101 @@
+"""Idempotently schedule the device-discovery Job on celery beat.
+
+Registers a daily ``ScheduledJob`` bound to nautobot-device-onboarding's
+"Sync Devices From Network" (``SSOTSyncDevices``) with the device-onboarding
+SecretsGroup and the target set supplied in the environment.
+
+Inert by design: SSOTSyncDevices sweeps SSH-CLI (netmiko) network platforms, so
+it stays UNSCHEDULED unless real SSH targets + a platform are configured
+(NAUTOBOT_ONBOARD_TARGETS + NAUTOBOT_ONBOARD_PLATFORM). Proxmox / iDRAC / UniFi
+discovery via native APIs is a tracked follow-up, not this job.
+
+Best-effort and self-guarding like schedule_export.py: prints
+``DISCOVERY_SCHEDULED`` / ``DISCOVERY_EXISTS`` / ``DISCOVERY_SKIPPED <reason>``
+and never raises.
+"""
+import os
+
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+JOB_NAME = "Sync Devices From Network"
+SCHEDULE_NAME = "discovery-sync-devices-daily"
+GROUP_NAME = os.environ.get("ONBOARDING_SECRETS_GROUP", "device-onboarding")
+
+targets = os.environ.get("NAUTOBOT_ONBOARD_TARGETS", "").strip()
+platform = os.environ.get("NAUTOBOT_ONBOARD_PLATFORM", "").strip()
+location_name = os.environ.get("NAUTOBOT_ONBOARD_LOCATION", "homelab").strip()
+port = int(os.environ.get("NAUTOBOT_ONBOARD_PORT", "22"))
+hour = int(os.environ.get("NAUTOBOT_DISCOVERY_SCHEDULE_HOUR", "5"))
+minute = int(os.environ.get("NAUTOBOT_DISCOVERY_SCHEDULE_MINUTE", "43"))
+
+try:
+    if not targets:
+        print("DISCOVERY_SKIPPED no-targets")
+        raise SystemExit(0)
+
+    from nautobot.dcim.models import Location
+    from nautobot.extras.choices import JobExecutionType
+    from nautobot.extras.models import Job, ScheduledJob, SecretsGroup, Status
+
+    job = Job.objects.filter(name=JOB_NAME).first()
+    if job is None:
+        print("DISCOVERY_SKIPPED job-not-registered")
+        raise SystemExit(0)
+    if not job.enabled:
+        job.enabled = True
+        job.save()
+
+    group = SecretsGroup.objects.filter(name=GROUP_NAME).first()
+    location = Location.objects.filter(name=location_name).first()
+    approver = get_user_model().objects.filter(is_superuser=True).order_by("pk").first()
+    active = Status.objects.filter(name="Active").first()
+    if not (group and location and approver and active):
+        missing = [
+            label
+            for label, obj in (
+                ("secrets-group", group),
+                ("location", location),
+                ("superuser", approver),
+                ("active-status", active),
+            )
+            if obj is None
+        ]
+        print("DISCOVERY_SKIPPED missing:%s" % ",".join(missing))
+        raise SystemExit(0)
+
+    job_kwargs = {
+        "location": str(location.pk),
+        "ip_addresses": targets,
+        "port": port,
+        "timeout": 30,
+        "secrets_group": str(group.pk),
+        "platform": platform or None,
+        "device_role": None,
+        "device_status": str(active.pk),
+        "interface_status": str(active.pk),
+        "ip_address_status": str(active.pk),
+        "namespace": None,
+        "set_mgmt_only": True,
+        "update_devices_without_primary_ip": False,
+    }
+
+    obj, created = ScheduledJob.objects.get_or_create(
+        name=SCHEDULE_NAME,
+        defaults={
+            "job_model": job,
+            "task": job.class_path,
+            "interval": JobExecutionType.TYPE_CUSTOM,
+            "crontab": f"{minute} {hour} * * *",
+            "user": approver,
+            "start_time": timezone.now(),
+            "enabled": True,
+            "approval_required": False,
+            "kwargs": job_kwargs,
+        },
+    )
+    print("DISCOVERY_SCHEDULED" if created else "DISCOVERY_EXISTS")
+except SystemExit:
+    raise
+except Exception as exc:  # noqa: BLE001 - best-effort; never fail the converge
+    print(f"DISCOVERY_SKIPPED {type(exc).__name__}: {exc}")

--- a/roles/nautobot/tasks/main.yml
+++ b/roles/nautobot/tasks/main.yml
@@ -313,6 +313,25 @@
       become: true
       become_user: "{{ nautobot_user }}"
 
+    # Schedule the SSH-CLI discovery sweep (SSOTSyncDevices). Inert unless
+    # NAUTOBOT_ONBOARD_TARGETS is set — see the scope note in defaults/main.yml.
+    - name: Schedule the device-discovery Job via celery beat
+      ansible.builtin.command:
+        cmd: "{{ nautobot_root }}/bin/nautobot-server shell --interface python"
+        stdin: "{{ lookup('ansible.builtin.file', 'schedule_discovery.py') }}"
+      environment: >-
+        {{ nautobot_env | combine({
+             'NAUTOBOT_ONBOARD_TARGETS': nautobot_onboard_targets,
+             'NAUTOBOT_ONBOARD_PLATFORM': nautobot_onboard_platform,
+             'NAUTOBOT_ONBOARD_LOCATION': nautobot_onboard_location,
+             'NAUTOBOT_ONBOARD_PORT': nautobot_onboard_port | string,
+             'NAUTOBOT_DISCOVERY_SCHEDULE_HOUR': nautobot_discovery_schedule_hour | string,
+             'NAUTOBOT_DISCOVERY_SCHEDULE_MINUTE': nautobot_discovery_schedule_minute | string}) }}
+      register: nautobot_discovery_schedule
+      changed_when: "'DISCOVERY_SCHEDULED' in nautobot_discovery_schedule.stdout"
+      become: true
+      become_user: "{{ nautobot_user }}"
+
     - name: Wait for the Nautobot web UI to answer
       ansible.builtin.uri:
         url: "http://127.0.0.1:{{ nautobot_web_port }}/"


### PR DESCRIPTION
Replaces the log-only onboarding scaffolding with real, idempotent wiring for `nautobot-device-onboarding`'s "Sync Devices From Network" job (`SSOTSyncDevices`).

## What
- **Credential** — env-sourced `NAUTOBOT_ONBOARD_USERNAME`/`PASSWORD`, folded into `nautobot.env` only when set (same conditional-combine as the export S3 keys).
- **SecretsGroup** — `device_onboarding_setup.py` now creates two `environment-variable` Secret objects and binds them into the `device-onboarding` SecretsGroup as the **Generic** username/password associations `SSOTSyncDevices` expects (credential values resolve from the worker env at run time — never stored in the Nautobot DB).
- **Schedule** — `schedule_discovery.py` registers a daily `ScheduledJob` for the sweep, wired into the converge like the export schedule; `run_seed_jobs` runs the onboarding setup job (a plain Job — no `dryrun`).

## Scope finding (important)
`SSOTSyncDevices` drives **SSH-CLI (netmiko) discovery of network devices** (switches/routers). **Proxmox VE nodes (Linux), iDRAC/BMC (IPMI/Redfish), and the UniFi controller (HTTP API) are not netmiko platforms** — so the discovery run stays **inert** unless real SSH targets + a platform are supplied (`NAUTOBOT_ONBOARD_TARGETS`). Full pve/iDRAC/UniFi discovery requires their **native APIs** (Proxmox API, Redfish, UniFi API) and is a tracked follow-up, not this plugin. The SecretsGroup/credential wiring here is correct and reused by whatever drives those.

## Verification
- ansible-lint (production profile): 0 failures; all three Python files parse.
- SecretsGroup access-type/secret-type + `SSOTSyncDevices` inputs verified against the app's `jobs.py` (marked for live validation at cutover).
- Molecule unaffected (gated behind `nautobot_manage_app`).

Refs #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrBt9kMzgRZZXCxyrmkdiF