### PR TITLE
fix(hermes_agent): hourly digest heartbeat per operator law

### DIFF
--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -424,10 +424,11 @@ hermes_agent_splunk_deepdive_cron_prompt: >-
 
 # Routine status post: always delivered (never [SILENT]).
 hermes_agent_splunk_digest_cron_name: splunk-digest
-# Daily digest (calmed from hourly): a visible "here's what I'm seeing" post so
-# silence never reads as "is it even running?". Anomaly sweeps stay
-# silent-unless-anomaly.
-hermes_agent_splunk_digest_cron_schedule: "52 8 * * *"
+# HOURLY by operator law (2026-07-16): Hermes must deliver useful information
+# at least once per hour, 24/7 — this digest IS that heartbeat (and its silence
+# is the outage signal). Anomaly sweeps stay silent-unless-anomaly; only they
+# were calmed.
+hermes_agent_splunk_digest_cron_schedule: "52 * * * *"
 hermes_agent_splunk_digest_cron_prompt: >-
   Post a concise Splunk digest to the home channel: what you looked at recently,
   the current normal (top indexes/sourcetypes by volume and their freshness), any


### PR DESCRIPTION
Operator law (2026-07-16): Hermes must deliver useful information at least once per hour, 24/7 — the always-delivered digest is that heartbeat and its silence is the outage signal. #959 wrongly calmed it to daily along with the anomaly sweeps; back to hourly (`52 * * * *`, still a unique start minute).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6JuKQiA3nNTJ81ww1wgFo