### PR TITLE
feat(hermes_agent): cap inbound job-API concurrency from the measured envelope

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,9 +27,12 @@ repos:
         files: \.(yaml|yml)$
         pass_filenames: false
 
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.48.0
+  # markdownlint-cli2, not markdownlint-cli: the repo's canonical markdown
+  # config is .markdownlint-cli2.yaml (auto-discovered; line_length 160 +
+  # CHANGELOG.md in its `ignores`). The previous markdownlint-cli hook pointed
+  # at a .markdownlint.json that does not exist, so it linted with built-in
+  # defaults (line_length 80) and failed on files the canonical config passes.
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.23.0
     hooks:
-      - id: markdownlint
-        args: [--config, .markdownlint.json]
-        exclude: ^CHANGELOG\.md$
+      - id: markdownlint-cli2

--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -236,6 +236,14 @@ are pre-declared event triggers, this is arbitrary job submission. The
 post-converge gate probes `/health` and asserts a keyless `POST /v1/runs`
 is refused with 401.
 
+Concurrency is capped (`hermes_agent_api_max_concurrent_runs`, rendered as
+`gateway.api_server.max_concurrent_runs`): the brain is one shared serving
+deployment the cron fleet already uses, so over-cap submissions get
+`429 + Retry-After` at the door instead of stacking prefills on the GPU.
+Upstream already provides per-run `cancelled` state and `POST
+/v1/runs/{run_id}/stop`; idempotency keys and a priority queue on `/v1/runs`
+are upstream feature gaps tracked as a build-out issue, not role config.
+
 ## Brain-health watchdog (no cron-failure spam)
 
 The cron fleet above talks to a **single-deployment brain** (`ai-default`, served

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -183,6 +183,18 @@ hermes_agent_api_server_host: "0.0.0.0"
 hermes_agent_api_server_port: >-
   {{ hostvars['localhost']['tofu_data']['constants']['service_ports']['hermes_api']
      | mandatory('tofu_data.constants.service_ports.hermes_api missing — regenerate tofu_inventory.json') }}
+# Queue hardening: cap in-flight agent runs across ALL of the platform's
+# agent-serving endpoints (/v1/runs, /v1/chat/completions, /v1/responses).
+# Upstream reads this from config.yaml (gateway.api_server.max_concurrent_runs)
+# and refuses over-cap submissions with 429 + Retry-After — the submitter
+# retries, nothing stacks unbounded prefills on the shared brain. Upstream's
+# default (10) is sized for cloud brains; ours is a SINGLE serving deployment
+# the cron fleet already shares, and the serving tier runs one stream well
+# but does not batch (measured 2-stream aggregate ~0.71x of single-stream,
+# 2026-07-11 bench). 2 = one operator submission + one background/curriculum
+# run in flight; anything more waits at the door, not in the GPU queue.
+# 0 would disable the cap entirely — assert.yml forbids that.
+hermes_agent_api_max_concurrent_runs: 2
 
 # --- Memory: best self-hostable as of June 2026 (Agy-validated) ---
 # Hindsight: local knowledge-graph + multi-strategy retrieval. Runs alongside the

--- a/roles/hermes_agent/tasks/assert.yml
+++ b/roles/hermes_agent/tasks/assert.yml
@@ -27,6 +27,12 @@
       #     the outermost link (nix-darwin vllm-mlx server guard, 3600s) lives
       #     out of this repo's reach and is not assertable here.
       - hermes_agent_stream_read_timeout | int < ai_router_request_timeout_seconds | int
+      # (4) Job-API concurrency cap must be a real cap. Upstream treats 0 as
+      #     "cap disabled" — on a single shared serving deployment that means
+      #     an unbounded request flood lands directly on the brain, which is
+      #     exactly what the cap exists to prevent. Negative values clamp to
+      #     0 upstream, so they are equally forbidden.
+      - hermes_agent_api_max_concurrent_runs | int >= 1
     fail_msg: >-
       Hermes Agent brain-wiring contract violated (roles/hermes_agent/tasks/assert.yml).
       (1) model.context_length is {{ hermes_agent_model_context_length }}; it must be
@@ -36,7 +42,11 @@
       per-attempt timeout is {{ ai_router_request_timeout_seconds }}; read must be < router
       so the client decides (chain: hermes read < router attempt < nix-darwin server
       guard 3600). Fix the offending value in all.yml / roles/hermes_agent/defaults.
+      (4) hermes_agent_api_max_concurrent_runs is
+      {{ hermes_agent_api_max_concurrent_runs }}; it must be >= 1 — 0 disables the
+      upstream cap entirely and exposes the single shared brain to request floods.
     success_msg: >-
       Hermes Agent brain-wiring contracts hold (context_length
       {{ hermes_agent_model_context_length }} >= 64000; read
-      {{ hermes_agent_stream_read_timeout }} < router {{ ai_router_request_timeout_seconds }}).
+      {{ hermes_agent_stream_read_timeout }} < router {{ ai_router_request_timeout_seconds }};
+      api cap {{ hermes_agent_api_max_concurrent_runs }} >= 1).

--- a/roles/hermes_agent/templates/config.yaml.j2
+++ b/roles/hermes_agent/templates/config.yaml.j2
@@ -71,6 +71,17 @@ plugins:
   enabled:
     - observability/otel
 
+{% if hermes_agent_api_server_key | length > 0 %}
+# Inbound job-submission API queue hardening. The platform itself is enabled by
+# key presence via the .env bridge (API_SERVER_* in hermes-env.j2); this caps
+# in-flight agent runs across all its agent-serving endpoints. Over-cap
+# submissions are refused up front (429 + Retry-After) instead of stacking
+# prefills on the single shared serving deployment — see defaults/main.yml
+# for the measured-envelope rationale behind the value.
+gateway:
+  api_server:
+    max_concurrent_runs: {{ hermes_agent_api_max_concurrent_runs }}
+{% endif %}
 {% set _slack_on = hermes_agent_slack_bot_token | length > 0 %}
 {% set _webhook_on = (hermes_agent_webhook_enabled | bool) and (hermes_agent_webhook_secret | length > 0) %}
 {% if _slack_on or _webhook_on %}


### PR DESCRIPTION
## What

Job-queue hardening for the merged inbound job-submission API (`api_server` platform, #861), per the Hermes blueprint's job-api hardening list:

- Render `gateway.api_server.max_concurrent_runs` into `config.yaml`, gated on the same key-presence contract as the platform itself (`hermes_agent_api_max_concurrent_runs`, default 2).
- Rationale as data: the brain is one shared serving deployment the cron fleet already uses, and the serving tier does not batch (measured 2-stream aggregate ~0.71x of single-stream). Upstream's default cap (10) is sized for cloud brains. Over-cap submissions are refused with `429 + Retry-After` at the door instead of stacking prefills on the GPU.
- Layer-1 assert (`tasks/assert.yml`) forbids a value of 0 — upstream treats 0 as "cap disabled", which would expose the single brain to unbounded request floods.
- README documents the cap and the intentional boundary: upstream (pinned v2026.7.7.2) already ships per-run `cancelled` state and `POST /v1/runs/{run_id}/stop`; Idempotency-Key and a priority queue on `/v1/runs` are upstream feature gaps tracked as a build-out issue, not role config.

Also fixes the broken pre-commit markdown hook (own commit): it pointed at a nonexistent `.markdownlint.json` and linted with 80-col defaults, failing files the canonical `.markdownlint-cli2.yaml` passes. Switched to `markdownlint-cli2`, which auto-discovers that config.

## Test evidence

- `ansible-lint roles/hermes_agent/`: 0 failures, 0 warnings (production profile).
- Template render smoke: `config.yaml.j2` rendered with representative vars both with and without the API key, output YAML-parsed; `gateway.api_server.max_concurrent_runs` present (=2) only when the key is set.
- `pre-commit run` on all changed files: all hooks pass (including the repaired markdownlint-cli2 hook).

## Notes

No live converge (AWS-creds cutover in flight) — lands as IaC for the post-cutover apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nw6KWXN6S7k13w2xAhRZb3