### PR TITLE
fix(hermes_agent): pin compression summary_model to a >=64K-window deployment

### DIFF
--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -52,6 +52,15 @@ hermes_agent_installer_path: "/usr/local/lib/hermes-agent-installer-{{ hermes_ag
 hermes_agent_model: "{{ ai_default_model }}"
 hermes_agent_model_base_url: "https://llm.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}/v1"
 hermes_agent_model_api_mode: chat_completions
+# Context-compression summary model. Hermes hard-requires >=64K context on the
+# compression model, and `ai-default` cannot promise that: its rotating backend
+# is whatever the phase brain is, and the stock 35B twin serves a 32,768-token
+# window — cron fleet failed on exactly this 2026-07-16 ("Auxiliary compression
+# model ai-default has a context window of 32,768"). Pin compression to the
+# OptiQ tuned alias: 65,536-token serving window, resident on the serving host,
+# carries its own repetition-penalty guard. Named by model family on purpose —
+# a generic alias must not be used where a >=64K window is a hard requirement.
+hermes_agent_compression_model: Qwen3.6-35B-A3B-OptiQ-4bit
 # The context window Hermes budgets against and compacts under (it compresses at
 # hermes_agent_context_compression_threshold * this value). The model's TRUE
 # native window is 262144 (Qwen3.6-35B-A3B), but we deliberately DECLARE a

--- a/roles/hermes_agent/templates/config.yaml.j2
+++ b/roles/hermes_agent/templates/config.yaml.j2
@@ -66,10 +66,12 @@ security:
 # Auto-shrink long autonomous sessions. summary_model MUST be a model our router
 # serves — the upstream default (google/gemini-3-flash-preview) is unreachable
 # here (no external egress/key), which would make compression fail mid-session.
+# It must also serve a >=64K window (Hermes hard minimum), which the rotating
+# `ai-default` alias cannot promise — see hermes_agent_compression_model.
 compression:
   enabled: {{ hermes_agent_context_compression_enabled | to_json }}
   threshold: {{ hermes_agent_context_compression_threshold }}
-  summary_model: {{ hermes_agent_model }}
+  summary_model: {{ hermes_agent_compression_model }}
 
 plugins:
   enabled:


### PR DESCRIPTION
## Summary

After the 2026-07-16 serving wedge cleared, the cron fleet immediately failed on the next layer: Hermes hard-requires ≥64K context on its auxiliary compression model, and `compression.summary_model` was `ai-default` — whose rotating backend is currently the stock 35B twin serving a **32,768-token** window.

```
ERROR cron.scheduler: Job 'splunk-security' failed: ValueError: Auxiliary compression model ai-default has a context window of 32,768 tokens, which is below the minimum 64,000 required by Hermes Agent.
```

Fix: new `hermes_agent_compression_model` (default `Qwen3.6-35B-A3B-OptiQ-4bit` — 65,536-token serving window, resident, tuned alias with its own repetition-penalty guard). Per the naming rule: a generic rotating alias must not back a hard family/window-specific requirement.

## Verification

Post-converge: next cron tick completes without the ValueError; `config.yaml` on the guest renders `summary_model: Qwen3.6-35B-A3B-OptiQ-4bit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6JuKQiA3nNTJ81ww1wgFo