### PR TITLE
feat(openbao): reproduce openbao-iac-admin AWS broker role in IaC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,7 @@ documented once at
 | `OPENBAO_AWS_ROOT_ACCESS_KEY_ID` | AWS engine bootstrap/rotation access key | tier-0 injection |
 | `OPENBAO_AWS_ROOT_SECRET_ACCESS_KEY` | AWS engine bootstrap/rotation secret key | tier-0 injection |
 | `OPENBAO_AWS_TF_PROXMOX_ROLE_ARN` | IAM role exposed by `aws/sts/tf-proxmox` | environment |
+| `OPENBAO_AWS_IAC_ADMIN_ROLE_ARN` | IAM role exposed by `aws/sts/openbao-iac-admin` | environment |
 | `OPENBAO_GITHUB_APP_ID` | Dedicated GitHub broker App ID | one-time environment |
 | `OPENBAO_GITHUB_APP_PRIVATE_KEY` | Dedicated GitHub broker App private key | one-time environment |
 | `OPENBAO_GITHUB_DRYVIST_INSTALLATION_ID` | GitHub App installation on `dryvist` | environment |

--- a/roles/openbao/README.md
+++ b/roles/openbao/README.md
@@ -216,9 +216,11 @@ select another workspace's policy. Terrakube stores only the non-secret dynamic
 credential controls. Provider credentials remain in their native OpenBao KV or
 secrets-engine paths and are returned through a short-lived OpenBao token.
 
-[^aws-sts]: Also grants `read`+`update` on `aws/sts/tf-proxmox` — dynamic AWS
-    STS creds (assumed_role) for `role/tf-proxmox`, replacing the laptop's
-    static aws-vault base key. See the AWS secrets engine section below.
+[^aws-sts]: Also grants `read`+`update` on `aws/sts/tf-proxmox` and
+    `aws/sts/openbao-iac-admin` — dynamic AWS STS creds (assumed_role) for
+    `role/tf-proxmox` and the broader, permissions-boundary-capped
+    `role/openbao-iac-admin`, replacing static aws-vault base keys. See the
+    AWS secrets engine section below.
 
 **Secret-zero model**: each AppRole's `role_id`/`secret_id` is published to
 Doppler tier-0 and reaches its consumer as ambient environment under
@@ -271,8 +273,14 @@ prebuilt, checksum-verified release binaries. The role therefore:
   `default_sts_ttl=1h`, `max_sts_ttl=2h`) — declares the assumable role.
   Add-if-missing; bumping the TTLs on an existing role needs a manual
   `bao write` (not re-driven by a routine converge).
-- The `terraform-apply` AppRole reads `aws/sts/tf-proxmox` to mint a session —
-  see the [^aws-sts] policy footnote above.
+- `aws/roles/openbao-iac-admin` — a second, independent assumed_role broker
+  for a broader IaC/admin identity capped by its own AWS permissions
+  boundary (not tf-proxmox-scoped). Same shape as the role above
+  (`default_sts_ttl=1h`, `max_sts_ttl=1h` — this role's AWS
+  `MaxSessionDuration` is 3600s), same add-if-missing semantics.
+- The `terraform-apply` AppRole reads `aws/sts/tf-proxmox` and
+  `aws/sts/openbao-iac-admin` to mint a session — see the [^aws-sts] policy
+  footnote above.
 - The laptop side (nix-darwin `credential_process` wrapper reading
   `terraform-apply`'s `role_id`/`secret_id` secret-zero from the ambient
   environment, injected by running terragrunt under `doppler run`) is

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -170,6 +170,14 @@ openbao_aws_role_arn: "{{ lookup('env', 'OPENBAO_AWS_TF_PROXMOX_ROLE_ARN') }}"
 openbao_aws_root_region: us-east-2
 openbao_aws_default_sts_ttl: 1h
 openbao_aws_max_sts_ttl: 2h
+# Second assumed_role broker: a broad IaC/admin identity capped by its own AWS
+# permissions boundary (not tf-proxmox-scoped). Mirrors the tf-proxmox role
+# above — same env-var indirection, same add-if-missing create task.
+openbao_aws_iac_admin_role_name: openbao-iac-admin
+openbao_aws_iac_admin_role_arn: "{{ lookup('env', 'OPENBAO_AWS_IAC_ADMIN_ROLE_ARN') | default('', true) }}"
+openbao_aws_iac_admin_default_sts_ttl: 1h
+# 1h, not 2h like tf-proxmox: this role's AWS MaxSessionDuration is 3600s.
+openbao_aws_iac_admin_max_sts_ttl: 1h
 # The base-user key OpenBao uses to call sts:AssumeRole. Minted via an
 # independent admin path (never the key being rotated out), seeded from Doppler
 # tier-0. Written to aws/config/root ONLY on first configuration — a routine

--- a/roles/openbao/tasks/init.yml
+++ b/roles/openbao/tasks/init.yml
@@ -461,6 +461,39 @@
     - (openbao_aws_role_check.rc | default(1)) != 0
     - openbao_aws_role_arn | length > 0
 
+- name: Check whether the openbao-iac-admin AWS role already exists
+  ansible.builtin.command:
+    cmd: "bao read -format=json {{ openbao_aws_mount }}/roles/{{ openbao_aws_iac_admin_role_name }}"
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  register: openbao_aws_iac_admin_role_check
+  no_log: true
+  changed_when: false
+  failed_when: false
+  when:
+    - openbao_bootstrap_token is defined
+    - openbao_aws_engine_enabled | bool
+
+- name: Create the openbao-iac-admin AWS role (assumed_role, add-if-missing)
+  ansible.builtin.command:
+    cmd: >-
+      bao write {{ openbao_aws_mount }}/roles/{{ openbao_aws_iac_admin_role_name }}
+      credential_type=assumed_role
+      role_arns={{ openbao_aws_iac_admin_role_arn }}
+      default_sts_ttl={{ openbao_aws_iac_admin_default_sts_ttl }}
+      max_sts_ttl={{ openbao_aws_iac_admin_max_sts_ttl }}
+  environment:
+    BAO_ADDR: "{{ openbao_api_addr }}"
+    BAO_TOKEN: "{{ openbao_bootstrap_token }}"
+  no_log: true
+  changed_when: true
+  when:
+    - openbao_bootstrap_token is defined
+    - openbao_aws_engine_enabled | bool
+    - (openbao_aws_iac_admin_role_check.rc | default(1)) != 0
+    - openbao_aws_iac_admin_role_arn | length > 0
+
 # --- GitHub secrets engine (independent GitHub App token broker) ------------
 - name: Read the staged GitHub plugin binary's sha256
   ansible.builtin.stat:

--- a/roles/openbao/templates/terraform-apply-policy.hcl.j2
+++ b/roles/openbao/templates/terraform-apply-policy.hcl.j2
@@ -8,10 +8,11 @@
 # infra kernel. KV v2 splits data
 # and metadata paths, so both are listed explicitly.
 #
-# Plus: dynamic AWS STS creds for role/tf-proxmox (the AWS secrets engine,
-# assumed_role type) — replaces the laptop's static aws-vault base key. "read"
-# generates a new lease; "update" is required by some OpenBao/Vault client
-# libraries that issue the STS request as a write against aws/sts/:role.
+# Plus: dynamic AWS STS creds for role/tf-proxmox and role/openbao-iac-admin
+# (the AWS secrets engine, assumed_role type) — replaces static aws-vault base
+# keys. "read" generates a new lease; "update" is required by some
+# OpenBao/Vault client libraries that issue the STS request as a write against
+# aws/sts/:role.
 
 {% for sub in ['infra', openbao_homelab_path] %}
 path "{{ openbao_kv_mount }}/data/{{ sub }}/*" {
@@ -45,5 +46,12 @@ path "{{ openbao_kv_mount }}/metadata/apps/nautobot/*" {
 # Dynamic AWS STS creds for role/tf-proxmox — replaces the laptop's static
 # aws-vault base key.
 path "{{ openbao_aws_mount }}/sts/{{ openbao_aws_role_name }}" {
+  capabilities = ["read", "update"]
+}
+
+# Dynamic AWS STS creds for the general OpenBao-brokered IaC/admin identity —
+# a broad IaC/admin role capped by its own AWS permissions boundary, not
+# scoped to tf-proxmox.
+path "{{ openbao_aws_mount }}/sts/{{ openbao_aws_iac_admin_role_name }}" {
   capabilities = ["read", "update"]
 }


### PR DESCRIPTION
## Summary

Adds a second assumed_role AWS STS broker role, `openbao-iac-admin`, to the
OpenBao role so a from-scratch converge reproduces it — mirroring the
existing `tf-proxmox` broker role pattern already in the role:

- `roles/openbao/defaults/main.yml`: `openbao_aws_iac_admin_role_name`,
  `openbao_aws_iac_admin_role_arn` (env-var indirection, no default),
  `openbao_aws_iac_admin_default_sts_ttl` (1h), `openbao_aws_iac_admin_max_sts_ttl`
  (1h — this role's AWS `MaxSessionDuration` is 3600s, unlike tf-proxmox's 2h).
- `roles/openbao/tasks/init.yml`: an add-if-missing check+create task pair for
  the new role, same shape (`bao read`/`bao write`, same `no_log`/`changed_when`/
  guard pattern) as the existing tf-proxmox pair, placed immediately after it.
- `roles/openbao/templates/terraform-apply-policy.hcl.j2`: a second
  `aws/sts/<role>` grant stanza for the new role, alongside the existing
  tf-proxmox one.
- `roles/openbao/README.md` and `AGENTS.md`: doc/env-var-table updates so
  they stay accurate (new role's env var, AWS engine section, policy
  footnote).

This role is intentionally broader than `tf-proxmox` — a general IaC/admin
identity capped by its own AWS permissions boundary, not scoped to a single
Terraform workflow.

**No refactor to a list-of-roles.** A second mirrored block was chosen over
a DRY loop refactor of the existing tf-proxmox tasks: touching the live
pattern's task shape to generalize it is higher-risk than adding one
parallel, reviewable block, for a net gain of two roles today.

**Known follow-up, not addressed here:** the live cluster's `terraform-apply`
AppRole currently carries the pre-rename policy name `terraform` (not
`terraform-apply`), and the live AWS STS grant for this new role was added to
both policies by hand ahead of this PR. This PR only updates the
role-managed `terraform-apply` template. Reconciling the `terraform` →
`terraform-apply` policy rename is a separate migration and out of scope
here.

## Test plan

- [x] `ansible-lint` on `roles/openbao` — 0 failures, 0 warnings, 38 files,
      `production` profile.
- [x] `yamllint` on the changed YAML files — clean.
- [x] Jinja2 parse check on the changed template — clean.
- [x] Diff scanned for account IDs, ARNs, and real domains — none found (env-var
      indirection only, matching the existing tf-proxmox pattern).
- [ ] No converge/apply run as part of this PR (IaC-parity only, per scope).
      A live converge is a separate, explicit follow-up.