### PR TITLE
feat(openbao): least-privilege llm-gate AppRole + policy (Doppler→OpenBao gate migration)

### DIFF
--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -354,6 +354,13 @@ openbao_snapshot_approle_name: snapshot
 # (APPS_SEED_VAULT_ROLE_ID / _SECRET_ID), the same delivery as terraform-apply.
 openbao_apps_seed_policy_name: apps-seed
 openbao_apps_seed_approle_name: apps-seed
+# llm-gate — the Mac Studio's llm-large Caddy gate. Dedicated least-privilege
+# reader for EXACTLY the two secrets it injects into Caddy: the bearer token
+# (secret/ai/llm) and the Route53 ACME creds (secret/platform/acme). role_id/
+# secret_id are delivered to the Studio's auto-readable keychain and consumed
+# by openbao-run (the doppler-free replacement for the gate's ~/.doppler token).
+openbao_llm_gate_policy_name: llm-gate
+openbao_llm_gate_approle_name: llm-gate
 
 # The set of non-root AppRoles to provision, each {name, policy}. Driving the
 # bootstrap from this list keeps init.yml DRY as groups are added. Per-identity
@@ -401,6 +408,10 @@ openbao_approles:
   # apps-seed: Doppler-published writer for secret/apps/* (Terraform vault-secrets).
   - name: "{{ openbao_apps_seed_approle_name }}"
     policy: "{{ openbao_apps_seed_policy_name }}"
+  # llm-gate: role_id/secret_id delivered to the Studio's auto-readable keychain
+  # (openbao-run secret-zero); reads only the bearer + ACME creds it injects.
+  - name: "{{ openbao_llm_gate_approle_name }}"
+    policy: "{{ openbao_llm_gate_policy_name }}"
 # Policy templates rendered + written on the bootstrap host. Each entry maps a
 # policy name to its template; add a row to grow the RBAC surface.
 openbao_policies:
@@ -460,6 +471,8 @@ openbao_policies:
     template: snapshot-policy.hcl.j2
   - name: "{{ openbao_apps_seed_policy_name }}"
     template: apps-seed-policy.hcl.j2
+  - name: "{{ openbao_llm_gate_policy_name }}"
+    template: llm-gate-policy.hcl.j2
 
 # --- External admin token (provisioning against an ALREADY-LIVE cluster) -----
 # The initial `bao operator init` only happens once; after that, adding new

--- a/roles/openbao/templates/llm-gate-policy.hcl.j2
+++ b/roles/openbao/templates/llm-gate-policy.hcl.j2
@@ -1,0 +1,19 @@
+{{ ansible_managed | comment }}
+# OpenBao policy for the `llm-gate` AppRole — the Mac Studio's llm-large Caddy
+# gate. Least-privilege reader for EXACTLY the two secrets it injects into
+# Caddy at (re)start via openbao-run: the bearer token it enforces
+# (secret/ai/llm) and the Route53 ACME credentials for its Let's Encrypt cert
+# (secret/platform/acme, shared with the traefik ingress). Nothing else in the
+# ai subtree, the platform subtree, or any other domain.
+path "{{ openbao_kv_mount }}/data/ai/llm" {
+  capabilities = ["read"]
+}
+path "{{ openbao_kv_mount }}/metadata/ai/llm" {
+  capabilities = ["read", "list"]
+}
+path "{{ openbao_kv_mount }}/data/platform/acme" {
+  capabilities = ["read"]
+}
+path "{{ openbao_kv_mount }}/metadata/platform/acme" {
+  capabilities = ["read", "list"]
+}


### PR DESCRIPTION
OpenBao-side of migrating the Mac Studio llm-large gate off Doppler onto OpenBao (pairs with nix-darwin #1698 `openbao-run`).

Adds a dedicated least-privilege `llm-gate` AppRole + policy that reads **exactly** `secret/ai/llm` (the bearer token the gate enforces) and `secret/platform/acme` (the shared Route53 ACME creds) — nothing else. `init.yml` mints role_id/secret_id on the next converge; they're delivered to the Studio's auto-readable keychain and consumed by `openbao-run` as secret-zero, replacing the gate's ~/.doppler token.

Deploy needs the OpenBao admin (`BAO_TOKEN`) converge + a one-time write of the ACME creds into `secret/platform/acme`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)