### PR TITLE
fix(hermes): detect 200-wrapped brain errors and degrade instead of dying

### DIFF
--- a/roles/hermes_agent/templates/hermes-brain-watchdog.sh.j2
+++ b/roles/hermes_agent/templates/hermes-brain-watchdog.sh.j2
@@ -56,24 +56,23 @@ SLACK_USER="${SLACK_ALLOWED_USERS:-}"
 # read as DOWN — the same failures that would fail a cron. It hits the
 # already-active rotation model (no cold-model spawn), and probing on this
 # cadence keeps the brain warm, which matches the intended 24/7 posture.
-# ponytail: grep on the body, no jq on the guest for two fields.
+# ponytail: grep on the body, no jq and no temp file on the guest.
 probe_ok() {
-  local code body rc=1
-  body="$(mktemp)"
-  code="$(curl -sS -o "${body}" -w '%{http_code}' --max-time "${PROBE_TIMEOUT}" \
+  local response code body
+  # Body and status code in one call: -w appends the code on its own line
+  # after the body, so no temp file is needed on a 60s cadence.
+  response="$(curl -sS -w '\n%{http_code}' --max-time "${PROBE_TIMEOUT}" \
     -X POST "${PROBE_URL}" \
     -H "Authorization: Bearer ${API_KEY}" \
     -H "Content-Type: application/json" \
     -d "{\"model\":\"${MODEL}\",\"max_tokens\":8,\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}]}" \
-    2>/dev/null)" || code="000"
+    2>/dev/null)" || return 1
+  code="${response##*$'\n'}"
+  body="${response%$'\n'*}"
   # stop|length|tool_calls = the model really generated; "error" (or a body
   # with no finish_reason at all) = broken regardless of the 200.
-  if [[ "${code}" == "200" ]] \
-    && grep -Eq '"finish_reason"[[:space:]]*:[[:space:]]*"(stop|length|tool_calls)"' "${body}"; then
-    rc=0
-  fi
-  rm -f "${body}"
-  return "${rc}"
+  [[ "${code}" == "200" ]] \
+    && grep -Eq '"finish_reason"[[:space:]]*:[[:space:]]*"(stop|length|tool_calls)"' <<< "${body}"
 }
 
 # --- Cron fleet control (best-effort; idempotent) ----------------------------

--- a/roles/hermes_agent/templates/hermes-brain-watchdog.sh.j2
+++ b/roles/hermes_agent/templates/hermes-brain-watchdog.sh.j2
@@ -47,21 +47,33 @@ SLACK_TOKEN="${SLACK_BOT_TOKEN:-}"
 SLACK_USER="${SLACK_ALLOWED_USERS:-}"
 
 # --- Probe: a tiny real completion, mirroring what the crons actually do ------
-# Healthy iff HTTP 200. A connection error (curl fails -> 000), a 5xx, an auth
-# 4xx, or a wedged brain that hangs past PROBE_TIMEOUT all read as DOWN — the
-# same failures that would fail a cron. It hits the already-active rotation model
-# (no cold-model spawn), and probing on this cadence keeps the brain warm, which
-# matches the intended 24/7 posture. ponytail: 1-token probe, not a bare TCP
-# check, so "reachable but not serving" is caught too.
+# Healthy iff HTTP 200 AND the body carries a real finish_reason. HTTP code
+# alone is NOT health: when the MLX engine's batch scheduler wedges (2026-07-16
+# broadcast_shapes incident) every completion returns HTTP 200 with
+# `"finish_reason":"error"` and zero tokens — the code-only probe stayed green
+# for hours while every cron failed. A connection error (curl fails -> 000), a
+# 5xx, an auth 4xx, a hang past PROBE_TIMEOUT, or a 200-wrapped error body all
+# read as DOWN — the same failures that would fail a cron. It hits the
+# already-active rotation model (no cold-model spawn), and probing on this
+# cadence keeps the brain warm, which matches the intended 24/7 posture.
+# ponytail: grep on the body, no jq on the guest for two fields.
 probe_ok() {
-  local code
-  code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time "${PROBE_TIMEOUT}" \
+  local code body rc=1
+  body="$(mktemp)"
+  code="$(curl -sS -o "${body}" -w '%{http_code}' --max-time "${PROBE_TIMEOUT}" \
     -X POST "${PROBE_URL}" \
     -H "Authorization: Bearer ${API_KEY}" \
     -H "Content-Type: application/json" \
-    -d "{\"model\":\"${MODEL}\",\"max_tokens\":1,\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}]}" \
+    -d "{\"model\":\"${MODEL}\",\"max_tokens\":8,\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}]}" \
     2>/dev/null)" || code="000"
-  [[ "${code}" == "200" ]]
+  # stop|length|tool_calls = the model really generated; "error" (or a body
+  # with no finish_reason at all) = broken regardless of the 200.
+  if [[ "${code}" == "200" ]] \
+    && grep -Eq '"finish_reason"[[:space:]]*:[[:space:]]*"(stop|length|tool_calls)"' "${body}"; then
+    rc=0
+  fi
+  rm -f "${body}"
+  return "${rc}"
 }
 
 # --- Cron fleet control (best-effort; idempotent) ----------------------------

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -302,6 +302,14 @@ llm_router_rotation_actuator: >-
 llm_router_rotation_stagger_mm: "{{ '%02d' | format(llm_router_rotation_stagger_minutes | int) }}"
 llm_router_rotation_large_oncalendar: "*-*-* 00:{{ llm_router_rotation_stagger_mm }}:00 UTC"
 llm_router_rotation_optimized_oncalendar: "*-*-* 12:{{ llm_router_rotation_stagger_mm }}:00 UTC"
+# Degraded-mode fallback for the rotation alias. `ai-default` is otherwise a
+# single deployment (the Studio brain): any engine fault = every consumer
+# hard-fails, and a MID-STREAM engine error can never fall back at all
+# ("Available Model Group Fallbacks=None", 2026-07-16 wedge). Chaining the
+# light tier here means a Studio outage degrades to a small-but-alive brain
+# instead of dying — the estate direction is degrade, don't die, and the
+# brain watchdog deliberately treats degraded as UP. Empty string disables.
+llm_router_rotation_fallback_model: qwen3-4b
 # Per-phase rendered configs; config.yaml is a symlink to the live one.
 llm_router_rotation_config_large: "{{ llm_router_config_dir }}/config-large.yaml"
 llm_router_rotation_config_optimized: "{{ llm_router_config_dir }}/config-optimized.yaml"

--- a/roles/llm_router/templates/config.yaml.j2
+++ b/roles/llm_router/templates/config.yaml.j2
@@ -133,12 +133,22 @@ router_settings:
   routing_strategy: {{ llm_router_routing_strategy }}
   allowed_fails: {{ llm_router_allowed_fails }}
   cooldown_time: {{ llm_router_cooldown_time }}
+{% set _fb = [] %}
 {% if llm_router_night_enabled | default(false) | bool
      and llm_router_rotation_phase | default('') == 'large'
      and (llm_router_night_model | default('')) | length > 0 %}
-  # Night-cluster fallback chain: alias -> solo phase brain (see model_list).
+{% set _fb = _fb + [llm_router_rotation_alias ~ '-solo'] %}
+{% endif %}
+{% if (llm_router_rotation_fallback_model | default('')) | length > 0 %}
+{% set _fb = _fb + [llm_router_rotation_fallback_model] %}
+{% endif %}
+{% if _fb %}
+  # Fallback chain for the rotation alias: night cluster -> solo phase brain
+  # (night mode only), then the light tier as the standing degraded-mode
+  # deployment (see llm_router_rotation_fallback_model in defaults). Covers
+  # both pre-call failures and LiteLLM's mid-stream fallback path.
   fallbacks:
-    - {{ llm_router_rotation_alias }}: ["{{ llm_router_rotation_alias }}-solo"]
+    - {{ llm_router_rotation_alias }}: {{ _fb | to_json }}
 {% endif %}
   # Pre-call context-window checks so an over-long request is not routed to a model
   # that cannot serve it (no cross-tier fallback masks the error).


### PR DESCRIPTION
## Summary

Two resilience fixes from the 2026-07-16 brain wedge (MLX batch scheduler `broadcast_shapes` errors returned HTTP 200 with `finish_reason: error` and zero tokens for every request, for hours, unalerted):

- **hermes_agent watchdog**: the probe now requires a real `finish_reason` (`stop|length|tool_calls`) in the completion body. HTTP 200 alone stayed green through the entire wedge while every cron failed with `MidStreamFallbackError`.
- **llm_router**: `ai-default` gains a standing light-tier fallback deployment (`qwen3-4b`). It was a single deployment — any Studio engine fault hard-failed every consumer, and mid-stream errors could never fall back (`Available Model Group Fallbacks=None` in the router log). Night-solo still precedes the light tier when the night cluster is live. Set `llm_router_rotation_fallback_model: ""` to disable.

## Evidence

- Hermes cron `splunk-triage` failed 2026-07-16 11:03Z with `MidStreamFallbackError`; watchdog ran every 60s and never paused the fleet.
- Studio log: 805 `Error in batch generation step` / 603 consecutive zero-token completions in the recent window; engine restored by sanctioned `launchctl kickstart`.

## Verification

- Post-converge: wedge-window test — force a failing probe target and confirm the fleet pauses with a single alert, resumes on recovery.
- Fallback: stop the primary deployment in a test window; completions must degrade to the light tier instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6JuKQiA3nNTJ81ww1wgFo