### PR TITLE
feat: OpenRouter egress tier via llm_router with per-model keys from OpenBao ai/saas area

### DIFF
--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -374,10 +374,13 @@ options (fresh `codex login`, or copying an already-authenticated
 `~/.codex/auth.json`). Until that's done, the MCP entry is present but every
 call to it errors; the daemon itself starts and runs normally regardless.
 
-`OPENROUTER_API_KEY` is already seeded in OpenBao `secret/ai/hermes` (from an
-earlier pass at this problem) but is **not consumed** by anything in this
-role — parked for a possible future escalation option, not wired to an
-active MCP/delegation target this round.
+OpenRouter is reachable with **no Hermes-side wiring**: the `llm_router` role
+registers OpenRouter models as explicit router aliases (first:
+`openrouter-free`), with one OpenBao-held key **per model** under
+`secret/ai/saas/openrouter` — Hermes just names the alias like any other
+model. The old account-wide `OPENROUTER_API_KEY` parked in `secret/ai/hermes`
+is superseded by those per-model keys and should be retired once they are
+seeded.
 
 | Variable | Default | Meaning |
 | --- | --- | --- |

--- a/roles/llm_router/README.md
+++ b/roles/llm_router/README.md
@@ -18,12 +18,36 @@ tofu inventory). Tools come from the repo's Nix dev shell (`direnv allow`).
 | --- | --- | --- |
 | `gpt-oss-120b`, `Qwen3-Coder-30B-A3B`, `Qwen3.6-35B-A3B-4bit`, `claude-sonnet-5` | `llm-large` runner (`/v1`, bearer) | `LLM_LARGE_BEARER_TOKEN` |
 | `qwen3-4b`, `embeddings`, `claude-haiku-4-5` | `llm-fast` (GPU) **and** `llm-light` (CPU) | none |
+| `openrouter-free` (extensible list) | OpenRouter (paid-SaaS egress) | one key **per model** |
 
 Each light alias is registered as **two deployments** with the same `model_name`
 (the GPU `llm-fast` box and the CPU `llm-light` standby). LiteLLM load-balances the
 pair and cools a failed deployment down (`allowed_fails` / `cooldown_time`), so a GPU
 outage drains to CPU automatically. There is **no** cross-tier fallback — a large
 request that fails surfaces the error rather than silently degrading to a small model.
+
+## OpenRouter egress tier (optional, per-model keys)
+
+`llm_router_openrouter_models` registers explicitly-named aliases for
+OpenRouter-hosted models. Deliberate properties:
+
+- **One OpenRouter API key per MODEL** (never per harness/caller). Each entry's
+  `key_field` names its field in the OpenBao paid-SaaS key area
+  `secret/ai/saas/openrouter`; the `openbao_secrets` pre-play delivers it via
+  the `ai-saas-openrouter` policy leaf, and the rendered EnvironmentFile
+  carries it as `OPENROUTER_API_KEY_<KEY_FIELD upper-snaked>`.
+- **Inert until seeded** — an entry whose key is absent renders nothing, so
+  the list is safe to extend before the key exists.
+- **Opt-in only** — OpenRouter aliases are never chained into `ai-default`
+  rotation or fallbacks; consumers (Hermes, Open WebUI, workstation harnesses)
+  must name the alias to reach the SaaS egress.
+
+Seeding a new model (operator, once per model): mint a scoped key in the
+OpenRouter console, then
+`bao kv patch secret/ai/saas/openrouter <model-slug>=<key>` and re-converge
+this role. The first entry is `openrouter-free` →
+`nvidia/nemotron-3-ultra-550b-a55b:free` (rate-limited; NVIDIA logs prompts on
+the `:free` endpoint — never send confidential material through it).
 
 ## Daily brain rotation (optional)
 

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -169,6 +169,26 @@ llm_router_light_models:
   # longer served anywhere — >=14B GPU serving is barred from the fast tier).
   - { alias: claude-haiku-4-5, backend: qwen3-4b }
 
+# --- OpenRouter egress tier (paid-SaaS; one key per MODEL) --------------------
+# Explicitly-named aliases to OpenRouter-hosted models. NEVER part of the
+# ai-default rotation or any fallback chain — a flaky/rate-limited upstream
+# must not be able to degrade the local brain; consumers opt in by alias.
+# Key model (deliberate): ONE OpenRouter API key PER MODEL, irrespective of
+# which harness/caller makes the request. key_field names the per-model field
+# in OpenBao secret/ai/saas/openrouter (fetched into bao_local_llm_secrets by
+# the openbao_secrets pre-play via the ai-saas-openrouter policy leaf; env
+# fallback OPENROUTER_API_KEY_<KEY_FIELD upper-snaked>). An entry whose key is
+# not seeded renders nothing (inert-until-creds), so the list is safe to
+# extend ahead of key seeding. context_window is the model's real serving
+# window (never null — the compress-death rule applies to every alias).
+llm_router_openrouter_models:
+  # Free endpoint: rate-limited, and NVIDIA logs prompt/session data on the
+  # :free variant — never send confidential material through this alias.
+  - alias: openrouter-free
+    model: nvidia/nemotron-3-ultra-550b-a55b:free
+    key_field: nvidia-nemotron-3-ultra-550b-a55b-free
+    context_window: 1000000
+
 # --- Routing behaviour -------------------------------------------------------
 # Load-balance across same-name deployments; cool a failed one down so traffic
 # drains to its sibling (GPU -> CPU). No cross-tier fallbacks.

--- a/roles/llm_router/templates/config.yaml.j2
+++ b/roles/llm_router/templates/config.yaml.j2
@@ -103,6 +103,23 @@ model_list:
       api_base: {{ llm_router_llm_large_base_url }}
       api_key: os.environ/LLM_LARGE_BEARER_TOKEN
 {% endif %}
+  # --- OpenRouter egress tier: explicit opt-in aliases, one key per MODEL ---
+  # Never chained into ai-default rotation or fallbacks (see defaults). Keys
+  # come from OpenBao ai/saas/openrouter via the EnvironmentFile; an unseeded
+  # model renders no entry at all.
+{% for m in llm_router_openrouter_models %}
+{% set _or_env = 'OPENROUTER_API_KEY_' ~ (m.key_field | upper | replace('-', '_')) %}
+{% set _or_key = bao_local_llm_secrets[m.key_field] | default(lookup('env', _or_env), true) %}
+{% if _or_key | length > 0 %}
+  - model_name: {{ m.alias }}
+    litellm_params:
+      model: openrouter/{{ m.model }}
+      api_key: os.environ/{{ _or_env }}
+    model_info:
+      max_input_tokens: {{ m.context_window }}
+      max_tokens: {{ m.context_window }}
+{% endif %}
+{% endfor %}
   # --- light tier: two deployments per alias (GPU llm-fast + CPU llm-light) ---
   # Same model_name => LiteLLM load-balances the pair and cools a failed deployment
   # down, so a GPU outage drains to the CPU standby automatically.

--- a/roles/llm_router/templates/litellm.env.j2
+++ b/roles/llm_router/templates/litellm.env.j2
@@ -6,3 +6,11 @@ LLM_LARGE_BEARER_TOKEN={{ llm_router_llm_large_bearer }}
 # OTLP/HTTP traces to the Cribl Edge collector (otlp_http wants the full signal path).
 OTEL_EXPORTER=otlp_http
 OTEL_ENDPOINT={{ llm_router_otel_endpoint }}/v1/traces
+{% for m in llm_router_openrouter_models %}
+{% set _or_env = 'OPENROUTER_API_KEY_' ~ (m.key_field | upper | replace('-', '_')) %}
+{% set _or_key = bao_local_llm_secrets[m.key_field] | default(lookup('env', _or_env), true) %}
+{% if _or_key | length > 0 %}
+# OpenRouter per-MODEL key ({{ m.alias }}) — OpenBao ai/saas/openrouter field {{ m.key_field }}.
+{{ _or_env }}={{ _or_key }}
+{% endif %}
+{% endfor %}

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -269,7 +269,13 @@ openbao_github_permission_sets:
 #                      secret/platform/{object-storage,compute}
 #   monitoring       — read-only, secret/apps/monitoring
 #   media            — read-only, secret/apps/media
-#   local-llm        — LLM serving stack; read-only, secret/ai/*
+#   local-llm        — LLM serving stack; read-only, secret/ai/* MINUS the
+#                      ai/saas/* carve-out (paid-SaaS provider keys)
+#   ai-saas-openrouter — per-provider read leaf for the paid-SaaS key area
+#                      secret/ai/saas/<provider> (anthropic/google/openai/
+#                      openrouter, one field per MODEL). Attached to local-llm
+#                      so the llm_router converge reads OpenRouter keys only;
+#                      future providers get their own sibling policy.
 #   hermes           — Hermes AI agent; read-only, exact secret/ai/hermes and
 #                      secret/ai/mcp/splunk paths, NOT the broad ai subtree
 #   hermes-write     — least-privilege WRITE to exact secret/ai/hermes and
@@ -343,6 +349,7 @@ openbao_apps_policy_name: apps
 openbao_apps_approle_name: apps
 openbao_local_llm_policy_name: local-llm
 openbao_local_llm_approle_name: local-llm
+openbao_ai_saas_openrouter_policy_name: ai-saas-openrouter
 openbao_hermes_policy_name: hermes
 openbao_hermes_approle_name: hermes
 openbao_hermes_write_policy_name: hermes-write
@@ -472,8 +479,13 @@ openbao_base_approles:
     policy: "{{ openbao_media_policy_name }}"
   - name: "{{ openbao_apps_approle_name }}"
     policy: "{{ openbao_apps_policy_name }}"
+  # local-llm additionally attaches the OpenRouter SaaS read leaf: the
+  # llm_router converge renders per-model OpenRouter keys, while the
+  # local-llm policy itself denies the rest of the ai/saas/* provider area.
   - name: "{{ openbao_local_llm_approle_name }}"
-    policy: "{{ openbao_local_llm_policy_name }}"
+    token_policies:
+      - "{{ openbao_local_llm_policy_name }}"
+      - "{{ openbao_ai_saas_openrouter_policy_name }}"
   - name: "{{ openbao_hermes_approle_name }}"
     policy: "{{ openbao_hermes_policy_name }}"
   - name: "{{ openbao_hermes_write_approle_name }}"
@@ -578,6 +590,8 @@ openbao_base_policies:
     template: apps-policy.hcl.j2
   - name: "{{ openbao_local_llm_policy_name }}"
     template: local-llm-policy.hcl.j2
+  - name: "{{ openbao_ai_saas_openrouter_policy_name }}"
+    template: ai-saas-openrouter-policy.hcl.j2
   - name: "{{ openbao_hermes_policy_name }}"
     template: hermes-policy.hcl.j2
   - name: "{{ openbao_hermes_write_policy_name }}"

--- a/roles/openbao/templates/ai-saas-openrouter-policy.hcl.j2
+++ b/roles/openbao/templates/ai-saas-openrouter-policy.hcl.j2
@@ -1,0 +1,18 @@
+{{ ansible_managed | comment }}
+# OpenBao policy for OpenRouter consumption — read-only on the single
+# ai/saas/openrouter KV entry (one field per OpenRouter MODEL, field name =
+# model slug, e.g. nvidia-nemotron-3-ultra-550b-a55b-free). Part of the
+# paid-SaaS provider key area ai/saas/<provider> (anthropic/google/openai/
+# openrouter, ...): each provider gets its own read policy so a consumer is
+# granted exactly the providers it uses, never the whole SaaS area. Attached
+# to the local-llm AppRole so the llm_router converge can render per-model
+# keys; the exact path here out-precedences local-llm's ai/saas/* deny
+# (longest-prefix match).
+
+path "{{ openbao_kv_mount }}/data/ai/saas/openrouter" {
+  capabilities = ["read"]
+}
+
+path "{{ openbao_kv_mount }}/metadata/ai/saas/openrouter" {
+  capabilities = ["read", "list"]
+}

--- a/roles/openbao/templates/local-llm-policy.hcl.j2
+++ b/roles/openbao/templates/local-llm-policy.hcl.j2
@@ -12,3 +12,16 @@ path "{{ openbao_kv_mount }}/data/ai/*" {
 path "{{ openbao_kv_mount }}/metadata/ai/*" {
   capabilities = ["read", "list"]
 }
+
+# Carve the paid-SaaS provider key area (ai/saas/<provider>) OUT of the broad
+# ai/* read: those keys (Anthropic/Google/OpenAI/OpenRouter, one field per
+# model) are consumed by per-provider policies (e.g. ai-saas-openrouter),
+# not by every local-llm converge. Longest-prefix match means an attached
+# per-provider policy's exact-path read still wins over this glob deny.
+path "{{ openbao_kv_mount }}/data/ai/saas/*" {
+  capabilities = ["deny"]
+}
+
+path "{{ openbao_kv_mount }}/metadata/ai/saas/*" {
+  capabilities = ["deny"]
+}

--- a/roles/openbao_secrets/defaults/main.yml
+++ b/roles/openbao_secrets/defaults/main.yml
@@ -90,9 +90,18 @@ openbao_secrets_domains:
       - ai/qdrant      # QDRANT_API_KEY
       - ai/open-webui  # OPEN_WEBUI_SECRET_KEY, OPEN_WEBUI_OPENAI_API_KEY
       - ai/hermes      # GH_PAT_WRITE_PROJECT_ISSUES, HERMES_GITHUB_APP_{ID,INSTALLATION_ID,
-                       #   PRIVATE_KEY}, OPENROUTER_API_KEY (seeded,
-                       #   parked — not consumed by any role yet, see hermes_agent's
-                       #   "Escalation" README section)
+                       #   PRIVATE_KEY}. The old account-wide OPENROUTER_API_KEY
+                       #   parked here is SUPERSEDED by the per-model keys in
+                       #   ai/saas/openrouter below — retire it (bao kv delete
+                       #   field) once the per-model keys are seeded.
+      - ai/saas/openrouter  # Paid-SaaS provider key area (ai/saas/<provider>).
+                       #   One field per OpenRouter MODEL (field name = model
+                       #   slug, e.g. nvidia-nemotron-3-ultra-550b-a55b-free),
+                       #   consumed by llm_router's OpenRouter egress tier.
+                       #   Readable via the ai-saas-openrouter policy leaf only —
+                       #   local-llm's broad ai/* read explicitly denies the rest
+                       #   of ai/saas/* (sibling providers: anthropic/google/
+                       #   openai seeded later for workstation consumers).
       - ai/mcp/splunk  # SPLUNK_MCP_URL, SPLUNK_MCP_TOKEN; merged into the same
                        #   bao_local_llm_secrets fact consumed by Hermes
       - ai/langfuse    # LANGFUSE_{POSTGRES_PASSWORD,CLICKHOUSE_PASSWORD,REDIS_AUTH,

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -2082,6 +2082,20 @@
       - { alias: qwen3-4b, backend: qwen3-4b }
       - { alias: embeddings, backend: embeddings, embedding: true }
       - { alias: claude-haiku-4-5, backend: hermes-4-14b }
+    # OpenRouter egress tier: one key per MODEL. First entry's key is "seeded"
+    # via the bao fact stand-in below; the second is deliberately unseeded and
+    # must render nothing (inert-until-creds contract).
+    llm_router_openrouter_models:
+      - alias: openrouter-free
+        model: nvidia/nemotron-3-ultra-550b-a55b:free
+        key_field: nvidia-nemotron-3-ultra-550b-a55b-free
+        context_window: 1000000
+      - alias: openrouter-unseeded
+        model: example/unseeded-model
+        key_field: example-unseeded-model
+        context_window: 32768
+    bao_local_llm_secrets:
+      nvidia-nemotron-3-ultra-550b-a55b-free: test-openrouter-key-placeholder
     llm_router_routing_strategy: simple-shuffle
     llm_router_large_passthrough_enabled: true
     llm_router_allowed_fails: 2
@@ -2140,8 +2154,21 @@
           - _model_names | select('equalto', 'mlx-community/gpt-oss-120b-MXFP4-Q8') | list | length == 1
           - _model_names | select('equalto', 'mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit') | list | length == 1
           - _model_names | select('equalto', 'mlx-community/Qwen3.6-35B-A3B-4bit') | list | length == 1
+          # OpenRouter egress tier: the seeded model renders exactly once with
+          # its per-MODEL key as an os.environ ref; the unseeded model renders
+          # nothing (inert-until-creds).
+          - _model_names | select('equalto', 'openrouter-free') | list | length == 1
+          - >-
+            (_litellm.model_list | selectattr('model_name', 'equalto', 'openrouter-free')
+             | first).litellm_params.model == 'openrouter/nvidia/nemotron-3-ultra-550b-a55b:free'
+          - >-
+            (_litellm.model_list | selectattr('model_name', 'equalto', 'openrouter-free')
+             | first).litellm_params.api_key
+             == 'os.environ/OPENROUTER_API_KEY_NVIDIA_NEMOTRON_3_ULTRA_550B_A55B_FREE'
+          - _model_names | select('equalto', 'openrouter-unseeded') | list | length == 0
           # Secrets referenced via os.environ, never a literal in the config.
           - "'test-master-key-placeholder' not in (lookup('file', '/tmp/test_litellm_config.yaml'))"
+          - "'test-openrouter-key-placeholder' not in (lookup('file', '/tmp/test_litellm_config.yaml'))"
           - _litellm.general_settings.master_key == 'os.environ/LLM_ROUTER_MASTER_KEY'
           # 429 absorption: rate-limit errors retry with backoff and never cool
           # down the single large deployment (they get their own huge budget).
@@ -2227,6 +2254,12 @@
           - "'LLM_LARGE_BEARER_TOKEN=test-bearer-placeholder' in _litellm_env"
           - "'OTEL_EXPORTER=otlp_http' in _litellm_env"
           - "'OTEL_ENDPOINT=http://cribl-edge.pve.example.net:4318/v1/traces' in _litellm_env"
+          # OpenRouter per-MODEL keys: seeded model's env line present (bao-first
+          # value), unseeded model absent entirely.
+          - >-
+            'OPENROUTER_API_KEY_NVIDIA_NEMOTRON_3_ULTRA_550B_A55B_FREE=test-openrouter-key-placeholder'
+            in _litellm_env
+          - "'OPENROUTER_API_KEY_EXAMPLE_UNSEEDED_MODEL' not in _litellm_env"
         fail_msg: "litellm.env.j2 missing secrets or OTLP traces path: {{ _litellm_env }}"
 
     - name: Render litellm.service.j2 to /tmp


### PR DESCRIPTION
## What

Two coupled changes giving every fabric consumer (Hermes, Open WebUI, workstation harnesses) opt-in access to OpenRouter-hosted models through the existing router front door, with promptless OpenBao-sourced keys:

1. **OpenBao paid-SaaS AI provider key area** — `secret/ai/saas/<provider>` (`openrouter` first; `anthropic`/`google`/`openai` follow later for workstation consumers). A dedicated `ai-saas-openrouter` read-leaf policy is attached to the `local-llm` AppRole, and the broad `local-llm` `ai/*` read now **denies** `ai/saas/*` — so the serving converge can read exactly the OpenRouter keys and nothing else in the SaaS area (longest-prefix match lets the exact-path leaf win the carve-out).
2. **`llm_router` OpenRouter egress tier** — `llm_router_openrouter_models`, explicit opt-in aliases that are never chained into `ai-default` rotation or fallbacks. **One key per OpenRouter MODEL** (never per harness/caller): each entry renders its own `OPENROUTER_API_KEY_<MODEL>` env ref, resolved bao-first from `ai/saas/openrouter` with env fallback. Unseeded entries render nothing (inert-until-creds). First alias: `openrouter-free` → `nvidia/nemotron-3-ultra-550b-a55b:free` (1M context; rate-limited free endpoint that logs prompts — confidential material must not use it).

Hermes needs **zero changes** to reach it — it names the alias like any other router model. The account-wide `OPENROUTER_API_KEY` parked in `ai/hermes` is superseded.

## Verification

- `ansible-lint`: 0 failures, 0 warnings (production profile) on the changed roles.
- `tests/template_render/verify_templates.yml` llm_router play extended and passing: seeded model renders exactly once with an `os.environ/` per-model key ref, unseeded model renders nothing, no key literal appears in `config.yaml`, env file carries only the seeded model's line.
- Rotation per-phase configs render from the same `config.yaml.j2`, so the tier is present in all phases.

## Operator steps (not automated)

1. Mint a scoped key in the OpenRouter console for the free model.
2. `bao kv patch secret/ai/saas/openrouter nvidia-nemotron-3-ultra-550b-a55b-free=<key>`
3. Re-converge `--tags openbao` (policy + AppRole update), then `--tags llm_router`.
4. Retire the superseded `OPENROUTER_API_KEY` field from `secret/ai/hermes`.
5. Live check: `curl https://llm.<subdomain>/v1/models` lists `openrouter-free`; a 1-token completion against it succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUqvNUuZP36gQMRgb7dcEn