### PR TITLE
fix(llm_router): point ai-default at 80B while OptiQ engine bug is open

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -103,8 +103,14 @@ llm_large_serving_ip: >-
 # remains the fabric alias; the sentinel holds the optimized phase until a
 # candidate passes the re-enable gates in docs/BRAIN_ROTATION.md
 # (measured-peak capacity + fleet-throughput).
+# OptiQ-4bit temporarily DE-DEFAULTED (2026-07-13): the current vllm-mlx build
+# regressed its inference path — OptiQ is misdetected as a VLM and its MTP patch
+# throws `Cannot broadcast array of shape (1,1,1,0) into shape (1,16,1,1)` mid
+# generation, returning finish_reason=error (0 tokens) and killing the worker.
+# The 80B and stock 35B run clean on the same build. Both rotation phases point
+# at the 80B until OptiQ's engine bug is fixed (then revert optimized to OptiQ).
 ai_rotation_enabled: true
-ai_default_model_optimized: Qwen3.6-35B-A3B-OptiQ-4bit
+ai_default_model_optimized: Qwen3-Next-80B-A3B-Thinking-4bit
 ai_default_model_large: Qwen3-Next-80B-A3B-Thinking-4bit
 ai_default_model: "{{ 'ai-default' if ai_rotation_enabled | bool else ai_default_model_optimized }}"
 


### PR DESCRIPTION
## What

Point both brain-rotation phases (`ai_default_model_optimized` and `ai_default_model_large`) at `Qwen3-Next-80B-A3B-Thinking-4bit` so the fabric `ai-default` alias resolves to the 80B on both phases.

## Why

The current vllm-mlx build regressed the OptiQ inference path: `Qwen3.6-35B-A3B-OptiQ-4bit` is misdetected as a VLM and its MTP patch throws a broadcast-shape error mid-generation, returning `finish_reason=error` (0 tokens) and killing the worker. This surfaced to Hermes as `litellm.MidStreamFallbackError` on every `splunk-*` cron (failing ~every 8 min). The 80B and stock 35B run clean on the same build.

This is a **temporary de-default** — revert the optimized phase to OptiQ once its engine bug is fixed (comment in `all.yml` records the tripwire).

## Verification (live)

- Converge repointed `ai-default` on all 3 routers (`changed=2`, `failed=0` each); `Restart litellm` handler fired; liveness endpoint `ok` on all 3.
- Studio 80B serves clean tool calls warm (`finish_reason: tool_calls`, valid args, ~4s).
- Zero `finish_reason=error` on the Studio for 69 min post-fix (previously every ~8 min).

## Follow-up (not in this PR)

Throughput: the 80B serves `running=2` at ~6 tok/s; a burst of thinking-mode crons backlogs (metastable `waiting=6`). No timeouts observed, but cron latency is high. Addressed separately by cron-cadence redesign + resident-preload/concurrency tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)