### PR TITLE
feat(hermes_agent): watchdog to pause cron fleet + alert once on brain outage

### DIFF
--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -213,6 +213,49 @@ When Hermes finds a signal worth watching continuously it may register its own
 | `hermes_agent_splunk_alert_deliver` | `slack:<member-id>` | DM target for anomaly alerts |
 | `hermes_agent_splunk_digest_deliver` | `slack` | home-channel target for the digest |
 
+## Brain-health watchdog (no cron-failure spam)
+
+The cron fleet above talks to a **single-deployment brain** (`ai-default`, served
+by one Mac Studio via the `llm_router` proxy) with **no viable fallback**. When
+that brain is unreachable, two upstream facts combine badly: each cron run is a
+**fresh, stateless session**, and upstream *always* delivers a failure —
+*"Failed jobs always deliver regardless of the `[SILENT]` marker; only successful
+runs can be silenced."* So a brain outage makes every seeded job fail and DM the
+operator (twice an hour for `splunk-security` alone), while nothing pages that the
+brain is even down — `service_deadman` watches DNS/Traefik/HAProxy/OpenBao, not
+the LLM fabric.
+
+This watchdog closes both gaps with a small `systemd` timer
+(`hermes-brain-watchdog.timer`, every 60s, run as the `hermes` user):
+
+1. **Probe** `ai-default` end-to-end through the same router URL the crons use — a
+   1-token completion, so it catches a connection error *and* a reachable-but-
+   wedged brain. It hits the already-active model (no cold-model spawn) and keeps
+   it warm, matching the intended 24/7 posture.
+2. **Debounce** — declare DOWN only after `down_after` consecutive failures (3 ≈
+   3 min) and UP after `up_after` successes (2). This rides brief bounces
+   (rotation flips, cold reloads) so the watchdog never becomes a *new* source of
+   spam.
+3. **On a transition** — `hermes cron pause` (or `resume`) the role-seeded fleet
+   (`hermes_agent_seeded_cron_names`; user/agent jobs are never touched) and alert
+   **exactly once** per edge to **both** a Slack DM (the operator, same place the
+   spam was) and an **urgent ntfy** push (the `keystone` feed other homelab
+   outages page on). Paused jobs don't fire, so the outage stops producing spam
+   instead of amplifying it.
+
+Pausing loses no coverage a run would otherwise achieve — the brain is down either
+way — it just makes the gap visible **once** instead of drowning it in 500s.
+Gated on the same Slack tokens that seed the fleet (no fleet → nothing to guard).
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `hermes_agent_brain_watchdog_enabled` | `true` | Deploy + start the watchdog timer |
+| `hermes_agent_brain_watchdog_interval` | `60s` | Probe cadence (`OnUnitActiveSec`) |
+| `hermes_agent_brain_watchdog_probe_timeout` | `15` | Per-probe curl deadline (seconds) |
+| `hermes_agent_brain_watchdog_down_after` | `3` | Consecutive fails → pause + alert |
+| `hermes_agent_brain_watchdog_up_after` | `2` | Consecutive oks → resume + alert |
+| `hermes_agent_brain_watchdog_ntfy_topic` | `keystone` | ntfy topic for the urgent page |
+
 ## Live docs (Context7)
 
 Registers Context7's hosted HTTP MCP server (`mcp_servers.context7`) so Hermes

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -387,3 +387,35 @@ hermes_agent_verify_fatal_log_patterns:
 hermes_agent_verify_probe_timeout: 300
 hermes_agent_verify_probe_retries: 3
 hermes_agent_verify_probe_delay: 10
+
+# --- Brain-health watchdog: stop cron-failure spam during brain outages -------
+# ai-default is a single-deployment brain (llm_router role) with no viable
+# fallback, and upstream Hermes ALWAYS delivers a cron failure ("Failed jobs
+# always deliver regardless of the [SILENT] marker"). So a brain outage makes the
+# stateless seeded fleet fail-and-DM the operator twice an hour per job, while
+# nothing pages that the brain is even down (service_deadman watches DNS/Traefik/
+# HAProxy/OpenBao, not the LLM fabric). This watchdog closes both gaps: a systemd
+# timer probes the brain end-to-end and, on a DEBOUNCED transition, pauses/resumes
+# the seeded cron fleet and alerts EXACTLY ONCE per edge. See templates/ +
+# tasks/main.yml and the README.
+hermes_agent_brain_watchdog_enabled: true
+hermes_agent_brain_watchdog_script_path: /usr/local/bin/hermes-brain-watchdog.sh
+# Probe cadence (systemd OnUnitActiveSec). 60s matches service_deadman.
+hermes_agent_brain_watchdog_interval: "60s"
+# Per-probe curl deadline. Comfortably covers a warm 1-token completion; a hung or
+# unreachable brain trips it and counts as one failure toward the debounce.
+hermes_agent_brain_watchdog_probe_timeout: 15
+# Hysteresis: consecutive failures before declaring DOWN (pause+alert), and
+# consecutive successes before declaring UP (resume+alert). down_after=3 over the
+# 60s cadence (~3 min) rides rotation-flip bounces and cold reloads so the
+# watchdog never becomes a new source of spam; up_after=2 damps flapping.
+hermes_agent_brain_watchdog_down_after: 3
+hermes_agent_brain_watchdog_up_after: 2
+# Urgent page target. Same ntfy LXC + notification port + topic service_deadman
+# pages on ("same feed as other homelab outages", operator decision) — the brain
+# is now a keystone. Port is single-sourced from tofu constants; host from the
+# ntfy inventory entry (fallback to the bare name).
+hermes_agent_brain_watchdog_ntfy_topic: "keystone"
+hermes_agent_brain_watchdog_ntfy_url: >-
+  http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
+  tofu_data.constants.notification_ports.ntfy_http }}/{{ hermes_agent_brain_watchdog_ntfy_topic }}

--- a/roles/hermes_agent/handlers/main.yml
+++ b/roles/hermes_agent/handlers/main.yml
@@ -9,3 +9,9 @@
   ansible.builtin.systemd:
     name: ssh
     state: restarted
+
+- name: Restart hermes-brain-watchdog timer
+  ansible.builtin.systemd:
+    name: hermes-brain-watchdog.timer
+    state: restarted
+    daemon_reload: true

--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -475,6 +475,55 @@
     enabled: true
     daemon_reload: true
 
+# --- Brain-health watchdog ---------------------------------------------------
+# A single-deployment brain (ai-default) with no fallback + upstream that ALWAYS
+# delivers cron failures means a brain outage DMs the operator twice an hour per
+# seeded job while nothing pages that the brain is down. This timer probes the
+# brain end-to-end and, on a debounced transition, pauses/resumes the seeded
+# fleet and alerts once per edge (Slack DM + urgent ntfy). Gated on the Slack
+# tokens that seed the spammy fleet in the first place — no fleet, nothing to
+# guard. ponytail: no disable-cleanup path; flip the flag + `systemctl disable
+# --now hermes-brain-watchdog.timer` if ever turned off.
+- name: Deploy the Hermes brain-health watchdog script
+  ansible.builtin.template:
+    src: hermes-brain-watchdog.sh.j2
+    dest: "{{ hermes_agent_brain_watchdog_script_path }}"
+    owner: root
+    group: root
+    mode: "0755"
+  notify: Restart hermes-brain-watchdog timer
+  when:
+    - hermes_agent_brain_watchdog_enabled | bool
+    - hermes_agent_slack_bot_token | length > 0
+    - hermes_agent_slack_app_token | length > 0
+
+- name: Deploy the Hermes brain-health watchdog systemd units
+  ansible.builtin.template:
+    src: "{{ item }}.j2"
+    dest: "/etc/systemd/system/{{ item }}"
+    owner: root
+    group: root
+    mode: "0644"
+  loop:
+    - hermes-brain-watchdog.service
+    - hermes-brain-watchdog.timer
+  notify: Restart hermes-brain-watchdog timer
+  when:
+    - hermes_agent_brain_watchdog_enabled | bool
+    - hermes_agent_slack_bot_token | length > 0
+    - hermes_agent_slack_app_token | length > 0
+
+- name: Enable and start the Hermes brain-health watchdog timer
+  ansible.builtin.systemd:
+    name: hermes-brain-watchdog.timer
+    state: started
+    enabled: true
+    daemon_reload: true
+  when:
+    - hermes_agent_brain_watchdog_enabled | bool
+    - hermes_agent_slack_bot_token | length > 0
+    - hermes_agent_slack_app_token | length > 0
+
 - name: Flush handlers so config/unit changes apply before verification
   ansible.builtin.meta: flush_handlers
 

--- a/roles/hermes_agent/templates/hermes-brain-watchdog.service.j2
+++ b/roles/hermes_agent/templates/hermes-brain-watchdog.service.j2
@@ -1,0 +1,19 @@
+{{ ansible_managed | comment }}
+# One probe cycle of the Hermes brain-health watchdog. Fired by
+# hermes-brain-watchdog.timer; runs as the hermes user so `hermes cron
+# pause/resume` sees the same $HERMES_HOME the gateway uses.
+[Unit]
+Description=Hermes brain-health watchdog (pause/resume the cron fleet on a brain outage)
+After=network-online.target hermes-gateway.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User={{ hermes_agent_user }}
+Group={{ hermes_agent_user }}
+Environment=HERMES_HOME={{ hermes_agent_hermes_home }}
+# Same secrets file the gateway loads: HERMES_AGENT_MODEL_API_KEY (probe auth) +
+# SLACK_BOT_TOKEN / SLACK_ALLOWED_USERS (DM alert). Leading '-' keeps the probe
+# runnable while .env is still empty.
+EnvironmentFile=-{{ hermes_agent_hermes_home }}/.env
+ExecStart={{ hermes_agent_brain_watchdog_script_path }}

--- a/roles/hermes_agent/templates/hermes-brain-watchdog.sh.j2
+++ b/roles/hermes_agent/templates/hermes-brain-watchdog.sh.j2
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# {{ ansible_managed }}
+#
+# Hermes brain-health watchdog. Rendered by the hermes_agent role and run on a
+# systemd timer (every {{ hermes_agent_brain_watchdog_interval }}) as the hermes
+# user. It exists because Hermes cron runs are stateless and upstream ALWAYS
+# delivers a failure notification ("Failed jobs always deliver regardless of the
+# [SILENT] marker") — so when the single-deployment brain (ai-default) is
+# unreachable, every seeded cron fires, 500s, and DMs the operator, twice an hour
+# per job, with nobody getting one clean "the brain is down" signal.
+#
+# Fix: probe the brain end-to-end; on a DEBOUNCED transition, `hermes cron
+# pause`/`resume` the role-seeded fleet and alert EXACTLY ONCE per edge (Slack DM
+# + urgent ntfy). Paused jobs don't fire, so a brain outage stops producing spam
+# instead of amplifying it. Pausing loses no coverage a run would otherwise
+# achieve — the brain is down either way — it just makes the gap visible once.
+set -uo pipefail
+
+# --- Rendered config ---------------------------------------------------------
+HERMES_BIN="{{ hermes_agent_bin }}"
+MODEL="{{ hermes_agent_model }}"
+BASE_URL="{{ hermes_agent_model_base_url }}"
+PROBE_URL="${BASE_URL}/chat/completions"
+PROBE_TIMEOUT="{{ hermes_agent_brain_watchdog_probe_timeout }}"
+DOWN_AFTER="{{ hermes_agent_brain_watchdog_down_after }}"
+UP_AFTER="{{ hermes_agent_brain_watchdog_up_after }}"
+NTFY_URL="{{ hermes_agent_brain_watchdog_ntfy_url }}"
+STATE_DIR="{{ hermes_agent_hermes_home }}/brain-watchdog"
+# Rendered at template time (the seeded list is static) so the script avoids
+# bash's array-length parameter form, whose brace-hash opener would be misread as
+# a Jinja comment start in this .j2 and mangle the template.
+JOB_COUNT="{{ hermes_agent_seeded_cron_names | length }}"
+
+# Role-seeded, brain-dependent cron fleet — the only jobs this watchdog touches
+# (never user/agent-created jobs). Same list the model-drift recovery uses.
+SEEDED_JOBS=(
+{% for job in hermes_agent_seeded_cron_names %}
+  "{{ job }}"
+{% endfor %}
+)
+
+# Secrets arrive via the systemd unit's EnvironmentFile (the same $HERMES_HOME/.env
+# the gateway loads): HERMES_AGENT_MODEL_API_KEY (probe auth), SLACK_BOT_TOKEN +
+# SLACK_ALLOWED_USERS (DM alert). Defaulted empty so `set -u` is safe when unset.
+API_KEY="${HERMES_AGENT_MODEL_API_KEY:-}"
+SLACK_TOKEN="${SLACK_BOT_TOKEN:-}"
+SLACK_USER="${SLACK_ALLOWED_USERS:-}"
+
+# --- Probe: a tiny real completion, mirroring what the crons actually do ------
+# Healthy iff HTTP 200. A connection error (curl fails -> 000), a 5xx, an auth
+# 4xx, or a wedged brain that hangs past PROBE_TIMEOUT all read as DOWN — the
+# same failures that would fail a cron. It hits the already-active rotation model
+# (no cold-model spawn), and probing on this cadence keeps the brain warm, which
+# matches the intended 24/7 posture. ponytail: 1-token probe, not a bare TCP
+# check, so "reachable but not serving" is caught too.
+probe_ok() {
+  local code
+  code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time "${PROBE_TIMEOUT}" \
+    -X POST "${PROBE_URL}" \
+    -H "Authorization: Bearer ${API_KEY}" \
+    -H "Content-Type: application/json" \
+    -d "{\"model\":\"${MODEL}\",\"max_tokens\":1,\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}]}" \
+    2>/dev/null)" || code="000"
+  [[ "${code}" == "200" ]]
+}
+
+# --- Cron fleet control (best-effort; idempotent) ----------------------------
+# HERMES_HOME comes from the unit's Environment=. pause/resume are no-ops on an
+# already-paused/active job; a missing job just logs and is ignored.
+cron_do() {
+  local verb="$1" job
+  for job in "${SEEDED_JOBS[@]}"; do
+    if "${HERMES_BIN}" cron "${verb}" "${job}" >/dev/null 2>&1; then
+      logger -t hermes-brain-watchdog "${verb}d ${job}"
+    else
+      logger -t hermes-brain-watchdog "${verb} skipped (missing/already ${verb}d): ${job}"
+    fi
+  done
+}
+
+# --- Alerting: one Slack DM + one urgent ntfy per transition -----------------
+# Messages are kept JSON-safe (no double quotes / backslashes) so the Slack body
+# can be built with printf — the guest has no jq, and adding one for two strings
+# is not worth a dependency (ponytail).
+slack_post() {
+  local text="$1" channel
+  [[ -n "${SLACK_TOKEN}" && -n "${SLACK_USER}" ]] || return 0
+  channel="${SLACK_USER%%,*}"   # first member id; channel=<user id> DMs them
+  curl -fsS --max-time 10 -X POST https://slack.com/api/chat.postMessage \
+    -H "Authorization: Bearer ${SLACK_TOKEN}" \
+    -H "Content-Type: application/json; charset=utf-8" \
+    --data "$(printf '{"channel":"%s","text":"%s"}' "${channel}" "${text}")" \
+    >/dev/null 2>&1 || true
+}
+
+ntfy_push() {
+  local kind="$1" text="$2" prio tags title
+  [[ -n "${NTFY_URL}" ]] || return 0
+  if [[ "${kind}" == "down" ]]; then
+    prio="urgent"; tags="rotating_light"; title="hermes brain down"
+  else
+    prio="default"; tags="white_check_mark"; title="hermes brain recovered"
+  fi
+  curl -fsS --max-time 8 -H "Title: ${title}" -H "Priority: ${prio}" \
+    -H "Tags: ${tags}" -d "${text}" "${NTFY_URL}" >/dev/null 2>&1 || true
+}
+
+alert() {
+  local kind="$1" msg now
+  now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  if [[ "${kind}" == "down" ]]; then
+    msg=":warning: Hermes brain unreachable (${MODEL} via ${BASE_URL}) since ${now} -- paused ${JOB_COUNT} seeded cron jobs; will auto-resume on recovery."
+  else
+    msg=":white_check_mark: Hermes brain recovered at ${now} -- resumed ${JOB_COUNT} seeded cron jobs."
+  fi
+  logger -t hermes-brain-watchdog "${msg}"
+  slack_post "${msg}"
+  ntfy_push "${kind}" "${msg}"
+}
+
+# --- Debounced state machine -------------------------------------------------
+# state: up|down (default up so a fresh start never emits a spurious recovery).
+# streak: signed run of consecutive same-result probes (+ok / -fail). A DOWN edge
+# needs DOWN_AFTER consecutive fails, an UP edge UP_AFTER consecutive oks — this
+# rides brief bounces (rotation flips, cold reloads) so the watchdog never becomes
+# a new source of spam. ponytail: if state is ever lost while paused (persistent
+# ZFS makes this rare), the next real down->up cycle or a converge re-resumes.
+mkdir -p "${STATE_DIR}"
+STATE_FILE="${STATE_DIR}/state"
+STREAK_FILE="${STATE_DIR}/streak"
+state="$(cat "${STATE_FILE}" 2>/dev/null || echo up)"
+streak="$(cat "${STREAK_FILE}" 2>/dev/null || echo 0)"
+
+if probe_ok; then
+  if (( streak < 0 )); then streak=1; else streak=$(( streak + 1 )); fi
+  if [[ "${state}" == "down" ]] && (( streak >= UP_AFTER )); then
+    cron_do resume
+    alert up
+    state="up"; streak=0
+  fi
+else
+  if (( streak > 0 )); then streak=-1; else streak=$(( streak - 1 )); fi
+  if [[ "${state}" == "up" ]] && (( streak <= -DOWN_AFTER )); then
+    cron_do pause
+    alert down
+    state="down"; streak=0
+  fi
+fi
+
+printf '%s\n' "${state}" > "${STATE_FILE}"
+printf '%s\n' "${streak}" > "${STREAK_FILE}"
+exit 0

--- a/roles/hermes_agent/templates/hermes-brain-watchdog.timer.j2
+++ b/roles/hermes_agent/templates/hermes-brain-watchdog.timer.j2
@@ -1,0 +1,13 @@
+{{ ansible_managed | comment }}
+# Drive the Hermes brain-health watchdog every
+# {{ hermes_agent_brain_watchdog_interval }} (mirrors the service_deadman cadence).
+[Unit]
+Description=Periodic Hermes brain-health probe
+
+[Timer]
+OnBootSec={{ hermes_agent_brain_watchdog_interval }}
+OnUnitActiveSec={{ hermes_agent_brain_watchdog_interval }}
+AccuracySec=5s
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## What

Adds a brain-health watchdog to the `hermes_agent` role that stops Hermes cron
jobs from spamming failure DMs when the `ai-default` brain is unreachable, and
turns a silent outage into a single actionable alert.

## Why

`ai-default` is a single-deployment brain with no viable fallback. Upstream
Hermes always delivers a cron failure ("Failed jobs always deliver regardless of
the `[SILENT]` marker; only successful runs can be silenced"), and each cron run
is a fresh, stateless session. So when the brain is unreachable, every seeded job
fails and DMs the operator — twice an hour for `splunk-security` alone — while
nothing pages that the brain is even down (`service_deadman` covers
DNS/Traefik/HAProxy/OpenBao, not the LLM fabric).

Observed: a sustained brain outage produced a stream of identical
`HTTP 500 ... Connection error ... Available Model Group Fallbacks=None` DMs
across `splunk-security`, `splunk-triage`, and `splunk-parsing`, with no single
"the brain is down" signal.

## How

A `systemd` timer (`hermes-brain-watchdog.timer`, every 60s, run as the `hermes`
user) probes `ai-default` end-to-end with a 1-token completion. On a **debounced**
transition it:

- **down** (3 consecutive fails ~ 3 min): `hermes cron pause` the role-seeded
  fleet + one Slack DM + one urgent ntfy page.
- **up** (2 consecutive oks): `hermes cron resume` + one recovery Slack DM + ntfy.

Paused jobs do not fire, so an outage stops producing spam instead of amplifying
it. Debounce rides rotation-flip bounces and cold reloads so the watchdog never
becomes a new source of spam. Edge-triggered via a small state file; only the
role-seeded jobs are touched (user/agent jobs never). Gated on the same Slack
tokens that seed the fleet. Reuses upstream `hermes cron pause`/`resume` and the
`service_deadman` ntfy page path — no new backend, no fallback, no cross-machine
change.

Probe is a 1-token completion (not a bare TCP check) so it also catches a
reachable-but-wedged brain; it hits the already-active model and keeps it warm,
matching the intended 24/7 posture.

## Verification

- `ansible-lint` (production profile) + full pre-commit (yamllint, markdownlint,
  ...): clean.
- `shellcheck` on the Jinja-rendered script: clean at `style` severity.
- All three templates render via Jinja2 without error.

Post-merge, on the Hermes LXC (CI cannot exercise the live brain):

1. Converge with `--tags openbao_secrets,hermes_agent`; confirm
   `hermes-brain-watchdog.timer` is active and a second converge is `changed=0`.
2. Simulate down (point the probe at an unreachable endpoint / stop the brain):
   after the debounce window confirm the seeded jobs show `paused`, **exactly
   one** Slack DM + **one** ntfy arrived, and no repeat alerts / no `HTTP 500`
   cron DMs follow.
3. Restore: confirm the jobs `resume` and **exactly one** recovery Slack DM +
   ntfy.

## Deferred (not in this PR)

- Mac-side brain self-heal (endpoint-liveness restart) to shorten outages.
- Wiring the LLM fabric into `service_deadman` as an independent low-level page.
- Gap backfill on resume (widen the first post-recovery lookback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CrsAMW1rBAHJNSsMjF7a5
