### PR TITLE
docs(hermes): operations runbook + rotation-alias repetition breakage

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -13,10 +13,15 @@ production and each took the fabric down:
 | Every request compressed to death | brain alias fell through the `*` wildcard → null `max_input_tokens` | L1 router-alias assert; L2 tool-call probe fails |
 | Generations killed mid-stream | server guard below generation time / inverted timeout chain | L1 timeout-ordering assert |
 | "invalid tool call" loop | wrong tool parser / mis-wired brain | L2 tool-call probe returns no valid `function.name` |
+| Cron output loops/repeats | `ai-default` alias ran with `repetition_penalty` off (`extra_body` misses the distinct `model_name`) | Cron-cycle watch |
 
 Every one was **machine-detectable before or immediately after converge**. The
 two guardrail layers below make that detection automatic, so an unvalidated
-converge can no longer reach production silently.
+converge can no longer reach production silently. The last row (2026-07-14) is
+the exception the others are not: the repetition degeneration produced valid
+tool calls, so the Layer-2 probe passed — only watching a full cron cycle
+surfaced it (see [HERMES_OPS.md](HERMES_OPS.md) "Repetition guard"). Prefer a
+cron-cycle observation over declaring a brain-affecting converge settled.
 
 ## The staged deployment path
 
@@ -41,6 +46,24 @@ Always deploy the fabric in this order. Each stage gates the next.
    doppler run -- ansible-playbook \
      -i inventory/hosts.yml playbooks/site.yml --tags llm_router
    ```
+
+   **Converging without object-storage inventory access.** Inventory is
+   normally the object-storage-published `tofu_inventory.json`, fetched with an
+   OpenBao-authed AppRole. From a workstation lacking that AppRole, pin the
+   local gitignored cache instead — `inventory_resolve` resolves
+   `TOFU_INVENTORY_PATH` first (tier 1) and skips the object-storage fetch
+   entirely:
+
+   ```bash
+   TOFU_INVENTORY_PATH="$PWD/inventory/tofu_inventory.json" \
+     doppler run -- ansible-playbook \
+       -i inventory/hosts.yml playbooks/site.yml --tags llm_router
+   ```
+
+   The cache is safe when topology is stable (host set unchanged) — the common
+   case for a config-only converge. If a host moved or was added, refresh the
+   cache from the tofu-proxmox workspace first, or converge with normal
+   object-storage resolution.
 
 3. **Verify gate (post-converge, Layer 2).** `roles/hermes_agent/tasks/verify.yml`
    runs at the end of the role, after handlers flush. It proves the wiring

--- a/docs/HERMES_OPS.md
+++ b/docs/HERMES_OPS.md
@@ -1,0 +1,147 @@
+# Hermes agent — operations runbook
+
+The Hermes agent is an autonomous LLM operator that runs a fleet of scheduled
+jobs (Splunk sweeps, a daily fabric-status digest, GitHub triage, a nightly
+wiki job) and answers ad-hoc requests over Slack. It reaches its brain through
+the same serving fabric documented in [DEPLOYMENT.md](DEPLOYMENT.md) and
+[BRAIN_ROTATION.md](BRAIN_ROTATION.md); this doc covers the agent itself — its
+cron fleet, its memory, the credentials it needs, and how the serving path
+self-heals.
+
+Everything here is seeded declaratively by the `hermes_agent` role. Every cron
+run is a **fresh, isolated agent session** — there is no in-process state
+carried between runs, so anything a job needs to remember it must write to
+memory (below).
+
+## Cron fleet
+
+All jobs are defined in `roles/hermes_agent/defaults/main.yml` and seeded at
+converge time via `hermes cron create` in `tasks/main.yml`. Schedules are UTC
+(`hermes_agent_timezone: UTC`). Splunk jobs are gated on the Splunk MCP URL
+**and** Slack tokens being present; GitHub triage on the issues PAT **and**
+Slack tokens — a job whose credentials are unseeded is simply not created
+(the role runs inert, never errors).
+
+| Job | Schedule (UTC) | Purpose | Delivery |
+| --- | --- | --- | --- |
+| `homelab-ai-fabric-status` | `0 9 * * *` (daily 09:00) | Summarize AI-fabric health — router/gateway/DNS, merge-ready PRs | Slack |
+| `hermes-nightly-wiki` | `0 2 * * *` (daily 02:00) | Lint + health-check the llm-wiki | default |
+| `splunk-triage` | `3,18,33,48 * * * *` (every 15 min) | Broad self-directed anomaly sweep; `[SILENT]` unless something is off | alert → operator DM |
+| `splunk-security` | `9,39 * * * *` (every 30 min) | Security lens — firewall drops, auth failures, honeypot hits, unexpected IPs | alert → operator DM |
+| `splunk-parsing` | `24 * * * *` (hourly) | Data-quality lens — timestamp/line-merge/sourcetype/parse anomalies | alert → operator DM |
+| `splunk-deepdive` | `44 */6 * * *` (every 6h) | Quiet RAG research — characterize one index → wiki + memory baseline | local, no alert |
+| `splunk-digest` | `50 * * * *` (hourly) | Splunk heartbeat digest to the home channel; **never** `[SILENT]` | Slack (home) |
+| `github-triage` | `12 */2 * * *` (every 2h) | Read-only dryvist-org PR/issue triage; report only, never mutate | Slack (home) |
+
+Drift recovery: when the brain model changes, only *drifted* seeded jobs are
+removed and re-seeded (`tasks/main.yml`); the canonical set is
+`hermes_agent_seeded_cron_names`.
+
+## Memory
+
+- **Provider:** Hindsight (local knowledge-graph + multi-strategy retrieval) in
+  `local_embedded` mode, running alongside the always-on built-in
+  `MEMORY.md` / `USER.md`. Set in `defaults/main.yml`
+  (`hermes_agent_memory_provider: hindsight`, `hermes_agent_memory_mode:
+  local_embedded`). The Hindsight daemon config is rendered to
+  `$HERMES_HOME/hindsight/config.json`; its entity-extraction LLM points at the
+  same router the agent uses.
+- **Persistence:** the entire `HERMES_HOME` (`/var/lib/hermes/.hermes`) is the
+  durable surface — memory, skills, profiles, the Kanban DB, sessions and logs
+  all live there, on a dedicated ZFS dataset that is snapshotted and replicated
+  between nodes.
+- **`local_embedded` matters:** Hindsight defaults to a *cloud* mode that needs
+  an API key. With no key, `is_available()` returns false and every memory tool
+  call warns "Memory is not available" — a repeated, useless status line.
+  `local_embedded` + the rendered `hindsight/config.json` is what makes memory
+  actually work. Verify with a non-fatal `hermes memory status` probe (run in
+  `verify.yml`).
+
+> If you see a runtime loop of a repeated memory status line (e.g.
+> `Opening memory…Opening memory…`), that is the **brain degenerating**, not a
+> memory bug — see "Repetition guard" below. The literal string is an upstream
+> runtime line, not something this role emits.
+
+## Credentials — `secret/ai/hermes`
+
+Hermes reads its app credentials from OpenBao `secret/ai/hermes`
+(`bao_local_llm_secrets`, bao-first with env fallback). By design every field
+defaults to empty and an empty value **disables that capability** rather than
+failing the converge — so an un-seeded field silently turns a platform off.
+That is the deliberate contract; there is no converge-time assertion that a
+field is present.
+
+| Field | Enables | Notes |
+| --- | --- | --- |
+| `SPLUNK_MCP_URL` + `SPLUNK_MCP_TOKEN` | the entire `splunk-*` cron fleet | minted by the ansible-splunk path; known stale-token caveat |
+| `GH_PAT_WRITE_PROJECT_ISSUES` | `github-triage` cron + github-issues skill | empty until the token is issued |
+| `HERMES_GITHUB_APP_ID` / `_INSTALLATION_ID` / `_PRIVATE_KEY` | GitHub-App docs-contributor / nightly-wiki path | empty until the App is provisioned |
+| `HERMES_API_SERVER_KEY` | inbound job-submission API (`POST /v1/runs`, cron CRUD) | seeded programmatically; empty disables the api_server platform |
+| `WEBHOOK_SECRET` | inbound webhook receiver | generate-if-absent; empty disables webhooks |
+| `CONTEXT7_API_KEY` | Context7 MCP (on-demand library docs) | bao-first, env fallback |
+| `ZAMMAD_API_TOKEN` | Zammad ITSM client | same token the zammad role seeds; empty until Zammad is deployed |
+| `CODEX_AUTH_JSON` | Codex CLI for the isolated codex-runner user | create-only on the guest; empty until an operator seeds it |
+| `OPENROUTER_API_KEY` | — | seeded but **parked** — not consumed by any role yet |
+
+To verify seeding, the sanctioned path is the `hermes_agent` converge itself:
+`verify.yml` proves a live tool-call round-trip through the router and, when
+`HERMES_API_SERVER_KEY` is present, that the job API answers `/health` 200 and
+refuses a keyless `POST /v1/runs` with 401. A missing Splunk token shows up as
+the `splunk-*` crons simply not being seeded.
+
+## Serving self-heal (the zombie watchdog)
+
+The Mac serving host runs llama-swap under a launchd agent whose `KeepAlive`
+only restarts on process **exit**. llama-swap can panic (`sync: WaitGroup is
+reused`) into a process that stays alive and holds the listen socket but
+answers nothing — a zombie launchd never notices — so every request gets
+connection-refused and litellm surfaces `MidStreamFallbackError` until a human
+intervenes.
+
+The serving layer (in the nix-ai MLX module) now ships a **liveness watchdog**:
+a launchd agent probes the proxy's own `/v1/models` every 60s and, on two
+consecutive failures, `launchctl kickstart`s the server agent. It gates
+re-fires with a cooldown marker so a 20–60s model reload is not
+restart-stormed. Health, not PID. This is the durable fix for the recurring
+`MidStreamFallbackError` outage; a manual `launchctl kickstart` remains the
+sanctioned break-fix if the watchdog is not yet deployed.
+
+## Repetition guard
+
+The stable router alias every consumer addresses (`ai-default`) is a **distinct
+litellm `model_name`** from the per-phase model aliases, so per-phase sampling
+defaults (`extra_body`) never reach it. Without its own guard the alias ran
+with `repetition_penalty` at the backend default of 1.0 (off), and under long
+agentic contexts the brain degenerated into non-terminating repetition
+(`!!!!`, a repeated status line) that runs to the disconnect guard and aborts
+mid-stream. The rotation alias now carries its own
+`repetition_penalty: 1.05` guard (`llm_router_rotation_repetition_penalty`). If
+1.05 proves insufficient the next levers are `temperature ~1.0` /
+`presence_penalty 0.0` in the same `extra_body`.
+
+## Cron schedule — review (proposed, pending operator decision)
+
+The current fleet is anomaly-first and heavy on the single-stream brain
+(concurrency 1). Points worth an operator decision — **none applied here**:
+
+- **`splunk-digest` hourly, never `[SILENT]`** is the noisiest, lowest-signal
+  job — 24 heartbeat posts/day to the home channel. Consider every 4–6h, or
+  folding the heartbeat into the daily `homelab-ai-fabric-status`, keeping the
+  alert-on-anomaly jobs (`triage`/`security`/`parsing`) as the real signal.
+- **`splunk-triage` every 15 min** (96 runs/day) is aggressive for a
+  single-stream brain. If contention shows up, 20–30 min keeps anomaly latency
+  reasonable while freeing brain time.
+- **Stagger heavy jobs off the same minute.** `triage`, `security`, `parsing`
+  and `digest` can co-fire near the top of the hour; spreading their minutes
+  avoids two long agentic runs hitting the one resident brain at once.
+- **Self-directed work.** `splunk-deepdive` (quiet RAG, no alert) is the model
+  for "propose your own work"; a second reflective job that reviews recent
+  memory baselines and proposes follow-ups would extend that with no alert
+  noise.
+
+Keep the anomaly/security sweeps — a constant Splunk review is the highest-value
+loop. The lever is cadence and staggering, not removal.
+
+---
+
+[docs.jacobpevans.com](https://docs.jacobpevans.com)


### PR DESCRIPTION
## What

- **New** `docs/HERMES_OPS.md` — a standalone Hermes operations runbook. None existed; the cron/memory/credential knowledge lived only in role code. Covers:
  - the full cron fleet (schedules, purpose, delivery)
  - the Hindsight `local_embedded` memory mechanism + `HERMES_HOME`/ZFS persistence
  - the `secret/ai/hermes` credential surface — every field, what it gates, and the empty-disables-capability contract
  - the serving-layer zombie self-heal watchdog (nix-ai)
  - the rotation-alias `repetition_penalty` guard
  - a **cron-schedule review** (proposed, not applied — for operator decision)
- **Extend** `docs/DEPLOYMENT.md`:
  - add the 2026-07-14 rotation-alias repetition breakage to the failure table — it produced *valid* tool calls so the Layer-2 probe passed; only a cron-cycle watch surfaced it
  - document converging without object-storage inventory access via the `TOFU_INVENTORY_PATH` tier-1 local-cache pin

## Why

Captures the 2026-07-14 serving-reliability work (repetition guard #919, zombie watchdog, timeout/resident brain) and the operational knowledge that had no home. Docs-only; no code or role behavior changes.

## Verification

markdownlint clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)