### PR TITLE
feat(openbao): add apps-seed AppRole for automated secret/apps/* writes

### DIFF
--- a/roles/openbao/README.md
+++ b/roles/openbao/README.md
@@ -186,8 +186,9 @@ plans):
 
 | AppRole | Reads | Writes | Notes |
 | --- | --- | --- | --- |
-| `terraform-apply` | `secret/infra/*`, `secret/platform/{dns,traefik}`, `secret/apps/nautobot/*`, legacy `homelab/*` | `secret/infra/*`, `secret/platform/{dns,traefik}`, `secret/apps/nautobot/*`, legacy `homelab/*` | Human-triggered IaC apply; Nautobot grant is narrow seed-only for P1 secrets |
-| `flow-lock` | `secret/locks/global`, `secret/infra/*` | `secret/locks/global` | Cross-repo apply lock holder; can release the global lock via metadata delete |
+| `terraform-apply` | `secret/infra/*`, `secret/platform/{dns,traefik}`, `secret/apps/nautobot/*`, legacy `homelab/*` | (same) | Human-triggered IaC apply |
+| `apps-seed` | `secret/apps/*` | `secret/apps/*` create/update | Doppler-published writer; Terraform `vault-secrets` seeds `secret/apps/<app>` at source |
+| `flow-lock` | `secret/locks/global`, `secret/infra/*` | `secret/locks/global` | Cross-repo apply lock; releases the lock via metadata delete |
 | `terrakube-plan` | `secret/platform/terrakube` only | — | Terrakube VCS-driven runs; deliberately walled off from `secret/infra/*` |
 | `ansible-converge` | `secret/platform/*`, `secret/apps/*` | — | Config-management pulls |
 | `observability` | `secret/platform/{splunk,cribl}` | — | Ingest pipeline (shared HEC tokens) |

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -202,6 +202,13 @@ openbao_ai_elevated_policy_name: ai-elevated
 openbao_ai_elevated_approle_name: ai-elevated
 openbao_snapshot_policy_name: snapshot
 openbao_snapshot_approle_name: snapshot
+# apps-seed — the automated WRITER for per-app service secrets under
+# secret/apps/* (create/update/read only, no other domain). Terraform
+# (terraform-proxmox vault-secrets) authenticates as this role to generate +
+# store each app's credentials at the source. Doppler-published creds
+# (APPS_SEED_VAULT_ROLE_ID / _SECRET_ID), the same delivery as terraform-apply.
+openbao_apps_seed_policy_name: apps-seed
+openbao_apps_seed_approle_name: apps-seed
 
 # The set of non-root AppRoles to provision, each {name, policy}. Driving the
 # bootstrap from this list keeps init.yml DRY as groups are added. Per-identity
@@ -247,6 +254,9 @@ openbao_approles:
     policy: "{{ openbao_ai_elevated_policy_name }}"
   - name: "{{ openbao_snapshot_approle_name }}"
     policy: "{{ openbao_snapshot_policy_name }}"
+  # apps-seed: Doppler-published writer for secret/apps/* (Terraform vault-secrets).
+  - name: "{{ openbao_apps_seed_approle_name }}"
+    policy: "{{ openbao_apps_seed_policy_name }}"
 # Policy templates rendered + written on the bootstrap host. Each entry maps a
 # policy name to its template; add a row to grow the RBAC surface.
 openbao_policies:
@@ -282,6 +292,8 @@ openbao_policies:
     template: ai-elevated-policy.hcl.j2
   - name: "{{ openbao_snapshot_policy_name }}"
     template: snapshot-policy.hcl.j2
+  - name: "{{ openbao_apps_seed_policy_name }}"
+    template: apps-seed-policy.hcl.j2
 
 # --- External admin token (provisioning against an ALREADY-LIVE cluster) -----
 # The initial `bao operator init` only happens once; after that, adding new

--- a/roles/openbao/templates/apps-seed-policy.hcl.j2
+++ b/roles/openbao/templates/apps-seed-policy.hcl.j2
@@ -1,0 +1,23 @@
+{{ ansible_managed | comment }}
+# OpenBao policy for the apps-seed AppRole — the automated writer that seeds
+# per-app service secrets under secret/apps/*. Terraform (terraform-proxmox
+# vault-secrets) authenticates as this role to generate-at-source and store
+# each app's credentials (e.g. secret/apps/zammad, secret/apps/nautobot):
+# random_password + vault_kv_secret_v2, generate-if-absent.
+#
+# Scope is secret/apps/* and nothing else — NO infra/platform/ai paths. The
+# trailing `*` (not `/*`) matters: `secret/data/apps/*` matches the exact path
+# `secret/data/apps/zammad` as well as any `secret/data/apps/zammad/<sub>`. A
+# `/*` glob would match only the sub-paths and 403 on the parent write.
+#
+# create/update/read is enough for Terraform to manage the value; no `delete`
+# (secrets are generate-if-absent and never torn down under a live service).
+# See terraform-proxmox docs/SECRETS_HIERARCHY.md.
+
+path "{{ openbao_kv_mount }}/data/apps/*" {
+  capabilities = ["create", "update", "read"]
+}
+
+path "{{ openbao_kv_mount }}/metadata/apps/*" {
+  capabilities = ["read", "list"]
+}


### PR DESCRIPTION
## What

Adds a dedicated least-privilege **`apps-seed`** OpenBao AppRole so per-app service secrets under `secret/apps/*` can be created **fully automatically** — no root or bootstrap token.

Terraform (`terraform-proxmox/vault-secrets`) authenticates as this role to generate-at-source (`random_password` + `vault_kv_secret_v2`, generate-if-absent) and seed each app's credentials, e.g. `secret/apps/zammad`.

## Why

Today no AppRole can create a *new* `secret/apps/<app>` path — `terraform-apply` is walled to `infra/*`, `platform/{dns,traefik}`, and a one-off `apps/nautobot` grant. That gap is why a new app (Zammad) had no automated OpenBao home. This closes it with a scoped writer instead of widening `terraform-apply`'s blast radius.

## Scope / safety

- Policy grants `create/update/read` on `secret/data/apps/*` + `read/list` on `secret/metadata/apps/*` — **nothing else** (no infra/platform/ai). OpenBao's path-scoped policy is the admission control.
- Trailing `*` (not `/*`) matches the exact `secret/data/apps/<app>` path as well as sub-paths.
- Creds Doppler-published (`APPS_SEED_VAULT_ROLE_ID` / `_SECRET_ID`), same delivery as `terraform-apply`.
- Additive: registers a new policy + AppRole in `openbao_policies`/`openbao_approles`; touches no existing identity. `init.yml` mints creds only for AppRoles missing on a run.
- Also shortens two pre-existing over-long RBAC-table rows to satisfy MD013.

## Follow-ups (separate PRs)

- `terraform-proxmox/vault-secrets`: add `apps/zammad` (+ route apps writes through this role).
- Canonical secrets-policy docs (docs-starlight) update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)