### PR TITLE
feat(hermes_agent): enable inbound webhook receiver (event-driven trigger)

### DIFF
--- a/inventory/group_vars/hermes_agent_group.yml
+++ b/inventory/group_vars/hermes_agent_group.yml
@@ -31,6 +31,14 @@ hermes_agent_context7_api_key: >-
   {{ bao_local_llm_secrets.CONTEXT7_API_KEY
      | default(lookup('env', 'CONTEXT7_API_KEY'), true) }}
 
+# Inbound webhook receiver global HMAC secret. Bao-first (local-llm domain,
+# secret/ai/hermes, generated-if-absent at the least-shared tier — hermes is its
+# only consumer), env fallback. Global fallback for every route that doesn't set
+# its own secret; empty disables the webhook platform (see defaults).
+hermes_agent_webhook_secret: >-
+  {{ bao_local_llm_secrets.WEBHOOK_SECRET
+     | default(lookup('env', 'WEBHOOK_SECRET'), true) }}
+
 # Zammad ITSM client (dryvist/zammad-incidents skill). URL is the Traefik-fronted
 # FQDN (non-secret, derived from PROXMOX_SUBDOMAIN). The API token is bao-first
 # (local-llm domain, secret/ai/hermes — the SAME token the zammad role seeds INTO

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -144,6 +144,21 @@ hermes_agent_daily_status_cron_prompt: >-
   Summarize the homelab AI fabric status, including router health, Hermes
   gateway health, DNS readiness, and any merge-ready PRs. Keep it concise.
 
+# --- Inbound webhook receiver (event-driven agent trigger) ------------------
+# The `hermes gateway` webhook platform: an HTTP receiver (/webhooks/<name>,
+# HMAC-signed) so any homelab agent/system can trigger Hermes without speaking
+# A2A. Traefik fronts it as https://hermes.<sub>/webhooks/<name>; the guest
+# firewall opens the port from internal only (modules/firewall in terraform-proxmox).
+# The adapter binds 0.0.0.0 by default (Traefik reaches it from another guest).
+# Port is DRY from the tofu pipeline constant — never a literal. The global HMAC
+# secret is bao-first (group_vars) and injected via .env (WEBHOOK_SECRET), never
+# config.yaml; the platform only renders when a secret is present (a route with
+# no secret and no global secret fails the adapter at startup, by design).
+hermes_agent_webhook_enabled: true
+hermes_agent_webhook_port: >-
+  {{ hostvars['localhost']['tofu_data']['constants']['service_ports']['hermes_webhook']
+     | mandatory('tofu_data.constants.service_ports.hermes_webhook missing — regenerate tofu_inventory.json') }}
+
 # --- Memory: best self-hostable as of June 2026 (Agy-validated) ---
 # Hindsight: local knowledge-graph + multi-strategy retrieval. Runs alongside the
 # always-on built-in MEMORY.md/USER.md. The whole HERMES_HOME is the durable surface.

--- a/roles/hermes_agent/templates/config.yaml.j2
+++ b/roles/hermes_agent/templates/config.yaml.j2
@@ -71,20 +71,47 @@ plugins:
   enabled:
     - observability/otel
 
-{% if hermes_agent_slack_bot_token | length > 0 %}
-# Slack delivery behavior. Every scheduled (cron) run is an isolated, fresh
-# session, so its Slack post should read that way too — a NEW top-level channel
-# message, not another reply threaded under one ever-growing root. Upstream
-# defaults reply_in_thread=true, which makes cron deliveries continue in a single
-# thread; reply_in_thread=false posts them flat/top-level, and
-# cron_continuable_surface=in_channel keeps those flat posts continuable (a reply
-# in the channel still continues that run's session) without a dedicated thread.
-# These are bridged from platforms.<p> by gateway/config.py; Slack enablement
-# still comes from the SLACK_* tokens in .env, so this block only tunes behavior.
+{% set _slack_on = hermes_agent_slack_bot_token | length > 0 %}
+{% set _webhook_on = (hermes_agent_webhook_enabled | bool) and (hermes_agent_webhook_secret | length > 0) %}
+{% if _slack_on or _webhook_on %}
 platforms:
+{% if _slack_on %}
+  # Slack delivery behavior. Every scheduled (cron) run is an isolated, fresh
+  # session, so its Slack post should read that way too — a NEW top-level channel
+  # message, not another reply threaded under one ever-growing root. Upstream
+  # defaults reply_in_thread=true, which makes cron deliveries continue in a single
+  # thread; reply_in_thread=false posts them flat/top-level, and
+  # cron_continuable_surface=in_channel keeps those flat posts continuable (a reply
+  # in the channel still continues that run's session) without a dedicated thread.
+  # These are bridged from platforms.<p> by gateway/config.py; Slack enablement
+  # still comes from the SLACK_* tokens in .env, so this block only tunes behavior.
   slack:
     reply_in_thread: {{ hermes_agent_slack_reply_in_thread | to_json }}
     cron_continuable_surface: {{ hermes_agent_slack_cron_continuable_surface }}
+{% endif %}
+{% if _webhook_on %}
+  # Inbound webhook receiver (event-driven agent trigger). `enabled` + the global
+  # HMAC secret + port arrive via .env (WEBHOOK_ENABLED/SECRET/PORT), injected by
+  # gateway/config.py's env bridge — which merges those keys and preserves the
+  # `routes` declared here. Keeping the secret in .env (0600, no_log) means it
+  # never lands in this 0640 file. The `inbound` route is a zero-LLM demo of the
+  # inter-agent trigger path: a signed POST to https://hermes.<sub>/webhooks/inbound
+  # relays its rendered payload straight to Slack (deliver_only skips the agent).
+  # It inherits the global secret (no per-route secret). Real agent-triggering
+  # routes are added per concrete producer later — scaffolding a paid agent run
+  # with no producer is YAGNI.
+  webhook:
+    enabled: true
+    extra:
+      port: {{ hermes_agent_webhook_port }}
+{% if _slack_on %}
+      routes:
+        inbound:
+          deliver: slack
+          deliver_only: true
+          prompt: "Inbound webhook ping: {__raw__}"
+{% endif %}
+{% endif %}
 {% endif %}
 {% set _mcp_splunk = (hermes_agent_splunk_mcp_enabled | bool) and (hermes_agent_splunk_mcp_url | length > 0) %}
 {# Context7's hosted MCP serves unauthenticated requests (verified: keyless

--- a/roles/hermes_agent/templates/hermes-env.j2
+++ b/roles/hermes_agent/templates/hermes-env.j2
@@ -62,3 +62,14 @@ CONTEXT7_API_KEY={{ hermes_agent_context7_api_key }}
 # is deployed and its API token is seeded.
 ZAMMAD_URL={{ hermes_agent_zammad_url }}
 ZAMMAD_API_TOKEN={{ hermes_agent_zammad_api_token }}
+
+# Inbound webhook receiver. The gateway env-bridge (gateway/config.py) enables the
+# webhook adapter and injects the global HMAC secret + port here when
+# WEBHOOK_ENABLED is truthy — the secret stays in this 0600/no_log file, never
+# config.yaml. Routes are declared declaratively in config.yaml (platforms.webhook).
+# Rendered only when the platform is enabled AND a secret is set.
+{% if hermes_agent_webhook_enabled | bool and hermes_agent_webhook_secret | length > 0 %}
+WEBHOOK_ENABLED=true
+WEBHOOK_PORT={{ hermes_agent_webhook_port }}
+WEBHOOK_SECRET={{ hermes_agent_webhook_secret }}
+{% endif %}


### PR DESCRIPTION
## What

Front the `hermes gateway` webhook platform so other agents/systems can trigger
the one non-A2A agent via `https://hermes.<sub>/webhooks/<name>` (HMAC-signed).
Companion to the tofu PR that adds the port constant, firewall SG, and Traefik
ingress alias.

- **defaults/main.yml**: `hermes_agent_webhook_enabled` + `_webhook_port` (port
  DRY from tofu `constants.service_ports.hermes_webhook`, mandatory-guarded).
- **group_vars/hermes_agent_group.yml**: `webhook_secret` Bao-first
  (`secret/ai/hermes`, generate-if-absent at the least-shared tier — hermes is
  its only consumer), env fallback.
- **templates/hermes-env.j2**: `WEBHOOK_ENABLED/PORT/SECRET`, rendered only when
  enabled AND a secret is present; the secret stays in the `0600` no_log `.env`,
  never `config.yaml`.
- **templates/config.yaml.j2**: `platforms.webhook` block (routes declared here,
  merged with the env-bridged enable/port/secret). A zero-LLM `deliver_only`
  demo route proves the inbound path without scaffolding a paid agent run (YAGNI).

Off unless a secret is set, so this is inert until configured. The daemon binds
the port on gateway restart — no new systemd unit.

## Validation

- Live converge (`openbao_secrets,hermes_agent`): the gateway restarts cleanly
  with the webhook config — the **stays-up** and **no-config-rejection** gates
  pass, confirming the rendered `config.yaml` + `.env` are accepted.
- `ansible-lint` (production profile): 0 failures, 0 warnings on all 4 files.

## Notes

The `WEBHOOK_SECRET` was generated-if-absent into `secret/ai/hermes` via the
ai-orchestrator AppRole (least-shared tier). Full external HMAC round-trip
verification is gated on DNS/Traefik ingress propagation (companion tofu PR) and
was slow under active LLM-serving bench load; the receiver binds and the daemon
is healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)