### PR TITLE
Reduce hard-coded addressing; advance DHCP-first / Nautobot IPAM model

### DIFF
--- a/docs/IP_AUTHORITY.md
+++ b/docs/IP_AUTHORITY.md
@@ -1,0 +1,132 @@
+# IP Addressing Authority & DHCP-first Model
+
+This document records **who owns addressing** across the homelab repos, the
+**static-anchor policy** that decides which guests may keep a static IP, and the
+**cross-repo work** required to move the remaining guests onto DHCP reservations
+and, later, dual-stack IPv6.
+
+It is the "why" behind [`/.claude/rules/ip-addressing.md`](../.claude/rules/ip-addressing.md)
+(the "what": never hard-code an IP/port; consume from the source of truth).
+
+## Why this exists
+
+Terraform/OpenTofu can create a VM, but that does not make the platform safe to
+build on. The goal is an **IPAM-driven, DHCP-first** foundation where addressing
+intent lives in exactly one place, guests get their address by reservation
+rather than a baked-in static IP, and downstream config **fails loud** when the
+addressing authority is missing rather than silently wiring itself to a wrong or
+loopback address. Concretely we want ~90% of guests to carry **no static IP** —
+only a deterministic MAC and an FQDN — so that re-addressing (including the move
+to IPv6) is a reservation change, not an edit sprawled across roles.
+
+## Authority model — one owner per concern
+
+| Concern | Authority | Notes |
+| --- | --- | --- |
+| DHCP + core networking (L2/L3, VLANs, gateway, reservations) | **UniFi** | Issues every DHCP reservation (MAC → IP); this repo never runs a DHCP server. |
+| IPAM / DCIM source of truth | **Nautobot** (`roles/nautobot`, #138) | Staged SSoT DiffSync + export pipeline, currently gated off. |
+| Provisioning + constants | **terraform-proxmox** (upstream) | Owns `deployment.json`; publishes `tofu_inventory.json` + `pipeline_constants` to S3. |
+| Reservation seed (MAC → host) | **tofu-unifi** | `fixed-ips.json` — committed reservations, no literal IP (`cidrhost(cidr, host)`). |
+| App configuration | **this repo** | **Read-only consumer**; reads the published inventory, never defines an IP/port, fails loud. |
+
+The one-directional boundary matters: this repo consumes `tofu_data` and must not
+reintroduce a value the upstream owns. Roles that need a value they cannot yet
+read should fail, not fall back to a literal — a masking fallback produces a
+role that "succeeds" while emitting broken config.
+
+## The DHCP-first inventory contract
+
+Every guest in `tofu_inventory.json` is described by three addressing fields
+(see `tests/inventory_load/tofu_inventory.schema.json`):
+
+| Field | Static anchor | DHCP-first guest |
+| --- | --- | --- |
+| `ip` | dotted IPv4 literal | an **FQDN** (DNS resolves it) |
+| `mac` | `null` | deterministic locally-administered MAC (`02:` prefix) |
+| `reserved_ip` | `null` | the UniFi DHCP **reservation** address (what DNS A records point at) |
+
+`inventory/load_tofu.yml` surfaces `container_ip` (= `ip`) and
+`container_reserved_ip` (= `reserved_ip`) as hostvars. Consumers that need a
+literal address prefer `reserved_ip`, then `ip`, then the peer's
+`container_ip` — and now stop there (no loopback tail). Consumers that can use a
+name resolve the FQDN through Technitium/Traefik instead of any literal.
+
+## Static-anchor policy
+
+A guest may keep a **static IP only if it is a bootstrap anchor** — something the
+rest of the fabric must reach before DNS/DHCP/IPAM is fully converged:
+
+- **DNS / Technitium** — resolves everyone else; cannot depend on itself.
+- **Proxmox hosts** — the hypervisors the `proxmox_pct_remote` connection dials.
+- **Traefik / ingress VIP** — the ingress front door + its floating VIP.
+
+**Everything else is DHCP-first**: no static IP, a deterministic MAC, a UniFi
+reservation, and an FQDN. This is the rule to apply when adding or reviewing a
+guest — if it is not one of the anchors above, it should have `mac` +
+`reserved_ip` + an FQDN `ip`, not a static IPv4.
+
+## Cross-repo instructions (work outside this repo)
+
+The guest static→DHCP conversion and the constants this repo consumes live
+upstream. Track them there:
+
+### terraform-proxmox (`deployment.json` + constants)
+
+1. **Convert non-anchor guests to DHCP-first**: for each guest that is not a
+   static anchor, drop the static IPv4, and give it a deterministic `mac`, an
+   FQDN, and a `reserved_host` so the export emits `reserved_ip`. Keep only the
+   anchors static.
+2. **Publish the missing constants** so this repo can drop the remaining port
+   `default()` fallbacks (kept for now precisely because these are absent):
+   `service_ports.{openbao_api, satellite_exporter, smokeping_prober,
+   prometheus_web, blackbox_exporter, mssql}`, `ingress_ports.keepalived_vrid`,
+   and the `syslog_port_map.{dns_query, macos}` families. Add each to
+   `pipeline_constants`, `terragrunt apply`, then this repo removes the matching
+   `| default(...)` and adds the constant to the CI fixture.
+
+### tofu-unifi (`fixed-ips.json`)
+
+- Add the MAC → host reservation for each newly DHCP-first guest.
+- At the IPv6 phase, add dual-stack reservations (see roadmap below).
+
+### homelab-contracts (`inventory_resolve` role + schema)
+
+- Mirror any `tofu_inventory.schema.json` change here into the shared contract
+  and the `inventory_resolve` output shape (this repo installs it via
+  `requirements.yml`; CI installs it in `_data-contract.yml`).
+
+### Nautobot cutover
+
+- Sequenced separately in [`roles/nautobot/README.md`](../roles/nautobot/README.md).
+  Seed + export are safe to run as an observed shadow SSoT; the authority-flip
+  (terraform deriving `tofu_inventory.json` **from** Nautobot) stays an
+  operator-gated step.
+
+## IPv6 roadmap (planned; not yet code)
+
+The contract is IPv4-only today. When upstream begins assigning v6, land these
+**additively** (a guest resolvable by FQDN is already v4/v6-transparent, so
+name-based consumers need no change):
+
+1. **Schema** — widen `container_entry.reserved_ip` and the `ip`/`vm` entries in
+   `tests/inventory_load/tofu_inventory.schema.json` to accept an IPv6 literal
+   (an `anyOf` branch alongside IPv4/hostname). `mac` is address-family neutral —
+   no change. Static anchors (e.g. `splunk`) may stay IPv4-only.
+2. **Technitium** — emit `AAAA` for a `reserved_ip` that is an IPv6 literal:
+   tag each record `A`/`AAAA` by family in the builder, relax the "must be IPv4"
+   assertion to "must be IPv4 **or** IPv6" (still fail on a bare FQDN = a
+   DHCP-first guest missing its reservation), and extend the retired-record
+   prune to enumerate `AAAA` as well as `A`
+   (`roles/technitium_dns/tasks/main.yml`).
+3. **Nautobot** — bump the export contract to `v1.1.0` with additive v4-or-v6
+   patterns, and derive the SSoT `mask_length` from the address family
+   (v4→32, v6→128) instead of a hard-coded `/32`
+   (`ssot_ip_addresses.py`, `ssot_virtualization.py`).
+4. **CI** — add a dual-stack fixture guest to `tofu_inventory.json` and an
+   assertion in `verify_inventory.yml` so the v6 branch is exercised.
+
+## Golden rule
+
+Per `/.claude/rules/ip-addressing.md`: **document how to retrieve a value, never
+the value itself.** This file names mechanisms, fields, and constant *keys* — not
+IPs, subnets, or port numbers.

--- a/molecule/download_vpn/converge.yml
+++ b/molecule/download_vpn/converge.yml
@@ -15,6 +15,10 @@
     download_vpn_manage_services: false
     # Mirror prepare.yml so the role's tofu_data lookups resolve.
     container_ip: "192.168.0.210"
+    # ntfy peer host isn't part of this single-container scenario; pin the
+    # alert URL so the killswitch validator template renders without a
+    # hostvars['ntfy'] lookup (mirrors molecule/openbao's override).
+    download_vpn_ntfy_url: "http://192.168.0.222:8080/killswitch"
     tofu_data:
       constants:
         media_ports:

--- a/roles/configarr/defaults/main.yml
+++ b/roles/configarr/defaults/main.yml
@@ -36,12 +36,12 @@ configarr_sonarr_host: >-
   {{ tofu_data.containers['sonarr'].reserved_ip
      if (tofu_data.containers['sonarr'].reserved_ip | default('', true) | length > 0)
      else (tofu_data.containers['sonarr'].ip
-           | default(hostvars['sonarr'].container_ip, true) | default('127.0.0.1', true)) }}
+           | default(hostvars['sonarr'].container_ip, true)) }}
 configarr_radarr_host: >-
   {{ tofu_data.containers['radarr'].reserved_ip
      if (tofu_data.containers['radarr'].reserved_ip | default('', true) | length > 0)
      else (tofu_data.containers['radarr'].ip
-           | default(hostvars['radarr'].container_ip, true) | default('127.0.0.1', true)) }}
+           | default(hostvars['radarr'].container_ip, true)) }}
 configarr_sonarr_port: "{{ tofu_data.constants.media_ports.sonarr_web }}"
 configarr_radarr_port: "{{ tofu_data.constants.media_ports.radarr_web }}"
 

--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -326,7 +326,7 @@ download_vpn_validator_interval: "2min"
 # by the runtime killswitch validator above AND the persistent-storage guards
 # in tasks/main.yml (Phase 2b) — both are fail-loud, alert-then-refuse gates.
 download_vpn_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
+  http://{{ hostvars['ntfy']['container_ip'] }}:{{
   tofu_data.constants.notification_ports.ntfy_http }}/{{ download_vpn_ntfy_topic }}
 download_vpn_ntfy_topic: "killswitch"
 # healthchecks.io-style deadman ping URL. Empty => deadman ping skipped (the

--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -326,7 +326,7 @@ download_vpn_validator_interval: "2min"
 # by the runtime killswitch validator above AND the persistent-storage guards
 # in tasks/main.yml (Phase 2b) — both are fail-loud, alert-then-refuse gates.
 download_vpn_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] }}:{{
+  http://{{ hostvars['ntfy']['container_reserved_ip'] | default(hostvars['ntfy']['container_ip'], true) }}:{{
   tofu_data.constants.notification_ports.ntfy_http }}/{{ download_vpn_ntfy_topic }}
 download_vpn_ntfy_topic: "killswitch"
 # healthchecks.io-style deadman ping URL. Empty => deadman ping skipped (the

--- a/roles/healthchecks_docker/defaults/main.yml
+++ b/roles/healthchecks_docker/defaults/main.yml
@@ -27,7 +27,9 @@ healthchecks_docker_allowed_hosts: "*"
 # Override per-inventory to your internal domain. Default keeps the IP form
 # so the role works on a fresh LXC before DNS is wired.
 healthchecks_docker_site_root: >-
-  http://{{ hostvars[inventory_hostname]['container_ip'] }}:{{ healthchecks_docker_http_port }}
+  http://{{ hostvars[inventory_hostname]['container_reserved_ip']
+  | default(hostvars[inventory_hostname]['container_ip'], true) }}:{{
+  healthchecks_docker_http_port }}
 healthchecks_docker_site_name: "Healthchecks (homelab)"
 
 # Email delivery. Defaults wire to Mailpit LXC (already in this repo) so

--- a/roles/healthchecks_docker/defaults/main.yml
+++ b/roles/healthchecks_docker/defaults/main.yml
@@ -27,7 +27,7 @@ healthchecks_docker_allowed_hosts: "*"
 # Override per-inventory to your internal domain. Default keeps the IP form
 # so the role works on a fresh LXC before DNS is wired.
 healthchecks_docker_site_root: >-
-  http://{{ hostvars[inventory_hostname]['container_ip'] | default('127.0.0.1') }}:{{ healthchecks_docker_http_port }}
+  http://{{ hostvars[inventory_hostname]['container_ip'] }}:{{ healthchecks_docker_http_port }}
 healthchecks_docker_site_name: "Healthchecks (homelab)"
 
 # Email delivery. Defaults wire to Mailpit LXC (already in this repo) so
@@ -35,7 +35,7 @@ healthchecks_docker_site_name: "Healthchecks (homelab)"
 # per-inventory to use a real SMTP server when you want alerts to leave
 # the LAN.
 healthchecks_docker_email_host: >-
-  {{ hostvars['mailpit']['container_ip'] | default('mailpit') }}
+  {{ hostvars['mailpit']['container_ip'] }}
 healthchecks_docker_email_port: 1025
 healthchecks_docker_email_use_tls: false
 healthchecks_docker_email_host_user: ""

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -447,8 +447,8 @@ hermes_agent_brain_watchdog_up_after: 2
 # Urgent page target. Same ntfy LXC + notification port + topic service_deadman
 # pages on ("same feed as other homelab outages", operator decision) — the brain
 # is now a keystone. Port is single-sourced from tofu constants; host from the
-# ntfy inventory entry (fallback to the bare name).
+# ntfy inventory entry (fail loud if the ntfy guest is absent from inventory).
 hermes_agent_brain_watchdog_ntfy_topic: "keystone"
 hermes_agent_brain_watchdog_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
+  http://{{ hostvars['ntfy']['container_ip'] }}:{{
   tofu_data.constants.notification_ports.ntfy_http }}/{{ hermes_agent_brain_watchdog_ntfy_topic }}

--- a/roles/media_monitor/defaults/main.yml
+++ b/roles/media_monitor/defaults/main.yml
@@ -46,5 +46,5 @@ media_monitor_audit_log: "{{ media_monitor_state_dir }}/codec-audit.log"
 # ntfy alert target. Reuses the repo ntfy LXC + notification-port convention.
 media_monitor_ntfy_topic: media
 media_monitor_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
+  http://{{ hostvars['ntfy']['container_ip'] }}:{{
   tofu_data.constants.notification_ports.ntfy_http }}/{{ media_monitor_ntfy_topic }}

--- a/roles/media_remux/defaults/main.yml
+++ b/roles/media_remux/defaults/main.yml
@@ -33,5 +33,5 @@ media_remux_compatible_codecs_re: '^(ac3|aac)$'
 # (repo ntfy LXC + notification-port convention).
 media_remux_ntfy_topic: media
 media_remux_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
+  http://{{ hostvars['ntfy']['container_ip'] }}:{{
   tofu_data.constants.notification_ports.ntfy_http }}/{{ media_remux_ntfy_topic }}

--- a/roles/nautobot/README.md
+++ b/roles/nautobot/README.md
@@ -1,0 +1,92 @@
+# nautobot
+
+Deploys **Nautobot** as the homelab's IPAM/DCIM **source of truth** (issue #138):
+a native install plus the SSoT DiffSync jobs that seed it from the hand-maintained
+upstream sources, and an export Job that publishes the inventory artifact to S3.
+
+Nautobot is the IPAM authority in the [addressing model](../../docs/IP_AUTHORITY.md);
+**UniFi remains the DHCP + core-networking authority** and **terraform-proxmox
+remains the provisioning + constants authority**. This role never runs a DHCP
+server and never re-defines an upstream-owned value.
+
+## Two layers
+
+`tasks/main.yml` splits into:
+
+- **Deterministic layer (always on):** system deps, user, Redis on loopback,
+  SECRET_KEY, rendered config/env/uWSGI, jobs + contract copied into place,
+  systemd units. Idempotent, no live-DB writes. This is what Molecule validates
+  (with `nautobot_manage_app: false`).
+- **Live layer (`when: nautobot_manage_app`):** venv + pip install, migrate,
+  collectstatic, superuser, service start, export/discovery schedules, health
+  check, and — only when gated on — the one-shot seed run.
+
+## Flag ladder
+
+Enabling flags is **ordered**: `manage_app` → `build_seed` → `run_seed_jobs` →
+`run_export`. Seed and export are safe to run as an **observed shadow SSoT**; no
+flag here flips authority.
+
+| Flag | Default | What it does | Enable when |
+| --- | --- | --- | --- |
+| `nautobot_manage_app` | `true` | Runs the live layer (install/migrate/services). | Production path (default). |
+| `nautobot_build_seed` | `false` | Assembles `nautobot_seed.json` — a file only, no DB write. | Cutover, via `-e`. |
+| `nautobot_run_seed_jobs` | `false` | DiffSyncs the seed into live Nautobot (additive). | Cutover, after the seed. |
+| `nautobot_run_export` | `false` | One-shot publish of the export during the converge. | Optional. |
+| `nautobot_run_discovery` | `false` | SSH-CLI device onboarding (netmiko). | Optional; out of scope. |
+
+Caveats:
+
+- **`manage_app`** — idempotent; Molecule pins it `false` to skip the multi-minute install and live DB.
+- **`build_seed`** — needs the sibling-repo sources on the controller; never enable in Molecule (it stamps `generated_at`, breaking idempotence).
+- **`run_seed_jobs`** — every model's `delete()` is a no-op, so re-runs are safe and cannot delete another owner's objects; an empty bundle is a no-op.
+- **`run_export`** — only meaningful with `run_seed_jobs`; steady-state publishing already runs daily via the beat schedule.
+- **`run_discovery`** — inert unless `NAUTOBOT_ONBOARD_TARGETS` is set; native-API discovery of Proxmox/iDRAC/UniFi is a tracked follow-up.
+
+**Publish safety:** the export writes a **separate S3 key**
+(`nautobot/nautobot_export.json`) — distinct from terraform's authoritative
+`ansible_inventory.json`. No consumer reads it as source, so it stays a shadow
+until the authority-flip. If the export bucket is unset the upload fails closed
+(nothing is published).
+
+## Prefix roles and `dhcp-pool`
+
+`tasks/seed_bundle.yml` builds Nautobot prefixes from `NAUTOBOT_SEED_NETWORKS`
+(a list of `{vid, name, cidr, role?}`). Each network's prefix `role` now comes
+from an **optional per-network `role`**, defaulting to the VLAN `name`:
+
+```jmespath
+{prefix: cidr, vlan_vid: vid, role: role || name}
+```
+
+This lets a scope be modelled as a first-class **`dhcp-pool`** prefix (or any
+free-form role) without inventing a VLAN by that name — e.g. a
+`{vid: 20, name: "servers", cidr: "…", role: "dhcp-pool"}` entry, or a standalone
+pool prefix. Downstream (`ssot_vlans_prefixes.py`, `export_nautobot.py`) and the
+export contract already accept any free-form role, so no other change is needed.
+IPv6 prefixes seed with no code change once a v6 CIDR is present in
+`NAUTOBOT_SEED_NETWORKS` (see the [IPv6 roadmap](../../docs/IP_AUTHORITY.md#ipv6-roadmap-planned-not-yet-code)).
+
+## Go-live runbook (operator-gated)
+
+All runtime gates ship `false`/`true` at their safe defaults above; advance the
+cutover deliberately:
+
+1. Place the four sources on the controller and export their paths +
+   `NAUTOBOT_SEED_NETWORKS` (now optionally carrying `role: dhcp-pool` and, later,
+   v6 CIDRs) + `NAUTOBOT_EXPORT_S3_BUCKET`.
+2. `… site.yml -t nautobot -e nautobot_build_seed=true` → writes
+   `nautobot_seed.json` only. **Inspect it.**
+3. Re-run with `-e nautobot_build_seed=true -e nautobot_run_seed_jobs=true` →
+   additive DiffSync populates live Nautobot. Re-runnable safely.
+4. Optionally `-e nautobot_run_export=true` for an immediate publish; otherwise
+   the daily beat schedule publishes.
+5. **Observe** the shadow `nautobot_export.json` for one or more cycles.
+6. The **authority-flip** — terraform-proxmox deriving `tofu_inventory.json`
+   *from* Nautobot instead of `deployment.json` — is a separate, upstream,
+   operator-approved step. It also requires the export contract to first grow to
+   a superset of the inventory (`vmid`, `node`, `tags`, ports, static-vs-reserved
+   distinction). Never a default here.
+
+See [`docs/IP_AUTHORITY.md`](../../docs/IP_AUTHORITY.md) for the full authority
+model, the static-anchor policy, and the cross-repo instructions.

--- a/roles/nautobot/tasks/seed_bundle.yml
+++ b/roles/nautobot/tasks/seed_bundle.yml
@@ -64,7 +64,10 @@
   no_log: true
 
 # --- Transform into the nautobot_seed.json schema ---------------------------
-# VLANs + prefixes from the provided network definitions (list of {vid,name,cidr}).
+# VLANs + prefixes from the provided network definitions
+# (list of {vid, name, cidr, role?}). An optional per-network `role` names the
+# prefix's IPAM role (e.g. "dhcp-pool" for a DHCP scope prefix); when omitted the
+# role defaults to the VLAN `name`, preserving the previous behaviour.
 - name: Build VLANs and prefixes from the network definitions
   ansible.builtin.set_fact:
     nautobot_seed_vlans: >-
@@ -73,7 +76,7 @@
          | list }}
     nautobot_seed_prefixes: >-
       {{ nautobot_seed_networks
-         | map('community.general.json_query', '{prefix: cidr, vlan_vid: vid, role: name}')
+         | map('community.general.json_query', '{prefix: cidr, vlan_vid: vid, role: role || name}')
          | list }}
 
 # Devices from the decrypted rack_servers (known shape).

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -349,7 +349,7 @@ openbao_snapshot_secret_id: "{{ lookup('env', 'OPENBAO_SNAPSHOT_SECRET_ID') | de
 # ntfy alert target (reuses the repo's ntfy LXC + notification-port convention,
 # matching service_deadman). Topic 'openbao'.
 openbao_snapshot_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
+  http://{{ hostvars['ntfy']['container_ip'] }}:{{
   tofu_data.constants.notification_ports.ntfy_http }}/openbao
 # healthchecks deadman ping URL for the snapshot job; EMPTY => ping skipped
 # (ntfy + journal alert still fire). Set per-node from the healthchecks LXC.

--- a/roles/plex/defaults/main.yml
+++ b/roles/plex/defaults/main.yml
@@ -81,7 +81,7 @@ plex_manage_services: true
 # ntfy alert target for the persistent-mount guard (tasks/main.yml). Mirrors
 # the repo's ntfy LXC + push topic convention (see download_vpn/service_deadman).
 plex_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
+  http://{{ hostvars['ntfy']['container_ip'] }}:{{
   tofu_data.constants.notification_ports.ntfy_http }}/{{ plex_ntfy_topic }}
 plex_ntfy_topic: "persistence"
 

--- a/roles/radarr/defaults/main.yml
+++ b/roles/radarr/defaults/main.yml
@@ -36,6 +36,6 @@ radarr_auth_required: DisabledForLocalAddresses
 # ntfy alert target for the persistent-mount guard (tasks/main.yml). Mirrors
 # the repo's ntfy LXC + push topic convention (see download_vpn/service_deadman).
 radarr_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
+  http://{{ hostvars['ntfy']['container_ip'] }}:{{
   tofu_data.constants.notification_ports.ntfy_http }}/{{ radarr_ntfy_topic }}
 radarr_ntfy_topic: "persistence"

--- a/roles/seerr/defaults/main.yml
+++ b/roles/seerr/defaults/main.yml
@@ -108,6 +108,6 @@ seerr_manage_services: true
 # ntfy alert target for the persistent-mount guard (tasks/main.yml). Mirrors
 # the repo's ntfy LXC + push topic convention (see download_vpn/service_deadman).
 seerr_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
+  http://{{ hostvars['ntfy']['container_ip'] }}:{{
   tofu_data.constants.notification_ports.ntfy_http }}/{{ seerr_ntfy_topic }}
 seerr_ntfy_topic: "persistence"

--- a/roles/servarr_wiring/defaults/main.yml
+++ b/roles/servarr_wiring/defaults/main.yml
@@ -44,17 +44,17 @@ servarr_wiring_sonarr_host: >-
   {{ tofu_data.containers['sonarr'].reserved_ip
      if (tofu_data.containers['sonarr'].reserved_ip | default('', true) | length > 0)
      else (tofu_data.containers['sonarr'].ip
-           | default(hostvars['sonarr'].container_ip, true) | default('127.0.0.1', true)) }}
+           | default(hostvars['sonarr'].container_ip, true)) }}
 servarr_wiring_radarr_host: >-
   {{ tofu_data.containers['radarr'].reserved_ip
      if (tofu_data.containers['radarr'].reserved_ip | default('', true) | length > 0)
      else (tofu_data.containers['radarr'].ip
-           | default(hostvars['radarr'].container_ip, true) | default('127.0.0.1', true)) }}
+           | default(hostvars['radarr'].container_ip, true)) }}
 servarr_wiring_prowlarr_host: >-
   {{ tofu_data.containers['download-vpn'].reserved_ip
      if (tofu_data.containers['download-vpn'].reserved_ip | default('', true) | length > 0)
      else (tofu_data.containers['download-vpn'].ip
-           | default(hostvars['download-vpn'].container_ip, true) | default('127.0.0.1', true)) }}
+           | default(hostvars['download-vpn'].container_ip, true)) }}
 
 servarr_wiring_sonarr_port: "{{ tofu_data.constants.media_ports.sonarr_web }}"
 servarr_wiring_radarr_port: "{{ tofu_data.constants.media_ports.radarr_web }}"

--- a/roles/service_deadman/defaults/main.yml
+++ b/roles/service_deadman/defaults/main.yml
@@ -16,7 +16,7 @@ service_deadman_interval: "60s"
 
 # ntfy alert target. Reuses the repo's ntfy LXC + notification-port convention.
 service_deadman_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
+  http://{{ hostvars['ntfy']['container_ip'] }}:{{
   tofu_data.constants.notification_ports.ntfy_http }}/{{ service_deadman_ntfy_topic }}
 service_deadman_ntfy_topic: "keystone"
 

--- a/roles/sonarr/defaults/main.yml
+++ b/roles/sonarr/defaults/main.yml
@@ -36,6 +36,6 @@ sonarr_auth_required: DisabledForLocalAddresses
 # ntfy alert target for the persistent-mount guard (tasks/main.yml). Mirrors
 # the repo's ntfy LXC + push topic convention (see download_vpn/service_deadman).
 sonarr_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
+  http://{{ hostvars['ntfy']['container_ip'] }}:{{
   tofu_data.constants.notification_ports.ntfy_http }}/{{ sonarr_ntfy_topic }}
 sonarr_ntfy_topic: "persistence"

--- a/roles/sortarr/defaults/main.yml
+++ b/roles/sortarr/defaults/main.yml
@@ -84,7 +84,7 @@ sortarr_manage_services: true
 # ntfy alert target for the persistent-mount guard (tasks/main.yml). Mirrors
 # the seerr/download_vpn/service_deadman convention.
 sortarr_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] | default('ntfy') }}:{{
+  http://{{ hostvars['ntfy']['container_ip'] }}:{{
   tofu_data.constants.notification_ports.ntfy_http }}/{{ sortarr_ntfy_topic }}
 
 # --- Security & Session Persistence -------------------------------------------


### PR DESCRIPTION
## Why

Applies the "IPAM-driven, DHCP-first, fail-loud foundation" idea to our stack.
Our repo already implements most of it — a DHCP-first inventory contract
(`mac` / `reserved_ip` / FQDN), UniFi as the DHCP authority, Nautobot as a
staged IPAM source of truth, and a no-hardcode rule. The goal here is to move
further toward **~90% of guests carrying no static IP** (only a MAC reservation
+ FQDN), keeping static addresses **only for the critical anchors** (DNS/Technitium,
Proxmox hosts, Traefik/ingress VIP), and to be ready for the IPv6 move.

The guest static→DHCP conversion itself lives **upstream** (terraform-proxmox
`deployment.json` + tofu-unifi `fixed-ips.json`), so that part ships here as
**cross-repo instructions** in the new authority doc. This PR does the in-repo
enablers.

## What changed

**1. Remove IP/loopback masking fallbacks (fail-loud)**
Dropped the trailing `default('127.0.0.1')` in `servarr_wiring`, `configarr`, and
`healthchecks_docker` — the exact anti-pattern `.claude/rules/ip-addressing.md`
forbids (it silently wires a service to loopback and emits broken config while
the role "succeeds"). The `reserved_ip → ip → container_ip` cascade is preserved,
so a truly-missing inventory host now fails loud instead of masking. (`servarr_wiring`'s
own comment already said *"NEVER a hardcoded IP"*.)

**2. Remove hostname-string masking fallbacks (fail-loud)**
Dropped `default('ntfy')` / `default('mailpit')` across 12 role defaults.
`container_ip` is always set by `load_tofu.yml` for every guest, so the bare
short-name was dead/masking (and wasn't a resolvable FQDN anyway).

**3. Advance the Nautobot IPAM model**
`seed_bundle.yml` prefixes now honor an optional per-network `role` via JMESPath
`role || name`, making a first-class **`dhcp-pool`** prefix role possible without
inventing a fake VLAN. Backward compatible (absent/empty `role` → the VLAN name).
**All runtime gates stay at their current defaults** — the export writes a separate
shadow S3 key and every SSoT write is additive, so nothing here touches live
Nautobot.

**4. Docs**
- `docs/IP_AUTHORITY.md` — authority model (UniFi = DHCP/network, Nautobot = IPAM
  SSoT, terraform-proxmox = provisioning/constants, this repo = read-only consumer),
  the static-anchor policy, the DHCP-first contract, the **cross-repo instructions**
  (terraform-proxmox / tofu-unifi / homelab-contracts), and the **IPv6 roadmap**.
- `roles/nautobot/README.md` — the cited-but-missing role README: flag ladder +
  operator-gated go-live runbook.

## Deferred (documented, not in this PR)
- IPv6 schema/AAAA/contract **code** — captured as the roadmap in `docs/IP_AUTHORITY.md`.
- Port `default()` removals + the mssql port TODO — need upstream constants first
  (listed in the cross-repo instructions).
- Flipping any `nautobot_run_*` gate or the terraform-proxmox authority-flip —
  operator-gated (documented in the runbook).

## Verification
This container lacks the Nix dev shell, so ansible-lint / molecule / `verify_inventory.yml`
run in CI (`_data-contract.yml` / `_molecule.yml`). Locally I confirmed:
- JMESPath `role || name` returns the explicit role, falling back to the VLAN name when absent/empty.
- All 17 changed YAML files parse; `yamllint` clean.
- `python3 tests/inventory_load/validate_schema.py` → OK.
- `markdownlint` clean on both new docs; internal links resolve; no literal IPs/ports (golden rule).


---
_Generated by [Claude Code](https://claude.ai/code/session_01UQDoDYXR8oHWEfFQCoo6Kd)_