### PR TITLE
feat(hermes_agent): enable inbound job-submission API (api_server platform)

### DIFF
--- a/inventory/group_vars/hermes_agent_group.yml
+++ b/inventory/group_vars/hermes_agent_group.yml
@@ -39,6 +39,15 @@ hermes_agent_webhook_secret: >-
   {{ bao_local_llm_secrets.WEBHOOK_SECRET
      | default(lookup('env', 'WEBHOOK_SECRET'), true) }}
 
+# Inbound job-submission API bearer key. Bao-first (local-llm domain,
+# secret/ai/hermes), env fallback. Unlike the webhook secret, this key has
+# external consumers by design (any sanctioned submitter dials
+# https://hermes-api.<sub> with it), so it lives in the shared engine — seeded
+# programmatically, never hand-typed. Empty disables the platform (see defaults).
+hermes_agent_api_server_key: >-
+  {{ bao_local_llm_secrets.HERMES_API_SERVER_KEY
+     | default(lookup('env', 'HERMES_API_SERVER_KEY'), true) }}
+
 # Zammad ITSM client (dryvist/zammad-incidents skill). URL is the Traefik-fronted
 # FQDN (non-secret, derived from PROXMOX_SUBDOMAIN). The API token is bao-first
 # (local-llm domain, secret/ai/hermes — the SAME token the zammad role seeds INTO

--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -213,6 +213,29 @@ When Hermes finds a signal worth watching continuously it may register its own
 | `hermes_agent_splunk_alert_deliver` | `slack:<member-id>` | DM target for anomaly alerts |
 | `hermes_agent_splunk_digest_deliver` | `slack` | home-channel target for the digest |
 
+## Inbound job-submission API (sanctioned non-exec path)
+
+The upstream `api_server` gateway platform, enabled when
+`hermes_agent_api_server_key` is present (bao-first, `secret/ai/hermes`
+`HERMES_API_SERVER_KEY`). It is the **sanctioned way to submit work to the
+agent without touching the guest** — no `pct exec`, no SSH-in-and-run:
+
+- `POST /v1/runs` — enqueue an agent run (`{"input": "<prompt>"}`),
+  returns `202` + `run_id`; poll `GET /v1/runs/{run_id}` (or stream
+  `/v1/runs/{run_id}/events`).
+- `/api/jobs` — full cron-job CRUD (create/pause/resume/run), the REST
+  equivalent of `hermes cron …`.
+- `GET /health` — unauthenticated liveness (everything else requires
+  `Authorization: Bearer <key>`; upstream refuses to start the platform
+  keyless).
+
+Traefik fronts it as `https://hermes-api.<subdomain>` (tofu ingress row;
+port DRY from `service_ports.hermes_api`); the guest firewall scopes the
+port to internal sources. Distinct from the webhook receiver below: webhooks
+are pre-declared event triggers, this is arbitrary job submission. The
+post-converge gate probes `/health` and asserts a keyless `POST /v1/runs`
+is refused with 401.
+
 ## Brain-health watchdog (no cron-failure spam)
 
 The cron fleet above talks to a **single-deployment brain** (`ai-default`, served

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -159,6 +159,24 @@ hermes_agent_webhook_port: >-
   {{ hostvars['localhost']['tofu_data']['constants']['service_ports']['hermes_webhook']
      | mandatory('tofu_data.constants.service_ports.hermes_webhook missing — regenerate tofu_inventory.json') }}
 
+# --- Inbound job-submission API (`api_server` platform) ----------------------
+# The `hermes gateway` api_server platform: a bearer-authenticated HTTP API
+# (POST /v1/runs enqueues an agent run -> 202 + run_id; /api/jobs is cron CRUD;
+# GET /health). The SANCTIONED non-exec path to submit work to the agent — the
+# webhook above is event-trigger-only (pre-declared routes, no job submission).
+# Traefik fronts it as https://hermes-api.<sub>; the guest firewall opens the
+# port from internal only (modules/firewall in terraform-proxmox). Enablement is
+# key-presence (empty key = platform off, port closed) — the same contract as
+# the Slack tokens; upstream also refuses to start the platform without a key.
+# Key is bao-first (group_vars); port DRY from the tofu constant. Upstream
+# defaults to a loopback bind, so the non-loopback host below only takes effect
+# when the key-gated platform renders at all.
+hermes_agent_api_server_key: "{{ lookup('env', 'HERMES_API_SERVER_KEY') | default('', true) }}"
+hermes_agent_api_server_host: "0.0.0.0"
+hermes_agent_api_server_port: >-
+  {{ hostvars['localhost']['tofu_data']['constants']['service_ports']['hermes_api']
+     | mandatory('tofu_data.constants.service_ports.hermes_api missing — regenerate tofu_inventory.json') }}
+
 # --- Memory: best self-hostable as of June 2026 (Agy-validated) ---
 # Hindsight: local knowledge-graph + multi-strategy retrieval. Runs alongside the
 # always-on built-in MEMORY.md/USER.md. The whole HERMES_HOME is the durable surface.

--- a/roles/hermes_agent/tasks/verify.yml
+++ b/roles/hermes_agent/tasks/verify.yml
@@ -114,6 +114,30 @@
           from a mis-wired brain (wrong parser, null context, unroutable alias).
         success_msg: "Brain returned a valid tool call ({{ hermes_agent_model }})."
 
+    # Inbound job-submission API (api_server platform), only when the key is
+    # seeded: the platform must be listening (health 200 on the guest) AND must
+    # refuse unauthenticated submissions (401 on a keyless POST /v1/runs) — the
+    # negative half proves the bearer gate is actually on, not just the port.
+    - name: Gate — the job-submission API answers its health check
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ hermes_agent_api_server_port }}/health"
+        method: GET
+      register: hermes_agent_api_health
+      retries: "{{ hermes_agent_verify_probe_retries }}"
+      delay: "{{ hermes_agent_verify_probe_delay }}"
+      until: hermes_agent_api_health.status | default(0) == 200
+      when: hermes_agent_api_server_key | length > 0
+
+    - name: Gate — an unauthenticated job submission is refused (401)
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ hermes_agent_api_server_port }}/v1/runs"
+        method: POST
+        body_format: json
+        body:
+          input: "unauthenticated probe — must be refused"
+        status_code: 401
+      when: hermes_agent_api_server_key | length > 0
+
   rescue:
     - name: Verification gate failed — fail loudly with a rollback recipe
       ansible.builtin.fail:

--- a/roles/hermes_agent/templates/hermes-env.j2
+++ b/roles/hermes_agent/templates/hermes-env.j2
@@ -73,3 +73,15 @@ WEBHOOK_ENABLED=true
 WEBHOOK_PORT={{ hermes_agent_webhook_port }}
 WEBHOOK_SECRET={{ hermes_agent_webhook_secret }}
 {% endif %}
+
+# Inbound job-submission API (api_server platform). Key presence enables the
+# platform via the gateway env bridge (gateway/config.py); the bearer key stays
+# in this 0600/no_log file, never config.yaml. Non-loopback bind so Traefik
+# (hermes-api.<sub>) reaches it from the ingress guest; the guest firewall
+# scopes the port to internal sources.
+{% if hermes_agent_api_server_key | length > 0 %}
+API_SERVER_ENABLED=1
+API_SERVER_KEY={{ hermes_agent_api_server_key }}
+API_SERVER_HOST={{ hermes_agent_api_server_host }}
+API_SERVER_PORT={{ hermes_agent_api_server_port }}
+{% endif %}


### PR DESCRIPTION
Enables the upstream `api_server` gateway platform: a bearer-authenticated HTTP job path (`POST /v1/runs` → 202 + run_id; `/api/jobs` cron CRUD; unauthenticated `GET /health`). This is the sanctioned replacement for guest-exec job submission (policy-banned); the webhook platform (#860) remains event-trigger-only.

- Key-presence enablement (empty key = platform off, port closed) — Slack-token contract.
- `HERMES_API_SERVER_KEY` bao-first from `secret/ai/hermes`, env fallback; key only ever lands in the 0600 `no_log` `.env`.
- Port DRY from `tofu_data.constants.service_ports.hermes_api` — requires the companion tofu-proxmox PR (port constant + internal-only firewall + `hermes-api.<sub>` ingress) applied first.
- Post-converge gates: `/health` 200 + keyless `POST /v1/runs` refused with 401.

Verification plan (after tofu apply + key seed): converge `--tags hermes_agent`, then an end-to-end `POST https://hermes-api.<sub>/v1/runs` → 202 → poll run status; negative keyless POST → 401. Output will be posted on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuJXrGxy5PS1HwpUKBu8LY