### PR TITLE
feat(openbao): dynamic AWS STS creds for tf-proxmox via AWS secrets engine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,12 +208,8 @@ Template: `secrets.enc.yaml.example` — copy, fill in real values, then encrypt
 **Roles are injection-agnostic.** Every role reads a secret as plain
 `lookup('env', 'KEY')` and doesn't know or care where the value came from —
 never bake a specific backend (OpenBao, Doppler, SOPS) into a role default.
-Our deployment currently populates those env vars via `doppler run --`; the
-target is an ambient injection step (an `openbao-keychain` LaunchAgent +
-`from_bao`-style wrapper) that exports the same env vars from OpenBao before
-the converge runs — zero role changes either way. OpenBao's per-domain
-AppRole RBAC is documented in `docs-starlight` as *our infra*, not a
-requirement of this repo.
+The secrets architecture (which store holds what, per-domain RBAC, the
+workstation consumption path) is documented on the docs site, not here.
 
 ## Commands
 
@@ -258,15 +254,24 @@ ansible-lint
 
 ### Execution Performance & Optimization
 
-Since site playbook runs or dry-runs evaluate 55+ hosts, checks can take a long time even when 99% of the tasks are no-ops (due to SSH/LXC connection overhead and fact-gathering serialization).
+Since site playbook runs or dry-runs evaluate 55+ hosts, checks can take a
+long time even when 99% of the tasks are no-ops (due to SSH/LXC connection
+overhead and fact-gathering serialization).
 
 To increase execution speed, you can leverage several options:
-1. **Parallel Execution (`--forks` or `ANSIBLE_FORKS`)**: Increase the concurrency from the default 5 hosts at once. Using `25` forks (e.g. `doppler run -- ansible-playbook ... --forks 25`) runs significantly faster across large fleets.
-2. **Targeted Runs (`--limit`)**: Keep play scope narrow by limiting execution to the specific role host and localhost (e.g., `--limit sortarr,localhost`).
-3. **Scoping via Tags (`--tags`)**: Use `--tags <tag-name>` to run only a subset of roles (e.g., `--tags github_runner`).
-4. **SSH Pipelining & Multiplexing**: Already enabled for SSH (`pipelining = True` and `ControlPersist=60s` in `ansible.cfg`).
-5. **Disable Fact Gathering**: For ad-hoc plays where host facts are not needed, set `gather_facts: false` to skip the costly gathering step.
 
+1. **Parallel Execution (`--forks` or `ANSIBLE_FORKS`)**: Increase the
+   concurrency from the default 5 hosts at once. Using `25` forks
+   (e.g. `doppler run -- ansible-playbook ... --forks 25`) runs significantly
+   faster across large fleets.
+2. **Targeted Runs (`--limit`)**: Keep play scope narrow by limiting execution
+   to the specific role host and localhost (e.g., `--limit sortarr,localhost`).
+3. **Scoping via Tags (`--tags`)**: Use `--tags <tag-name>` to run only a
+   subset of roles (e.g., `--tags github_runner`).
+4. **SSH Pipelining & Multiplexing**: Already enabled for SSH
+   (`pipelining = True` and `ControlPersist=60s` in `ansible.cfg`).
+5. **Disable Fact Gathering**: For ad-hoc plays where host facts are not
+   needed, set `gather_facts: false` to skip the costly gathering step.
 
 ## Testing
 

--- a/molecule/openbao/verify.yml
+++ b/molecule/openbao/verify.yml
@@ -199,3 +199,44 @@
       loop: "{{ bao_policy_templates.results }}"
       loop_control:
         label: "{{ item.item }}"
+
+    # The AWS secrets engine registration/config only runs against a live
+    # server (init.yml is entirely docker-guarded), so it can't be exercised
+    # here either. What CAN be checked without a live server: the external
+    # plugin binary actually staged, the server config pointing at it, and the
+    # terraform-apply policy template source still granting the dynamic AWS
+    # STS path — catches a future edit silently dropping any of them.
+    - name: Assert the rendered config sets plugin_directory
+      ansible.builtin.assert:
+        that:
+          - "'plugin_directory' in (bao_cfg_content.content | b64decode)"
+        fail_msg: "openbao.hcl is missing plugin_directory (external plugins would be unloadable)"
+
+    - name: Stat the staged AWS plugin binary
+      ansible.builtin.stat:
+        path: /opt/openbao/plugins/openbao-plugin-secrets-aws_linux_amd64_v1
+      register: bao_aws_plugin
+
+    - name: Assert the AWS plugin binary is staged, root-owned, and not world/group-writable
+      ansible.builtin.assert:
+        that:
+          - bao_aws_plugin.stat.exists
+          - bao_aws_plugin.stat.pw_name == 'root'
+          - bao_aws_plugin.stat.mode == '0750'
+        fail_msg: >-
+          AWS plugin binary missing or wrong owner/mode:
+          {{ bao_aws_plugin.stat | default({}) }}
+
+    - name: Read the terraform-apply policy template source
+      ansible.builtin.slurp:
+        src: "{{ playbook_dir }}/../../roles/openbao/templates/terraform-apply-policy.hcl.j2"
+      register: bao_terraform_apply_policy_src
+      delegate_to: localhost
+      become: false
+
+    - name: Assert the terraform-apply policy grants aws/sts/tf-proxmox
+      ansible.builtin.assert:
+        that:
+          - "'aws/sts/' in (bao_terraform_apply_policy_src.content | b64decode)"
+          - "'\"read\", \"update\"' in (bao_terraform_apply_policy_src.content | b64decode)"
+        fail_msg: "terraform-apply-policy.hcl.j2 is missing the dynamic AWS STS grant"

--- a/roles/openbao/README.md
+++ b/roles/openbao/README.md
@@ -186,7 +186,7 @@ plans):
 
 | AppRole | Reads | Writes | Notes |
 | --- | --- | --- | --- |
-| `terraform-apply` | `secret/infra/*`, `secret/platform/{dns,traefik}`, `secret/apps/nautobot/*`, legacy `homelab/*` | (same) | Human-triggered IaC apply |
+| `terraform-apply` | `secret/infra/*`, `secret/platform/{dns,traefik}`, `secret/apps/nautobot/*`, `homelab/*` | (same) | Human-triggered IaC apply[^aws-sts] |
 | `apps-seed` | `secret/apps/*` | `secret/apps/*` create/update | Doppler-published writer; Terraform `vault-secrets` seeds `secret/apps/<app>` at source |
 | `flow-lock` | `secret/locks/global`, `secret/infra/*` | `secret/locks/global` | Cross-repo apply lock; releases the lock via metadata delete |
 | `terrakube-plan` | `secret/platform/terrakube` only | — | Terrakube VCS-driven runs; deliberately walled off from `secret/infra/*` |
@@ -204,6 +204,10 @@ plans):
 | `ai-elevated` | `ai-readonly` + `secret/platform/*` | — | trusted infra-touching agents; no write |
 | `snapshot` | `sys/storage/raft/snapshot` | — | least-priv backup identity |
 
+[^aws-sts]: Also grants `read`+`update` on `aws/sts/tf-proxmox` — dynamic AWS
+    STS creds (assumed_role) for `role/tf-proxmox`, replacing the laptop's
+    static aws-vault base key. See the AWS secrets engine section below.
+
 **Secret-zero model**: each AppRole's `role_id`/`secret_id` lives as its own
 item in a dedicated macOS keychain (`openbao.keychain-db`, 72h auto-lock) —
 the keychain's LOCK STATE is the entire access boundary, not the AppRole's own
@@ -217,6 +221,56 @@ goes beside the others in `templates/`). Adding a row **after** the cluster is
 already initialized needs a privileged token supplied via `BAO_TOKEN` (see
 [Idempotency](#idempotency)) — only the newly-added identities get created and
 get fresh credentials; existing ones are untouched.
+
+## AWS secrets engine (dynamic STS creds)
+
+Mounted at `aws/` (add-if-missing, in `tasks/init.yml`) alongside the KV
+engine. Purpose: eliminate the last static AWS key on the workstation — the
+`terraform` IAM base user's aws-vault key, used only for
+`sts:AssumeRole` into `role/tf-proxmox`.
+
+**The AWS engine is NOT builtin to OpenBao** (dropped at the Vault fork; the
+builtin secrets plugins are kv/pki/ssh/transit/totp/rabbitmq/ldap/kubernetes).
+It ships as an external plugin from
+[openbao/openbao-plugins](https://github.com/openbao/openbao-plugins) with
+prebuilt, checksum-verified release binaries. The role therefore:
+
+1. Stages the release tarball from the controller (same WAN-firewall staging
+   pattern as the server .deb) and extracts the binary into
+   `openbao_plugin_dir` on **every** node — the catalog is cluster-replicated
+   but each node execs its own copy, which must match the registered sha256.
+2. Points `plugin_directory` at it in `openbao.hcl` (always set; the dir
+   always exists).
+3. Registers the plugin in the catalog (bootstrap host, add-if-missing,
+   `-sha256` pinned to the staged binary) and mounts it.
+
+**Version upgrade** (deliberately manual, like root-config rotation): bump
+`openbao_aws_plugin_version`, converge (stages the new binary everywhere),
+then re-register with the new sha256 and reload:
+
+```bash
+bao plugin register -sha256=<new-sha256> \
+  -command=openbao-plugin-secrets-aws_linux_amd64_v1 secret aws
+bao plugin reload -plugin aws
+```
+
+- `aws/config/root` holds the ONE long-lived base-user key OpenBao itself uses
+  to call `sts:AssumeRole`. Seeded from `OPENBAO_AWS_ROOT_ACCESS_KEY_ID` /
+  `OPENBAO_AWS_ROOT_SECRET_ACCESS_KEY` (Doppler tier-0). **Write-once**: a
+  routine converge with root already configured never overwrites it — treat
+  key rotation as a deliberate, separate operator action, same as the seal key.
+  If the engine is mounted with no root config and no env key, the converge
+  **fails loudly** rather than leaving a silently-dead engine.
+- `aws/roles/tf-proxmox` (`credential_type=assumed_role`,
+  `role_arns=arn:aws:iam::<acct>:role/tf-proxmox`,
+  `default_sts_ttl=1h`, `max_sts_ttl=2h`) — declares the assumable role.
+  Add-if-missing; bumping the TTLs on an existing role needs a manual
+  `bao write` (not re-driven by a routine converge).
+- The `terraform-apply` AppRole reads `aws/sts/tf-proxmox` to mint a session —
+  see the [^aws-sts] policy footnote above.
+- The laptop side (nix-darwin `credential_process` wrapper reading
+  `terraform-apply`'s `role_id`/`secret_id` from `openbao.keychain-db`) is
+  documented in the nix-darwin repo, not here.
 
 ## Break-glass handling (read this)
 

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -130,11 +130,72 @@ openbao_vikunja_secrets:
   svc_mcp_ro_password: VIKUNJA_SVC_MCP_RO_PASSWORD
   svc_mcp_rw_password: VIKUNJA_SVC_MCP_RW_PASSWORD
 
+# --- AWS secrets engine (dynamic STS creds, no static laptop key) -----------
+# Replaces the aws-vault `tf-proxmox` static base-user key with short-lived STS
+# creds minted on demand. OpenBao holds ONE long-lived base-user key server-side
+# (Doppler tier-0, secret/infra/aws in spirit — actually stored in the engine's
+# own config, not KV); the `terraform-apply` AppRole reads aws/sts/tf-proxmox to
+# get an assumed_role STS session for role/tf-proxmox. See roles/openbao/README.md.
+#
+# The AWS engine is NOT builtin to OpenBao (dropped at the Vault fork) — it
+# ships as an external plugin from openbao/openbao-plugins with prebuilt,
+# checksum-verified release binaries. The role stages the binary from the
+# controller (same WAN-firewall pattern as the server .deb) onto EVERY node
+# (the catalog sha256 must match the on-disk binary wherever a request lands),
+# then init.yml registers it once and mounts it.
+openbao_aws_engine_enabled: true
+openbao_aws_mount: aws
+# Catalog name the plugin is registered under; `bao secrets enable aws`
+# resolves to it (no builtin shadows the name).
+openbao_aws_plugin_name: aws
+openbao_aws_role_name: tf-proxmox
+# The tf-proxmox IAM role ARN (assumes via the OpenBao-held base user, same
+# relationship aws-vault used). Not a tofu constant today — set via env/extra-vars
+# per the account; see AGENTS.md IP-addressing-style rule (never hardcode).
+openbao_aws_role_arn: "{{ lookup('env', 'OPENBAO_AWS_TF_PROXMOX_ROLE_ARN') }}"
+openbao_aws_root_region: us-east-2
+openbao_aws_default_sts_ttl: 1h
+openbao_aws_max_sts_ttl: 2h
+# The base-user key OpenBao uses to call sts:AssumeRole. Minted via an
+# independent admin path (never the key being rotated out), seeded from Doppler
+# tier-0. Written to aws/config/root ONLY on first configuration — a routine
+# converge never overwrites/rotates it silently (mirrors the seal-key pattern).
+openbao_aws_root_access_key_id: "{{ lookup('env', 'OPENBAO_AWS_ROOT_ACCESS_KEY_ID') | default('', true) }}"
+openbao_aws_root_secret_access_key: "{{ lookup('env', 'OPENBAO_AWS_ROOT_SECRET_ACCESS_KEY') | default('', true) }}"
+
+# --- External plugin staging (openbao/openbao-plugins releases) --------------
+# Every external plugin binary lives here; openbao.hcl points plugin_directory
+# at it. Root-owned, openbao-group-exec, never world/group-writable (the server
+# validates the catalog sha256 against the file before every plugin launch).
+openbao_plugin_dir: /opt/openbao/plugins
+# Version bumps follow the .deb pinning convention: change it here only. On an
+# upgrade the new binary's sha256 differs, so re-registration is a deliberate
+# operator step (see README "AWS secrets engine") — a routine converge never
+# silently re-points the catalog.
+openbao_aws_plugin_version: "0.3.0"
+openbao_aws_plugin_release_base_url: "https://github.com/openbao/openbao-plugins/releases/download"
+openbao_aws_plugin_release_tag: "secrets-aws-v{{ openbao_aws_plugin_version }}"
+# Exact goreleaser asset/member names (verified against the release):
+# tarball openbao-plugin-secrets-aws_linux_amd64_v1.tar.gz contains LICENSE +
+# the binary, which keeps its platform suffix.
+openbao_aws_plugin_tarball: "openbao-plugin-secrets-aws_linux_amd64_v1.tar.gz"
+openbao_aws_plugin_binary: "openbao-plugin-secrets-aws_linux_amd64_v1"
+openbao_aws_plugin_tarball_url: >-
+  {{ openbao_aws_plugin_release_base_url }}/{{ openbao_aws_plugin_release_tag }}/{{ openbao_aws_plugin_tarball }}
+# SHA256SUMS-format file covering the release tarballs.
+openbao_aws_plugin_checksums_filename: "checksums-secrets-aws.txt"
+openbao_aws_plugin_checksums_url: >-
+  {{ openbao_aws_plugin_release_base_url }}/{{ openbao_aws_plugin_release_tag
+  }}/{{ openbao_aws_plugin_checksums_filename }}
+
 # Policy + AppRole names, one per RBAC identity (see docs/SECRETS_HIERARCHY.md
 # for the full rationale). Split by resource domain, least-privilege:
 #   terraform-apply  — human-triggered IaC apply (was "terraform"); read+write
-#                      secret/infra/*, secret/platform/{dns,traefik}, plus
-#                      narrow secret/apps/nautobot/* seed grant for Nautobot P1
+#                      secret/infra/*, secret/platform/{dns,traefik}, narrow
+#                      secret/apps/nautobot/* seed grant for Nautobot P1, plus
+#                      read+update aws/sts/tf-proxmox (dynamic AWS STS creds for
+#                      the tf-proxmox IAM role — replaces the laptop's static
+#                      aws-vault base key)
 #   flow-lock        — cross-repo apply lock holder; read/write only the global
 #                      lock record, metadata-delete for release, and read-only
 #                      secret/infra/* context for lock decisions

--- a/roles/openbao/tasks/init.yml
+++ b/roles/openbao/tasks/init.yml
@@ -239,6 +239,171 @@
       or (openbao_vikunja_current.stdout | default('{}') | from_json).data.data | default({})
          != (openbao_vikunja_desired | default({}))
 
+# --- AWS secrets engine (external plugin: register + enable, add-if-missing) -
+# Dynamic STS creds for role/tf-proxmox — replaces the laptop's static
+# aws-vault base key. The engine is NOT builtin: main.yml staged the plugin
+# binary on every node; here the bootstrap host registers it in the
+# cluster-replicated catalog (pinned to the staged binary's sha256), then
+# mounts it. See defaults/main.yml for the var docs.
+- name: Read the staged AWS plugin binary's sha256
+  ansible.builtin.stat:
+    path: "{{ openbao_plugin_dir }}/{{ openbao_aws_plugin_binary }}"
+    checksum_algorithm: sha256
+  register: openbao_aws_plugin_stat
+  when:
+    - openbao_bootstrap_token is defined
+    - openbao_aws_engine_enabled
+
+- name: Assert the AWS plugin binary is staged
+  ansible.builtin.assert:
+    that:
+      - openbao_aws_plugin_stat.stat.exists
+    fail_msg: >-
+      {{ openbao_plugin_dir }}/{{ openbao_aws_plugin_binary }} is missing —
+      the staging phase in main.yml should have extracted it. Re-run the full
+      role (not init in isolation).
+  when:
+    - openbao_bootstrap_token is defined
+    - openbao_aws_engine_enabled
+
+- name: Check whether the AWS plugin is already registered
+  ansible.builtin.command:
+    cmd: "bao plugin info secret {{ openbao_aws_plugin_name }}"
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  register: openbao_aws_plugin_check
+  no_log: true
+  changed_when: false
+  failed_when: false
+  when:
+    - openbao_bootstrap_token is defined
+    - openbao_aws_engine_enabled
+
+# Add-if-missing, like every other identity this file provisions. A VERSION
+# BUMP (new binary, new sha256) is deliberately NOT re-registered here — see
+# README "AWS secrets engine" for the manual upgrade step, mirroring how the
+# root config and role TTLs are never silently re-driven by a converge.
+- name: Register the AWS plugin (pinned to the staged binary's sha256)
+  ansible.builtin.command:
+    cmd: >-
+      bao plugin register
+      -sha256={{ openbao_aws_plugin_stat.stat.checksum }}
+      -command={{ openbao_aws_plugin_binary }}
+      secret {{ openbao_aws_plugin_name }}
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  no_log: true
+  changed_when: true
+  when:
+    - openbao_bootstrap_token is defined
+    - openbao_aws_engine_enabled
+    - (openbao_aws_plugin_check.rc | default(1)) != 0
+
+- name: Enable the AWS secrets engine
+  ansible.builtin.command:
+    cmd: "bao secrets enable -path={{ openbao_aws_mount }} {{ openbao_aws_plugin_name }}"
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  no_log: true
+  changed_when: true
+  when:
+    - openbao_bootstrap_token is defined
+    - openbao_aws_engine_enabled
+    - (openbao_aws_mount ~ '/') not in (openbao_mounts_raw.stdout | from_json).keys()
+
+# Root config holds the ONE long-lived AWS base-user key OpenBao uses to call
+# sts:AssumeRole. Checked via `bao read`, not the mounts list above — a mount
+# can exist with no root config yet configured (fresh `secrets enable`).
+- name: Check whether the AWS engine root config already exists
+  ansible.builtin.command:
+    cmd: "bao read -format=json {{ openbao_aws_mount }}/config/root"
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  register: openbao_aws_root_check
+  no_log: true
+  changed_when: false
+  failed_when: false
+  when:
+    - openbao_bootstrap_token is defined
+    - openbao_aws_engine_enabled
+
+# Fail loudly rather than silently leave a mounted-but-unconfigured engine: a
+# skip here would make `bao read aws/sts/tf-proxmox` fail later with a much
+# more confusing error, and a routine converge that forgot the root key would
+# look green while doing nothing.
+- name: Refuse to leave the AWS engine mounted with no root config and no key supplied
+  ansible.builtin.fail:
+    msg: >-
+      The AWS secrets engine at {{ openbao_aws_mount }}/ has no root config yet,
+      and OPENBAO_AWS_ROOT_ACCESS_KEY_ID/OPENBAO_AWS_ROOT_SECRET_ACCESS_KEY are
+      unset. Seed the base-user key (minted via an independent admin path, NOT
+      the key being rotated out) into Doppler tier-0 and re-run with those env
+      vars set, or set openbao_aws_engine_enabled: false to skip AWS entirely.
+  when:
+    - openbao_bootstrap_token is defined
+    - openbao_aws_engine_enabled
+    - (openbao_aws_root_check.rc | default(1)) != 0
+    - (openbao_aws_root_access_key_id | length == 0) or (openbao_aws_root_secret_access_key | length == 0)
+
+# Write-once: a routine converge with root already configured never
+# overwrites/rotates it silently (mirrors the seal-key pattern) — rotation is a
+# deliberate, separate operator action.
+- name: Configure the AWS engine root credentials (first configuration only)
+  ansible.builtin.command:
+    cmd: >-
+      bao write {{ openbao_aws_mount }}/config/root
+      access_key={{ openbao_aws_root_access_key_id }}
+      secret_key={{ openbao_aws_root_secret_access_key }}
+      region={{ openbao_aws_root_region }}
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  no_log: true
+  changed_when: true
+  when:
+    - openbao_bootstrap_token is defined
+    - openbao_aws_engine_enabled
+    - (openbao_aws_root_check.rc | default(1)) != 0
+    - openbao_aws_root_access_key_id | length > 0
+    - openbao_aws_root_secret_access_key | length > 0
+
+- name: Check whether the tf-proxmox AWS role already exists
+  ansible.builtin.command:
+    cmd: "bao read -format=json {{ openbao_aws_mount }}/roles/{{ openbao_aws_role_name }}"
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  register: openbao_aws_role_check
+  no_log: true
+  changed_when: false
+  failed_when: false
+  when:
+    - openbao_bootstrap_token is defined
+    - openbao_aws_engine_enabled
+
+- name: Create the tf-proxmox AWS role (assumed_role, add-if-missing)
+  ansible.builtin.command:
+    cmd: >-
+      bao write {{ openbao_aws_mount }}/roles/{{ openbao_aws_role_name }}
+      credential_type=assumed_role
+      role_arns={{ openbao_aws_role_arn }}
+      default_sts_ttl={{ openbao_aws_default_sts_ttl }}
+      max_sts_ttl={{ openbao_aws_max_sts_ttl }}
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  no_log: true
+  changed_when: true
+  when:
+    - openbao_bootstrap_token is defined
+    - openbao_aws_engine_enabled
+    - (openbao_aws_role_check.rc | default(1)) != 0
+    - openbao_aws_role_arn | length > 0
+
 # --- RBAC policies (write-if-missing-or-changed) ----------------------------
 # Rendered on the TARGET: `bao policy write` below executes there and reads
 # the file from its local filesystem (a controller-side render is unreachable

--- a/roles/openbao/tasks/main.yml
+++ b/roles/openbao/tasks/main.yml
@@ -156,6 +156,84 @@
     group: "{{ openbao_group }}"
     mode: "0700"
 
+# Always created (openbao.hcl sets plugin_directory unconditionally, and the
+# server refuses to start if the configured path is absent). Root-owned and
+# never group-writable: the server validates each plugin launch against the
+# catalog sha256, but a writable directory would still invite tampering.
+- name: Create OpenBao plugin directory (0750, root-owned, openbao-exec)
+  ansible.builtin.file:
+    path: "{{ openbao_plugin_dir }}"
+    state: directory
+    owner: root
+    group: "{{ openbao_group }}"
+    mode: "0750"
+
+# --- Phase 5c: stage the AWS secrets engine plugin (external, all nodes) -----
+# The AWS engine is not builtin (see defaults) — stage its checksum-verified
+# release tarball from the controller exactly like the server .deb, on EVERY
+# node: the plugin catalog is cluster-replicated but each node execs its OWN
+# copy of the binary, which must match the registered sha256.
+- name: Stage the AWS plugin checksums file on controller
+  ansible.builtin.get_url:
+    url: "{{ openbao_aws_plugin_checksums_url }}"
+    dest: "/tmp/openbao-{{ openbao_aws_plugin_release_tag }}-checksums.txt"
+    mode: "0644"
+    force: true
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  run_once: true
+  when: openbao_aws_engine_enabled
+
+- name: Read the expected SHA256 for the AWS plugin tarball
+  ansible.builtin.set_fact:
+    openbao_aws_plugin_sha256: >-
+      {{ (lookup('file', '/tmp/openbao-' ~ openbao_aws_plugin_release_tag ~ '-checksums.txt')
+          | regex_search('([0-9a-f]{64})\s+' ~ (openbao_aws_plugin_tarball | regex_escape), '\1')
+          | first) }}
+  run_once: true
+  when: openbao_aws_engine_enabled
+
+- name: Assert a checksum was found for the AWS plugin tarball
+  ansible.builtin.assert:
+    that:
+      - openbao_aws_plugin_sha256 is defined
+      - openbao_aws_plugin_sha256 | length == 64
+    fail_msg: >-
+      Could not find a SHA256 for {{ openbao_aws_plugin_tarball }} in the
+      upstream checksums file. Did the asset naming change for
+      {{ openbao_aws_plugin_release_tag }}?
+  run_once: true
+  when: openbao_aws_engine_enabled
+
+- name: Stage the AWS plugin tarball on controller (checksum-verified)
+  ansible.builtin.get_url:
+    url: "{{ openbao_aws_plugin_tarball_url }}"
+    dest: "/tmp/{{ openbao_aws_plugin_tarball }}"
+    checksum: "sha256:{{ openbao_aws_plugin_sha256 }}"
+    mode: "0644"
+    force: true
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  run_once: true
+  when: openbao_aws_engine_enabled
+
+- name: Extract the AWS plugin binary into the plugin directory
+  ansible.builtin.unarchive:
+    src: "/tmp/{{ openbao_aws_plugin_tarball }}"
+    dest: "{{ openbao_plugin_dir }}"
+    include:
+      - "{{ openbao_aws_plugin_binary }}"
+    owner: root
+    group: "{{ openbao_group }}"
+    mode: "0750"
+  when: openbao_aws_engine_enabled
+
 # --- Phase 6: configuration --------------------------------------------------
 - name: Render OpenBao server config
   ansible.builtin.template:

--- a/roles/openbao/templates/openbao.hcl.j2
+++ b/roles/openbao/templates/openbao.hcl.j2
@@ -47,6 +47,13 @@ listener "tcp" {
 api_addr     = "{{ openbao_api_addr }}"
 cluster_addr = "{{ openbao_cluster_addr }}"
 
+# External plugins (e.g. the AWS secrets engine, which is NOT builtin to
+# OpenBao). Binaries are staged here by the role (checksum-verified, from the
+# controller) and registered in the catalog by init.yml. The directory always
+# exists (main.yml creates it) — OpenBao refuses to start if this path is set
+# but absent.
+plugin_directory = "{{ openbao_plugin_dir }}"
+
 # OpenBao 2.x dropped mlock support entirely — any `disable_mlock` line is a
 # fatal config error since 2.5 (the server refuses to start). Swap hygiene is
 # the host's job instead: the OpenBao LXCs carry memory_swap = 0 in

--- a/roles/openbao/templates/terraform-apply-policy.hcl.j2
+++ b/roles/openbao/templates/terraform-apply-policy.hcl.j2
@@ -7,6 +7,11 @@
 # kept separate because Terrakube executes untrusted VCS-driven plans and
 # must never be able to read or rewrite the infra kernel. KV v2 splits data
 # and metadata paths, so both are listed explicitly.
+#
+# Plus: dynamic AWS STS creds for role/tf-proxmox (the AWS secrets engine,
+# assumed_role type) — replaces the laptop's static aws-vault base key. "read"
+# generates a new lease; "update" is required by some OpenBao/Vault client
+# libraries that issue the STS request as a write against aws/sts/:role.
 
 {% for sub in ['infra', openbao_homelab_path] %}
 path "{{ openbao_kv_mount }}/data/{{ sub }}/*" {
@@ -35,4 +40,10 @@ path "{{ openbao_kv_mount }}/data/apps/nautobot/*" {
 
 path "{{ openbao_kv_mount }}/metadata/apps/nautobot/*" {
   capabilities = ["read", "list"]
+}
+
+# Dynamic AWS STS creds for role/tf-proxmox — replaces the laptop's static
+# aws-vault base key.
+path "{{ openbao_aws_mount }}/sts/{{ openbao_aws_role_name }}" {
+  capabilities = ["read", "update"]
 }


### PR DESCRIPTION
## What

Add an OpenBao **AWS secrets engine** (`assumed_role`) so the `tf-proxmox`
workstation profile can obtain short-lived STS credentials on demand instead of
holding a static base-user key. A leaked workstation credential then expires on
its own within the hour.

## Changes (`roles/openbao`)

- **`defaults/main.yml`** — AWS-engine + external-plugin staging vars
  (`openbao_aws_*`, `openbao_plugin_dir`, pinned plugin version/tarball/checksum
  URLs). Root key and role ARN come from env (`lookup('env', ...)`), never
  hardcoded.
- **`tasks/main.yml`** — controller-staged, checksum-verified download of the
  prebuilt plugin binary onto **every** node, extracted into `plugin_directory`
  (0750 root-owned). Same WAN-firewall staging pattern the role already uses for
  the server package.
- **`tasks/init.yml`** — register the plugin sha256-pinned, `secrets enable aws`,
  write `config/root` **write-once** (a routine converge never rotates it), and
  create `roles/tf-proxmox`. If the engine is mounted but unconfigured **and** the
  root-key env is empty, it fails loudly rather than leaving a dead engine.
- **`templates/openbao.hcl.j2`** — `plugin_directory` (the AWS engine is an
  external plugin; OpenBao dropped the builtin at the Vault fork).
- **`templates/terraform-apply-policy.hcl.j2`** — grant `terraform-apply`
  read+update on `aws/sts/tf-proxmox`.
- **`molecule/openbao/verify.yml`** — assert `plugin_directory` renders, the
  staged binary is root-owned 0750, and the policy carries the `aws/sts` grant.
- **`AGENTS.md`** — the secrets-architecture narrative moves to the docs site;
  only operational reality stays here.

## Notes

- The consumer side (workstation `credential_process` wrapper + `~/.aws/config`)
  lands in the nix-darwin / nix-home PRs.
- `config/root` still holds one long-lived base-user key server-side — the
  irreducible static credential. Dynamic STS bounds its *use*, not its existence.
- Plugin upgrades are deliberately manual (re-register new sha256 +
  `bao plugin reload`), documented in `roles/openbao/README.md`.

## Test

- `ansible-lint roles/openbao/` — passes (production profile, 0 failures).
- Live converge + end-to-end STS verification are gated on the operator (needs an
  admin token and the Doppler tier-0 root key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gb6NwqwMGy3kW3Bf9kR13R
