### PR TITLE
docs(openbao): drop stale terragrunt secret-zero mechanism note

### DIFF
--- a/roles/openbao/README.md
+++ b/roles/openbao/README.md
@@ -282,9 +282,8 @@ prebuilt, checksum-verified release binaries. The role therefore:
   `aws/sts/openbao-iac-admin` to mint a session — see the [^aws-sts] policy
   footnote above.
 - The laptop side (nix-darwin `credential_process` wrapper reading
-  `terraform-apply`'s `role_id`/`secret_id` secret-zero from the ambient
-  environment, injected by running terragrunt under `doppler run`) is
-  documented in the nix-darwin repo, not here.
+  `terraform-apply`'s `role_id`/`secret_id` secret-zero) is documented in the
+  nix-darwin repo, not here.
 
 ## GitHub secrets engine (ephemeral GitHub App tokens)
 


### PR DESCRIPTION
## What

`roles/openbao/README.md` described the nix-darwin `credential_process` wrapper's secret-zero as "injected by running terragrunt under `doppler run`". Terragrunt is retired (the fleet applies via Terrakube), and the current wrapper reads secret-zero directly — so the mechanism clause was stale and contradicted the live wrapper.

## Change

The sentence already defers to the nix-darwin repo as the authoritative source for that wrapper, so the stale mechanism detail is dropped rather than restated. One-line docs change; no behavior change.

The other two `aws-vault` mentions in this file (lines ~221, ~241) are intentionally retained — they frame the static aws-vault base key as the thing the OpenBao AWS engine *replaced*, which is accurate.