### PR TITLE
fix(openbao): use PROXMOX_SUBDOMAIN for the Terrakube JWT issuer

### DIFF
--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -291,7 +291,7 @@ openbao_flow_lock_approle_name: flow-lock
 # OpenBao verifies it through internal OIDC discovery and binds the exact
 # organization/workspace `sub` claim before issuing a short-lived token.
 openbao_terrakube_jwt_auth_path: terrakube
-openbao_terrakube_jwt_issuer: "https://terrakube-api.{{ (tofu_data | default({})).domain | default('local') }}"
+openbao_terrakube_jwt_issuer: "https://terrakube-api.{{ lookup('env', 'PROXMOX_SUBDOMAIN') | default('local', true) }}"
 openbao_terrakube_jwt_audience: openbao.workload.identity
 openbao_terrakube_jwt_token_ttl: 90m
 # Real org login is environment-specific; override in group_vars/host_vars.


### PR DESCRIPTION
## Summary

The OpenBao `openbao_terrakube_jwt_issuer` default built its URL from the
bare configured domain. Terrakube's own OIDC discovery document advertises
its issuer under the ingress subdomain instead, so the two values never
matched and OpenBao's JWT auth backend failed OIDC discovery validation
against the real issuer.

This changes the default to source the ingress subdomain via an
environment variable lookup, matching the pattern already used by the
`technitium_dns` role for other ingress-fronted URLs. No real domain or
subdomain value is introduced — only the env-var name.

## Test plan

- [x] `ansible-lint` (production profile) passes on the openbao role tasks: 0 failures, 0 warnings
- [x] YAML parses cleanly
- [x] Self-audit grep confirms no real domain/subdomain/IP literal was introduced
- [ ] Live converge + OIDC discovery check against the running OpenBao/Terrakube instances (infra-level verification, not covered by CI)

Assisted-by: Claude:claude-opus-4-8