### PR TITLE
fix(zammad): restate path.data/path.logs in the managed elasticsearch.yml

### DIFF
--- a/roles/zammad/templates/elasticsearch.yml.j2
+++ b/roles/zammad/templates/elasticsearch.yml.j2
@@ -6,6 +6,12 @@
 # because nothing but the local Zammad process ever reaches it.
 cluster.name: zammad
 node.name: zammad-es
+# The stock deb config carries these; this template REPLACES that file, so they
+# must be restated — without them ES defaults to dirs under its read-only
+# install root (/usr/share/elasticsearch) and dies at startup with exit 78
+# ("Unable to create logs dir").
+path.data: /var/lib/elasticsearch
+path.logs: /var/log/elasticsearch
 network.host: {{ zammad_es_host }}
 http.port: {{ zammad_es_port }}
 discovery.type: single-node


### PR DESCRIPTION
First-ever zammad converge (2026-07-16) died at ES startup: the role's template replaces `/etc/elasticsearch/elasticsearch.yml` wholesale and dropped the stock `path.data`/`path.logs` entries, so ES defaulted to dirs under its read-only install root — exit 78, `Unable to create logs dir [/usr/share/elasticsearch/logs]`.

Restates both paths (the deb's standard locations, already owned by the elasticsearch user).

Verification: converge `--tags zammad` proceeds past ES start (will be run immediately after merge as part of the Zammad restore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6JuKQiA3nNTJ81ww1wgFo