### PR TITLE
feat(hermes_agent): add read-only github-triage monitoring cron

### DIFF
--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -428,12 +428,40 @@ hermes_agent_splunk_cron_jobs:
     prompt: "{{ hermes_agent_splunk_digest_cron_prompt }}"
     deliver: "{{ hermes_agent_splunk_digest_deliver }}"
 
+# --- GitHub monitor: periodic read-only org-triage sweep -------------------
+# The poll-based counterpart to the Splunk fleet, reusing the existing
+# dryvist/github-issues skill + its PAT — no webhook ingress, no new skill.
+# Each run is a fresh isolated agent session (context never builds up run to
+# run). Read-only by contract: it reports, it never comments/labels/closes.
+# Minute 12 keeps it clear of the Splunk minutes above (bounds concurrent load
+# on the shared serving tier). Gated in tasks on BOTH the github-issues PAT
+# (can query) AND the Slack tokens (can deliver) — same shape as splunk.
+hermes_agent_github_monitor_enabled: true
+hermes_agent_github_monitor_cron_name: github-triage
+hermes_agent_github_monitor_cron_schedule: "12 */2 * * *"
+hermes_agent_github_monitor_cron_prompt: >-
+  Do a read-only triage sweep of the dryvist GitHub org right now using your
+  github-issues skill. Enumerate open PRs and issues across non-archived repos;
+  flag PRs older than 7 days as stale, Renovate/bot PRs open >7 days, and issues
+  untouched for 30+ days. NEVER comment on, label, close, or edit anything — you
+  are producing a report, not acting on it. If nothing genuinely needs a human
+  decision, reply with exactly [SILENT]; otherwise post one concise top-5 action
+  list (repo, number, why) plus totals to the home channel.
+hermes_agent_github_monitor_cron_deliver: slack
+
+hermes_agent_github_cron_jobs:
+  - name: "{{ hermes_agent_github_monitor_cron_name }}"
+    schedule: "{{ hermes_agent_github_monitor_cron_schedule }}"
+    prompt: "{{ hermes_agent_github_monitor_cron_prompt }}"
+    deliver: "{{ hermes_agent_github_monitor_cron_deliver }}"
+
 # Every cron job this role seeds. The model-drift recovery task (tasks/main.yml)
 # only ever removes jobs on this list — user- and agent-created jobs are never
 # touched.
 hermes_agent_seeded_cron_names: >-
   {{ [hermes_agent_daily_status_cron_name, hermes_agent_nightly_wiki_cron_name]
-     + (hermes_agent_splunk_cron_jobs | map(attribute='name') | list) }}
+     + (hermes_agent_splunk_cron_jobs | map(attribute='name') | list)
+     + (hermes_agent_github_cron_jobs | map(attribute='name') | list) }}
 
 # --- Context7 MCP client (current library/framework docs on demand) ---
 # Registers Context7 so Hermes can pull up-to-date, version-specific docs

--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -493,6 +493,52 @@
     - hermes_agent_slack_home_channel | length > 0
     - item.name not in (hermes_agent_splunk_cron_list.stdout | default(''))
 
+# --- GitHub monitor: poll-based read-only org-triage cron --------------------
+# The dryvist/github-issues skill is already materialized unconditionally above,
+# so no per-job skill step is needed here. Seed idempotently (create-if-absent),
+# gated on the agent being able to BOTH query GitHub (the issues PAT is set) AND
+# deliver to Slack (tokens + home channel) — same shape as the Splunk fleet.
+- name: Check which GitHub monitor cron jobs already exist
+  ansible.builtin.command: "{{ hermes_agent_bin }} cron list --all"
+  environment:
+    HERMES_HOME: "{{ hermes_agent_hermes_home }}"
+  become: true
+  become_user: "{{ hermes_agent_user }}"
+  register: hermes_agent_github_cron_list
+  changed_when: false
+  failed_when: false
+  when:
+    - hermes_agent_github_monitor_enabled | bool
+    - hermes_agent_github_issues_pat | length > 0
+    - hermes_agent_slack_bot_token | length > 0
+    - hermes_agent_slack_app_token | length > 0
+    - hermes_agent_slack_home_channel | length > 0
+
+- name: Seed the GitHub monitor cron jobs
+  ansible.builtin.command:
+    cmd: >-
+      {{ hermes_agent_bin }} cron create "{{ item.schedule }}"
+      "{{ item.prompt }}"
+      --name "{{ item.name }}"
+      --skill dryvist/github-issues
+      --deliver "{{ item.deliver }}"
+  environment:
+    HERMES_HOME: "{{ hermes_agent_hermes_home }}"
+  become: true
+  become_user: "{{ hermes_agent_user }}"
+  loop: "{{ hermes_agent_github_cron_jobs }}"
+  loop_control:
+    label: "{{ item.name }}"
+  register: hermes_agent_github_cron_create
+  changed_when: true
+  when:
+    - hermes_agent_github_monitor_enabled | bool
+    - hermes_agent_github_issues_pat | length > 0
+    - hermes_agent_slack_bot_token | length > 0
+    - hermes_agent_slack_app_token | length > 0
+    - hermes_agent_slack_home_channel | length > 0
+    - item.name not in (hermes_agent_github_cron_list.stdout | default(''))
+
 - name: Deploy the hermes-gateway systemd unit
   ansible.builtin.template:
     src: hermes-gateway.service.j2


### PR DESCRIPTION
## What

Adds a poll-based **read-only GitHub org-triage cron** to the `hermes_agent` role, mirroring the existing Splunk cron fleet. This is the "basic GitHub monitoring now" path — no webhook ingress required.

- New `github-triage` job (`12 */2 * * *`): a fresh isolated agent session sweeps the dryvist org's open PRs and issues via the **existing** `dryvist/github-issues` skill and posts a top-5 action list to Slack, `[SILENT]` unless a human decision is needed.
- **Read-only by contract** — the prompt forbids commenting, labeling, closing, or editing any PR/issue. It reports, it never mutates GitHub.

## Changes (2 files, role-scoped)

- `roles/hermes_agent/defaults/main.yml`: adds the `github-triage` vars + `hermes_agent_github_cron_jobs`, and appends the job name to `hermes_agent_seeded_cron_names` (so model-drift recovery manages it).
- `roles/hermes_agent/tasks/main.yml`: adds the paired `cron list` check + seed-loop tasks, mirroring the Splunk seed loop.

## Gating / activation (honest)

Seeding is gated on `hermes_agent_github_issues_pat` being set **AND** the Slack tokens + home channel — the same gate shape as the Splunk fleet. The `dryvist/github-issues` skill is already materialized unconditionally, so no new skill step.

**This PR lands the definition only; it does not activate the job.** The cron is seeded only once:
1. `GH_PAT_WRITE_PROJECT_ISSUES` is present in OpenBao `secret/ai/hermes` (**currently empty**), and
2. a `site.yml --tags hermes_agent` converge runs.

No converge, no live-guest changes, and no secrets are seeded by this PR.

## Out of scope

True GitHub **webhook** handling is a separate, larger effort: public ingress to the webhook port + a GitHub App configured to POST there + a non-`deliver_only` agent-triggering route. Not attempted here.

## Verification

pre-commit passed on the changed files (yamllint, check-yaml, trailing-whitespace, end-of-file). `ansible-lint` was skipped locally (executable not installed in this env) — CI runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018vQAhPemL4heN2VxvcDLJC