### PR TITLE
fix(llm_router): disable rotation fallback below the primary's context floor

### DIFF
--- a/roles/hermes_agent/templates/hermes-brain-watchdog.sh.j2
+++ b/roles/hermes_agent/templates/hermes-brain-watchdog.sh.j2
@@ -70,9 +70,14 @@ probe_ok() {
   code="${response##*$'\n'}"
   body="${response%$'\n'*}"
   # stop|length|tool_calls = the model really generated; "error" (or a body
-  # with no finish_reason at all) = broken regardless of the 200.
+  # with no finish_reason at all) = broken regardless of the 200. The
+  # finish_reason check alone is not enough: LiteLLM can remap an upstream
+  # finish_reason "error" to "stop" (core_helpers "Unmapped finish_reason
+  # 'error', defaulting to 'stop'", seen live 2026-07-16), so also require
+  # completion_tokens >= 1 — a wedged engine always reports 0.
   [[ "${code}" == "200" ]] \
-    && grep -Eq '"finish_reason"[[:space:]]*:[[:space:]]*"(stop|length|tool_calls)"' <<< "${body}"
+    && grep -Eq '"finish_reason"[[:space:]]*:[[:space:]]*"(stop|length|tool_calls)"' <<< "${body}" \
+    && grep -Eq '"completion_tokens"[[:space:]]*:[[:space:]]*[1-9]' <<< "${body}"
 }
 
 # --- Cron fleet control (best-effort; idempotent) ----------------------------

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -302,14 +302,18 @@ llm_router_rotation_actuator: >-
 llm_router_rotation_stagger_mm: "{{ '%02d' | format(llm_router_rotation_stagger_minutes | int) }}"
 llm_router_rotation_large_oncalendar: "*-*-* 00:{{ llm_router_rotation_stagger_mm }}:00 UTC"
 llm_router_rotation_optimized_oncalendar: "*-*-* 12:{{ llm_router_rotation_stagger_mm }}:00 UTC"
-# Degraded-mode fallback for the rotation alias. `ai-default` is otherwise a
-# single deployment (the Studio brain): any engine fault = every consumer
-# hard-fails, and a MID-STREAM engine error can never fall back at all
-# ("Available Model Group Fallbacks=None", 2026-07-16 wedge). Chaining the
-# light tier here means a Studio outage degrades to a small-but-alive brain
-# instead of dying — the estate direction is degrade, don't die, and the
-# brain watchdog deliberately treats degraded as UP. Empty string disables.
-llm_router_rotation_fallback_model: qwen3-4b
+# Degraded-mode fallback for the rotation alias. Empty string disables — and
+# it MUST stay disabled until a fallback deployment exists that satisfies the
+# same context floor as the primary (>= the rotation alias's served window).
+# The 2026-07-16 attempt chained qwen3-4b here, but the light tier's only live
+# deployment is llm-light (CPU, 2048-token context; llm-fast GPU is frozen for
+# hardware hard-locks): every Hermes-sized fallback request died with
+# ContextWindowExceeded, Hermes adopted the 2048 window and compressed itself
+# to death ("Cannot compress further"), and the watchdog's tiny probe DID fit
+# in 2048 — so the fallback masked the engine wedge from the watchdog while
+# every real request failed. A fallback smaller than the primary's window is
+# worse than none: fail loud, let the watchdog pause the fleet.
+llm_router_rotation_fallback_model: ""
 # Per-phase rendered configs; config.yaml is a symlink to the live one.
 llm_router_rotation_config_large: "{{ llm_router_config_dir }}/config-large.yaml"
 llm_router_rotation_config_optimized: "{{ llm_router_config_dir }}/config-optimized.yaml"


### PR DESCRIPTION
## Problem (live, 2026-07-16 14:33–15:18Z)

The `ai-default → qwen3-4b` fallback introduced in #939 is actively harmful:

- The light tier's only live deployment is **llm-light (CPU, 2048-token context)** — llm-fast (GPU, 8192) is frozen for hardware hard-locks. Neither satisfies Hermes' context floor.
- When the engine wedge (nix-ai#1234) recurred, mid-stream fallback sent full Hermes prompts (16k+) to the 2048-token backend → `ContextWindowExceeded` → Hermes adopted the tiny window and failed every cron with "Context length exceeded (2,948 tokens). Cannot compress further."
- The watchdog's 1-token probe **fit in 2048**, so the probe succeeded via fallback while every real request failed — the fallback masked the wedge from the watchdog and the fleet was never paused.

## Fix

1. `llm_router_rotation_fallback_model: ""` — disabled until a fallback deployment exists that satisfies the same context floor as the primary. Fail loud; the watchdog pauses the fleet.
2. Watchdog probe additionally requires `completion_tokens >= 1`: LiteLLM can remap upstream `finish_reason: error` → `stop` (`core_helpers.py:112` warning seen live 15:21Z), which defeats the finish_reason-only check; a wedged engine always reports 0 completion tokens.

## Verification plan

Converge `--tags llm_router` (×3 routers) + `--tags hermes_agent`, then confirm the next cron tick after a wedge shows the fleet PAUSED (single alert) instead of per-job failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6JuKQiA3nNTJ81ww1wgFo