### PR TITLE
feat(hermes_agent): pre-staged maintenance window (zero-alert planned outages)

### DIFF
--- a/playbooks/hermes-maintenance.yml
+++ b/playbooks/hermes-maintenance.yml
@@ -1,0 +1,112 @@
+---
+# Hermes maintenance window — pre-staged, non-interactive alert suppression.
+#
+# Stages a "<start_epoch> <end_epoch>" window file the brain-health watchdog
+# (roles/hermes_agent/templates/hermes-brain-watchdog.sh.j2) reads every tick.
+# Inside the window the watchdog pauses the role-seeded cron fleet once and
+# suppresses every alert; at expiry it resumes the fleet by itself (alerting
+# only if the brain is STILL down — then it's an unplanned outage). So a
+# planned brain outage (the night cluster borrowing the Studio at 2am) needs
+# zero live decisions and wakes nobody: stage the window in the afternoon,
+# walk away. Stage the start a few minutes before the actual quiesce — the
+# watchdog ticks every 60s, and a job firing in the sub-tick gap would still
+# deliver.
+#
+# Usage (times are parsed by GNU date on the guest — ISO 8601 works):
+#   Stage:  doppler run -- ansible-playbook -i inventory/hosts.yml \
+#             playbooks/hermes-maintenance.yml \
+#             -e hermes_maintenance_start='2026-07-12T01:45:00-04:00' \
+#             -e hermes_maintenance_end='2026-07-12T06:00:00-04:00'
+#           (or -e hermes_maintenance_minutes=240 for start=now)
+#   Cancel: ... -e hermes_maintenance_cancel=true
+#   Status: run with no -e vars — prints the window file, pause marker, and
+#           recent watchdog journal lines.
+#
+# --limit must include localhost (inventory loader), e.g.
+#   --limit hermes_agent_group,localhost
+
+- name: Import OpenTofu infrastructure inventory
+  import_playbook: ../inventory/load_tofu.yml
+
+- name: Hermes maintenance window (stage / cancel / status)
+  hosts: hermes_agent_group
+  become: true
+  gather_facts: false
+  vars_files:
+    # Reuse the role's defaults so HERMES_HOME stays defined in ONE place —
+    # the same DRY pattern validate-media.yml uses for servarr_wiring.
+    - ../roles/hermes_agent/defaults/main.yml
+  vars:
+    hermes_maintenance_state_dir: "{{ hermes_agent_hermes_home }}/brain-watchdog"
+    hermes_maintenance_file: "{{ hermes_maintenance_state_dir }}/maintenance-window"
+    hermes_maintenance_marker: "{{ hermes_maintenance_state_dir }}/maintenance-paused"
+  tasks:
+    - name: Cancel the maintenance window
+      when: hermes_maintenance_cancel | default(false) | bool
+      ansible.builtin.file:
+        path: "{{ hermes_maintenance_file }}"
+        state: absent
+      # The watchdog's marker path resumes the fleet within one 60s tick.
+
+    - name: Stage the maintenance window
+      when:
+        - not (hermes_maintenance_cancel | default(false) | bool)
+        - (hermes_maintenance_end is defined) or (hermes_maintenance_minutes is defined)
+      block:
+        - name: Resolve window epochs on the guest (GNU date)
+          ansible.builtin.command:
+            cmd: >-
+              date -d "{{ item }}" +%s
+          loop:
+            - "{{ hermes_maintenance_start | default('now') }}"
+            - >-
+              {{ hermes_maintenance_end
+                 | default(hermes_maintenance_start | default('now')
+                           ~ ' + ' ~ hermes_maintenance_minutes | default(0) ~ ' minutes') }}
+          register: hermes_maintenance_epochs
+          changed_when: false
+
+        - name: Assert the window is in the future and ordered
+          ansible.builtin.assert:
+            quiet: true
+            that:
+              - hermes_maintenance_epochs.results[1].stdout | int
+                > hermes_maintenance_epochs.results[0].stdout | int
+            fail_msg: >-
+              Window end must be after start
+              ({{ hermes_maintenance_epochs.results[0].stdout }} ..
+              {{ hermes_maintenance_epochs.results[1].stdout }}).
+
+        - name: Ensure the watchdog state dir exists
+          ansible.builtin.file:
+            path: "{{ hermes_maintenance_state_dir }}"
+            state: directory
+            owner: hermes
+            group: hermes
+            mode: "0755"
+
+        - name: Write the window file the watchdog consumes
+          ansible.builtin.copy:
+            content: >-
+              {{ hermes_maintenance_epochs.results[0].stdout }}
+              {{ hermes_maintenance_epochs.results[1].stdout }}
+            dest: "{{ hermes_maintenance_file }}"
+            owner: hermes
+            group: hermes
+            mode: "0644"
+
+    - name: Read window file, pause marker, and recent watchdog journal
+      ansible.builtin.shell: |
+        set -o pipefail
+        echo "window-file: $(cat {{ hermes_maintenance_file }} 2>/dev/null || echo '<absent>')"
+        echo "pause-marker: $(test -f {{ hermes_maintenance_marker }} && echo present || echo absent)"
+        echo "now-epoch: $(date +%s)"
+        journalctl -t hermes-brain-watchdog -n 8 --no-pager -o cat 2>/dev/null | tail -8
+      args:
+        executable: /bin/bash
+      register: hermes_maintenance_status
+      changed_when: false
+
+    - name: Show maintenance status
+      ansible.builtin.debug:
+        var: hermes_maintenance_status.stdout_lines

--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -256,6 +256,26 @@ Gated on the same Slack tokens that seed the fleet (no fleet → nothing to guar
 | `hermes_agent_brain_watchdog_up_after` | `2` | Consecutive oks → resume + alert |
 | `hermes_agent_brain_watchdog_ntfy_topic` | `keystone` | ntfy topic for the urgent page |
 
+### Maintenance window (planned outages, zero live decisions)
+
+A **pre-staged, non-interactive** window for planned brain outages (e.g. the
+night cluster borrowing the Studio at 2am). `playbooks/hermes-maintenance.yml`
+stages a `"<start_epoch> <end_epoch>"` file in the watchdog state dir — hours
+ahead if desired. While `now` is inside the window the watchdog pauses the
+seeded fleet once and **suppresses every alert** (Slack DM, ntfy page,
+resume notifications); at expiry it resumes the fleet by itself. If the brain
+is *still* down at expiry, the outage is no longer planned — the suppressed
+DOWN alert fires then, exactly once. Cancel = the playbook's
+`-e hermes_maintenance_cancel=true` (fleet resumes within one tick).
+
+```sh
+# Stage a 01:45–06:00 window in the afternoon; nothing else to do.
+doppler run -- ansible-playbook -i inventory/hosts.yml \
+  playbooks/hermes-maintenance.yml --limit hermes_agent_group,localhost \
+  -e hermes_maintenance_start='2026-07-12T01:45:00-04:00' \
+  -e hermes_maintenance_end='2026-07-12T06:00:00-04:00'
+```
+
 ## Live docs (Context7)
 
 Registers Context7's hosted HTTP MCP server (`mcp_servers.context7`) so Hermes

--- a/roles/hermes_agent/templates/hermes-brain-watchdog.sh.j2
+++ b/roles/hermes_agent/templates/hermes-brain-watchdog.sh.j2
@@ -147,6 +147,11 @@ m_start=0; m_end=0
 if [[ -f "${MAINT_FILE}" ]]; then
   read -r m_start m_end < "${MAINT_FILE}" || true
 fi
+# A hand-touched/truncated window file must degrade to "no window", not crash
+# the tick (non-numeric tokens would blow up the arithmetic below).
+if [[ ! "${m_start}" =~ ^[0-9]+$ ]] || [[ ! "${m_end}" =~ ^[0-9]+$ ]]; then
+  m_start=0; m_end=0
+fi
 now_epoch="$(date +%s)"
 if [[ -f "${MAINT_FILE}" ]] && (( now_epoch >= m_start && now_epoch < m_end )); then
   maint_active=1

--- a/roles/hermes_agent/templates/hermes-brain-watchdog.sh.j2
+++ b/roles/hermes_agent/templates/hermes-brain-watchdog.sh.j2
@@ -131,18 +131,66 @@ STREAK_FILE="${STATE_DIR}/streak"
 state="$(cat "${STATE_FILE}" 2>/dev/null || echo up)"
 streak="$(cat "${STREAK_FILE}" 2>/dev/null || echo 0)"
 
+# --- Maintenance window (pre-staged, non-interactive) -------------------------
+# playbooks/hermes-maintenance.yml stages "<start_epoch> <end_epoch>" in
+# MAINT_FILE, hours ahead if desired. While now is inside the window the seeded
+# fleet is paused ONCE (marker) and every alert is suppressed — a PLANNED brain
+# outage (e.g. the night cluster borrowing the Studio) makes zero noise and
+# needs zero live decisions. At expiry (or cancel = the playbook deleting the
+# file) the watchdog cleans up and resumes the fleet by itself within one tick —
+# unless the brain is still down, in which case the outage is no longer planned
+# and the suppressed DOWN alert fires now instead of being lost.
+MAINT_FILE="${STATE_DIR}/maintenance-window"
+MAINT_MARKER="${STATE_DIR}/maintenance-paused"
+maint_active=0
+m_start=0; m_end=0
+if [[ -f "${MAINT_FILE}" ]]; then
+  read -r m_start m_end < "${MAINT_FILE}" || true
+fi
+now_epoch="$(date +%s)"
+if [[ -f "${MAINT_FILE}" ]] && (( now_epoch >= m_start && now_epoch < m_end )); then
+  maint_active=1
+  if [[ ! -f "${MAINT_MARKER}" ]]; then
+    cron_do pause
+    touch "${MAINT_MARKER}"
+    logger -t hermes-brain-watchdog "maintenance window active until ${m_end} (epoch) — fleet paused, alerts suppressed"
+  fi
+elif [[ -f "${MAINT_MARKER}" ]]; then
+  # Window over (expired or cancelled): clean up and hand back to normal ops.
+  rm -f "${MAINT_FILE}" "${MAINT_MARKER}"
+  if probe_ok; then
+    cron_do resume
+    logger -t hermes-brain-watchdog "maintenance window ended — fleet resumed"
+    state="up"
+  else
+    # Still down past the window: an unplanned outage now — say so, once.
+    alert down
+    state="down"
+  fi
+  streak=0
+  printf '%s\n' "${state}" > "${STATE_FILE}"
+  printf '%s\n' "${streak}" > "${STREAK_FILE}"
+  exit 0
+elif [[ -f "${MAINT_FILE}" ]] && (( now_epoch >= m_end )); then
+  rm -f "${MAINT_FILE}"   # expired before it ever activated (stale stage)
+fi
+
 if probe_ok; then
   if (( streak < 0 )); then streak=1; else streak=$(( streak + 1 )); fi
   if [[ "${state}" == "down" ]] && (( streak >= UP_AFTER )); then
-    cron_do resume
-    alert up
+    if (( ! maint_active )); then
+      cron_do resume
+      alert up
+    fi
     state="up"; streak=0
   fi
 else
   if (( streak > 0 )); then streak=-1; else streak=$(( streak - 1 )); fi
   if [[ "${state}" == "up" ]] && (( streak <= -DOWN_AFTER )); then
-    cron_do pause
-    alert down
+    if (( ! maint_active )); then
+      cron_do pause
+      alert down
+    fi
     state="down"; streak=0
   fi
 fi


### PR DESCRIPTION
Extends the brain-health watchdog (#859) with a pre-staged, non-interactive maintenance window so a planned brain outage (the 2am cluster quiesce) needs zero live decisions and wakes nobody — the exact gap that blocked the autonomous cluster run.

- Watchdog reads `<start_epoch> <end_epoch>` from `maintenance-window` in its state dir: inside the window it pauses the seeded fleet once and suppresses every alert; at expiry it auto-resumes by itself. If the brain is still down at expiry the deferred DOWN alert fires once (it's an unplanned outage now).
- `playbooks/hermes-maintenance.yml`: stage (ISO times or `-e hermes_maintenance_minutes=N`), cancel, status. Stage hours ahead; walk away.

Verification (output in the commit + reproducible via the test script): 5-scenario behavioral test of the rendered template with stubbed `curl`/`hermes`/`logger` — all pass:
```
S1 ok: window start -> fleet paused once, zero alerts
S2 ok: brain down inside window -> zero alerts, fleet stays paused
S3 ok: window expiry + healthy brain -> auto-resume, zero alerts, cleaned up
S4 ok: expiry with brain still down -> single deferred DOWN alert, no resume
S5 ok: normal (no-window) DOWN edge unchanged — pause + alert
```
ansible-lint (production profile) + syntax-check pass. Live converge + a short real window run happens post-merge; output will be posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuJXrGxy5PS1HwpUKBu8LY
