### PR TITLE
feat(llamaindex): build a Qdrant RAG index from the docs llms.txt exports

### DIFF
--- a/molecule/llamaindex/verify.yml
+++ b/molecule/llamaindex/verify.yml
@@ -80,3 +80,38 @@
         that:
           - not ollama_binary.stat.exists
         fail_msg: "Legacy Ollama binary still present at /usr/local/bin/ollama"
+
+    - name: Assert config.yaml declares the index collection and sources
+      ansible.builtin.assert:
+        that:
+          - "'collection' in (config_content.content | b64decode)"
+          - "'sources' in (config_content.content | b64decode)"
+        fail_msg: "config.yaml is missing the index collection/sources block"
+
+    - name: Check the RAG indexer script was deployed
+      ansible.builtin.stat:
+        path: "{{ llamaindex_data_dir }}/index_docs.py"
+      register: indexer_script
+
+    - name: Assert the RAG indexer script exists and is executable
+      ansible.builtin.assert:
+        that:
+          - indexer_script.stat.exists
+          - indexer_script.stat.executable
+        fail_msg: "index_docs.py missing or not executable"
+
+    - name: Byte-compile the RAG indexer script
+      ansible.builtin.command:
+        cmd: "{{ llamaindex_data_dir }}/venv/bin/python -m py_compile {{ llamaindex_data_dir }}/index_docs.py"
+      changed_when: false
+
+    - name: Check the RAG index timer unit was installed
+      ansible.builtin.stat:
+        path: /etc/systemd/system/llamaindex-index.timer
+      register: index_timer_unit
+
+    - name: Assert the RAG index timer unit exists
+      ansible.builtin.assert:
+        that:
+          - index_timer_unit.stat.exists
+        fail_msg: "llamaindex-index.timer was not installed"

--- a/roles/llamaindex/defaults/main.yml
+++ b/roles/llamaindex/defaults/main.yml
@@ -13,3 +13,29 @@ llamaindex_qdrant_api_key: "{{ lookup('env', 'QDRANT_API_KEY') }}"
 # llamaindex_qdrant_host is injected from hostvars (inventory) and
 # llamaindex_qdrant_port from tofu_data.constants at the playbook
 # level (see playbooks/site.yml) to keep the role decoupled from inventory.
+
+# --- RAG indexing ------------------------------------------------------------
+# The indexer (index_docs.py) turns the otherwise-idle Qdrant into a queryable
+# index. It embeds each source via the router and rebuilds one collection.
+llamaindex_qdrant_collection: homelab_docs
+# Install + enable the systemd timer that periodically rebuilds the index.
+llamaindex_index_enabled: true
+# systemd OnCalendar for the refresh timer (daily; off the :00 mark).
+llamaindex_index_on_calendar: "*-*-* 04:17:00"
+# Documents to index. Each source has a name and either a `url` or a `path`.
+# A url source may name a Cloudflare Access service-token env pair; the indexer
+# skips that source (non-fatal) when the env is absent, so a converge without
+# the token still indexes every reachable source.
+llamaindex_sources:
+  - name: public-docs
+    url: "https://docs.jacobpevans.com/llms-full.txt"
+  - name: dryvist-docs
+    url: "https://docs.dryvist.com/llms-full.txt"
+    cf_access_client_id_env: CF_ACCESS_CLIENT_ID
+    cf_access_client_secret_env: CF_ACCESS_CLIENT_SECRET
+  - name: ai-stack-registry
+    path: "{{ llamaindex_data_dir }}/registry.json"
+# Render the service-registry doc (ports/endpoints from tofu_data.constants) so
+# the index also covers the service registry. Skipped when tofu_data is absent
+# (e.g. molecule), leaving the ai-stack-registry source to skip its missing file.
+llamaindex_registry_enabled: true

--- a/roles/llamaindex/files/index_docs.py
+++ b/roles/llamaindex/files/index_docs.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Build/refresh the homelab RAG index in Qdrant from the configured sources.
+
+Reads {data_dir}/config.yaml (rendered by the llamaindex Ansible role), fetches
+each source (the docs sites' llms-full.txt plus the local service registry),
+embeds via the OpenAI-compatible fabric router, and (re)builds a single Qdrant
+collection. This is the consumer that turns the otherwise-idle Qdrant into a
+queryable RAG index.
+
+Run by the llamaindex-index.timer systemd unit; safe to run by hand:
+    /opt/llamaindex/venv/bin/python /opt/llamaindex/index_docs.py --dry-run
+
+ponytail: full reindex each run (recreate the collection). Fine for a handful
+of small llms-full.txt sources; switch to incremental (per-doc hash -> skip
+unchanged) only if the source set or embed cost grows enough to notice.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+
+def load_config(config_path: Path) -> dict:
+    with config_path.open() as fh:
+        return yaml.safe_load(fh)
+
+
+def fetch_url(name: str, source: dict) -> str | None:
+    """Return the source text, or None to skip it.
+
+    A source may name a Cloudflare Access service-token env pair via
+    cf_access_client_id_env / cf_access_client_secret_env. When those env vars
+    are absent the source is skipped (non-fatal) so a converge without the
+    token still indexes every reachable source.
+    """
+    headers = {"User-Agent": "homelab-rag-indexer"}
+    cid_env = source.get("cf_access_client_id_env")
+    csec_env = source.get("cf_access_client_secret_env")
+    if cid_env or csec_env:
+        cid = os.environ.get(cid_env or "")
+        csec = os.environ.get(csec_env or "")
+        if not (cid and csec):
+            print(f"skip {name}: Cloudflare Access token env not set", file=sys.stderr)
+            return None
+        headers["CF-Access-Client-Id"] = cid
+        headers["CF-Access-Client-Secret"] = csec
+    req = urllib.request.Request(source["url"], headers=headers)
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 (trusted config URLs)
+        return resp.read().decode("utf-8", "replace")
+
+
+def read_path(name: str, source: dict) -> str | None:
+    path = Path(source["path"])
+    if not path.is_file():
+        print(f"skip {name}: {path} not found", file=sys.stderr)
+        return None
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def gather_documents(cfg: dict) -> list:
+    from llama_index.core import Document
+
+    docs = []
+    for source in cfg.get("index", {}).get("sources", []):
+        name = source.get("name", "source")
+        text = fetch_url(name, source) if source.get("url") else read_path(name, source)
+        if not text:
+            continue
+        docs.append(Document(text=text, metadata={"source": name}))
+        print(f"loaded {name}: {len(text)} chars", file=sys.stderr)
+    return docs
+
+
+def build_index(cfg: dict, docs: list) -> None:
+    import qdrant_client
+    from llama_index.core import Settings, StorageContext, VectorStoreIndex
+    from llama_index.embeddings.openai import OpenAIEmbedding
+    from llama_index.vector_stores.qdrant import QdrantVectorStore
+
+    qdrant = cfg["qdrant"]
+    emb = cfg["embeddings"]
+    collection = cfg["index"]["collection"]
+
+    # OpenAI-compatible embeddings served by the fabric router. model_name is
+    # the router alias, not a real OpenAI model. If this llama-index version
+    # rejects an unknown model name, pin a known name here and rely on api_base
+    # routing -- the router maps by deployment, not by the model string.
+    Settings.embed_model = OpenAIEmbedding(
+        model_name=emb["model"],
+        api_base=emb["base_url"],
+        api_key=emb["api_key"],
+    )
+
+    client = qdrant_client.QdrantClient(
+        host=qdrant["host"],
+        port=int(qdrant["port"]),
+        api_key=qdrant.get("api_key") or None,
+    )
+    # Full rebuild: drop the collection first so re-runs replace rather than
+    # duplicate points.
+    if client.collection_exists(collection):
+        client.delete_collection(collection)
+    vector_store = QdrantVectorStore(client=client, collection_name=collection)
+    storage = StorageContext.from_defaults(vector_store=vector_store)
+    VectorStoreIndex.from_documents(docs, storage_context=storage)
+    print(
+        f"indexed {len(docs)} documents into qdrant collection '{collection}'",
+        file=sys.stderr,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build the homelab RAG index in Qdrant.")
+    parser.add_argument("--config", default="/opt/llamaindex/config.yaml", type=Path)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="fetch sources and report sizes; do not embed or write to Qdrant",
+    )
+    args = parser.parse_args()
+
+    cfg = load_config(args.config)
+    docs = gather_documents(cfg)
+    if not docs:
+        print("no sources produced content; nothing to index", file=sys.stderr)
+        return 1
+    if args.dry_run:
+        total = sum(len(doc.text) for doc in docs)
+        print(f"dry-run: {len(docs)} documents ready, {total} total chars", file=sys.stderr)
+        return 0
+    build_index(cfg, docs)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/roles/llamaindex/tasks/main.yml
+++ b/roles/llamaindex/tasks/main.yml
@@ -59,6 +59,9 @@
       - llama-index-core
       - llama-index-vector-stores-qdrant
       - llama-index-embeddings-openai
+      # index_docs.py reads the rendered config.yaml; qdrant-client arrives via
+      # llama-index-vector-stores-qdrant, PyYAML is not guaranteed transitively.
+      - pyyaml
     state: present
     virtualenv: "{{ llamaindex_data_dir }}/venv"
 
@@ -73,6 +76,49 @@
     owner: root
     group: root
     mode: "0640"
+
+# =============================================================================
+# RAG Indexer (the consumer that makes Qdrant a live index)
+# =============================================================================
+
+- name: Deploy the RAG indexer script
+  ansible.builtin.copy:
+    src: index_docs.py
+    dest: "{{ llamaindex_data_dir }}/index_docs.py"
+    owner: root
+    group: root
+    mode: "0750"
+
+- name: Render the service-registry document for indexing
+  ansible.builtin.template:
+    src: registry.json.j2
+    dest: "{{ llamaindex_data_dir }}/registry.json"
+    owner: root
+    group: root
+    mode: "0640"
+  when:
+    - llamaindex_registry_enabled | default(true)
+    - tofu_data is defined
+
+- name: Install the RAG index refresh systemd units
+  ansible.builtin.template:
+    src: "{{ item }}.j2"
+    dest: "/etc/systemd/system/{{ item }}"
+    owner: root
+    group: root
+    mode: "0644"
+  loop:
+    - llamaindex-index.service
+    - llamaindex-index.timer
+  when: llamaindex_index_enabled | default(true)
+
+- name: Enable the RAG index refresh timer
+  ansible.builtin.systemd:
+    name: llamaindex-index.timer
+    enabled: true
+    state: started
+    daemon_reload: true
+  when: llamaindex_index_enabled | default(true)
 
 # =============================================================================
 # Health Checks

--- a/roles/llamaindex/templates/llamaindex-config.yaml.j2
+++ b/roles/llamaindex/templates/llamaindex-config.yaml.j2
@@ -10,3 +10,20 @@ embeddings:
   api_key: "{{ llamaindex_router_api_key }}"
 
 data_dir: "{{ llamaindex_data_dir }}"
+
+index:
+  collection: "{{ llamaindex_qdrant_collection }}"
+  sources:
+{% for source in llamaindex_sources %}
+    - name: "{{ source.name }}"
+{% if source.url is defined %}
+      url: "{{ source.url }}"
+{% endif %}
+{% if source.path is defined %}
+      path: "{{ source.path }}"
+{% endif %}
+{% if source.cf_access_client_id_env is defined %}
+      cf_access_client_id_env: "{{ source.cf_access_client_id_env }}"
+      cf_access_client_secret_env: "{{ source.cf_access_client_secret_env }}"
+{% endif %}
+{% endfor %}

--- a/roles/llamaindex/templates/llamaindex-index.service.j2
+++ b/roles/llamaindex/templates/llamaindex-index.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Rebuild the homelab RAG index in Qdrant
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+# Router key and Qdrant key are baked into config.yaml at converge time. Only
+# the optional Cloudflare Access service token for the private docs source is
+# read from the environment at runtime; point EnvironmentFile at wherever it
+# lives to enable that source (otherwise it is skipped, non-fatally).
+{% if llamaindex_index_environment_file is defined %}
+EnvironmentFile={{ llamaindex_index_environment_file }}
+{% endif %}
+ExecStart={{ llamaindex_data_dir }}/venv/bin/python {{ llamaindex_data_dir }}/index_docs.py --config {{ llamaindex_data_dir }}/config.yaml

--- a/roles/llamaindex/templates/llamaindex-index.timer.j2
+++ b/roles/llamaindex/templates/llamaindex-index.timer.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Periodic homelab RAG index refresh
+
+[Timer]
+OnCalendar={{ llamaindex_index_on_calendar }}
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/roles/llamaindex/templates/registry.json.j2
+++ b/roles/llamaindex/templates/registry.json.j2
@@ -1,0 +1,5 @@
+{
+  "generated_by": "ansible role llamaindex from tofu_data.constants",
+  "vector_db_ports": {{ tofu_data.constants.vector_db_ports | default({}) | to_nice_json(indent=2) }},
+  "service_ports": {{ tofu_data.constants.service_ports | default({}) | to_nice_json(indent=2) }}
+}


### PR DESCRIPTION
## Summary

The `llamaindex` role previously rendered config and installed libraries but shipped no runner, so the provisioned Qdrant stayed idle. This change adds the consumer that turns Qdrant into a live RAG index:

- `roles/llamaindex/files/index_docs.py` — reads the rendered `config.yaml`, fetches each configured source (the docs sites' `llms-full.txt` plus the on-guest service registry), embeds via the OpenAI-compatible fabric router, and rebuilds a single `homelab_docs` Qdrant collection (full reindex per run; `--dry-run` supported).
- `templates/llamaindex-index.service.j2` + `llamaindex-index.timer.j2` — a systemd oneshot + timer (`OnCalendar` default off the :00 mark, `Persistent=true`) that periodically refreshes the index.
- `templates/registry.json.j2` — renders the service registry (ports/endpoints from `tofu_data.constants`) as an indexable source; skipped when `tofu_data` is absent (e.g. molecule).
- `defaults/main.yml` — new `llamaindex_qdrant_collection`, `llamaindex_index_*`, `llamaindex_sources`, and `llamaindex_registry_enabled` knobs.
- `tasks/main.yml` — deploys the runner, renders the registry, installs + enables the timer units; adds `pyyaml` to the venv (not guaranteed transitively).
- `molecule/llamaindex/verify.yml` — asserts the config sources block, the runner script (present, executable, byte-compilable), and the timer unit are all in place.

## Verification

- `python3 -m py_compile roles/llamaindex/files/index_docs.py` — pass.
- `ansible-lint roles/llamaindex molecule/llamaindex/verify.yml` (production profile, via the nix dev shell) — **0 failures, 0 warnings on 9 files**.
- `yamllint roles/llamaindex molecule/llamaindex/verify.yml` — clean (exit 0).
- Molecule (`create → converge → verify`) needs Docker and runs in CI; not executed locally.

## Scope / follow-ups

- This PR does **not** converge against live hosts. Applying the role to the `llamaindex_group` guest is a user follow-up.
- The private `docs.dryvist.com` source activates only when a Cloudflare Access service-token env pair (`CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET`) is present; without it that single source is skipped non-fatally and the public source(s) still index.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166vNDsU1hLRFgp9CHymrjf