### PR TITLE
feat(openbao): grant ansible-converge exact-path write to ai/mcp/splunk

### DIFF
--- a/roles/openbao/templates/ansible-converge-policy.hcl.j2
+++ b/roles/openbao/templates/ansible-converge-policy.hcl.j2
@@ -1,7 +1,8 @@
 {{ ansible_managed | comment }}
 # OpenBao policy for the ansible-converge AppRole — config-management pulls
 # (was "ansible"). Read-only on the platform + apps subtrees (the credentials
-# roles consume); no write, and no access to the infra kernel (secret/infra/*).
+# roles consume); no access to the infra kernel (secret/infra/*). The single
+# exact-path write below is the only exception (see it for scope).
 
 {% for sub in ['platform', 'apps'] %}
 path "{{ openbao_kv_mount }}/data/{{ sub }}/*" {
@@ -13,3 +14,16 @@ path "{{ openbao_kv_mount }}/metadata/{{ sub }}/*" {
 }
 
 {% endfor %}
+# Transitional exact-path exception: ansible-splunk's converge publishes the
+# shared Splunk MCP connection (SPLUNK_MCP_URL + the minted SPLUNK_MCP_TOKEN)
+# here. Narrow create/update/read on the SINGLE secret — deliberately NOT a
+# wildcard and NOT blanket secret/ai/* write (that stays with ai-orchestrator).
+# `read` is required: the publisher does a read-modify-write to preserve sibling
+# fields. Mirrors the hermes-write exact-path precedent.
+path "{{ openbao_kv_mount }}/data/ai/mcp/splunk" {
+  capabilities = ["create", "update", "read"]
+}
+
+path "{{ openbao_kv_mount }}/metadata/ai/mcp/splunk" {
+  capabilities = ["read"]
+}


### PR DESCRIPTION
## What

Grants the `ansible-converge` AppRole policy `create`/`update`/`read` on the single exact path `secret/ai/mcp/splunk` (+ `metadata` read).

## Why

The Splunk MCP publish (ansible-splunk #341) moved the canonical shared-connection secret to `secret/ai/mcp/splunk` and writes it during the converge, which authenticates with the `ansible-converge` AppRole. That policy was read-only on platform/apps with no `ai` access — verified via `sys/capabilities-self` returning `["deny"]` on `secret/data/ai/mcp/splunk`. Without this grant the publish 403s.

## Scope

- Exact path only — deliberately NOT a wildcard, NOT blanket `secret/ai/*` write (that stays with `ai-orchestrator`).
- `read` included because the publisher does a read-modify-write to preserve sibling fields.
- Mirrors the existing `hermes-write` exact-path precedent.
- No contract test asserts on ansible-converge policy content; the molecule template-existence check still passes (editing an already-listed template).

Verification after merge + promote + openbao converge: re-run `sys/capabilities-self` on `secret/data/ai/mcp/splunk` → expect `create`/`update`/`read`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)