### PR TITLE
fix(openbao): pin apply-tier token_max_ttl and repair contract test

### DIFF
--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -416,7 +416,8 @@ openbao_ai_capability_policies: >-
 openbao_ai_apply_approles: >-
   {{ openbao_ai_domains | map('regex_replace', '^(.+)$',
        '{"name": "ai-apply-\1", "token_policies": ["read-\1", "write-\1", "github-mint"],
-         "token_ttl": "1h", "manage_secret_id": false, "secret_id_ttl": "15m", "secret_id_num_uses": 1}')
+         "token_ttl": "1h", "token_max_ttl": "1h",
+         "manage_secret_id": false, "secret_id_ttl": "15m", "secret_id_num_uses": 1}')
      | map('from_json') | list }}
 openbao_ai_admin_policy_name: ai-admin
 openbao_ai_admin_approle_name: ai-admin
@@ -498,6 +499,7 @@ openbao_base_approles:
   - name: ai-apply-all
     token_policies: "{{ openbao_read_write_all_policies + ['github-mint'] }}"
     token_ttl: "{{ openbao_ai_apply_token_ttl }}"
+    token_max_ttl: "{{ openbao_ai_apply_token_ttl }}"
     manage_secret_id: false
     secret_id_ttl: "{{ openbao_ai_elevated_secret_id_ttl }}"
     secret_id_num_uses: 1

--- a/tests/test_splunk_mcp_openbao_contract.py
+++ b/tests/test_splunk_mcp_openbao_contract.py
@@ -23,13 +23,17 @@ def test_hermes_can_read_own_bundle_and_shared_splunk_secret():
 
 
 def test_default_ai_policies_can_read_shared_splunk_secret():
-    ai_readonly = _read("roles/openbao/templates/ai-readonly-policy.hcl.j2")
+    # ai-readonly is now a composed actor role (#931): it attaches the read-ai
+    # capability leaf, which the kv-capability template renders as read on
+    # secret/data/ai/* — covering ai/mcp/splunk.
+    defaults = yaml.safe_load(_read("roles/openbao/defaults/main.yml"))
+    leaf = _read("roles/openbao/templates/kv-capability-policy.hcl.j2")
     local_llm = _read("roles/openbao/templates/local-llm-policy.hcl.j2")
 
-    assert "{% for sub in ['ai', 'apps'] %}" in ai_readonly
-    assert 'path "{{ openbao_kv_mount }}/data/{{ sub }}/*"' in ai_readonly
+    assert "ai" in defaults["openbao_ai_domains"]
+    assert 'path "{{ openbao_kv_mount }}/data/{{ item.subtree }}/*"' in leaf
+    assert 'capabilities = ["read"]' in leaf
     assert 'path "{{ openbao_kv_mount }}/data/ai/*"' in local_llm
-    assert 'capabilities = ["read"]' in ai_readonly
     assert 'capabilities = ["read"]' in local_llm
 
 


### PR DESCRIPTION
Two develop fixes from the #931 security review + merge fallout:

1. **Apply-tier max TTL pinned**: `ai-apply-<svc>` and `ai-apply-all` set `token_ttl: 1h` but not `token_max_ttl`, falling back to the 4h role default — a renewable apply token could outlive the documented ≤1h containment. Both now pin `token_max_ttl` to match (mirroring ai-admin's 10m/10m pattern).
2. **Contract test regression**: `test_default_ai_policies_can_read_shared_splunk_secret` still read `ai-readonly-policy.hcl.j2`, deleted by #931's composed-policy refactor — develop tests were red. The test now asserts the same read contract through `openbao_ai_domains` + the kv-capability leaf template.

Validation: 6 passed / 42 skipped pytest; ansible-lint production profile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjEuNpmGyrfftQk7VVCDZA