### PR TITLE
fix(llm_router): add repetition_penalty guardrail to 80B deep-brain aliases

### DIFF
--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -141,6 +141,7 @@ llm_router_large_models:
   - alias: Qwen3-Next-80B-A3B-Thinking-4bit
     backend: mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit
     context_window: 32768
+    extra_body: { repetition_penalty: 1.05 }
   # ai-deep-analysis: the STABLE tier alias for the escalation rubric's
   # deep-analysis tier (ai_escalation_rubric, all.yml) — "what else breaks /
   # find what the author missed" second-order analysis. A tier NAME decoupled
@@ -153,6 +154,7 @@ llm_router_large_models:
   - alias: ai-deep-analysis
     backend: mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit
     context_window: 32768
+    extra_body: { repetition_penalty: 1.05 }
   # claude-sonnet-5 is a Claude Code alias deliberately mapped to a local Qwen3.6
   # backend (PR #624) — not a mis-map; it inherits that backend's serving window.
   - { alias: claude-sonnet-5, backend: mlx-community/Qwen3.6-35B-A3B-4bit, context_window: 32768 }


### PR DESCRIPTION
The 80B aliases (Qwen3-Next-80B-A3B-Thinking-4bit and ai-deep-analysis,
both the same backend) shipped with no extra_body.repetition_penalty,
while the sibling OptiQ-35B brain in the same file carries 1.05 as its
anti-repetition-loop guardrail. On 2026-07-09 an unguarded 80B generation
ran 40m51s (repetition-runaway at the 32768 token cap) under sustained
load and contributed to crashing the serving host, after which the 80B
large-phase rotation was paused.

Add extra_body: { repetition_penalty: 1.05 } to both 80B aliases, matching
OptiQ's exact shape. context_window / max_tokens are unchanged — the
generous token budget is intentional for the thinking verdict.

This is defense against the repetition-runaway class from the 2026-07-09
incident, matching OptiQ's proven-clean config. It does not by itself
re-enable the paused 80B rotation (capacity gating is separate, per
docs/BRAIN_ROTATION.md).

Assisted-by: Claude:Sonnet 5
Claude-Session: https://claude.ai/code/session_018vQAhPemL4heN2VxvcDLJC
