### PR TITLE
fix(openbao): bind Terrakube JWT roles to the real org name

### DIFF
--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -302,8 +302,13 @@ openbao_terrakube_jwt_auth_path: terrakube
 openbao_terrakube_jwt_issuer: "https://terrakube-api.{{ lookup('env', 'PROXMOX_SUBDOMAIN') | default('local', true) }}"
 openbao_terrakube_jwt_audience: openbao.workload.identity
 openbao_terrakube_jwt_token_ttl: 90m
-# Real org login is environment-specific; override in group_vars/host_vars.
-openbao_terrakube_organization: "{{ (tofu_data | default({})).organization | default('example-org') }}"
+# Org login that Terrakube stamps into the JWT `sub`
+# (`organization:<name>:workspace:<name>`, from job.getOrganization().getName()).
+# Must equal the Terrakube organization name — set by iac-platform's
+# `organization_name` var (mirrors the GitHub org login). The tofu inventory
+# does not carry an `organization` key, so this is sourced directly here;
+# override in group_vars/host_vars for a different environment.
+openbao_terrakube_organization: dryvist
 openbao_terrakube_workspaces:
   - name: iac-platform
     kv_read: [platform/terrakube/main]


### PR DESCRIPTION
Every Terrakube workspace run failed the OpenBao JWT login:

```
POST /v1/auth/terrakube/login
400: error validating claims: claim "sub" does not match any associated bound claim values
```

## Root cause

Terrakube signs the workload-identity JWT with `sub = organization:<orgName>:workspace:<workspaceName>` — organization/workspace **name**, per its `DynamicCredentialsService` token builder. The live org name is the one `iac-platform` provisions via `organization_name`.

`openbao_terrakube_organization` resolved `(tofu_data).organization | default("example-org")`, but the OpenTofu inventory never emits an `organization` key, so it always fell through to the placeholder `example-org`. OpenBao therefore bound `organization:example-org:workspace:*` while Terrakube presented `organization:<realorg>:workspace:*` — failing all 8 `terrakube-<workspace>` roles identically. The `sub` **shape** was already correct; only the org value was a placeholder.

## Fix

Source the org login directly (overridable in `group_vars`/`host_vars`) instead of a dead inventory lookup, so the bound `sub` matches what Terrakube emits. Workspace names and every other role field were already correct.

Live roles can be corrected immediately (without waiting for a full converge) via a root-gated idempotent script that declaratively rewrites the known-good field set for all 8 roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzxS5Ji7fKYSNfnr7HSn1U