### PR TITLE
feat(llm_router): encode escalation rubric v1 as config data + deep-analysis tier alias

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -148,10 +148,11 @@ ai_escalation_rubric:
         - mlx-lm pipeline-generate bug (upstream fix drafted)
         - serving-host wired-memory headroom mitigation required
   decision_rule:
-    # Prospective F1-F8 scores (0-3 each) per the curriculum rubric schema.
-    # Reasoning depth + cross-source synthesis weighted highest (hypothesis:
-    # where a bigger brain most outperforms; long tool chains are
-    # executor-bound, not brain-bound).
+    # Prospective F1-F7 difficulty scores (0-3 each) are weighted below; F8
+    # latency_tolerance is the routing veto after the weighted score. Reasoning
+    # depth + cross-source synthesis are weighted highest (hypothesis: where a
+    # bigger brain most outperforms; long tool chains are executor-bound, not
+    # brain-bound).
     weights:
       reasoning_depth: 2.0
       cross_source_synthesis: 1.5
@@ -162,7 +163,9 @@ ai_escalation_rubric:
       output_structure_complexity: 0.5
     deep_threshold: 12 # score >= 12 -> deep
     broad_threshold: 6 # score <= 6 -> broad; between -> either (by availability)
-    latency_veto: latency_tolerance 0 routes broad regardless of score
+    latency_veto:
+      latency_tolerance: 0
+      target_tier: broad
 
 # AI serving timeout chain (client-is-decider). Each OUTER layer must OUTLIVE the
 # inner one, so no intermediate guard kills a still-healthy generation and the

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -108,6 +108,62 @@ ai_default_model_optimized: Qwen3.6-35B-A3B-OptiQ-4bit
 ai_default_model_large: Qwen3-Next-80B-A3B-Thinking-4bit
 ai_default_model: "{{ 'ai-default' if ai_rotation_enabled | bool else ai_default_model_optimized }}"
 
+# Escalation rubric v1 — WHICH tier a task deserves, encoded as data (from the
+# 2026-07-12 document benchmark: two planted traps, three model classes).
+# Consumers: the llm_router renders a stable alias per active tier
+# (llm_router_large_models), and the curriculum loop re-fits decision_rule
+# from graded 30B-vs-deep run deltas — the feature definitions (F1-F8) live
+# with the curriculum (roles/hermes_agent/files/curriculum/
+# escalation-rubric-schema.md). This block is the single source the fitted
+# values update; nothing here changes routing until a consumer reads it.
+ai_escalation_rubric:
+  version: 1
+  fitted: false # decision_rule holds PRIORS until curriculum grade deltas land
+  tiers:
+    # Default for everything, including "is this claim true" verification —
+    # benchmark: caught the arithmetic trap with correct math in 50 s wall.
+    # Known ceiling: shallow on second-order effects (flagged the hidden
+    # constraint as a bullet, never did the math).
+    - id: broad
+      router_alias: ai-default
+      status: active
+    # "What else breaks / find what the author missed" second-order analysis —
+    # benchmark: caught BOTH traps and dissected the source's own
+    # contradiction, a class deeper than broad. Constraints are hard: only
+    # worth invoking while the backend is RESIDENT (a cold escalation pays a
+    # multi-minute swap load and can wedge the serving proxy), and with a
+    # generous output-token budget (thinking output truncates at small caps).
+    - id: deep-analysis
+      router_alias: ai-deep-analysis
+      status: active
+      constraint: resident-only
+    # The cluster-served deep tier: queued deep packets during a cluster
+    # window; the latency veto below already excluded anything that cannot
+    # wait, so an unavailable window DEFERS a deep task, never silently
+    # downgrades it.
+    - id: cluster-deep
+      router_alias: null # registered only when a window is up (gated build-out)
+      status: blocked-upstream
+      blocked_by:
+        - mlx-lm pipeline-generate bug (upstream fix drafted)
+        - serving-host wired-memory headroom mitigation required
+  decision_rule:
+    # Prospective F1-F8 scores (0-3 each) per the curriculum rubric schema.
+    # Reasoning depth + cross-source synthesis weighted highest (hypothesis:
+    # where a bigger brain most outperforms; long tool chains are
+    # executor-bound, not brain-bound).
+    weights:
+      reasoning_depth: 2.0
+      cross_source_synthesis: 1.5
+      context_breadth: 1.0
+      ambiguity: 1.0
+      tool_chain_length: 0.5
+      error_recovery_demand: 0.5
+      output_structure_complexity: 0.5
+    deep_threshold: 12 # score >= 12 -> deep
+    broad_threshold: 6 # score <= 6 -> broad; between -> either (by availability)
+    latency_veto: latency_tolerance 0 routes broad regardless of score
+
 # AI serving timeout chain (client-is-decider). Each OUTER layer must OUTLIVE the
 # inner one, so no intermediate guard kills a still-healthy generation and the
 # CLIENT alone decides when to give up:

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -141,6 +141,18 @@ llm_router_large_models:
   - alias: Qwen3-Next-80B-A3B-Thinking-4bit
     backend: mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit
     context_window: 32768
+  # ai-deep-analysis: the STABLE tier alias for the escalation rubric's
+  # deep-analysis tier (ai_escalation_rubric, all.yml) — "what else breaks /
+  # find what the author missed" second-order analysis. A tier NAME decoupled
+  # from the physical model (same pattern as ai-default) so re-pinning the
+  # tier is one data edit here, no consumer changes. Currently the 80B
+  # thinking brain; rubric constraint: invoke only while the backend is
+  # resident, with a generous output-token budget. The cluster deep tier gets
+  # its alias only when a cluster window is up (blocked-upstream — see the
+  # rubric data).
+  - alias: ai-deep-analysis
+    backend: mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit
+    context_window: 32768
   # claude-sonnet-5 is a Claude Code alias deliberately mapped to a local Qwen3.6
   # backend (PR #624) — not a mis-map; it inherits that backend's serving window.
   - { alias: claude-sonnet-5, backend: mlx-community/Qwen3.6-35B-A3B-4bit, context_window: 32768 }


### PR DESCRIPTION
## What (blueprint curriculum page: the escalation rubric as a maintained artifact)

Encodes rubric v1 (2026-07-12 document benchmark: two planted traps across three model classes) as versioned config data, so tier routing is a data edit rather than tribal knowledge:

- **`ai_escalation_rubric` (group_vars/all.yml)** — three tiers with status/constraints and the provisional decision rule (prospective F1–F8 weights with reasoning-depth + cross-source-synthesis weighted highest, deep/broad thresholds, latency veto), explicitly `fitted: false` until the graded curriculum runs supply grade deltas. Feature definitions (F1–F8) live with the curriculum artifact set (#878).
- **`ai-deep-analysis` router alias (llm_router)** — a stable tier NAME for the deep-analysis tier, decoupled from the physical model (same pattern as `ai-default`), currently mapped to the 80B thinking backend. Benchmark basis: broad tier caught the arithmetic trap in 50 s but only bulleted the hidden second-order constraint; the 80B caught both and dissected the source's own contradiction — but only pays off **resident** (a cold escalation costs a multi-minute swap load and can wedge the serving proxy) and with a generous output-token budget. Both constraints are recorded in the rubric data.
- **Cluster tier marked `blocked-upstream`** — no alias registered until a cluster window exists (upstream pipeline-generate bug with a drafted fix + serving-host wired-memory headroom mitigation). The rubric's latency veto means an unavailable window defers a deep task; it never silently downgrades.

## Test evidence

- `ansible-lint` (production profile), yamllint, full pre-commit: all green.
- Data-only change: no template/task behavior changes; the new alias entry follows the exact shape of the existing first-class 80B alias, and the rendered router config gains one model_name entry.

## Notes

No live converge (AWS-creds cutover in flight). Fitting the weights from graded 30B-vs-deep packets is the mlx-benchmarks follow-up (H-10), consuming this block as its single source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nw6KWXN6S7k13w2xAhRZb3