### PR TITLE
feat(llm_router): absorb serving-tier 429s with retry-backoff, no cooldown

### DIFF
--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -188,6 +188,19 @@ llm_router_cooldown_time: 30
 # to 2400.
 llm_router_num_retries: 2
 llm_router_request_timeout_seconds: "{{ ai_router_request_timeout_seconds }}"
+# 429 absorption (queue-by-retry). The serving proxies (llama-swap
+# concurrencyLimit) 429 anything past their in-flight cap. Two failure modes
+# without special handling: (a) the 429 surfaces raw to the caller, which
+# retries into the same wall (the 2026-07-08 bench collapse: 9,262 429s ->
+# session death); (b) worse, with allowed_fails=2/min the router COOLS DOWN
+# the single large deployment, escalating a momentary queue into
+# "no deployments available". So rate-limit errors get their own budget:
+# retried more times with LiteLLM's backoff, and effectively never counted
+# toward cooldown. Real faults (auth, 5xx, timeouts) still cool down via
+# allowed_fails. Retries=6 with exponential backoff spans ~1-2 min of queue
+# pressure — roughly one long large-tier generation ahead in line.
+llm_router_rate_limit_retries: 6
+llm_router_rate_limit_allowed_fails: 1000
 # Background health checks send REAL test requests to every deployment — on the
 # llama-swap fast tier each probe spawns the target model, and with 3 routers
 # probing every model this both churns VRAM constantly and (pre swap-groups)

--- a/roles/llm_router/templates/config.yaml.j2
+++ b/roles/llm_router/templates/config.yaml.j2
@@ -112,6 +112,18 @@ router_settings:
   # how long one attempt waits before LiteLLM calls it a connection failure.
   num_retries: {{ llm_router_num_retries }}
   timeout: {{ llm_router_request_timeout_seconds }}
+  # 429 absorption. The serving tiers cap in-flight requests at the proxy
+  # (llama-swap concurrencyLimit) and 429 the excess; without this, a burst of
+  # concurrent agents trips allowed_fails ({{ llm_router_allowed_fails }}/min)
+  # and cools down the SINGLE large deployment — turning a momentary queue into
+  # a hard "no deployments available" cascade (the 2026-07-08 bench collapse
+  # signature). Rate-limit errors instead retry with backoff (queue-by-retry)
+  # and never count toward cooldown; real faults still cool down via
+  # allowed_fails above.
+  retry_policy:
+    RateLimitErrorRetries: {{ llm_router_rate_limit_retries }}
+  allowed_fails_policy:
+    RateLimitErrorAllowedFails: {{ llm_router_rate_limit_allowed_fails }}
 
 general_settings:
   master_key: os.environ/LLM_ROUTER_MASTER_KEY

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -2087,6 +2087,8 @@
     llm_router_allowed_fails: 2
     llm_router_cooldown_time: 30
     llm_router_num_retries: 2
+    llm_router_rate_limit_retries: 6
+    llm_router_rate_limit_allowed_fails: 1000
     llm_router_request_timeout_seconds: 300
     llm_router_health_check_interval: 300
     llm_router_background_health_checks: false
@@ -2141,6 +2143,10 @@
           # Secrets referenced via os.environ, never a literal in the config.
           - "'test-master-key-placeholder' not in (lookup('file', '/tmp/test_litellm_config.yaml'))"
           - _litellm.general_settings.master_key == 'os.environ/LLM_ROUTER_MASTER_KEY'
+          # 429 absorption: rate-limit errors retry with backoff and never cool
+          # down the single large deployment (they get their own huge budget).
+          - _litellm.router_settings.retry_policy.RateLimitErrorRetries == 6
+          - _litellm.router_settings.allowed_fails_policy.RateLimitErrorAllowedFails == 1000
         fail_msg: "config.yaml.j2 model_list / auth wrong: {{ _litellm.model_list }}"
 
     - name: Index each model's rendered max_input_tokens by name


### PR DESCRIPTION
Part of the overnight-run remediation (serving 429 storm). The serving proxies cap in-flight requests and 429 the excess; today a burst of concurrent agents both surfaces raw 429 cascades to clients (the 2026-07-08 bench collapse: 9,262×429 → session death) and — because `allowed_fails: 2`/min uses the legacy cooldown path — cools down the *single* large deployment, turning a momentary queue into hard "no deployments available".

Config-only fix in `router_settings`:
- `retry_policy.RateLimitErrorRetries: 6` — 429s retry with LiteLLM's exponential backoff (queue-by-retry over ~1–2 min of pressure).
- `allowed_fails_policy.RateLimitErrorAllowedFails: 1000` — 429s never cool the deployment; genuine faults still cool down via `allowed_fails`.

Companion measurements (mlx-benchmarks journal PR): within the serving cap nothing errors and continuous batching reaches 1.6–2.3× aggregate; the cap moves 2→4 in nix-ai. Verification: ansible-lint passes; post-merge converge of `llm_router_group` + `/health/liveliness` 200 will be posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuJXrGxy5PS1HwpUKBu8LY