### PR TITLE
fix(sonarr): retry transient upstream downloads

### DIFF
--- a/roles/sonarr/defaults/main.yml
+++ b/roles/sonarr/defaults/main.yml
@@ -17,6 +17,8 @@ sonarr_downloads_dir: /data/torrents
 sonarr_web_port: "{{ tofu_data.constants.media_ports.sonarr_web }}"
 sonarr_tarball_url: >-
   https://services.sonarr.tv/v1/download/main/latest?version=4&os=linux&arch=x64
+sonarr_download_retries: 4
+sonarr_download_retry_delay: 10
 sonarr_manage_services: true
 
 # --- Self-owned deterministic API key + auth (decoupled from servarr_wiring) --

--- a/roles/sonarr/tasks/main.yml
+++ b/roles/sonarr/tasks/main.yml
@@ -114,6 +114,10 @@
     remote_src: true
     owner: "{{ sonarr_user }}"
     group: "{{ sonarr_group }}"
+  register: sonarr_download
+  until: sonarr_download is succeeded
+  retries: "{{ sonarr_download_retries }}"
+  delay: "{{ sonarr_download_retry_delay }}"
   when: not sonarr_bin.stat.exists
 
 - name: Deploy Sonarr systemd unit


### PR DESCRIPTION
## Summary

Retries Sonarr archive extraction when the upstream download service has a transient timeout.

## Validation

- `ansible-lint roles/sonarr` in the repository Nix dev shell
- `git diff --check`
- `molecule test -s sonarr` was attempted locally but Docker is unavailable on this host; CI provides the Docker-backed acceptance run.

Related: dryvist/ansible-proxmox-apps#932