### PR TITLE
fix(llm_router): repetition_penalty guard on the ai-default rotation alias

### DIFF
--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -269,6 +269,16 @@ llm_router_large_passthrough_enabled: true
 # whole block below is inert and config.yaml renders exactly as it did before.
 llm_router_rotation_enabled: "{{ ai_rotation_enabled | default(false) | bool }}"
 llm_router_rotation_alias: ai-default
+# Anti-repetition-loop guard for the rotation alias itself. `ai-default` is a
+# distinct model_name from the per-phase aliases in llm_router_large_models, so
+# their extra_body does NOT reach it — Hermes addresses `ai-default` and would
+# otherwise run with the engine's request-absent repetition_penalty 1.0 (OFF).
+# That is what regressed when the fleet brain switched OptiQ->stock 35B (#915):
+# the guard lived only on the OptiQ alias, so the 35B fleet brain looped
+# (identical-tool-call spam, !!!!/status degeneration; 2026-07-14 incident).
+# 1.05 matches the value validated on the OptiQ twin; raise toward the clean
+# bench's sampling (temperature ~1.0 / presence_penalty 0.0) if loops persist.
+llm_router_rotation_repetition_penalty: 1.05
 # The two phases, by their first-class alias id in llm_router_large_models above
 # (the role resolves each to its backend + context_window from that table).
 llm_router_rotation_large_model: "{{ ai_default_model_large }}"

--- a/roles/llm_router/templates/config.yaml.j2
+++ b/roles/llm_router/templates/config.yaml.j2
@@ -64,6 +64,11 @@ model_list:
       model: openai/{{ llm_router_night_model }}
       api_base: {{ llm_router_night_base_url }}
       api_key: os.environ/LLM_LARGE_BEARER_TOKEN
+      # See llm_router_rotation_repetition_penalty in defaults: the rotation
+      # alias needs its own guard (the per-phase aliases' extra_body never
+      # reaches this distinct model_name).
+      extra_body:
+        repetition_penalty: {{ llm_router_rotation_repetition_penalty }}
     model_info:
       max_input_tokens: {{ llm_router_night_context }}
       max_tokens: {{ llm_router_night_context }}
@@ -75,6 +80,11 @@ model_list:
       model: openai/{{ llm_router_rotation_active_backend }}
       api_base: {{ llm_router_llm_large_base_url }}
       api_key: os.environ/LLM_LARGE_BEARER_TOKEN
+      # See llm_router_rotation_repetition_penalty in defaults: the rotation
+      # alias needs its own guard (the per-phase aliases' extra_body never
+      # reaches this distinct model_name).
+      extra_body:
+        repetition_penalty: {{ llm_router_rotation_repetition_penalty }}
     model_info:
       max_input_tokens: {{ llm_router_rotation_active_context }}
       max_tokens: {{ llm_router_rotation_active_context }}


### PR DESCRIPTION
## Problem

`ai-default` is the stable rotation alias every fleet consumer addresses. It is
a distinct LiteLLM `model_name` from the per-phase model aliases, so the
`extra_body` sampling defaults pinned on those aliases never reach it. The
anti-repetition-loop guard (`repetition_penalty: 1.05`) was configured only on
the per-phase alias — so requests to `ai-default` ran with the serving engine's
request-absent default (`repetition_penalty` 1.0 = off).

When the fleet brain switched to the stock 35B (#915), the brain began
degenerating under long agentic contexts: repeated identical output that never
terminates, runs to the stream guard, and aborts mid-stream — surfacing to the
agent as a brain-unreachable event and cron-response garbage (2026-07-14).

## Fix

Inject `repetition_penalty` into the `ai-default` rotation-alias entries (normal
and night-live) via a tunable default `llm_router_rotation_repetition_penalty`
(1.05, the value already validated on the prior brain's alias). `extra_body`
forwards it verbatim past `drop_params` to the backend.

## Verification

A/B probe against the live 35B backend, identical prompt: malformed/looping
output with no penalty; clean coherent output with `repetition_penalty: 1.05`.

`--syntax-check` passes. Full `--check` in the author's environment is blocked
on the OpenBao inventory bootstrap (needs a `BAO_TOKEN` with object-storage
read); no code path here depends on that. Deploy with a `--tags llm_router`
converge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)