### PR TITLE
feat(hermes_agent): runner-enforced per-job-class tool policy (H-17)

### DIFF
--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -272,6 +272,27 @@ every `prompt_file` present in the role, and a non-empty `success_checks`
 list per job. Job ids follow clustered/normal naming (the original
 `night-orient` draft id shipped here as `orient`).
 
+## Runner-enforced tool policy (per job class)
+
+A submitted `input` — and everything a job retrieves while running — is
+untrusted text that can carry prompt injection. The **runner's toolset
+resolution**, not the prompt, decides what each job class may load; injected
+instructions cannot widen a toolset list the runner never registered. Policy
+is plain data in `defaults/main.yml`:
+
+| Layer | Rendered as | Scope |
+| --- | --- | --- |
+| `hermes_agent_disabled_toolsets` | `agent.disabled_toolsets` | Global deny floor; no allowlist can widen past it |
+| `hermes_agent_api_server_toolsets` | `platform_toolsets.api_server` | API-submitted runs (untrusted input) |
+| `hermes_agent_cron_toolsets` | `platform_toolsets.cron` | The scheduled fleet (upstream also hard-blocks cronjob/messaging/clarify in cron) |
+
+The allowlists deliberately exclude `cronjob` (no injected persistence),
+`browser`, `delegation`, and `clarify`; Layer-1 asserts fail the converge if
+any of those creep back in or a denied toolset is simultaneously allowlisted.
+Enabled MCP servers (splunk/context7/codex) layer onto the allowlists by
+upstream's platform-tools semantics. The interactive Slack surface keeps the
+upstream default (operator-driven, allowed-users gate) minus the deny floor.
+
 ## Brain-health watchdog (no cron-failure spam)
 
 The cron fleet above talks to a **single-deployment brain** (`ai-default`, served

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -212,6 +212,62 @@ hermes_agent_memory_llm_model: "{{ ai_default_model }}"
 # --- Safety: cap the agentic loop so a runaway can't pin the GPU overnight ---
 hermes_agent_max_turns: 90
 
+# --- Runner-enforced per-job-class tool policy (H-17) -------------------------
+# The RUNNER (upstream toolset resolution), not the prompt, decides which tools
+# each job class may load — injected text in a job's input can rewrite
+# instructions, but it cannot widen a toolset list the runner never registered.
+# Three layers, all plain data rendered into config.yaml; toolset names are the
+# upstream configurable keys (hermes_cli/tools_config.py CONFIGURABLE_TOOLSETS,
+# verified against the pinned hermes_agent_version):
+#
+#  1. agent.disabled_toolsets — the GLOBAL deny floor. Applies to every agent
+#     the gateway spawns and cannot be widened back by any per-job or
+#     per-platform allowlist (upstream layers it on top of per-job lists —
+#     cron/scheduler.py, upstream #25752). Entries here are capabilities no
+#     job class on this platform uses: media generation/analysis, desktop
+#     control, and messaging/media integrations that are not deployed.
+#  2. platform_toolsets.api_server — allowlist for API-submitted runs. The
+#     API's `input` (and everything a run retrieves) is untrusted text; this
+#     bounds what an injected instruction can reach. Deliberately ABSENT:
+#     `cronjob` (an injected one-off run must not schedule persistent jobs),
+#     `browser` (the widest tool attack surface; the `web` toolset covers
+#     research), `delegation` (cost amplification), and `clarify` (headless).
+#     Enabled MCP servers (splunk/context7/codex) are layered on by upstream's
+#     platform-tools semantics — the allowlist scopes native toolsets only.
+#  3. platform_toolsets.cron — allowlist for the scheduled fleet, same shape.
+#     Upstream additionally hard-disables cronjob/messaging/clarify in every
+#     cron context regardless of this list.
+#
+# The interactive Slack surface is deliberately NOT allowlisted: it is
+# operator-driven (allowed-users gate), so it keeps the upstream platform
+# default minus the global floor. Per-JOB granularity below these classes
+# (e.g. a read-only reposweep run) needs per-job enabled_toolsets, which the
+# CLI seeding path cannot set — tracked as a build-out issue; these platform
+# lists are the enforced envelope every job class runs inside.
+hermes_agent_disabled_toolsets:
+  - image_gen
+  - video_gen
+  - video
+  - tts
+  - x_search
+  - computer_use
+  - homeassistant
+  - spotify
+  - discord
+  - discord_admin
+  - yuanbao
+hermes_agent_api_server_toolsets:
+  - web
+  - terminal
+  - file
+  - code_execution
+  - skills
+  - todo
+  - memory
+  - context_engine
+  - session_search
+hermes_agent_cron_toolsets: "{{ hermes_agent_api_server_toolsets }}"
+
 # Pinned to UTC (workspace policy: no custom timezones), independent of the
 # target host's configured zone.
 hermes_agent_timezone: "UTC"

--- a/roles/hermes_agent/tasks/assert.yml
+++ b/roles/hermes_agent/tasks/assert.yml
@@ -104,3 +104,47 @@
   loop: "{{ hermes_agent_curriculum.jobs }}"
   loop_control:
     label: "{{ item.id }}"
+
+# H-17 tool-policy contracts. Negative regression checks: these confirm the
+# safety net actually excludes what it exists to exclude, so a future edit
+# that quietly re-adds a persistence or injection surface fails the play
+# before the config deploys.
+- name: Assert the runner-enforced tool policy excludes what it must exclude
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      # Both job-class allowlists must be real (non-empty) lists — an empty
+      # allowlist silently falls back to upstream's platform default, which
+      # is the opposite of a policy.
+      - hermes_agent_api_server_toolsets | length > 0
+      - hermes_agent_cron_toolsets | length > 0
+      # An API-submitted (untrusted-input) run must never be able to schedule
+      # persistent jobs, drive a browser, delegate sub-agents, or block on a
+      # clarifying question. Cron gets the same envelope.
+      - >-
+        ['cronjob', 'browser', 'delegation', 'clarify']
+        | intersect(hermes_agent_api_server_toolsets) | length == 0
+      - >-
+        ['cronjob', 'browser', 'delegation', 'clarify']
+        | intersect(hermes_agent_cron_toolsets) | length == 0
+      # A toolset cannot be both globally denied and platform-allowlisted:
+      # upstream resolves that contradiction by silently dropping the tool,
+      # which reads as a mysterious "Unknown tool" at run time. Catch it here.
+      - >-
+        hermes_agent_disabled_toolsets
+        | intersect(hermes_agent_api_server_toolsets) | length == 0
+      - >-
+        hermes_agent_disabled_toolsets
+        | intersect(hermes_agent_cron_toolsets) | length == 0
+    fail_msg: >-
+      Hermes tool-policy contract violated (roles/hermes_agent/tasks/assert.yml).
+      The api_server/cron allowlists must be non-empty, must not contain any of
+      cronjob/browser/delegation/clarify, and must be disjoint from
+      hermes_agent_disabled_toolsets (api_server:
+      {{ hermes_agent_api_server_toolsets }}; cron: {{ hermes_agent_cron_toolsets }};
+      denied: {{ hermes_agent_disabled_toolsets }}). Fix the lists in
+      roles/hermes_agent/defaults/main.yml.
+    success_msg: >-
+      Hermes tool-policy contracts hold ({{ hermes_agent_api_server_toolsets | length }}
+      api_server toolsets, {{ hermes_agent_cron_toolsets | length }} cron toolsets,
+      {{ hermes_agent_disabled_toolsets | length }} globally denied).

--- a/roles/hermes_agent/templates/config.yaml.j2
+++ b/roles/hermes_agent/templates/config.yaml.j2
@@ -43,6 +43,10 @@ memory:
 agent:
   max_turns: {{ hermes_agent_max_turns }}
   tool_use_enforcement: auto
+  # H-17 global deny floor: toolsets NO agent this gateway spawns may load,
+  # regardless of any per-platform or per-job allowlist (upstream layers this
+  # on top — see defaults/main.yml for the policy rationale).
+  disabled_toolsets: {{ hermes_agent_disabled_toolsets | to_json }}
 
 # Local execution backend (the LXC is the blast-radius boundary).
 terminal:
@@ -82,6 +86,19 @@ gateway:
   api_server:
     max_concurrent_runs: {{ hermes_agent_api_max_concurrent_runs }}
 {% endif %}
+
+# H-17 per-job-class tool policy, enforced by the runner's toolset resolution
+# (never the prompt). Each list is the NATIVE-toolset envelope for that job
+# class; enabled MCP servers are layered on by upstream's platform-tools
+# semantics. The interactive Slack platform is deliberately absent (operator-
+# driven; upstream default minus the deny floor above). Policy rationale and
+# the per-class exclusions live in defaults/main.yml.
+platform_toolsets:
+  cron: {{ hermes_agent_cron_toolsets | to_json }}
+{% if hermes_agent_api_server_key | length > 0 %}
+  api_server: {{ hermes_agent_api_server_toolsets | to_json }}
+{% endif %}
+
 {% set _slack_on = hermes_agent_slack_bot_token | length > 0 %}
 {% set _webhook_on = (hermes_agent_webhook_enabled | bool) and (hermes_agent_webhook_secret | length > 0) %}
 {% if _slack_on or _webhook_on %}


### PR DESCRIPTION
## What (blueprint H-17)

The blueprint's job-api page requires: *"The runner, not the prompt, enforces the tool policy for each job class"* — prompt-injection containment for the API's untrusted `input`. This lands that enforcement as pure config data, using the upstream runner's own toolset-resolution seams (verified against the pinned `hermes_agent_version` v2026.7.7.2 source):

| Layer | Rendered as | Enforced by |
| --- | --- | --- |
| `hermes_agent_disabled_toolsets` | `agent.disabled_toolsets` | Global deny floor — upstream layers it over every per-job/per-platform allowlist (cron/scheduler.py, upstream #25752), so nothing widens past it |
| `hermes_agent_api_server_toolsets` | `platform_toolsets.api_server` | Toolset envelope for API-submitted (untrusted-input) runs — `gateway/platforms/api_server.py` `_create_agent` resolves it per run |
| `hermes_agent_cron_toolsets` | `platform_toolsets.cron` | Envelope for the scheduled fleet; upstream additionally hard-blocks cronjob/messaging/clarify in all cron contexts |

Deliberate exclusions from both allowlists: `cronjob` (an injected one-off run must not schedule persistent jobs), `browser` (widest tool attack surface; `web` covers research), `delegation`, `clarify` (headless). MCP servers (splunk/context7/codex) layer on via upstream's platform-tools semantics. Interactive Slack surface keeps the upstream default (operator-driven) minus the deny floor.

## Tests (role-level asserts, negative regression)

New Layer-1 assert fails the converge if: an allowlist is empty (silent fallback to upstream defaults), any of the excluded four creeps back in, or a toolset is simultaneously denied and allowlisted (upstream drops it silently — a run-time "Unknown tool" mystery caught at render time instead).

- `ansible-lint roles/hermes_agent/`: 0 failures (production profile); pre-commit all green.
- Template render smoke: rendered `config.yaml` YAML-parses; `platform_toolsets.cron` always present, `.api_server` only when the platform key is set; `agent.disabled_toolsets` carries the floor.

## Boundary

True per-JOB granularity (e.g. a read-only reposweep run tighter than the platform envelope) requires per-job `enabled_toolsets`, which upstream's `cron create` CLI (the role's seeding path) cannot set — follow-up issue, not this PR. Includes the same markdownlint-cli2 pre-commit fix commit as #876 (identical content; merges cleanly whichever lands first).

No live converge (AWS-creds cutover in flight) — lands as IaC for the post-cutover apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nw6KWXN6S7k13w2xAhRZb3