### PR TITLE
test: parse hermes inventory as YAML in Splunk MCP contract test

### DIFF
--- a/tests/test_splunk_mcp_openbao_contract.py
+++ b/tests/test_splunk_mcp_openbao_contract.py
@@ -64,8 +64,11 @@ def test_local_llm_fetch_contract_merges_canonical_splunk_fields():
 
 
 def test_hermes_inventory_keeps_rendered_environment_interface():
-    inventory = _read("inventory/group_vars/hermes_agent_group.yml")
+    inventory = yaml.safe_load(_read("inventory/group_vars/hermes_agent_group.yml"))
 
-    assert "secret/ai/mcp/splunk" in inventory
-    assert "bao_local_llm_secrets.SPLUNK_MCP_URL" in inventory
-    assert "bao_local_llm_secrets.SPLUNK_MCP_TOKEN" in inventory
+    assert "bao_local_llm_secrets.SPLUNK_MCP_URL" in inventory.get(
+        "hermes_agent_splunk_mcp_url", ""
+    )
+    assert "bao_local_llm_secrets.SPLUNK_MCP_TOKEN" in inventory.get(
+        "hermes_agent_splunk_mcp_token", ""
+    )


### PR DESCRIPTION
Replace raw substring assertions with yaml.safe_load and key-scoped checks; the old path assertion matched only a comment. Addresses gemini-code-assist review feedback on #934.

All 6 contract tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjEuNpmGyrfftQk7VVCDZA