### PR TITLE
fix(llm_router): restore OptiQ as the fleet brain — stock twin serves below Hermes' context floor

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -114,15 +114,22 @@ llm_large_serving_ip: >-
 #      limit exceeded` → generation_error_recovery aborts ALL in-flight requests
 #      → Hermes retry storm, ~zero clean posts. The 80B is a competent
 #      concurrency-1 brain, not a fleet brain.
-# Stock Qwen3.6-35B-A3B-4bit is OptiQ's clean twin (same ~20 GB, clean 20/20
-# multi-turn, 4.1 tok/s) and runs clean on this build — the natural drop-in for
-# the broken resident OptiQ slot, fitting the existing cache + concurrency. Both
-# rotation phases point at it so the fleet never routes to the 80B. The 80B
-# stays reachable ONLY via the ai-deep-analysis alias (escalation, concurrency
-# 1). Revert optimized → OptiQ once its engine bug is fixed.
+# REVERTED to OptiQ 2026-07-16: the "stock twin runs clean on this build"
+# premise did not survive contact — the stock 35B wedged with the SAME
+# broadcast_shapes batch-scheduler crash (805 errors / 603 consecutive
+# zero-token completions wrapped in HTTP 200, ~15h of failed crons; nix-ai
+# #1234). With crash risk equal, the twins differ only where OptiQ wins:
+# 65,536-token serving window (the stock instance serves 32,768, BELOW
+# Hermes' hard 64K compression floor — the fleet cannot run on it at all)
+# and 7.4 vs 4.1 tok/s. The wedge is now survivable regardless of brain:
+# the watchdog detects 200-wrapped error bodies and pauses the fleet
+# (#939), ai-default carries a light-tier fallback (#939), and Splunk
+# alerts on the wedge signature (ansible-splunk#342). Both rotation phases
+# point at OptiQ so the fleet never routes to the 80B; the 80B stays
+# reachable ONLY via the ai-deep-analysis alias (escalation, concurrency 1).
 ai_rotation_enabled: true
-ai_default_model_optimized: Qwen3.6-35B-A3B-4bit
-ai_default_model_large: Qwen3.6-35B-A3B-4bit
+ai_default_model_optimized: Qwen3.6-35B-A3B-OptiQ-4bit
+ai_default_model_large: Qwen3.6-35B-A3B-OptiQ-4bit
 ai_default_model: "{{ 'ai-default' if ai_rotation_enabled | bool else ai_default_model_optimized }}"
 
 # Escalation rubric v1 — WHICH tier a task deserves, encoded as data (from the


### PR DESCRIPTION
## Summary

Roadmap T6-24c, pulled forward on live evidence. The #915 stock-35B routing was justified by "stock runs clean on this build" — today's wedge disproved that premise: the stock twin hit the identical `broadcast_shapes` batch-scheduler crash (805 errors, 603 consecutive zero-token HTTP-200 completions, ~15h of failed crons; nix-ai#1234).

With crash risk equal between the twins, OptiQ wins on everything left:
- **65,536-token serving window** — the stock instance serves 32,768, **below Hermes' hard 64K compression-model floor**; the cron fleet structurally cannot run on it (live failures at 11:51Z and 12:26Z today: context floor, then `ContextWindowExceededError` at 34k tokens).
- **7.4 vs 4.1 tok/s.**

A wedge on any brain is now survivable: watchdog validates completion bodies and pauses the fleet with one alert (#939), `ai-default` has a light-tier fallback (#939), and Splunk alerts on the wedge signature (ansible-splunk#342).

## Verification

Post-converge: `ai-default` model_info reports 65,536; next cron tick completes without context-floor or overflow errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6JuKQiA3nNTJ81ww1wgFo