### PR TITLE
feat(openbao): AWS secrets engine for dynamic tf-proxmox STS creds

### DIFF
--- a/roles/openbao/README.md
+++ b/roles/openbao/README.md
@@ -274,7 +274,8 @@ prebuilt, checksum-verified release binaries. The role therefore:
 - The `terraform-apply` AppRole reads `aws/sts/tf-proxmox` to mint a session —
   see the [^aws-sts] policy footnote above.
 - The laptop side (nix-darwin `credential_process` wrapper reading
-  `terraform-apply`'s `role_id`/`secret_id` from `openbao.keychain-db`) is
+  `terraform-apply`'s `role_id`/`secret_id` secret-zero from the ambient
+  environment, injected by running terragrunt under `doppler run`) is
   documented in the nix-darwin repo, not here.
 
 ## GitHub secrets engine (ephemeral GitHub App tokens)

--- a/roles/openbao/README.md
+++ b/roles/openbao/README.md
@@ -199,7 +199,7 @@ plans):
 | `hermes` | `secret/ai/hermes` only | — | Dedicated least-privilege reader for the Hermes agent; NO broad `secret/ai/*` |
 | `hermes-write` | `secret/ai/hermes` only | `secret/ai/hermes` only | Narrow Doppler-published writer; least-priv complement to `ai-orchestrator` |
 | `public` | `secret/public/*` | — | **Anonymous** — no secret-zero; shipped ambiently |
-| `ai-orchestrator` | `secret/ai/*` | `secret/ai/*` (create/update) | Broad AI-orchestrator WRITE; secret-zero operator-held in Doppler tier-0 |
+| `ai-orchestrator` | `secret/ai/{hermes,agents}` | `secret/ai/{hermes,agents}` (create/update) | WRITE; Doppler tier-0; narrowed + 30m TTL at Phase-3 |
 | `ai-readonly` | `secret/ai/*`, `secret/apps/*` | — | **default AI agent; NO `secret/infra/*`** |
 | `ai-elevated` | `ai-readonly` + `secret/platform/*` | — | trusted infra-touching agents; no write |
 | `snapshot` | `sys/storage/raft/snapshot` | — | least-priv backup identity |

--- a/roles/openbao/README.md
+++ b/roles/openbao/README.md
@@ -82,10 +82,10 @@ This role brings OpenBao live **before** anything that reads secrets from it.
    Doppler tier-0 as `OPENBAO_STATIC_SEAL_KEY` (+ `OPENBAO_STATIC_SEAL_KEY_ID`).
 2. `terraform-proxmox` — provision the 5 OpenBao LXCs (VMID/IP/firewall).
 3. **this role** — install + init the cluster, mint the AppRoles.
-4. Operator — transcribe recovery shares to paper (+ Bitwarden); load each
-   AppRole's `role_id`/`secret_id` into its own item in the dedicated
-   `openbao.keychain-db` keychain — except `public`, which is NOT
-   keychain-gated (see [Secret hierarchy & RBAC](#secret-hierarchy--rbac)).
+4. Operator — transcribe recovery shares to paper (+ Bitwarden); publish each
+   AppRole's `role_id`/`secret_id` to Doppler tier-0, consumed as ambient env
+   under `doppler run` — except `public`, which needs no secret-zero at all
+   (see [Secret hierarchy & RBAC](#secret-hierarchy--rbac)).
 5. `terraform-proxmox` `vault-secrets` — now able to authenticate as
    `terraform-apply` (read/write proof).
 
@@ -198,8 +198,8 @@ plans):
 | `local-llm` | `secret/ai/*` | — | The LLM serving stack itself |
 | `hermes` | `secret/ai/hermes` only | — | Dedicated least-privilege reader for the Hermes agent; NO broad `secret/ai/*` |
 | `hermes-write` | `secret/ai/hermes` only | `secret/ai/hermes` only | Narrow Doppler-published writer; least-priv complement to `ai-orchestrator` |
-| `public` | `secret/public/*` | — | **Anonymous** — creds NOT keychain-gated; shipped ambiently |
-| `ai-orchestrator` | `secret/ai/*` | `secret/ai/*` (create/update) | Broad AI-orchestrator WRITE; creds operator-held in the macOS keychain (not Doppler) |
+| `public` | `secret/public/*` | — | **Anonymous** — no secret-zero; shipped ambiently |
+| `ai-orchestrator` | `secret/ai/*` | `secret/ai/*` (create/update) | Broad AI-orchestrator WRITE; secret-zero operator-held in Doppler tier-0 |
 | `ai-readonly` | `secret/ai/*`, `secret/apps/*` | — | **default AI agent; NO `secret/infra/*`** |
 | `ai-elevated` | `ai-readonly` + `secret/platform/*` | — | trusted infra-touching agents; no write |
 | `snapshot` | `sys/storage/raft/snapshot` | — | least-priv backup identity |
@@ -220,11 +220,11 @@ secrets-engine paths and are returned through a short-lived OpenBao token.
     STS creds (assumed_role) for `role/tf-proxmox`, replacing the laptop's
     static aws-vault base key. See the AWS secrets engine section below.
 
-**Secret-zero model**: each AppRole's `role_id`/`secret_id` lives as its own
-item in a dedicated macOS keychain (`openbao.keychain-db`, 72h auto-lock) —
-the keychain's LOCK STATE is the entire access boundary, not the AppRole's own
-TTL (`secret_id_ttl=0` is intentional here, not an oversight). The one
-exception is `public`: its credential is deliberately NOT keychain-gated,
+**Secret-zero model**: each AppRole's `role_id`/`secret_id` is published to
+Doppler tier-0 and reaches its consumer as ambient environment under
+`doppler run` — access to Doppler tier-0 is the entire access boundary, not
+the AppRole's own TTL (`secret_id_ttl=0` is intentional here, not an
+oversight). The one exception is `public`: it needs no secret-zero at all,
 since it only unlocks non-exploitable facts.
 
 The policy/AppRole set is driven by `openbao_policies` / `openbao_approles` in
@@ -323,20 +323,19 @@ the seal key is ever lost, so they are treated as paper secrets:
   under `playbook_dir`**. Existing AppRoles' credentials are never re-emitted.
 - Every `bao` invocation that touches this material runs with `no_log: true`.
 - A **loud warning** names exactly which AppRoles were newly created and tells
-  the operator to transcribe recovery shares to paper (+ Bitwarden), load each
-  new AppRole's creds into its own item in the `openbao.keychain-db` keychain,
-  then **securely delete** the files.
+  the operator to transcribe recovery shares to paper (+ Bitwarden), publish
+  each new AppRole's creds to Doppler tier-0 (consumed as ambient env under
+  `doppler run`), then **securely delete** the files.
 - Nothing secret is ever written into the repo or onto a target host.
 
 These controller files are gitignored (`.openbao-recovery-*.json` /
 `.openbao-approle-*.json`). After transcription:
 
 ```sh
-security add-generic-password -s "openbao/<domain>" -a role_id -w <role_id> \
-  ~/Library/Keychains/openbao.keychain-db
-security add-generic-password -s "openbao/<domain>" -a secret_id -w <secret_id> \
-  ~/Library/Keychains/openbao.keychain-db
-# `public` is the one exception — ships ambiently, never keychain-gated.
+# Publish secret-zero to Doppler tier-0 (consumed as ambient env via `doppler run`).
+doppler secrets set OPENBAO_APPROLE_<ROLE>_ROLE_ID="<role_id>" --project <proj> --config <cfg>
+doppler secrets set OPENBAO_APPROLE_<ROLE>_SECRET_ID="<secret_id>" --project <proj> --config <cfg>
+# `public` needs no secret-zero — it ships ambiently.
 shred -u <playbook_dir>/.openbao-recovery-<host>.json
 shred -u <playbook_dir>/.openbao-approle-*-<host>.json
 ```

--- a/roles/openbao/templates/public-policy.hcl.j2
+++ b/roles/openbao/templates/public-policy.hcl.j2
@@ -2,8 +2,8 @@
 # OpenBao policy for the public AppRole — the ANONYMOUS domain. Read-only on
 # secret/public/*: sensitive-but-not-exploitable facts (e.g. the internal
 # domain/subdomain) that don't belong in a public repo but aren't secrets in
-# the security sense either. This identity's credentials are deliberately NOT
-# keychain-gated — see docs/SECRETS_HIERARCHY.md. OpenBao has no built-in
+# the security sense either. This identity deliberately needs no secret-zero
+# — see docs/SECRETS_HIERARCHY.md. OpenBao has no built-in
 # truly-unauthenticated read path, so this fixed low-privilege AppRole is the
 # closest real equivalent: bound to internal RFC1918 CIDRs at the operator
 # level, shipped ambiently, and scoped so leaking it costs nothing.


### PR DESCRIPTION
Adds an OpenBao **AWS secrets engine** (`assumed_role`) to the `openbao` role,
server-side. Stages + registers the external AWS plugin (sha256-pinned) on
every node, mounts `aws/`, writes `config/root` (write-once, seeded from
Doppler tier-0) and `roles/tf-proxmox` (1h/2h STS TTLs), and grants the
`terraform-apply` AppRole read+update on `aws/sts/tf-proxmox`.

This replaces the workstation's static aws-vault base key with short-lived STS
sessions minted on demand. The same role also feeds Terrakube's tofu-aws
workspace server-side; the laptop `credential_process` path is the local /
break-glass consumer.

Client secret-zero is sourced from Doppler env (documented in nix-darwin
#1686), not a local keychain — README updated to match.

Includes molecule verify coverage for the new engine.