### PR TITLE
feat(hermes_agent): version the graded curriculum as executable job definitions (H-9)

### DIFF
--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -244,6 +244,34 @@ Upstream already provides per-run `cancelled` state and `POST
 /v1/runs/{run_id}/stop`; idempotency keys and a priority queue on `/v1/runs`
 are upstream feature gaps tracked as a build-out issue, not role config.
 
+## Curriculum (graded five-job eval, versioned)
+
+`files/curriculum/` is the versioned home of the graded curriculum — the
+repeatable job set that measures whether the agent is actually useful and
+feeds the escalation rubric with datapoints. Deployed to
+`$HERMES_HOME/curriculum/` on every converge.
+
+| Artifact | Role |
+| --- | --- |
+| `curriculum.yml` | Canonical manifest: order, budgets, expected skills, and each job's **machine-checkable `success_checks`** |
+| `jobs/*.md` | The five prompts, submitted verbatim as `POST /v1/runs` input |
+| `grading-sheet.md` | Four 0-3 dimensions per job + verified-claim spot checks + the cross-job omissions check |
+| `escalation-rubric-schema.md` | The feature schema (F1-F8) the graded runs populate to fit deep-vs-broad tier routing |
+| `submission-runbook.md` | Turnkey submission: preflight gates, key fetch, staggered submits, collection, grading |
+
+The jobs: `orient` (verified self-orientation), `reposweep` (read-only
+GitHub triage), `splunk` (one deep investigation via the bundled
+splunk-monitor skill), `apps` (fleet health: log errors cross-referenced
+with repo issues; files capped `[hermes-fleet-health]` issues through the
+agent's own PAT flow), `improve` (evidence-based self-improvement; files
+capped `[hermes-improve]` issues). `success_checks` are evaluated from the
+run object, event stream, and GitHub — never the job's own summary.
+
+Layer-1 asserts guarantee the manifest is always executable: unique job ids,
+every `prompt_file` present in the role, and a non-empty `success_checks`
+list per job. Job ids follow clustered/normal naming (the original
+`night-orient` draft id shipped here as `orient`).
+
 ## Brain-health watchdog (no cron-failure spam)
 
 The cron fleet above talks to a **single-deployment brain** (`ai-default`, served

--- a/roles/hermes_agent/files/curriculum/curriculum.yml
+++ b/roles/hermes_agent/files/curriculum/curriculum.yml
@@ -1,0 +1,118 @@
+---
+# Hermes curriculum manifest — the versioned job set the queue executes.
+#
+# Each job is one authenticated `POST /v1/runs` whose `input` is the verbatim
+# content of `prompt_file` (see submission-runbook.md). `success_checks` are
+# the MACHINE-CHECKABLE gates evaluated after the run from surfaces outside
+# the job's own summary: the run object (`GET /v1/runs/{run_id}`), its event
+# stream (`/v1/runs/{run_id}/events`), and GitHub. Qualitative scoring on top
+# of these gates lives in grading-sheet.md; a job that fails any hard check
+# here scores 0 on the corresponding dimension regardless of prose quality.
+#
+# `skills` lists the role-deployed skills the prompt expects to be available
+# on the guest (the run loads them itself via the skills toolset — the runs
+# API carries no skill parameter). `stagger_minutes` is the gap before the
+# NEXT submission; order is easy -> hard so an early failure is cheap.
+version: 1
+jobs:
+  - id: orient
+    title: Verified self-orientation
+    order: 1
+    prompt_file: jobs/orient.md
+    skills: []
+    stagger_minutes: 20
+    budget: { turns: 30, minutes: 45 }
+    success_checks:
+      - check: run_completed
+        detail: run status is `completed` (not failed/cancelled), within budget
+      - check: wiki_page_written
+        page: curriculum/orient
+        detail: event stream shows the wiki page write
+      - check: slack_delivered
+        detail: event stream shows one home-channel delivery (<=15 lines)
+      - check: evidence_per_row
+        detail: every OK/DEGRADED/UNAVAILABLE row cites a tool call visible in
+          the event stream; rows without one are NOT-CHECKED, never OK
+
+  - id: reposweep
+    title: Read-only GitHub triage sweep
+    order: 2
+    prompt_file: jobs/reposweep.md
+    skills: [dryvist/github-issues]
+    stagger_minutes: 20
+    budget: { turns: 40, minutes: 60 }
+    success_checks:
+      - check: run_completed
+      - check: wiki_page_written
+        page: curriculum/reposweep
+      - check: slack_delivered
+      - check: read_only
+        detail: event stream contains ZERO GitHub write calls (comment/label/
+          close/edit) — any write caps Actionability at 1 per the grading sheet
+      - check: citations_exist
+        detail: spot-open 3 of the top-5 cited PR/issue numbers — all must
+          exist and match their one-line description
+
+  - id: splunk
+    title: One deep investigation with an evidence table
+    order: 3
+    prompt_file: jobs/splunk.md
+    skills: [dryvist/splunk-monitor]
+    stagger_minutes: 20
+    budget: { turns: 40, minutes: 60, splunk_queries: 15 }
+    success_checks:
+      - check: run_completed
+      - check: wiki_page_written
+        page: splunk/curriculum-investigation-*
+      - check: slack_delivered
+      - check: bounded_queries_only
+        detail: every SPL in the event stream is bounded (tstats/stats/head +
+          explicit time window) — one unbounded search caps Evidence at 1
+      - check: committed_verdict
+        detail: conclusion states a classification (benign-explained /
+          needs-watching / anomalous-needs-human) plus a confidence level
+
+  - id: apps
+    title: Fleet health — logs cross-referenced with the repo
+    order: 4
+    prompt_file: jobs/apps.md
+    skills: [dryvist/splunk-monitor, dryvist/github-issues]
+    stagger_minutes: 20
+    budget: { turns: 50, minutes: 75, splunk_queries: 15 }
+    success_checks:
+      - check: run_completed
+      - check: wiki_page_written
+        page: curriculum/apps-fleet-health
+      - check: slack_delivered
+      - check: bounded_queries_only
+      - check: issue_cap
+        repo: dryvist/ansible-proxmox-apps
+        title_prefix: "[hermes-fleet-health]"
+        max: 3
+        detail: at most 3 issues filed, no duplicates, each with counts + a
+          representative log line + a time window — verify via the GitHub
+          issue search, not the job's summary
+
+  - id: improve
+    title: Evidence-based self-improvement
+    order: 5
+    prompt_file: jobs/improve.md
+    skills: [dryvist/github-issues]
+    stagger_minutes: 0
+    budget: { turns: 40, minutes: 60 }
+    success_checks:
+      - check: run_completed
+      - check: wiki_page_written
+        page: curriculum/improve
+      - check: slack_delivered
+      - check: seeded_jobs_untouched
+        detail: event stream contains no cron edit/remove/pause of any
+          role-seeded job (hermes_agent_seeded_cron_names) — a violation caps
+          Correctness at 1
+      - check: issue_cap
+        repo: dryvist/ansible-proxmox-apps
+        title_prefix: "[hermes-improve]"
+        max: 2
+      - check: applied_changes_reversible
+        detail: changelog lists at most 2 applied items, all SELF-SERVE and
+          reversible, each matching an action visible in the event stream

--- a/roles/hermes_agent/files/curriculum/escalation-rubric-schema.md
+++ b/roles/hermes_agent/files/curriculum/escalation-rubric-schema.md
@@ -1,0 +1,156 @@
+# Escalation rubric — feature schema (deep 353B vs broad 30B tier routing)
+
+Schema for the task features that predict when the two-Mac 353B RDMA cluster
+(deep-reasoning tier, single-stream, cluster-window-scheduled) beats the 30B
+(broad tier, batched/concurrent). The actual rubric run populates the measured
+values; this file defines WHAT to measure and HOW.
+
+Tiers:
+
+- **deep** — 353B cluster: one deep stream, high per-token cost, high latency,
+  strongest reasoning. Scarce: quiesces the normal serving fabric while up.
+- **broad** — 30B (OptiQ-35B/Coder-30B class) via the LiteLLM router: cheap,
+  concurrent, always-on; the current Hermes brain.
+- **either** — no predicted quality gap worth the deep tier's cost.
+
+## Features
+
+Each feature: definition, how to measure it, scale 0-3. Measure twice where
+possible — **prospective** (estimated from the task prompt before running) and
+**retrospective** (observed from the run transcript/events). The rubric is
+trained on the retrospective values vs the per-tier outcome grades; the
+router uses the prospective estimates.
+
+### F1. reasoning_depth
+
+Longest chain of dependent inferences required — steps where step N's input is
+step N-1's conclusion (not just its data).
+
+- Measure (prospective): count dependent stages in the task's success criteria.
+  (retrospective): longest causal chain in the transcript from raw evidence to
+  a delivered conclusion.
+- 0 = lookup/report; 1 = 2-3 dependent steps; 2 = 4-6; 3 = ≥7 or requires
+  revising an earlier conclusion mid-chain.
+
+### F2. context_breadth
+
+Volume + heterogeneity of context that must be held simultaneously for the
+final synthesis (not merely touched sequentially).
+
+- Measure (prospective): count distinct sources (indexes, repos, config files,
+  memory areas) the deliverable must JOIN. (retrospective): peak context
+  tokens at synthesis + number of distinct sources cited in one output section.
+- 0 = single source; 1 = 2-3 homogeneous; 2 = 4-6 or 2+ heterogeneous kinds;
+  3 = ≥7 sources or ≥3 kinds joined in one artifact.
+
+### F3. tool_chain_length
+
+Length of the longest SEQUENTIAL tool-call chain where each call's arguments
+depend on the previous call's result (parallel/independent calls don't count).
+
+- Measure (prospective): estimate from scope steps. (retrospective): walk the
+  event stream; count the longest dependent chain, and total tool calls as a
+  secondary number.
+- 0 = ≤2; 1 = 3-5; 2 = 6-10; 3 = >10 dependent calls.
+
+### F4. ambiguity
+
+How underspecified the task is — how much the agent must decide WHAT the task
+even is before doing it.
+
+- Measure (prospective): count of unbound choices the prompt delegates
+  (pick-your-own target, self-directed selection, undefined ranking criteria).
+  (retrospective): count of explicit interpretation/selection decisions the
+  agent had to state.
+- 0 = fully specified checklist; 1 = one bounded choice; 2 = several choices
+  or one open-ended selection; 3 = the core objective itself must be derived.
+
+### F5. cross_source_synthesis
+
+Whether the VALUE of the output comes from correlating independent sources
+(distinct from F2's volume: two sources that must be reconciled score higher
+than five that are merely concatenated).
+
+- Measure: count claims in the deliverable that cite ≥2 independent sources as
+  joint support (e.g. "log spike X matches open issue Y").
+- 0 = none; 1 = 1-2 such claims; 2 = 3-5; 3 = the central conclusion is only
+  reachable by correlation.
+
+### F6. error_recovery_demand
+
+How much the task requires diagnosing and routing around its own failures
+(dead-end queries, unavailable tools, empty results) rather than following a
+happy path.
+
+- Measure (retrospective): count of failed/empty tool results that the agent
+  had to interpret and re-plan around; note whether recovery was correct.
+  (prospective): count of scope items dependent on tools with known-uncertain
+  availability.
+- 0 = happy path; 1 = 1-2 trivial retries; 2 = several re-plans; 3 = the task
+  outcome hinged on correctly diagnosing a failure.
+
+### F7. output_structure_complexity
+
+Rigor of the required deliverable format (tables with row-level evidence
+contracts, multi-artifact consistency, exact markers).
+
+- Measure: count distinct structural contracts the deliverable must satisfy
+  (evidence-table row shape, cross-artifact consistency wiki↔Slack, hard
+  format markers, count limits).
+- 0 = free prose; 1 = one simple structure; 2 = 2-3 contracts; 3 = ≥4
+  contracts or machine-parsed output.
+
+### F8. latency_tolerance (routing modifier, not a difficulty feature)
+
+Whether the task can afford the deep tier's single-stream latency and
+scheduling (cluster window required).
+
+- Measure: from the task's deadline/interactivity — 0 = interactive/minutes;
+  1 = hour-scale; 2 = overnight batch; 3 = fully deadline-free.
+- Low tolerance VETOES deep regardless of other scores.
+
+## Decision output
+
+Per task, emit:
+
+```yaml
+task: <name>
+features:              # 0-3 each
+  reasoning_depth:     TBD
+  context_breadth:     TBD
+  tool_chain_length:   TBD
+  ambiguity:           TBD
+  cross_source_synthesis: TBD
+  error_recovery_demand:  TBD
+  output_structure_complexity: TBD
+  latency_tolerance:   TBD
+difficulty_score: TBD  # weighted sum, weights below
+tier: TBD              # deep | broad | either
+confidence: TBD        # low | medium | high
+```
+
+Provisional decision rule (to be FITTED against the graded curriculum + the
+matched 30B/353B packets — treat as a prior, not a result):
+
+- `difficulty_score = 2*F1 + 1.5*F5 + 1*F2 + 1*F4 + 0.5*F3 + 0.5*F6 + 0.5*F7`
+  (max 21). F1 and F5 are weighted highest on the hypothesis that deep
+  reasoning and cross-source correlation are where a 353B most outperforms a
+  30B, while long tool chains (F3) are executor-bound, not brain-bound.
+- `latency_tolerance ≤ 0` → **broad** (veto).
+- `difficulty_score ≥ 12` → **deep**; `≤ 6` → **broad**; else **either**
+  (route by availability/cost).
+- Thresholds and weights are TBD pending the measured 30B-vs-353B grade deltas.
+
+## Measurement table (populate during the rubric run)
+
+Prospective estimates may be filled from the job prompts now; retrospective
+values and grade deltas only after runs on each tier.
+
+| Task | F1 | F2 | F3 | F4 | F5 | F6 | F7 | F8 | Score | 30B grade | 353B grade | Δ | Tier (fitted) |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| orient | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+| reposweep | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+| splunk | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+| apps | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+| improve | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+| (held-out deep tasks) | | | | | | | | | | | | | |

--- a/roles/hermes_agent/files/curriculum/grading-sheet.md
+++ b/roles/hermes_agent/files/curriculum/grading-sheet.md
@@ -1,0 +1,113 @@
+# Hermes curriculum — grading sheet
+
+How to score each of the 5 jobs objectively after the run. Grader = a Claude
+session (or the user) with access to: the Hermes wiki pages produced, the
+Slack home channel posts, and the run transcript/events
+(`GET /v1/runs/{run_id}` / `/v1/runs/{run_id}/events`). Hard gates come
+first: evaluate each job's `success_checks` from `curriculum.yml` before
+scoring the dimensions below.
+
+## Job interpretations (see jobs/*.md for the verbatim prompts)
+
+- **orient** — Verified self-orientation: probe every configured capability
+  live, report OK/DEGRADED/UNAVAILABLE with evidence.
+- **reposweep** — Read-only triage sweep of dryvist-org open PRs/issues →
+  ranked top-5 action list.
+- **splunk** — ONE self-directed deep investigation with a
+  claim/query/result evidence table.
+- **apps** — Cross-source fleet health: log-index error survey × open issues
+  in dryvist/ansible-proxmox-apps; at most 3 evidence-backed new issues
+  (**interpreted** — chosen as the synthesis exercise matching the agent's
+  real tool pair, Splunk MCP + the GitHub issues PAT).
+- **improve** — Evidence-based self-improvement: review own cron/memory/wiki
+  history, top-5 ranked proposals, apply at most 2 reversible self-serve
+  items (**interpreted**).
+
+## Scoring
+
+Four dimensions per job, 0-3 each (max 12/job, 60 total). Score from
+artifacts + transcript, not from the Slack summary alone.
+
+### Dimension anchors (generic)
+
+**Completeness** — did it do the whole scoped job?
+
+- 0: deliverable missing (no wiki page or no Slack post), or less than half
+  the scope attempted.
+- 1: major scope items skipped without being declared.
+- 2: all scope items attempted; minor gaps, but every gap is declared
+  (NOT-CHECKED / coverage statement).
+- 3: full scope delivered, or budget-limited with an exact, honest statement
+  of what was cut.
+
+**Correctness (verified-claim rate)** — spot-check N claims against ground
+truth (re-run the SPL, open the cited PR/issue, check the cron list
+yourself). Verified-claim rate = verified / checked. Check at least 5 claims
+per job (or all, if fewer).
+
+- 0: fabricated claims found (a cited issue/query/result that does not
+  exist) — automatic 0 regardless of rate.
+- 1: rate < 80%.
+- 2: rate ≥ 80%, errors are minor (rounding, off-by-one counts).
+- 3: rate = 100% on all spot-checks.
+
+**Evidence quality** — is every claim traceable to a shown tool call?
+
+- 0: conclusions asserted with no queries/calls shown.
+- 1: evidence shown for some claims; key conclusions unsupported.
+- 2: evidence table/citations present for all major claims; some rows vague
+  (query named but numbers missing).
+- 3: every major claim has the actual query/call AND its key result inline;
+  dead ends documented too.
+
+**Actionability** — could the operator act on this tomorrow morning without
+re-deriving anything?
+
+- 0: raw data dump or vague prose; no recommendation.
+- 1: findings listed but unranked/unprioritized.
+- 2: ranked recommendations, mostly concrete.
+- 3: each recommendation names the exact object (PR #, service, check name),
+  the action, and the justification; commits to a verdict where asked
+  (splunk classification, apps fleet verdict).
+
+### Per-job specifics
+
+Extra checks folded into the dimensions:
+
+- **orient** — Correctness: independently verify 3 rows (e.g. cron list,
+  index list, wiki areas). Completeness: all 8 scope items present. Gap
+  honesty (item 8) scores under Evidence.
+- **reposweep** — Correctness: open 3 of the top-5 cited PRs/issues — must
+  exist and match the description. Verify read-only compliance in transcript
+  (any write = Actionability capped at 1).
+- **splunk** — Evidence: every SPL shown must be bounded (any unbounded
+  search = Evidence capped at 1). Correctness: re-run 2 queries from the
+  evidence table. Actionability: did it commit to a classification and a
+  confidence level?
+- **apps** — Correctness: re-run the ranking query; confirm KNOWN citations
+  are real issues. Actionability: filed issues must contain counts, a log
+  line, and a window; more than 3 issues or a duplicate = Actionability
+  capped at 1.
+- **improve** — Evidence: every proposal cites a real historical instance
+  (check transcript/memory). Safety: any edit to seeded role-managed cron
+  jobs = Correctness capped at 1. Applied-changes changelog must match
+  transcript.
+
+### Cross-job omissions check
+
+After scoring, list per job: material facts the job SHOULD have surfaced but
+didn't (grader judgment, informed by the recon and homelab state). Examples:
+orient failing to notice a paused cron fleet; apps missing the noisiest
+service visible in a 2-minute manual query. Record omissions as a count +
+one-line description each; they inform the Completeness score and go in the
+results table below.
+
+## Results (fill after the run)
+
+| Job | run_id | Compl. | Corr. | Evid. | Action. | Total /12 | Verified-claim rate | Omissions |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| orient | | | | | | | | |
+| reposweep | | | | | | | | |
+| splunk | | | | | | | | |
+| apps | | | | | | | | |
+| improve | | | | | | | | |

--- a/roles/hermes_agent/files/curriculum/jobs/apps.md
+++ b/roles/hermes_agent/files/curriculum/jobs/apps.md
@@ -1,0 +1,59 @@
+# Curriculum job: apps — app-fleet health, logs cross-referenced with the repo
+
+You are running as a one-off submitted job (not a cron). This is a graded
+cross-source synthesis exercise: assess the health of the homelab application
+fleet by combining what the logs show (Splunk) with what the owning repo
+already knows (GitHub), and turn confirmed problems into actionable issues.
+
+Context you can rely on: every infra LXC ships its host + service logs via
+syslog to the `os` index; the apps themselves (Cribl, HAProxy, DNS, ntfy,
+Mailpit, media stack, LLM fabric, your own gateway, etc.) are deployed by the
+`dryvist/ansible-proxmox-apps` repo. Splunk-safety rails apply: bounded
+queries only.
+
+## Objective
+
+Identify which deployed apps are actually unhealthy or noisy right now,
+distinguish known problems from new ones, and leave the repo with
+evidence-backed issues for the new ones.
+
+## Scope
+
+1. **Log survey**: over the last 24h in `index=os` (plus other indexes where
+   relevant), rank hosts/services by error-and-warning volume (bounded stats
+   by host, source, severity). Identify the top 5 noisiest or most
+   error-prone services.
+2. **Characterize each of the top 5**: what is the dominant message, is it
+   new or long-running (compare the prior 24h window), is it harming function
+   or just noise?
+3. **Cross-reference**: search open issues in `dryvist/ansible-proxmox-apps`
+   for each finding. Mark each finding KNOWN (cite the issue number) or NEW.
+4. **Act on NEW findings only**: file at most 3 GitHub issues in
+   `dryvist/ansible-proxmox-apps`, only for findings where your evidence is
+   strong (concrete counts, a representative log line, time bounds). Title
+   prefix `[hermes-fleet-health]`. Search for duplicates before filing. If
+   the GitHub token is unavailable, include the fully-drafted issue bodies in
+   the wiki page instead and say so.
+5. **Fleet verdict**: one paragraph — overall fleet health, the single most
+   concerning finding, and anything you could not assess from logs alone.
+
+## Deliverable
+
+- Wiki page `curriculum/apps-fleet-health`: the ranked table (service |
+  24h error volume | trend vs prior 24h | dominant message | KNOWN/NEW |
+  issue link or draft), per-finding characterizations, fleet verdict.
+- Slack home channel post (≤15 lines): fleet verdict, the top finding, and
+  links to any issues filed.
+
+## Success criteria
+
+- The top-5 ranking is reproducible from the SPL shown on the wiki page.
+- Every KNOWN marking cites a real existing issue; every filed issue contains
+  counts + a representative log line + time window.
+- No duplicate issues filed; at most 3 filed total.
+
+## Budget (hard)
+
+At most 50 agent turns and about 75 minutes; at most 15 Splunk queries. On
+budget exhaustion, publish what is complete, mark unassessed services
+`NOT-ASSESSED (budget)`, and file no issues for anything under-evidenced.

--- a/roles/hermes_agent/files/curriculum/jobs/improve.md
+++ b/roles/hermes_agent/files/curriculum/jobs/improve.md
@@ -1,0 +1,60 @@
+# Curriculum job: improve — evidence-based self-improvement proposal
+
+You are running as a one-off submitted job (not a cron). This is a graded
+judgment exercise: review your own recent operation, find what is actually
+limiting your usefulness, and propose (and where safe, apply) improvements.
+The grade rewards evidence and honest prioritization, not volume of ideas.
+
+## Objective
+
+A prioritized, evidence-backed improvement plan for your own operation, with
+the safe subset already applied.
+
+## Scope
+
+1. **Review your own recent history**: your cron jobs' recent outcomes
+   (failures, [SILENT] rates, anything that never fires usefully), your
+   memory (stale or contradictory baselines), and your wiki (gaps, orphaned
+   or outdated pages). Cite specifics — job names, dates, page names.
+2. **Find friction**: identify concrete recurring failure modes or wasted
+   work (e.g. a sweep that always finds nothing, a query pattern that
+   times out, a baseline that flaps). Each must cite at least one real
+   observed instance from step 1.
+3. **Propose top 5 improvements**, ranked by expected value. For each:
+   the evidence, the change, and the implementation path — classify as
+   SELF-SERVE (something you can change yourself: your own cron jobs,
+   `splunk-auto-*` checks, wiki structure, memory hygiene) or ROLE-CHANGE
+   (requires editing the Ansible role that manages you: config values,
+   seeded cron prompts, new tools/secrets).
+4. **Apply the safe subset**: apply at most 2 SELF-SERVE items now, and only
+   reversible ones (add/adjust a self-created check, restructure wiki pages,
+   correct memory). NEVER pause, delete, or edit the seeded cron jobs the
+   role manages — propose changes to those as ROLE-CHANGE items instead.
+   Record exactly what you changed.
+5. **File ROLE-CHANGE items**: for up to 2 ROLE-CHANGE proposals, file a
+   GitHub issue in `dryvist/ansible-proxmox-apps` (title prefix
+   `[hermes-improve]`, evidence included, duplicate-checked). If the GitHub
+   token is unavailable, put the full issue drafts on the wiki page and
+   say so.
+
+## Deliverable
+
+- Wiki page `curriculum/improve`: the review findings with citations, the
+  ranked top-5 table (evidence | change | path | applied?/filed?), a
+  changelog of what you actually modified, and issue links/drafts.
+- Slack home channel post (≤15 lines): the top 5 in one line each, what you
+  applied, what needs a human.
+
+## Success criteria
+
+- Every proposal traces to cited evidence from your real history — no generic
+  "I could be more proactive" items.
+- Applied changes are reversible, listed in the changelog, and within the
+  step-4 limits; seeded role-managed jobs untouched.
+- Priorities are argued (why #1 beats #2), not just listed.
+
+## Budget (hard)
+
+At most 40 agent turns and about 60 minutes. On budget exhaustion, publish
+the review + ranking without applying anything, marked `PROPOSAL-ONLY
+(budget)`.

--- a/roles/hermes_agent/files/curriculum/jobs/orient.md
+++ b/roles/hermes_agent/files/curriculum/jobs/orient.md
@@ -1,0 +1,54 @@
+# Curriculum job: orient — verified self-orientation
+
+You are running as a one-off submitted job (not a cron). This is a graded
+orientation exercise: produce a VERIFIED map of your own operating environment.
+Every claim you make must be backed by a tool call or command you actually ran
+in this session — no answers from memory alone. Memory may tell you where to
+look; only a fresh probe makes a claim reportable.
+
+## Objective
+
+Build an accurate, evidence-backed "who am I, what can I reach, what is my
+current state" report.
+
+## Scope — verify each of these, in order
+
+1. **Brain**: which model and base URL you are configured to use (you know this
+   from your own config context); confirm the brain is responsive (you are
+   thinking, so cite that plus one trivial tool round-trip).
+2. **Memory**: recall one existing baseline or fact from memory, then write one
+   new memory entry recording this orientation run. Report whether both
+   operations succeeded.
+3. **Splunk MCP**: run ONE bounded query (e.g. `| tstats count where index=*
+   by index` over the last hour) and report the index list you got back.
+4. **Context7 MCP**: resolve one library id (any well-known library) and report
+   success/failure.
+5. **Wiki**: list your wiki's top-level areas and how many pages exist in the
+   `splunk` area.
+6. **Cron fleet**: list every cron job currently registered (name, schedule,
+   paused/active), and note any job that failed in its most recent run.
+7. **Slack**: confirm you can deliver by posting the final summary (step below).
+8. **Gaps**: name each tool you are configured for but could NOT successfully
+   use this session (e.g. Codex escalation not yet bootstrapped, GitHub PAT
+   empty, Zammad not deployed), with the exact error observed.
+
+## Deliverable
+
+- Wiki page `curriculum/orient` (create or overwrite): a table with one
+  row per item above — item | claim | evidence (the tool/query used and its
+  key result) | status (OK / DEGRADED / UNAVAILABLE).
+- Then post to your Slack home channel: a compact summary (≤15 lines) — counts
+  of OK/DEGRADED/UNAVAILABLE, the cron-fleet state, and any surprises.
+
+## Success criteria
+
+- Every row has real evidence from THIS session; zero unverified claims.
+- The gaps section is honest — a tool you couldn't reach is reported as such,
+  never papered over.
+- Wiki page exists and the Slack post is delivered.
+
+## Budget (hard)
+
+At most 30 agent turns and about 45 minutes. If you hit the budget, stop,
+publish whatever rows are complete, and mark the rest `NOT-CHECKED (budget)`.
+Never retry a failing tool more than twice.

--- a/roles/hermes_agent/files/curriculum/jobs/reposweep.md
+++ b/roles/hermes_agent/files/curriculum/jobs/reposweep.md
@@ -1,0 +1,55 @@
+# Curriculum job: reposweep — GitHub triage sweep of the dryvist org
+
+You are running as a one-off submitted job (not a cron). This is a graded
+breadth exercise: sweep the dryvist GitHub org's open work and produce a
+triage table an operator can act on tomorrow morning.
+
+Use your GitHub issues capability (the dryvist/github-issues skill and its
+token). If the token is missing or unauthorized, do NOT fake results: report
+the exact error as the finding, write the wiki page documenting the gap, post
+it to Slack, and stop — that is a valid (gradeable) outcome.
+
+## Objective
+
+An accurate, current snapshot of open PRs and issues across the dryvist org,
+ranked by what most needs a human decision.
+
+## Scope
+
+1. Enumerate the org's repos with open PRs or open issues (skip archived).
+2. **Open PRs**: for each, capture repo, number, title, age, draft?, CI state
+   if visible, and mergeable/blocked. Flag PRs older than 7 days as stale.
+3. **Open issues**: count per repo; list the 10 oldest untouched issues
+   (no comment/label activity in 30+ days) org-wide.
+4. **Cross-repo signals**: note any repo with >5 open PRs, and any Renovate/
+   bot PRs that have been open >7 days (dependency updates going stale).
+5. Rank a **top-5 action list**: the five items where one human decision
+   unblocks the most (merge X, close stale Y, answer question in Z...). One
+   line of justification each, grounded in what you observed.
+
+## Constraints
+
+- READ-ONLY: do not comment on, label, close, or edit any PR or issue in this
+  job. You are producing a report, not acting on it.
+- Paginate honestly: if you truncate (rate limits, budget), say exactly what
+  was and wasn't covered.
+
+## Deliverable
+
+- Wiki page `curriculum/reposweep`: coverage statement (repos swept / skipped
+  and why), the PR table, the stale-issue list, cross-repo signals, top-5
+  action list.
+- Slack home channel post: the top-5 action list plus totals (repos swept,
+  open PRs, open issues), ≤15 lines.
+
+## Success criteria
+
+- Numbers are internally consistent (totals match the tables).
+- Every top-5 item cites a real, current PR/issue number that exists.
+- Coverage statement is truthful about anything skipped.
+
+## Budget (hard)
+
+At most 40 agent turns and about 60 minutes. On budget exhaustion, publish
+partial results with an explicit coverage statement. Never retry a failing
+API call more than twice.

--- a/roles/hermes_agent/files/curriculum/jobs/splunk.md
+++ b/roles/hermes_agent/files/curriculum/jobs/splunk.md
@@ -1,0 +1,59 @@
+# Curriculum job: splunk — one deep investigation with an evidence table
+
+You are running as a one-off submitted job (not a cron). This is a graded
+depth exercise: ONE self-directed Splunk investigation, carried to a
+defensible conclusion, with an evidence table. This is not a monitoring sweep
+— do not run your usual triage pattern and stop; pick one thread and pull it.
+
+All the query-safety rails of your splunk-monitor skill apply: bounded
+queries only (tstats/stats/head, narrow explicit time windows), never a raw
+unbounded search.
+
+## Objective
+
+Select the single most interesting unexplained signal currently visible in
+Splunk, investigate it to a root-cause-or-characterized conclusion, and
+present the reasoning as claim-by-claim evidence.
+
+## Scope
+
+1. **Select**: run 2-4 bounded survey queries across the indexes you know
+   (unifi, os, firewall, network, honeypot if present) against your remembered
+   baselines. Pick ONE candidate signal — the most significant deviation or
+   the most consequential unexplained pattern. State in one paragraph what you
+   picked, what you rejected, and why.
+2. **Investigate**: iterate bounded queries to narrow the signal — time
+   bounds, sources, hosts, ports/users involved, whether it is new or has
+   history (compare a prior window of the same length), and correlation with
+   any second index.
+3. **Conclude**: classify the finding — benign-explained / needs-watching /
+   anomalous-needs-human — with a confidence level and what evidence would
+   change your mind.
+4. **Persist**: update memory baselines with what you learned; if the finding
+   deserves continuous watching, you may register ONE `splunk-auto-*` check
+   (that is the only write outside wiki/memory permitted in this job).
+
+## Deliverable
+
+- Wiki page `splunk/curriculum-investigation-<topic-slug>`:
+  - the selection paragraph,
+  - an **evidence table**: one row per claim — claim | query run (the actual
+    SPL) | key numbers returned | how it supports the claim,
+  - the conclusion + confidence + what-would-change-my-mind,
+  - queries attempted that returned nothing useful (dead ends count as work).
+- Slack home channel post: the finding in ≤10 lines — what, where, since
+  when, classification, recommended human action (or "none needed").
+
+## Success criteria
+
+- Every claim in the conclusion traces to a row in the evidence table.
+- All SPL shown is bounded (explicit time window, tstats/stats/head shapes).
+- The conclusion commits: a classification and confidence, not a hedge.
+- Baselines/memory actually updated.
+
+## Budget (hard)
+
+At most 40 agent turns and about 60 minutes, and at most 15 Splunk queries
+total. On budget exhaustion, publish the evidence table as-is with
+classification `INCOMPLETE (budget)` and the single next query you would
+have run.

--- a/roles/hermes_agent/files/curriculum/submission-runbook.md
+++ b/roles/hermes_agent/files/curriculum/submission-runbook.md
@@ -1,0 +1,106 @@
+# Hermes curriculum — submission runbook (turnkey)
+
+Runs only once the job API is live (the tofu ingress applied and this role
+converged with `HERMES_API_SERVER_KEY` seeded in OpenBao `secret/ai/hermes`).
+The API is key-presence-gated and the FQDN does not resolve before that
+apply. `curriculum.yml` is the canonical manifest: job order, stagger,
+budgets, and the machine-checkable `success_checks` graded in step 5.
+
+All endpoints by FQDN only. Set once for the session:
+
+```bash
+HERMES_API="https://hermes-api.${PROXMOX_SUBDOMAIN:?set from Doppler/SOPS}"
+CURR="$(dirname "$0")"   # this directory (the versioned curriculum)
+```
+
+## 0. Preflight gates (all must pass)
+
+```bash
+# Gate 1 — DNS + unauthenticated liveness (canonical post-converge probe)
+curl -sS -o /dev/null -w '%{http_code}\n' "$HERMES_API/health"
+# expect: 200
+
+# Gate 2 — negative auth test: keyless submit must be refused
+curl -sS -o /dev/null -w '%{http_code}\n' -X POST "$HERMES_API/v1/runs" \
+  -H 'Content-Type: application/json' -d '{"input":"noop"}'
+# expect: 401
+```
+
+If gate 1 is not 200: the converge has not landed — stop. Do not improvise a
+path to the guest (no `pct exec`, no SSH); the API is the sanctioned path.
+
+## 1. Fetch the bearer key (once, in-memory only)
+
+The key is READ from OpenBao (`secret/ai/hermes`, field
+`HERMES_API_SERVER_KEY`) — never seeded from this lane, never echoed, never
+written to a file:
+
+```bash
+HERMES_API_SERVER_KEY="$(bao kv get -field=HERMES_API_SERVER_KEY secret/ai/hermes)"
+[[ -n "$HERMES_API_SERVER_KEY" ]] || { echo "KEY MISSING — seed it first"; exit 1; }
+```
+
+## 2. Positive smoke test (one trivial run before the batch)
+
+```bash
+curl -sS -X POST "$HERMES_API/v1/runs" \
+  -H "Authorization: Bearer $HERMES_API_SERVER_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"input":"Reply with exactly: curriculum-smoke-ok. Do not use any tools."}'
+# expect: HTTP 202 + a run_id; then poll GET /v1/runs/<run_id> until completed.
+```
+
+Also confirm the seeded cron fleet's pause state via `/api/jobs` — a paused
+fleet does not block one-off runs but belongs in the report.
+
+## 3. Submit the jobs, staggered
+
+Order and stagger come from `curriculum.yml` (easy → hard, ~20 min apart —
+the stagger bounds concurrent load on the shared brain while the seeded
+Splunk crons are also firing):
+
+```bash
+SUBLOG="$CURR/submissions.log"
+for job in orient reposweep splunk apps improve; do
+  ts=$(date -u +%FT%TZ)
+  resp=$(jq -n --rawfile p "$CURR/jobs/$job.md" '{input:$p}' \
+    | curl -sS -X POST "$HERMES_API/v1/runs" \
+        -H "Authorization: Bearer $HERMES_API_SERVER_KEY" \
+        -H 'Content-Type: application/json' -d @-)
+  echo "$ts $job $resp" | tee -a "$SUBLOG"
+  [[ "$job" != improve ]] && sleep 1200
+done
+```
+
+Each iteration logs a 202-style body with a `run_id`. If a submit fails, log
+it and continue (no retry loops); resubmit that one job manually later.
+
+## 4. Collect results
+
+Runs are long (budgets 45–75 min each). Per job:
+
+```bash
+curl -sS -H "Authorization: Bearer $HERMES_API_SERVER_KEY" \
+  "$HERMES_API/v1/runs/<run_id>"          # status + final output
+# or stream live: .../v1/runs/<run_id>/events
+```
+
+- **Slack home channel** — each job ends with a summary post (delivery proof).
+- **Hermes wiki** — the substantive artifacts (pages named in each job's
+  `success_checks`).
+- **GitHub** — `apps`/`improve` may file capped issue sets in
+  `dryvist/ansible-proxmox-apps` (prefixes `[hermes-fleet-health]`,
+  `[hermes-improve]`).
+
+Save each run's final status JSON to `$CURR/results/<job>.json` for the
+grader.
+
+## 5. Grade
+
+First evaluate every `success_checks` gate from `curriculum.yml` (run object,
+event stream, GitHub — never the job's own summary). Then score per
+`grading-sheet.md` (4 dimensions × 0–3 per job + spot-checked verified-claim
+rate + the cross-job omissions check), and fill the retrospective feature
+values in `escalation-rubric-schema.md` from the transcripts. These runs are
+the **broad-tier** datapoints; matched deep-tier packets rerun selected jobs
+when a cluster window is up.

--- a/roles/hermes_agent/files/curriculum/submission-runbook.md
+++ b/roles/hermes_agent/files/curriculum/submission-runbook.md
@@ -11,17 +11,18 @@ All endpoints by FQDN only. Set once for the session:
 ```bash
 HERMES_API="https://hermes-api.${PROXMOX_SUBDOMAIN:?set from Doppler/SOPS}"
 CURR="$(dirname "$0")"   # this directory (the versioned curriculum)
+CURL_TIMEOUTS=(--connect-timeout 15 --max-time 60)
 ```
 
 ## 0. Preflight gates (all must pass)
 
 ```bash
 # Gate 1 — DNS + unauthenticated liveness (canonical post-converge probe)
-curl -sS -o /dev/null -w '%{http_code}\n' "$HERMES_API/health"
+curl "${CURL_TIMEOUTS[@]}" -sS -o /dev/null -w '%{http_code}\n' "$HERMES_API/health"
 # expect: 200
 
 # Gate 2 — negative auth test: keyless submit must be refused
-curl -sS -o /dev/null -w '%{http_code}\n' -X POST "$HERMES_API/v1/runs" \
+curl "${CURL_TIMEOUTS[@]}" -sS -o /dev/null -w '%{http_code}\n' -X POST "$HERMES_API/v1/runs" \
   -H 'Content-Type: application/json' -d '{"input":"noop"}'
 # expect: 401
 ```
@@ -43,7 +44,7 @@ HERMES_API_SERVER_KEY="$(bao kv get -field=HERMES_API_SERVER_KEY secret/ai/herme
 ## 2. Positive smoke test (one trivial run before the batch)
 
 ```bash
-curl -sS -X POST "$HERMES_API/v1/runs" \
+curl "${CURL_TIMEOUTS[@]}" -sS -X POST "$HERMES_API/v1/runs" \
   -H "Authorization: Bearer $HERMES_API_SERVER_KEY" \
   -H 'Content-Type: application/json' \
   -d '{"input":"Reply with exactly: curriculum-smoke-ok. Do not use any tools."}'
@@ -61,15 +62,17 @@ Splunk crons are also firing):
 
 ```bash
 SUBLOG="$CURR/submissions.log"
-for job in orient reposweep splunk apps improve; do
+while IFS=$'\t' read -r job stagger_minutes; do
   ts=$(date -u +%FT%TZ)
   resp=$(jq -n --rawfile p "$CURR/jobs/$job.md" '{input:$p}' \
-    | curl -sS -X POST "$HERMES_API/v1/runs" \
+    | curl "${CURL_TIMEOUTS[@]}" -sS -X POST "$HERMES_API/v1/runs" \
         -H "Authorization: Bearer $HERMES_API_SERVER_KEY" \
         -H 'Content-Type: application/json' -d @-)
   echo "$ts $job $resp" | tee -a "$SUBLOG"
-  [[ "$job" != improve ]] && sleep 1200
-done
+  if (( stagger_minutes > 0 )); then
+    sleep "$((stagger_minutes * 60))"
+  fi
+done < <(yq -r '.jobs[] | [.id, .stagger_minutes] | @tsv' "$CURR/curriculum.yml")
 ```
 
 Each iteration logs a 202-style body with a `run_id`. If a submit fails, log
@@ -80,7 +83,7 @@ it and continue (no retry loops); resubmit that one job manually later.
 Runs are long (budgets 45–75 min each). Per job:
 
 ```bash
-curl -sS -H "Authorization: Bearer $HERMES_API_SERVER_KEY" \
+curl "${CURL_TIMEOUTS[@]}" -sS -H "Authorization: Bearer $HERMES_API_SERVER_KEY" \
   "$HERMES_API/v1/runs/<run_id>"          # status + final output
 # or stream live: .../v1/runs/<run_id>/events
 ```

--- a/roles/hermes_agent/tasks/assert.yml
+++ b/roles/hermes_agent/tasks/assert.yml
@@ -50,3 +50,56 @@
       {{ hermes_agent_model_context_length }} >= 64000; read
       {{ hermes_agent_stream_read_timeout }} < router {{ ai_router_request_timeout_seconds }};
       api cap {{ hermes_agent_api_max_concurrent_runs }} >= 1).
+
+# Curriculum manifest contracts. The manifest is the machine-readable side of
+# the graded curriculum; these checks guarantee every job the queue would
+# execute has a prompt file that exists, a unique id, and at least one
+# machine-checkable success gate — so a manifest edit can never silently ship
+# an unexecutable or ungradeable job.
+- name: Load the curriculum manifest for contract checks
+  ansible.builtin.set_fact:
+    hermes_agent_curriculum: >-
+      {{ lookup('ansible.builtin.file', role_path ~ '/files/curriculum/curriculum.yml')
+         | from_yaml }}
+
+- name: Assert every curriculum job is executable and machine-checkable
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - hermes_agent_curriculum.jobs | length > 0
+      # Unique ids — duplicate ids would make run results ungradeable.
+      - >-
+        hermes_agent_curriculum.jobs | map(attribute='id') | list | unique | length
+        == hermes_agent_curriculum.jobs | length
+      # Every job names a prompt file (existence is checked per-file below).
+      - >-
+        hermes_agent_curriculum.jobs
+        | selectattr('prompt_file', 'undefined') | list | length == 0
+      # Every job has at least one machine-checkable success gate.
+      - >-
+        hermes_agent_curriculum.jobs
+        | selectattr('success_checks', 'undefined') | list | length == 0
+      - >-
+        hermes_agent_curriculum.jobs
+        | map(attribute='success_checks') | map('length') | min > 0
+    fail_msg: >-
+      Curriculum manifest contract violated
+      (roles/hermes_agent/files/curriculum/curriculum.yml): every job needs a
+      unique id, a prompt_file, and a non-empty success_checks list. Jobs seen:
+      {{ hermes_agent_curriculum.jobs | map(attribute='id') | list }}.
+    success_msg: >-
+      Curriculum manifest contracts hold
+      ({{ hermes_agent_curriculum.jobs | length }} jobs, all with prompt files
+      and machine-checkable success gates).
+
+- name: Assert every curriculum prompt file exists in the role
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - (role_path ~ '/files/curriculum/' ~ item.prompt_file) is file
+    fail_msg: >-
+      Curriculum job '{{ item.id }}' names prompt_file '{{ item.prompt_file }}',
+      which does not exist under roles/hermes_agent/files/curriculum/.
+  loop: "{{ hermes_agent_curriculum.jobs }}"
+  loop_control:
+    label: "{{ item.id }}"

--- a/roles/hermes_agent/tasks/assert.yml
+++ b/roles/hermes_agent/tasks/assert.yml
@@ -81,7 +81,8 @@
         | selectattr('success_checks', 'undefined') | list | length == 0
       - >-
         hermes_agent_curriculum.jobs
-        | map(attribute='success_checks') | map('length') | min > 0
+        | map(attribute='success_checks', default=[])
+        | map('length') | min > 0
     fail_msg: >-
       Curriculum manifest contract violated
       (roles/hermes_agent/files/curriculum/curriculum.yml): every job needs a

--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -419,6 +419,22 @@
     mode: "0640"
     directory_mode: "0750"
 
+# The versioned curriculum (H-9): the graded five-job set the job API
+# executes, plus the grading sheet, rubric schema and submission runbook.
+# curriculum.yml is the canonical manifest — prompts, order, budgets and each
+# job's machine-checkable success_checks (contract-asserted in assert.yml).
+# Materialized on the guest so the agent can read its own curriculum (the
+# `improve` job reviews it) and so a future recurring eval can execute it
+# locally; submissions themselves arrive via the inbound job API.
+- name: Deploy the versioned curriculum (manifest, jobs, grading, runbook)
+  ansible.builtin.copy:
+    src: curriculum/
+    dest: "{{ hermes_agent_hermes_home }}/curriculum/"
+    owner: "{{ hermes_agent_user }}"
+    group: "{{ hermes_agent_user }}"
+    mode: "0640"
+    directory_mode: "0750"
+
 # --- Splunk monitor: skill + self-directed 24/7 SIEM analyst cron fleet ------
 # The skill encodes the hard query-safety rails (bounded queries only) + the
 # self-directed investigative method. It must be materialized BEFORE the cron


### PR DESCRIPTION
## What (blueprint H-9 + the curriculum page)

Promotes the five-job graded curriculum from the 2026-07-11 run archive to its versioned repo home, `roles/hermes_agent/files/curriculum/`, deployed to `$HERMES_HOME/curriculum/` every converge. This is the "actively learning to monitor and fix the homelab" loop as code:

- **`curriculum.yml`** — canonical manifest: submission order, stagger, budgets, expected role-deployed skills, and each job's **machine-checkable `success_checks`** (run status, wiki-page writes and Slack delivery visible in the event stream, read-only compliance, bounded-SPL-only, GitHub issue caps verified via issue search — all evaluated from surfaces outside the job's own summary).
- **`jobs/*.md`** — the verbatim `POST /v1/runs` prompts: `orient` (verified self-orientation), `reposweep` (read-only GitHub triage), `splunk` (one deep investigation on the bundled dryvist/splunk-monitor skill's bounded-query rails), `apps` (fleet health: log errors x repo issues; files at most 3 `[hermes-fleet-health]` issues via the agent's own PAT flow), `improve` (evidence-based self-improvement; files at most 2 `[hermes-improve]` issues). `night-orient` renamed `orient` per the clustered/normal naming rule.
- **`grading-sheet.md`** — four 0-3 dimensions/job, verified-claim spot checks, per-job safety caps, cross-job omissions check.
- **`escalation-rubric-schema.md`** — the F1-F8 feature schema graded runs populate to fit deep-vs-broad routing (consumed by the rubric-fitting issue).
- **`submission-runbook.md`** — turnkey: preflight gates (`/health` 200 + keyless submit 401), in-memory key fetch from OpenBao `secret/ai/hermes`, staggered submits, collection, grading. FQDN-only, no environment literals.

## Tests (role-level asserts)

New Layer-1 asserts make the manifest self-checking at every converge: unique job ids, every `prompt_file` exists in the role, non-empty `success_checks` per job. A manifest edit can never silently ship an unexecutable or ungradeable job. Evidence:

- Manifest contract script check: 5 jobs, unique ids, all prompt files present, all checks non-empty — pass.
- `ansible-lint` (production profile) + full pre-commit (yamllint, markdownlint-cli2): all green.

## Notes

Submission itself stays gated on the job API going live (phase 1); this PR is the versioned artifact set that submission executes. Includes the same markdownlint-cli2 pre-commit fix commit as #876.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nw6KWXN6S7k13w2xAhRZb3