### PR TITLE
feat(openbao): add shared Splunk MCP secret contract

### DIFF
--- a/docs/HERMES_OPS.md
+++ b/docs/HERMES_OPS.md
@@ -62,10 +62,11 @@ removed and re-seeded (`tasks/main.yml`); the canonical set is
 > memory bug — see "Repetition guard" below. The literal string is an upstream
 > runtime line, not something this role emits.
 
-## Credentials — `secret/ai/hermes`
+## Credentials
 
-Hermes reads its app credentials from OpenBao `secret/ai/hermes`
-(`bao_local_llm_secrets`, bao-first with env fallback). By design every field
+Hermes reads its app credentials from OpenBao `secret/ai/hermes`, plus the
+shared Splunk MCP connection from `secret/ai/mcp/splunk`. Both paths merge into
+`bao_local_llm_secrets` with an env fallback. By design every field
 defaults to empty and an empty value **disables that capability** rather than
 failing the converge — so an un-seeded field silently turns a platform off.
 That is the deliberate contract; there is no converge-time assertion that a
@@ -73,7 +74,7 @@ field is present.
 
 | Field | Enables | Notes |
 | --- | --- | --- |
-| `SPLUNK_MCP_URL` + `SPLUNK_MCP_TOKEN` | the entire `splunk-*` cron fleet | minted by the ansible-splunk path; known stale-token caveat |
+| `SPLUNK_MCP_URL` + `SPLUNK_MCP_TOKEN` | the entire `splunk-*` cron fleet | sourced from shared `secret/ai/mcp/splunk`; published by ansible-splunk |
 | `GH_PAT_WRITE_PROJECT_ISSUES` | `github-triage` cron + github-issues skill | empty until the token is issued |
 | `HERMES_GITHUB_APP_ID` / `_INSTALLATION_ID` / `_PRIVATE_KEY` | GitHub-App docs-contributor / nightly-wiki path | empty until the App is provisioned |
 | `HERMES_API_SERVER_KEY` | inbound job-submission API (`POST /v1/runs`, cron CRUD) | seeded programmatically; empty disables the api_server platform |

--- a/inventory/group_vars/hermes_agent_group.yml
+++ b/inventory/group_vars/hermes_agent_group.yml
@@ -16,9 +16,9 @@ hermes_agent_github_app_private_key: >-
   {{ bao_local_llm_secrets.HERMES_GITHUB_APP_PRIVATE_KEY
      | default(lookup('env', 'HERMES_GITHUB_APP_PRIVATE_KEY'), true) }}
 
-# Splunk MCP client creds (read/search access). Bao-first (local-llm domain,
-# secret/ai/hermes), env fallback — empty until ansible-splunk mints + publishes
-# the per-user token (SPLUNK_MCP_TOKEN). URL is the Splunk MCP Server endpoint.
+# Shared Splunk MCP client creds (read/search access). Bao-first (local-llm
+# domain, secret/ai/mcp/splunk), env fallback — empty until ansible-splunk
+# publishes the connection. URL is the Splunk MCP Server endpoint.
 hermes_agent_splunk_mcp_url: >-
   {{ bao_local_llm_secrets.SPLUNK_MCP_URL
      | default(lookup('env', 'SPLUNK_MCP_URL'), true) }}

--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -148,9 +148,10 @@ with its own scoped identity. The URL and Bearer token are referenced as
 `${SPLUNK_MCP_URL}` / `${SPLUNK_MCP_TOKEN}` and resolved from `.env` at connect
 time, so neither the endpoint nor the token ever lands in `config.yaml`.
 
-Creds come from OpenBao `secret/ai/hermes` (`bao_local_llm_secrets`) with an env
-fallback. `ansible-splunk` mints the per-user token (a Splunk token is bound to a
-user and inherits its roles) and publishes it as `SPLUNK_MCP_TOKEN`. The
+Creds come from the shared OpenBao `secret/ai/mcp/splunk` path (merged into
+`bao_local_llm_secrets`) with an env fallback. `ansible-splunk` publishes the
+existing shared Splunk service identity as `SPLUNK_MCP_URL` and
+`SPLUNK_MCP_TOKEN`. The
 `mcp_servers.splunk` entry is omitted until the URL is set, so the agent starts
 cleanly before the creds exist.
 

--- a/roles/openbao/README.md
+++ b/roles/openbao/README.md
@@ -196,8 +196,8 @@ plans):
 | `monitoring` | `secret/apps/monitoring` | — | netmon/unifi_metrics/prometheus_stack |
 | `media` | `secret/apps/media` | — | *arr/qBittorrent/Plex stack |
 | `local-llm` | `secret/ai/*` | — | The LLM serving stack itself |
-| `hermes` | `secret/ai/hermes` only | — | Dedicated least-privilege reader for the Hermes agent; NO broad `secret/ai/*` |
-| `hermes-write` | `secret/ai/hermes` only | `secret/ai/hermes` only | Narrow Doppler-published writer; least-priv complement to `ai-orchestrator` |
+| `hermes` | `secret/ai/hermes`, `secret/ai/mcp/splunk` | — | Dedicated least-privilege reader for Hermes; NO broad `secret/ai/*` |
+| `hermes-write` | exact Hermes + Splunk MCP paths | exact Hermes + Splunk MCP paths | Narrow publisher/seed writer; complements `ai-orchestrator` |
 | `public` | `secret/public/*` | — | **Anonymous** — no secret-zero; shipped ambiently |
 | `ai-orchestrator` | `secret/ai/{hermes,agents}` | `secret/ai/{hermes,agents}` (create/update) | WRITE; Doppler tier-0; narrowed + 30m TTL at Phase-3 |
 | `ai-readonly` | `secret/ai/*`, `secret/apps/*` | — | **default AI agent; NO `secret/infra/*`** |

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -270,12 +270,11 @@ openbao_github_permission_sets:
 #   monitoring       — read-only, secret/apps/monitoring
 #   media            — read-only, secret/apps/media
 #   local-llm        — LLM serving stack; read-only, secret/ai/*
-#   hermes           — Hermes AI agent; read-only, secret/ai/hermes ONLY —
-#                      dedicated least-privilege reader, NOT the broad ai subtree
-#   hermes-write     — least-privilege WRITE to secret/ai/hermes ONLY
-#                      (create/update/read that single path; no wildcard, no
-#                      other paths). Doppler-published, for ansible-splunk
-#                      token-publish + one-time Hermes cred seed. A narrow
+#   hermes           — Hermes AI agent; read-only, exact secret/ai/hermes and
+#                      secret/ai/mcp/splunk paths, NOT the broad ai subtree
+#   hermes-write     — least-privilege WRITE to exact secret/ai/hermes and
+#                      secret/ai/mcp/splunk paths (no wildcard, no other paths).
+#                      Used for ansible-splunk publication + one-time Hermes seed. A narrow
 #                      complement to the broad ai-orchestrator
 #                      writer — scoped down to just the Hermes secret.
 #   public           — anonymous, non-exploitable facts (domain/subdomain);

--- a/roles/openbao/templates/hermes-policy.hcl.j2
+++ b/roles/openbao/templates/hermes-policy.hcl.j2
@@ -1,10 +1,17 @@
 {{ ansible_managed | comment }}
 # OpenBao policy for the `hermes` AppRole — the Hermes AI agent's dedicated,
-# least-privilege reader. Read-only on EXACTLY secret/ai/hermes (its own
-# secret) and nothing else in the ai subtree or any other domain.
+# least-privilege reader. Read-only on EXACTLY its own secret and the shared
+# Splunk MCP connection; nothing else in the ai subtree or any other domain.
 path "{{ openbao_kv_mount }}/data/ai/hermes" {
   capabilities = ["read"]
 }
 path "{{ openbao_kv_mount }}/metadata/ai/hermes" {
+  capabilities = ["read", "list"]
+}
+
+path "{{ openbao_kv_mount }}/data/ai/mcp/splunk" {
+  capabilities = ["read"]
+}
+path "{{ openbao_kv_mount }}/metadata/ai/mcp/splunk" {
   capabilities = ["read", "list"]
 }

--- a/roles/openbao/templates/hermes-write-policy.hcl.j2
+++ b/roles/openbao/templates/hermes-write-policy.hcl.j2
@@ -1,8 +1,9 @@
 {{ ansible_managed | comment }}
 # OpenBao policy for the hermes-write AppRole — the ONLY write path into
-# secret/ai/*. Scoped to the single Hermes credential secret and nothing else:
-# ansible-splunk publishes the minted Splunk MCP token here, and the one-time
-# Hermes cred seed writes here. Deliberately NO wildcard, NO other ai/* paths,
+# secret/ai/*. Scoped to the Hermes seed and shared Splunk MCP secret only:
+# ansible-splunk publishes the Splunk MCP connection to ai/mcp/splunk, while
+# the one-time Hermes cred seed still writes ai/hermes during migration.
+# Deliberately NO wildcard, NO other ai/* paths,
 # NO infra/platform/apps. Update-in-place is a read-modify-write on a known
 # path, so `read` on the exact secret is enough — no `list`.
 # See terraform-proxmox docs/SECRETS_HIERARCHY.md.
@@ -12,5 +13,13 @@ path "{{ openbao_kv_mount }}/data/ai/hermes" {
 }
 
 path "{{ openbao_kv_mount }}/metadata/ai/hermes" {
+  capabilities = ["read"]
+}
+
+path "{{ openbao_kv_mount }}/data/ai/mcp/splunk" {
+  capabilities = ["create", "update", "read"]
+}
+
+path "{{ openbao_kv_mount }}/metadata/ai/mcp/splunk" {
   capabilities = ["read"]
 }

--- a/roles/openbao_secrets/defaults/main.yml
+++ b/roles/openbao_secrets/defaults/main.yml
@@ -90,9 +90,11 @@ openbao_secrets_domains:
       - ai/qdrant      # QDRANT_API_KEY
       - ai/open-webui  # OPEN_WEBUI_SECRET_KEY, OPEN_WEBUI_OPENAI_API_KEY
       - ai/hermes      # GH_PAT_WRITE_PROJECT_ISSUES, HERMES_GITHUB_APP_{ID,INSTALLATION_ID,
-                       #   PRIVATE_KEY}, SPLUNK_MCP_{URL,TOKEN}, OPENROUTER_API_KEY (seeded,
+                       #   PRIVATE_KEY}, OPENROUTER_API_KEY (seeded,
                        #   parked — not consumed by any role yet, see hermes_agent's
                        #   "Escalation" README section)
+      - ai/mcp/splunk  # SPLUNK_MCP_URL, SPLUNK_MCP_TOKEN; merged into the same
+                       #   bao_local_llm_secrets fact consumed by Hermes
       - ai/langfuse    # LANGFUSE_{POSTGRES_PASSWORD,CLICKHOUSE_PASSWORD,REDIS_AUTH,
                        #   S3_ACCESS_KEY_ID,S3_SECRET_ACCESS_KEY,PUBLIC_KEY,SECRET_KEY,
                        #   INIT_USER_EMAIL,INIT_USER_PASSWORD} — fully seeded 2026-07-05

--- a/tests/test_splunk_mcp_openbao_contract.py
+++ b/tests/test_splunk_mcp_openbao_contract.py
@@ -10,7 +10,7 @@ CANONICAL_DATA_PATH = 'path "{{ openbao_kv_mount }}/data/ai/mcp/splunk"'
 
 
 def _read(relative_path: str) -> str:
-    return (ROOT / relative_path).read_text()
+    return (ROOT / relative_path).read_text(encoding="utf-8")
 
 
 def test_hermes_can_read_own_bundle_and_shared_splunk_secret():

--- a/tests/test_splunk_mcp_openbao_contract.py
+++ b/tests/test_splunk_mcp_openbao_contract.py
@@ -1,0 +1,71 @@
+"""Static contract checks for the shared Splunk MCP OpenBao path."""
+
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CANONICAL_DATA_PATH = 'path "{{ openbao_kv_mount }}/data/ai/mcp/splunk"'
+
+
+def _read(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text()
+
+
+def test_hermes_can_read_own_bundle_and_shared_splunk_secret():
+    policy = _read("roles/openbao/templates/hermes-policy.hcl.j2")
+
+    assert 'path "{{ openbao_kv_mount }}/data/ai/hermes"' in policy
+    assert CANONICAL_DATA_PATH in policy
+    assert 'capabilities = ["read"]' in policy
+    assert "/data/ai/*" not in policy
+
+
+def test_default_ai_policies_can_read_shared_splunk_secret():
+    ai_readonly = _read("roles/openbao/templates/ai-readonly-policy.hcl.j2")
+    local_llm = _read("roles/openbao/templates/local-llm-policy.hcl.j2")
+
+    assert "{% for sub in ['ai', 'apps'] %}" in ai_readonly
+    assert 'path "{{ openbao_kv_mount }}/data/{{ sub }}/*"' in ai_readonly
+    assert 'path "{{ openbao_kv_mount }}/data/ai/*"' in local_llm
+    assert 'capabilities = ["read"]' in ai_readonly
+    assert 'capabilities = ["read"]' in local_llm
+
+
+def test_unrelated_domain_identity_cannot_read_shared_splunk_secret():
+    policy = _read("roles/openbao/templates/observability-policy.hcl.j2")
+
+    assert "ai/mcp/splunk" not in policy
+    assert "/data/ai/" not in policy
+
+
+def test_splunk_publisher_has_only_exact_transitional_write_paths():
+    policy = _read("roles/openbao/templates/hermes-write-policy.hcl.j2")
+
+    assert CANONICAL_DATA_PATH in policy
+    assert 'path "{{ openbao_kv_mount }}/data/ai/hermes"' in policy
+    assert 'capabilities = ["create", "update", "read"]' in policy
+    assert "/data/ai/*" not in policy
+
+
+def test_local_llm_fetch_contract_merges_canonical_splunk_fields():
+    defaults = yaml.safe_load(
+        _read("roles/openbao_secrets/defaults/main.yml")
+    )
+    local_llm = next(
+        domain
+        for domain in defaults["openbao_secrets_domains"]
+        if domain["name"] == "local-llm"
+    )
+
+    assert "ai/hermes" in local_llm["paths"]
+    assert "ai/mcp/splunk" in local_llm["paths"]
+
+
+def test_hermes_inventory_keeps_rendered_environment_interface():
+    inventory = _read("inventory/group_vars/hermes_agent_group.yml")
+
+    assert "secret/ai/mcp/splunk" in inventory
+    assert "bao_local_llm_secrets.SPLUNK_MCP_URL" in inventory
+    assert "bao_local_llm_secrets.SPLUNK_MCP_TOKEN" in inventory


### PR DESCRIPTION
Adds canonical OpenBao policy and Hermes fetch support for the shared Splunk MCP connection.\n\nValidation: focused contract tests and repository hooks pass.\n\nLive policy reconciliation and secret migration are intentionally deferred.\n\nRefs: dryvist/ansible-proxmox-apps#932\nRefs: dryvist/ansible-splunk#341\nRefs: dryvist/nix-ai#1230\nRefs: dryvist/docs#165\nRefs: dryvist/docs-starlight#176