### PR TITLE
fix(openproject): pin AIO image to 14, block auto major bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>dryvist/.github"]
+  "extends": ["local>dryvist/.github"],
+  "packageRules": [
+    {
+      "description": "OpenProject AIO majors need a deliberate sequential upgrade + bundled Postgres data migration (see #928). Block automatic major bumps; minor/patch still flow.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["openproject/openproject"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    }
+  ]
 }

--- a/roles/openproject_docker/defaults/main.yml
+++ b/roles/openproject_docker/defaults/main.yml
@@ -3,7 +3,7 @@
 # https://www.openproject.org/docs/installation-and-operations/installation/docker/
 # The AIO image bundles PostgreSQL, memcached, web (Puma), and a background worker.
 
-openproject_docker_image: "openproject/openproject:16"
+openproject_docker_image: "openproject/openproject:14"
 openproject_docker_container_name: openproject
 openproject_docker_data_dir: /opt/openproject
 


### PR DESCRIPTION
## What

- Pin `openproject_docker_image` back to `openproject/openproject:14` (matches production / `origin/main`).
- Add a Renovate `packageRules` entry blocking **automatic major** updates for the OpenProject AIO image (minor/patch still flow).

## Why

Renovate bumped the image `14 → 16` on `develop`. That jump is breaking:

- OpenProject forbids skipping a major version — the upgrade must run **14 → 15 → 16** with each version's DB migrations completing in turn.
- The AIO image bundles PostgreSQL; `14` ships PG 13 and `16` ships PG 15. PostgreSQL cannot read a data dir from a different major, so the in-container DB crashes on startup.

There is **no Molecule scenario** for `openproject_docker`, so CI never exercised this path. Pinning back to `:14` keeps the `develop → main` promotion regression-free; the real upgrade is tracked separately.

Refs #928