### PR TITLE
feat(agentgateway_docker): front LangGraph A2A endpoint through the gateway

### DIFF
--- a/roles/agentgateway_docker/defaults/main.yml
+++ b/roles/agentgateway_docker/defaults/main.yml
@@ -82,6 +82,27 @@ agentgateway_docker_mcp_targets:
     host: "https://mcp.context7.com/mcp"
 
 # =============================================================================
+# A2A targets — native Agent2Agent (JSON-RPC) endpoints the gateway fronts on
+# the same proxy port. Each gets a prefix-matched route marked `a2a: {}`, so the
+# gateway parses the JSON-RPC and rewrites the agent card's `url` to point back
+# at itself. LangGraph is the only A2A-native agent today.
+#
+# host reaches the LangGraph CONTAINER directly on its API port.
+# tofu_data.containers.langgraph.ip is ALREADY the resolvable FQDN — the same
+# address Traefik uses as its own langgraph backend — so it hits the container
+# directly. Do NOT use langgraph.<sub> (the Traefik ingress alias on :443, a
+# needless double-hop). Bare host:port → HTTP, which is what `langgraph dev`
+# serves (no TLS), so no backendTLS policy.
+# =============================================================================
+agentgateway_docker_a2a_targets:
+  - name: langgraph
+    path_prefix: /a2a/
+    host: >-
+      {{ hostvars['localhost']['tofu_data']['containers']['langgraph']['ip'] }}:{{
+      hostvars['localhost']['tofu_data']['constants']['service_ports']['langgraph_api']
+      | mandatory('tofu_data.constants.service_ports.langgraph_api missing — regenerate tofu_inventory.json') }}
+
+# =============================================================================
 # Tracing — OTLP/HTTP to the shared Cribl Edge receiver (telemetry always via
 # Cribl; Cribl forks to Langfuse + Splunk). Endpoint contract comes from
 # group_vars/all.yml. Sampling: keep everything while traffic is low.

--- a/roles/agentgateway_docker/templates/config.yaml.j2
+++ b/roles/agentgateway_docker/templates/config.yaml.j2
@@ -40,3 +40,12 @@ binds:
                 insecure: true
 {% endif %}
 {% endfor %}
+{% for target in agentgateway_docker_a2a_targets | default([]) %}
+    - matches:
+      - path:
+          pathPrefix: {{ target.path_prefix }}
+      policies:
+        a2a: {}
+      backends:
+      - host: {{ target.host }}
+{% endfor %}


### PR DESCRIPTION
## What

Stand up the first **A2A (Agent2Agent)** path on the shared gateway: front LangGraph's native A2A (JSON-RPC) endpoint through the existing `mcp.<sub>` proxy plane, so agents reach it through one governed, traced front door.

## Change

- `defaults/main.yml`: new `agentgateway_docker_a2a_targets` list (LangGraph, prefix `/a2a/`). Backend = `containers.langgraph.ip` (the resolvable FQDN Traefik itself uses as the langgraph backend) on the `langgraph_api` port — reaches the container directly, plain HTTP, no double-hop through the ingress alias.
- `templates/config.yaml.j2`: second route loop emitting a `pathPrefix` match + `policies: {a2a: {}}` + a bare `host` backend per the agentgateway standalone A2A schema. Prefix match covers both `/a2a/<uuid>` and its `/.well-known/` agent card; the path passes through unchanged.

No firewall change — the gateway already has `outbound_internal` and LangGraph's API port already accepts inbound from internal; both live on the same VLAN.

## Verification (post-converge)

- Agent card via gateway (`/a2a/<uuid>/.well-known/agent-card.json`) returns 200 with the top-level `url` rewritten to the gateway.
- An A2A `message/send` through the gateway reaches LangGraph and returns a reply; the request shows up as a gateway trace in Langfuse.

Known limitation on the pinned v1.3.1 image: it rewrites the card's top-level `url` (A2A v0.3.0) but not `supportedInterfaces[].url` (v1.0, rewritten only in v1.4.0-alpha.1). Deferred to a future image bump.