### PR TITLE
fix(addressing): FQDN-first — eliminate IP variables from configs

### DIFF
--- a/.claude/rules/ip-addressing.md
+++ b/.claude/rules/ip-addressing.md
@@ -12,11 +12,15 @@ constants. This repository CONSUMES values, never DEFINES them.
 
 ## Prohibited Patterns
 
-Never hardcode IPs or port numbers in role defaults or tasks:
+Never hardcode IPs or port numbers in role defaults or tasks, and never wire
+an app config to an IP-valued variable when a name exists:
 
 ```yaml
 # BAD - hardcoded IP with fallback
 splunk_host: "{{ hostvars['splunk'].ansible_host | default('<any-ip>') }}"
+
+# BAD - IP-valued hostvar in an app config (the address belongs to DNS)
+ntfy_host: "{{ hostvars['ntfy']['container_ip'] }}"
 
 # BAD - hardcoded port
 splunk_hec_port: <some-port-number>
@@ -29,12 +33,18 @@ syslog_ports:
 
 ## Required Patterns
 
+Configs reference services **by FQDN, never by address** — see
+[docs/IP_AUTHORITY.md](../../docs/IP_AUTHORITY.md) for the full model and the
+short list of legitimate IP consumers (the DNS-record tier itself).
 `load_tofu.yml` delegates `tofu_data` to all inventory hosts, so
 roles can reference it directly:
 
 ```yaml
-# GOOD - IP from inventory (no fallback)
-splunk_ip: "{{ hostvars['splunk']['ansible_host'] }}"
+# GOOD - Traefik-fronted service, by name (port 443 implied)
+ntfy_url: "https://ntfy.{{ tofu_data.domain }}/topic"
+
+# GOOD - non-fronted guest, by name + tofu constant port
+splunk_host: "splunk.{{ tofu_data.domain }}"
 
 # GOOD - port from tofu constants
 splunk_hec_port: "{{ tofu_data.constants.service_ports.splunk_hec }}"

--- a/docs/IP_AUTHORITY.md
+++ b/docs/IP_AUTHORITY.md
@@ -46,10 +46,45 @@ Every guest in `tofu_inventory.json` is described by three addressing fields
 | `reserved_ip` | `null` | the UniFi DHCP **reservation** address (what DNS A records point at) |
 
 `inventory/load_tofu.yml` surfaces `container_ip` (= `ip`) and
-`container_reserved_ip` (= `reserved_ip`) as hostvars. Consumers that need a
-literal address prefer `reserved_ip`, then `ip`, then the peer's
-`container_ip` — and now stop there (no loopback tail). Consumers that can use a
-name resolve the FQDN through Technitium/Traefik instead of any literal.
+`container_reserved_ip` (= `reserved_ip`) as hostvars — but these exist for
+the **DNS tier only**. Application configs never consume them.
+
+## Consumers use FQDNs, full stop
+
+App configuration references services **by name, never by address**:
+
+- **Traefik-fronted service** (has a row in the upstream ingress table):
+  `https://<name>.{{ tofu_data.domain }}` — port 443, TLS via the wildcard
+  cert. The name resolves to the ingress; the backend address is Traefik's
+  concern, not the consumer's.
+- **Non-fronted guest**: `<hostname>.{{ tofu_data.domain }}` plus the port
+  from `tofu_data.constants` — the per-guest A record Technitium builds from
+  the inventory.
+- `{{ tofu_data.domain }}` is the **single domain source of truth**
+  (published by terraform-proxmox, validated non-empty by
+  `inventory/load_tofu.yml`). Never repeat a literal domain per role.
+- Hostnames **match the app/role/stanza name**. Never invent a third name.
+
+The bring-up order guarantees names work before any role converges:
+IaC creates the guest (deterministic MAC) → UniFi gets the reservation →
+Technitium gets the A record → the role converges by FQDN.
+
+### Where IP-valued variables are still legitimate
+
+1. **`roles/technitium_dns`** — builds the A records themselves. The DNS
+   record is the one place an IP belongs; `container_reserved_ip` /
+   `container_ip` exist for this consumer.
+2. **The IPAM tier** (`roles/nautobot` seed prefixes/CIDRs) — IPAM stores
+   addresses by definition. It feeds DNS records, never app configs.
+3. **`roles/download_vpn` ntfy alert target** — documented exception: the
+   guest resolves through the VPN tunnel, so internal FQDNs do not resolve,
+   and the killswitch alert must work exactly when the tunnel is down.
+   Removed once split-DNS lands inside that container (#870).
+
+Anything else that dereferences `container_ip` / `container_reserved_ip` /
+`tofu_data.containers[*].ip|reserved_ip` in a role is a defect to migrate —
+tracked in #871 (the configarr/servarr_wiring cascades are the largest
+remainder). Name-based SMTP for the Traefik-fronted mailpit is #872.
 
 ## Static-anchor policy
 
@@ -75,14 +110,8 @@ upstream. Track them there:
 1. **Convert non-anchor guests to DHCP-first**: for each guest that is not a
    static anchor, drop the static IPv4, and give it a deterministic `mac`, an
    FQDN, and a `reserved_host` so the export emits `reserved_ip`. Keep only the
-   anchors static.
-2. **Publish the missing constants** so this repo can drop the remaining port
-   `default()` fallbacks (kept for now precisely because these are absent):
-   `service_ports.{openbao_api, satellite_exporter, smokeping_prober,
-   prometheus_web, blackbox_exporter, mssql}`, `ingress_ports.keepalived_vrid`,
-   and the `syslog_port_map.{dns_query, macos}` families. Add each to
-   `pipeline_constants`, `terragrunt apply`, then this repo removes the matching
-   `| default(...)` and adds the constant to the CI fixture.
+   anchors static. App configs in this repo are unaffected either way — they
+   reference the FQDN, and only the DNS record's target changes.
 
 ### tofu-unifi (`fixed-ips.json`)
 

--- a/molecule/download_vpn/converge.yml
+++ b/molecule/download_vpn/converge.yml
@@ -17,8 +17,9 @@
     container_ip: "192.168.0.210"
     # ntfy peer host isn't part of this single-container scenario; pin the
     # alert URL so the killswitch validator template renders without a
-    # hostvars['ntfy'] lookup (mirrors molecule/openbao's override).
-    download_vpn_ntfy_url: "http://192.168.0.222:8080/killswitch"
+    # hostvars['ntfy'] lookup (mirrors molecule/openbao's override). Name-valued
+    # like every fixture — no IP literals outside the inventory fixture itself.
+    download_vpn_ntfy_url: "http://ntfy.test:8080/killswitch"
     tofu_data:
       constants:
         media_ports:

--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -322,9 +322,17 @@ download_vpn_natpmp_refresh_seconds: 45
 # systemd timer cadence for the fail-closed validator. On ANY breach it stops
 # qBittorrent and alerts (ntfy + healthchecks deadman).
 download_vpn_validator_interval: "2min"
-# ntfy alert target. Reuses the repo's ntfy LXC + push topic convention. Shared
-# by the runtime killswitch validator above AND the persistent-storage guards
-# in tasks/main.yml (Phase 2b) — both are fail-loud, alert-then-refuse gates.
+# ntfy alert target. Shared by the runtime killswitch validator above AND the
+# persistent-storage guards in tasks/main.yml (Phase 2b) — both are fail-loud,
+# alert-then-refuse gates.
+#
+# DOCUMENTED EXCEPTION to FQDN-first (2026-07-12): this guest's resolver goes
+# through the Proton VPN tunnel, so internal FQDNs do not resolve — and the
+# killswitch alert must reach ntfy over the LAN exactly when the tunnel is
+# DOWN. Until split-DNS (internal zone -> Technitium) exists inside this
+# container, the target stays a routable IP from the inventory (reservation
+# address first, static ip otherwise). Flip to https://ntfy.<domain> only
+# after the split-DNS follow-up (#870) lands.
 download_vpn_ntfy_url: >-
   http://{{ hostvars['ntfy']['container_reserved_ip'] | default(hostvars['ntfy']['container_ip'], true) }}:{{
   tofu_data.constants.notification_ports.ntfy_http }}/{{ download_vpn_ntfy_topic }}

--- a/roles/healthchecks_docker/defaults/main.yml
+++ b/roles/healthchecks_docker/defaults/main.yml
@@ -24,20 +24,22 @@ healthchecks_docker_db_path: /data/hc.sqlite
 healthchecks_docker_allowed_hosts: "*"
 
 # Base URL the UI emits in ping links — must be reachable from the Mac.
-# Override per-inventory to your internal domain. Default keeps the IP form
-# so the role works on a fresh LXC before DNS is wired.
+# FQDN-first: this guest's own DNS name (`hostname` fact from load_tofu.yml,
+# suffixed with the single tofu-published domain). Bring-up order guarantees
+# the DNS record exists before this role converges (reservation -> A record
+# -> converge), so no IP form is needed.
 healthchecks_docker_site_root: >-
-  http://{{ hostvars[inventory_hostname]['container_reserved_ip']
-  | default(hostvars[inventory_hostname]['container_ip'], true) }}:{{
-  healthchecks_docker_http_port }}
+  http://{{ hostname }}.{{ tofu_data.domain }}:{{ healthchecks_docker_http_port }}
 healthchecks_docker_site_name: "Healthchecks (homelab)"
 
-# Email delivery. Defaults wire to Mailpit LXC (already in this repo) so
+# Email delivery. Defaults wire to the Mailpit LXC (already in this repo) so
 # alerts land in the developer Mailpit UI without extra config. Override
 # per-inventory to use a real SMTP server when you want alerts to leave
-# the LAN.
-healthchecks_docker_email_host: >-
-  {{ hostvars['mailpit']['container_ip'] }}
+# the LAN. FQDN-first, matching the zammad role's mailpit derivation. NOTE:
+# mailpit's name currently resolves to the Traefik ingress, which has no TCP
+# entrypoint for SMTP — name-based SMTP needs the ingress TCP route (#872)
+# before delivery works end-to-end.
+healthchecks_docker_email_host: "mailpit.{{ tofu_data.domain }}"
 healthchecks_docker_email_port: 1025
 healthchecks_docker_email_use_tls: false
 healthchecks_docker_email_host_user: ""

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -451,11 +451,9 @@ hermes_agent_brain_watchdog_probe_timeout: 15
 # watchdog never becomes a new source of spam; up_after=2 damps flapping.
 hermes_agent_brain_watchdog_down_after: 3
 hermes_agent_brain_watchdog_up_after: 2
-# Urgent page target. Same ntfy LXC + notification port + topic service_deadman
-# pages on ("same feed as other homelab outages", operator decision) — the brain
-# is now a keystone. Port is single-sourced from tofu constants; host from the
-# ntfy inventory entry (fail loud if the ntfy guest is absent from inventory).
+# Urgent page target. Same topic service_deadman pages on ("same feed as other
+# homelab outages", operator decision) — the brain is now a keystone.
+# FQDN-first: the Traefik-fronted ntfy service name; DHCP/DNS own the address.
 hermes_agent_brain_watchdog_ntfy_topic: "keystone"
 hermes_agent_brain_watchdog_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] }}:{{
-  tofu_data.constants.notification_ports.ntfy_http }}/{{ hermes_agent_brain_watchdog_ntfy_topic }}
+  https://ntfy.{{ tofu_data.domain }}/{{ hermes_agent_brain_watchdog_ntfy_topic }}

--- a/roles/media_monitor/defaults/main.yml
+++ b/roles/media_monitor/defaults/main.yml
@@ -43,8 +43,7 @@ media_monitor_state_dir: /var/lib/media-playback-monitor
 media_monitor_probe_state_dir: "{{ media_monitor_state_dir }}"
 media_monitor_audit_log: "{{ media_monitor_state_dir }}/codec-audit.log"
 
-# ntfy alert target. Reuses the repo ntfy LXC + notification-port convention.
+# ntfy alert target — FQDN-first: the Traefik-fronted service name.
 media_monitor_ntfy_topic: media
 media_monitor_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] }}:{{
-  tofu_data.constants.notification_ports.ntfy_http }}/{{ media_monitor_ntfy_topic }}
+  https://ntfy.{{ tofu_data.domain }}/{{ media_monitor_ntfy_topic }}

--- a/roles/media_remux/defaults/main.yml
+++ b/roles/media_remux/defaults/main.yml
@@ -29,9 +29,8 @@ media_remux_bitrate: 640k
 # passthrough handshake is the original fault this guard exists to prevent.
 media_remux_compatible_codecs_re: '^(ac3|aac)$'
 
-# ntfy alert target on remux failure. Mirrors the sonarr role's ntfy derivation
-# (repo ntfy LXC + notification-port convention).
+# ntfy alert target on remux failure — FQDN-first: the Traefik-fronted
+# service name (mirrors the sonarr role's derivation).
 media_remux_ntfy_topic: media
 media_remux_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] }}:{{
-  tofu_data.constants.notification_ports.ntfy_http }}/{{ media_remux_ntfy_topic }}
+  https://ntfy.{{ tofu_data.domain }}/{{ media_remux_ntfy_topic }}

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -346,11 +346,10 @@ openbao_snapshot_service_name: openbao-snapshot
 # converge stays green (see the include guard in tasks/main.yml).
 openbao_snapshot_role_id: "{{ lookup('env', 'OPENBAO_SNAPSHOT_ROLE_ID') | default('', true) }}"
 openbao_snapshot_secret_id: "{{ lookup('env', 'OPENBAO_SNAPSHOT_SECRET_ID') | default('', true) }}"
-# ntfy alert target (reuses the repo's ntfy LXC + notification-port convention,
-# matching service_deadman). Topic 'openbao'.
+# ntfy alert target — FQDN-first: the Traefik-fronted service name
+# (matching service_deadman). Topic 'openbao'.
 openbao_snapshot_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] }}:{{
-  tofu_data.constants.notification_ports.ntfy_http }}/openbao
+  https://ntfy.{{ tofu_data.domain }}/openbao
 # healthchecks deadman ping URL for the snapshot job; EMPTY => ping skipped
 # (ntfy + journal alert still fire). Set per-node from the healthchecks LXC.
 openbao_snapshot_healthcheck_url: "{{ lookup('env', 'OPENBAO_SNAPSHOT_HC_URL') | default('', true) }}"

--- a/roles/plex/defaults/main.yml
+++ b/roles/plex/defaults/main.yml
@@ -78,11 +78,10 @@ plex_apt_repo: "deb [signed-by={{ plex_apt_keyring_path }}] https://repo.plex.tv
 plex_package: plexmediaserver
 plex_manage_services: true
 
-# ntfy alert target for the persistent-mount guard (tasks/main.yml). Mirrors
-# the repo's ntfy LXC + push topic convention (see download_vpn/service_deadman).
+# ntfy alert target for the persistent-mount guard (tasks/main.yml) —
+# FQDN-first: the Traefik-fronted service name (see service_deadman).
 plex_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] }}:{{
-  tofu_data.constants.notification_ports.ntfy_http }}/{{ plex_ntfy_topic }}
+  https://ntfy.{{ tofu_data.domain }}/{{ plex_ntfy_topic }}
 plex_ntfy_topic: "persistence"
 
 # Publish the server to plex.tv so account-based clients (the Plex app on Roku,

--- a/roles/radarr/defaults/main.yml
+++ b/roles/radarr/defaults/main.yml
@@ -33,9 +33,8 @@ radarr_api_key: "{{ lookup('env', 'RADARR_API_KEY') | default('', true) }}"
 radarr_auth_method: External
 radarr_auth_required: DisabledForLocalAddresses
 
-# ntfy alert target for the persistent-mount guard (tasks/main.yml). Mirrors
-# the repo's ntfy LXC + push topic convention (see download_vpn/service_deadman).
+# ntfy alert target for the persistent-mount guard (tasks/main.yml) —
+# FQDN-first: the Traefik-fronted service name (see service_deadman).
 radarr_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] }}:{{
-  tofu_data.constants.notification_ports.ntfy_http }}/{{ radarr_ntfy_topic }}
+  https://ntfy.{{ tofu_data.domain }}/{{ radarr_ntfy_topic }}
 radarr_ntfy_topic: "persistence"

--- a/roles/seerr/defaults/main.yml
+++ b/roles/seerr/defaults/main.yml
@@ -105,9 +105,8 @@ seerr_application_url: >-
 # need a running container. The live deploy leaves it true.
 seerr_manage_services: true
 
-# ntfy alert target for the persistent-mount guard (tasks/main.yml). Mirrors
-# the repo's ntfy LXC + push topic convention (see download_vpn/service_deadman).
+# ntfy alert target for the persistent-mount guard (tasks/main.yml) —
+# FQDN-first: the Traefik-fronted service name (see service_deadman).
 seerr_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] }}:{{
-  tofu_data.constants.notification_ports.ntfy_http }}/{{ seerr_ntfy_topic }}
+  https://ntfy.{{ tofu_data.domain }}/{{ seerr_ntfy_topic }}
 seerr_ntfy_topic: "persistence"

--- a/roles/service_deadman/defaults/main.yml
+++ b/roles/service_deadman/defaults/main.yml
@@ -14,10 +14,11 @@
 # systemd timer cadence (OnUnitActiveSec). Deadman semantics rely on regular runs.
 service_deadman_interval: "60s"
 
-# ntfy alert target. Reuses the repo's ntfy LXC + notification-port convention.
+# ntfy alert target — FQDN-first: the Traefik-fronted service name
+# (https://ntfy.<domain>), never an IP-valued hostvar. DHCP/DNS own the
+# address; this config only ever knows the name.
 service_deadman_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] }}:{{
-  tofu_data.constants.notification_ports.ntfy_http }}/{{ service_deadman_ntfy_topic }}
+  https://ntfy.{{ tofu_data.domain }}/{{ service_deadman_ntfy_topic }}
 service_deadman_ntfy_topic: "keystone"
 
 # Per-group keystone checks. The role selects every check whose group this host

--- a/roles/sonarr/defaults/main.yml
+++ b/roles/sonarr/defaults/main.yml
@@ -33,9 +33,8 @@ sonarr_api_key: "{{ lookup('env', 'SONARR_API_KEY') | default('', true) }}"
 sonarr_auth_method: External
 sonarr_auth_required: DisabledForLocalAddresses
 
-# ntfy alert target for the persistent-mount guard (tasks/main.yml). Mirrors
-# the repo's ntfy LXC + push topic convention (see download_vpn/service_deadman).
+# ntfy alert target for the persistent-mount guard (tasks/main.yml) —
+# FQDN-first: the Traefik-fronted service name (see service_deadman).
 sonarr_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] }}:{{
-  tofu_data.constants.notification_ports.ntfy_http }}/{{ sonarr_ntfy_topic }}
+  https://ntfy.{{ tofu_data.domain }}/{{ sonarr_ntfy_topic }}
 sonarr_ntfy_topic: "persistence"

--- a/roles/sortarr/defaults/main.yml
+++ b/roles/sortarr/defaults/main.yml
@@ -81,11 +81,10 @@ sortarr_waitress_trusted_proxy: "traefik"
 # leaves it true.
 sortarr_manage_services: true
 
-# ntfy alert target for the persistent-mount guard (tasks/main.yml). Mirrors
-# the seerr/download_vpn/service_deadman convention.
+# ntfy alert target for the persistent-mount guard (tasks/main.yml) —
+# FQDN-first: the Traefik-fronted service name (see service_deadman).
 sortarr_ntfy_url: >-
-  http://{{ hostvars['ntfy']['container_ip'] }}:{{
-  tofu_data.constants.notification_ports.ntfy_http }}/{{ sortarr_ntfy_topic }}
+  https://ntfy.{{ tofu_data.domain }}/{{ sortarr_ntfy_topic }}
 
 # --- Security & Session Persistence -------------------------------------------
 # Sourced from the Doppler/SOPS environment if present, otherwise generated


### PR DESCRIPTION
Corrective follow-up to #866. That PR reduced hard-coded addressing but kept injecting **IP-valued variables** into application configs — and in two places regressed to *preferring* the raw reservation address. The standing rule is stronger: **configs reference services by hostname/FQDN only, parameterized; DHCP + DNS own the IP entirely; the only place an IP belongs is the DNS record itself; Traefik fronts services by name.**

## Violation catalog (what #866 left or introduced)

| File | Variable | Problem | FQDN-first replacement |
| --- | --- | --- | --- |
| roles/{hermes_agent,media_monitor,media_remux,openbao,plex,radarr,seerr,service_deadman,sonarr,sortarr}/defaults | `*_ntfy_url` | `http://{{ hostvars['ntfy']['container_ip'] }}:<port>` — an IPv4 literal for today's static ntfy guest | `https://ntfy.{{ tofu_data.domain }}/<topic>` — the Traefik-fronted service name; port + hostvars indirection drop out |
| roles/healthchecks_docker/defaults | `site_root` | **#866 regression**: switched to *prefer* `container_reserved_ip` ("works before DNS is wired") | `http://{{ hostname }}.{{ tofu_data.domain }}:<port>` — the bring-up order (reservation → DNS record → converge by FQDN) guarantees the name exists first |
| roles/healthchecks_docker/defaults | `email_host` | `hostvars['mailpit']['container_ip']` | `mailpit.{{ tofu_data.domain }}` (matches zammad) — end-to-end SMTP needs #872, see Exceptions |
| roles/download_vpn/defaults | `download_vpn_ntfy_url` | **#866 regression**: switched to prefer `container_reserved_ip` | Kept, as the one documented exception (below), now with an explicit dated comment + #870 |
| molecule/download_vpn/converge.yml | `download_vpn_ntfy_url` pin | New raw IP literal in a fixture | Name-valued pin (`ntfy.test`) |
| roles/{configarr,servarr_wiring,sortarr,seerr,...}/defaults | `reserved_ip → ip → container_ip` cascades | Pre-existing; #866 trimmed the loopback tail but kept the IP-first cascade | Deferred to #871 (entangled: these *arr services are Traefik-fronted, so migration means moving ~20 inter-service API URLs to `https://<name>.<domain>`, including baseUrls stored inside Prowlarr) |

## The model (now written down in docs/IP_AUTHORITY.md + .claude/rules/ip-addressing.md)

- **Traefik-fronted service** → `https://<name>.{{ tofu_data.domain }}` (443, wildcard TLS). The backend address is Traefik's concern, never the consumer's.
- **Non-fronted guest** → `<hostname>.{{ tofu_data.domain }}` + port from `tofu_data.constants`.
- `tofu_data.domain` is the **single domain source of truth** (published upstream, validated non-empty by `inventory/load_tofu.yml`); hostnames match the app/role name — no third names, no per-role domain literals.
- Nautobot/IPAM and the DHCP reservations feed **DNS records** — never application configs. `container_ip` / `container_reserved_ip` exist for the DNS tier (`roles/technitium_dns`) only.

## Legitimate exceptions (each explicit, each tracked)

1. **`roles/technitium_dns`** — builds the A records; the one place an IP belongs. Untouched.
2. **Nautobot seed prefixes/CIDRs** — IPAM stores addresses by definition. Untouched.
3. **`roles/download_vpn` ntfy target** — the guest resolves through the Proton tunnel, so internal FQDNs don't resolve, and the killswitch alert must reach ntfy over LAN exactly when the tunnel is DOWN. Flipping it blind would kill the alert precisely when it matters. Stays IP-valued until split-DNS lands: #870.

## Known trade-offs (called out, not hidden)

- Alert paths (`service_deadman` keystone, hermes watchdog) now traverse DNS + Traefik. That is the standing "Traefik always" convention; if ingress/DNS themselves die, the deadman *ping* absence (healthchecks) still fires.
- `mailpit.<domain>` currently resolves to Traefik, which has no SMTP TCP entrypoint — healthchecks/zammad email delivery is blocked on #872 (it was equally unwired for zammad before this PR).

## Follow-ups filed

- #870 — download_vpn split-DNS, then flip the last exception to FQDN.
- #871 — migrate the remaining IP-variable consumers (configarr/servarr_wiring first) + CI guard so the pattern cannot regrow.
- #872 — name-based SMTP path for mailpit (ingress TCP entrypoint).
- dryvist/tofu-proxmox#630 — retire the dual-typed `ip` contract field.

## Verification

- `ansible-lint`: 0 failures / 0 warnings on 789 files (production profile).
- `pre-commit` on all changed files: all hooks pass (repo-wide `--all-files` markdownlint failures on vendored `.github/aw/imports` are pre-existing on `develop`, verified via stash).
- Molecule impact checked: no scenario renders the changed ntfy defaults (verified by #866's own fallback removal passing CI); download_vpn's unconditionally-rendered pin stays, now name-valued.

Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nw6KWXN6S7k13w2xAhRZb3