### PR TITLE
fix(nautobot): restart worker before enqueuing seed/export jobs (#138)

### DIFF
--- a/roles/nautobot/tasks/main.yml
+++ b/roles/nautobot/tasks/main.yml
@@ -344,12 +344,23 @@
       changed_when: false
 
     # The seed jobs enqueue to the worker, which executes them with its
-    # EnvironmentFile. Flush the restart handler now so a worker started this
-    # converge already carries the fresh nautobot.env (seed-file path + export
-    # S3 credentials) before any job is enqueued — otherwise the export runs on
-    # a stale worker and fails "NAUTOBOT_EXPORT_S3_BUCKET is not set".
+    # EnvironmentFile. Flush any pending restart handler first (covers the
+    # nautobot.env-changed case)...
     - name: Restart nautobot services before enqueuing jobs
       ansible.builtin.meta: flush_handlers
+
+    # ...then restart the worker UNCONDITIONALLY when a seed/export run is
+    # requested. flush_handlers only fires if a task notified the handler this
+    # converge; when nautobot.env is unchanged the worker keeps its start-time
+    # env, so the export would enqueue onto a stale worker and fail
+    # "NAUTOBOT_EXPORT_S3_BUCKET is not set". An explicit restart guarantees the
+    # worker carries the current env before any job is enqueued. Gated on the
+    # run flag so ordinary converges are untouched.
+    - name: Ensure the worker carries the current env before enqueuing jobs
+      ansible.builtin.systemd:
+        name: nautobot-worker
+        state: restarted
+      when: nautobot_run_seed_jobs | bool
 
     # Load the seed bundle into Nautobot by running the additive SSoT DiffSync
     # jobs (and, when NAUTOBOT_RUN_EXPORT is set, the export) once. Off by


### PR DESCRIPTION
`flush_handlers` before the seed/export enqueue only restarts the worker when `nautobot.env` **changed** this converge. On a rebuild where the env is unchanged, the worker keeps its start-time environment — so the export enqueues onto a **stale worker** and fails `NAUTOBOT_EXPORT_S3_BUCKET is not set` (observed live; worked only after a manual worker restart).

Adds an explicit, `nautobot_run_seed_jobs`-gated `nautobot-worker` restart right after the handler flush, so the worker always carries the current env before any job is enqueued. Ordinary converges (no seed/export run) are untouched.

Verified: ansible-lint (production profile) passes; the live export succeeded immediately after a worker restart, confirming the root cause.

Refs #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrBt9kMzgRZZXCxyrmkdiF