### PR TITLE
fix(hermes_agent): scope the verify-gate journal read to the current gateway start

### DIFF
--- a/roles/hermes_agent/tasks/verify.yml
+++ b/roles/hermes_agent/tasks/verify.yml
@@ -26,9 +26,15 @@
       retries: 5
       delay: 2
 
+    # Bound the read to THIS process start: a bare `-n 200` straddles the
+    # restart and re-matches errors the converge just fixed — a false gate
+    # failure observed 2026-07-16 (pre-fix "context window below minimum"
+    # lines from the old config failed the verify of the config that fixed
+    # them). ActiveEnterTimestamp is authoritative for the running unit.
     - name: Read the gateway journal since the restart
-      ansible.builtin.command: >-
+      ansible.builtin.shell: >-
         journalctl -u hermes-gateway
+        --since "$(systemctl show -p ActiveEnterTimestamp --value hermes-gateway)"
         -n {{ hermes_agent_verify_journal_lines }} --no-pager -o cat
       register: hermes_agent_gateway_journal
       changed_when: false


### PR DESCRIPTION
The post-converge gate reads `journalctl -u hermes-gateway -n 200` with no time bound, so it re-matches fatal lines from BEFORE the restart — the exact errors the converge just fixed. Observed live today: the compression-model fix (#946) converged cleanly, the gateway started with zero post-restart errors (verified in Splunk), yet the gate failed on the pre-restart "context window of 32,768 … below the minimum" line and told the operator to roll back a good deploy.

Fix: `--since "$(systemctl show -p ActiveEnterTimestamp --value hermes-gateway)"` bounds the read to the running instance; `-n` stays as a volume cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6JuKQiA3nNTJ81ww1wgFo