### PR TITLE
docs: rename terraform-proxmox references to tofu-proxmox

### DIFF
--- a/.claude/rules/ip-addressing.md
+++ b/.claude/rules/ip-addressing.md
@@ -7,7 +7,7 @@ description: No hardcoded values - OpenTofu is authority
 
 ## Principle
 
-**terraform-proxmox is the single source of truth** for all infrastructure
+**tofu-proxmox is the single source of truth** for all infrastructure
 constants. This repository CONSUMES values, never DEFINES them.
 
 ## Prohibited Patterns
@@ -57,7 +57,7 @@ syslog_ports: "{{ tofu_data.constants.syslog_ports.values() | list }}"
 
 To change any port or IP:
 
-1. Update `terraform-proxmox/main/locals.tf`
+1. Update `tofu-proxmox/main/locals.tf`
 2. Run the tofu-proxmox Terrakube workspace — the apply natively publishes
    the inventory to S3 and its after-hook refreshes the local
    `inventory/tofu_inventory.json` cache. `load_tofu.yml` resolves S3-first,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Ansible Proxmox Apps — AI Agent Documentation
 
 Configure applications on Proxmox VMs and LXC containers.
-VMs/containers are provisioned by `terraform-proxmox`;
+VMs/containers are provisioned by `tofu-proxmox`;
 this repo handles app config only.
 
 ## This Repo Owns
@@ -36,7 +36,7 @@ this repo handles app config only.
   Prowlarr indexers, Prowlarr -> Sonarr/Radarr app sync, and media-management
   settings — hardlinks + recycler bin). Root folders + qBittorrent download
   clients are owned by the devopsarr `servarr-config` tofu module
-  (`terraform-proxmox`); quality profiles + custom formats by the `configarr`
+  (`tofu-proxmox`); quality profiles + custom formats by the `configarr`
   role (TRaSH-Guides). `servarr_wiring` no longer touches those.
 - **Sortarr** (`sortarr` role — read-only media-library insights dashboard,
   Docker-in-LXC; reaches Sonarr/Radarr/Plex over the LAN via their existing
@@ -123,7 +123,7 @@ CI runners MUST NOT share Docker networks with dev/test services.
 | 6333 | Qdrant HTTP (from tofu `vector_db_ports`) |
 | 6334 | Qdrant gRPC (from tofu `vector_db_ports`) |
 
-Values are sourced from `terraform-proxmox/locals.tf`
+Values are sourced from `tofu-proxmox/locals.tf`
 `pipeline_constants.{service_ports, netflow_ports, vector_db_ports}`.
 Do not hand-edit — fix the constant and refresh
 `inventory/tofu_inventory.json`.
@@ -137,7 +137,7 @@ workspace; fetched with `amazon.aws` using credentials read directly from
 OpenBao `secret/platform/object-storage`) → the explicitly enabled local
 gitignored `inventory/tofu_inventory.json` cache.
 Port constants come from `tofu_data.constants`
-(defined in terraform-proxmox `locals.tf`).
+(defined in tofu-proxmox `locals.tf`).
 
 This repo is a **read-only consumer** — it never reads `deployment.json`; the
 published inventory is the source of truth, fetched fresh with no authoritative
@@ -354,6 +354,6 @@ nix develop "github:JacobPEvans/nix-devenv#ansible-apps"
 
 | Repo | Relationship |
 | --- | --- |
-| terraform-proxmox | Upstream: provisions VMs/containers |
+| tofu-proxmox | Upstream: provisions VMs/containers |
 | ansible-splunk | Peer: owns Splunk Enterprise deployment |
 | ansible-proxmox | Peer: owns Proxmox host config (kernel, ZFS, firewall) |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -133,7 +133,7 @@ can silently invert.
 
 A pre-production staging instance that catches these violations by *executing*
 the config — the way Hermes itself rejected the 64k-floor violation at startup —
-is tracked in [issue #800][staging]. It requires a new guest (a terraform-proxmox
+is tracked in [issue #800][staging]. It requires a new guest (a tofu-proxmox
 `deployment.json` change), so it is user-gated.
 
 [staging]: https://github.com/dryvist/ansible-proxmox-apps/issues/800

--- a/docs/IP_AUTHORITY.md
+++ b/docs/IP_AUTHORITY.md
@@ -25,7 +25,7 @@ to IPv6) is a reservation change, not an edit sprawled across roles.
 | --- | --- | --- |
 | DHCP + core networking (L2/L3, VLANs, gateway, reservations) | **UniFi** | Issues every DHCP reservation (MAC → IP); this repo never runs a DHCP server. |
 | IPAM / DCIM source of truth | **Nautobot** (`roles/nautobot`, #138) | Staged SSoT DiffSync + export pipeline, currently gated off. |
-| Provisioning + constants | **terraform-proxmox** (upstream) | Owns `deployment.json`; publishes `tofu_inventory.json` + `pipeline_constants` to S3. |
+| Provisioning + constants | **tofu-proxmox** (upstream) | Owns `deployment.json`; publishes `tofu_inventory.json` + `pipeline_constants` to S3. |
 | Reservation seed (MAC → host) | **tofu-unifi** | `fixed-ips.json` — committed reservations, no literal IP (`cidrhost(cidr, host)`). |
 | App configuration | **this repo** | **Read-only consumer**; reads the published inventory, never defines an IP/port, fails loud. |
 
@@ -61,7 +61,7 @@ App configuration references services **by name, never by address**:
   from `tofu_data.constants` — the per-guest A record Technitium builds from
   the inventory.
 - `{{ tofu_data.domain }}` is the **single domain source of truth**
-  (published by terraform-proxmox, validated non-empty by
+  (published by tofu-proxmox, validated non-empty by
   `inventory/load_tofu.yml`). Never repeat a literal domain per role.
 - Hostnames **match the app/role/stanza name**. Never invent a third name.
 
@@ -105,7 +105,7 @@ guest — if it is not one of the anchors above, it should have `mac` +
 The guest static→DHCP conversion and the constants this repo consumes live
 upstream. Track them there:
 
-### terraform-proxmox (`deployment.json` + constants)
+### tofu-proxmox (`deployment.json` + constants)
 
 1. **Convert non-anchor guests to DHCP-first**: for each guest that is not a
    static anchor, drop the static IPv4, and give it a deterministic `mac`, an

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -40,7 +40,7 @@ container IP for service testing, use `tofu_data.containers` from
 
 ### Port Constants
 
-Ports are defined once in terraform-proxmox `locals.tf`
+Ports are defined once in tofu-proxmox `locals.tf`
 (`pipeline_constants`), exported through the `ansible_inventory` output
 into `inventory/tofu_inventory.json`, and loaded as `tofu_data.constants`
 by `inventory/load_tofu.yml`:
@@ -59,7 +59,7 @@ unifi_port: "{{ tofu_data.constants.syslog_ports.unifi }}"
 
 ### Source of Truth
 
-Port assignments and IP derivation both live in the `terraform-proxmox`
+Port assignments and IP derivation both live in the `tofu-proxmox`
 repository (`locals.tf` `pipeline_constants`). To change port values,
 edit them there and apply; the apply publishes the inventory to S3
 (fetched directly by `load_tofu.yml` when AWS read creds are present)

--- a/roles/download_vpn/README.md
+++ b/roles/download_vpn/README.md
@@ -107,7 +107,7 @@ If/when IPv6 is enabled, do **all** of these or it can leak:
 
 ## Installation
 
-Provisioned by the `download-vpn` LXC in `terraform-proxmox` (unprivileged,
+Provisioned by the `download-vpn` LXC in `tofu-proxmox` (unprivileged,
 `/dev/net/tun` passthrough, `nesting`/`keyctl`, `tank/downloads` + `tank/media`
 bind-mounts). Deploy the role from this repo:
 

--- a/roles/idrac_kvm_docker/README.md
+++ b/roles/idrac_kvm_docker/README.md
@@ -15,7 +15,7 @@ it in via a local image rebuild (see "Viewer image" below).
 
 The role is wired into `playbooks/site.yml` (Phase 7b) and runs against any
 host in `idrac_kvm_group`. The group is populated by `inventory/load_tofu.yml`
-from `containers` tagged `idrac` in the OpenTofu inventory (see terraform-proxmox
+from `containers` tagged `idrac` in the OpenTofu inventory (see tofu-proxmox
 LXC 251 `idrac-kvm`), reached over `proxmox_pct_remote`.
 
 Prerequisites:

--- a/roles/immich/README.md
+++ b/roles/immich/README.md
@@ -20,7 +20,7 @@ ansible-galaxy collection install -r requirements.yml
 
 ## Prerequisites
 
-- An LXC tagged `immich` in terraform-proxmox (nesting enabled for Docker), with
+- An LXC tagged `immich` in tofu-proxmox (nesting enabled for Docker), with
   the photo-library ZFS dataset bind-mounted at `immich_library_dir`
   (`/mnt/photos`) — same model as the media stack's `/data`.
 - `IMMICH_DB_PASSWORD` provided via SOPS/Doppler (never committed):

--- a/roles/keepalived/README.md
+++ b/roles/keepalived/README.md
@@ -22,7 +22,7 @@ node loss or a local Traefik failure — there is no manual DR step.
 ## Requirements
 
 - Two or more LXCs tagged `ingress` (the Traefik HA pair), on different nodes.
-- terraform-proxmox publishing `ingress_vip` + `ingress_hosts` in the inventory.
+- tofu-proxmox publishing `ingress_vip` + `ingress_hosts` in the inventory.
 
 ## Key variables
 

--- a/roles/llama_cpp/README.md
+++ b/roles/llama_cpp/README.md
@@ -15,13 +15,13 @@ scoped to `llm_fast_group` only.
 ## Installation
 
 Ships with the `ansible-proxmox-apps` repo; no external install. The container is
-provisioned by `terraform-proxmox` and the GPU device nodes (`/dev/kfd`, `/dev/dri`)
+provisioned by `tofu-proxmox` and the GPU device nodes (`/dev/kfd`, `/dev/dri`)
 are passed in by `ansible-proxmox` (role `lxc_gpu_features`) — both must be in place
 first. Wired into `playbooks/site.yml` against `llm_fast_group` (guests tagged
 `llm-fast` in the tofu inventory). Tools come from the repo's Nix dev shell
 (`direnv allow`).
 
-Ordering: `terraform-proxmox` (LXC shell) → `ansible-proxmox` (GPU passthrough) →
+Ordering: `tofu-proxmox` (LXC shell) → `ansible-proxmox` (GPU passthrough) →
 **this role** (llama.cpp + llama-swap + models) → `llm_router` (LiteLLM front door).
 
 ## What it does

--- a/roles/llm_router/README.md
+++ b/roles/llm_router/README.md
@@ -86,7 +86,7 @@ Traefik health checks need no credential.
 
 ## Dependencies
 
-- `terraform-proxmox` constants must expose `service_ports.llm_router_api` **and**
+- `tofu-proxmox` constants must expose `service_ports.llm_router_api` **and**
   `service_ports.llm_fast_api` (added by the parallel constants PR). Both are
   hard-required — a missing constant fails loud.
 - Secrets `LLM_ROUTER_MASTER_KEY` + `LLM_LARGE_BEARER_TOKEN` are env-sourced

--- a/roles/nautobot/README.md
+++ b/roles/nautobot/README.md
@@ -5,7 +5,7 @@ a native install plus the SSoT DiffSync jobs that seed it from the hand-maintain
 upstream sources, and an export Job that publishes the inventory artifact to S3.
 
 Nautobot is the IPAM authority in the [addressing model](../../docs/IP_AUTHORITY.md);
-**UniFi remains the DHCP + core-networking authority** and **terraform-proxmox
+**UniFi remains the DHCP + core-networking authority** and **tofu-proxmox
 remains the provisioning + constants authority**. This role never runs a DHCP
 server and never re-defines an upstream-owned value.
 
@@ -82,7 +82,7 @@ cutover deliberately:
 4. Optionally `-e nautobot_run_export=true` for an immediate publish; otherwise
    the daily beat schedule publishes.
 5. **Observe** the shadow `nautobot_export.json` for one or more cycles.
-6. The **authority-flip** — terraform-proxmox deriving `tofu_inventory.json`
+6. The **authority-flip** — tofu-proxmox deriving `tofu_inventory.json`
    *from* Nautobot instead of `deployment.json` — is a separate, upstream,
    operator-approved step. It also requires the export contract to first grow to
    a superset of the inventory (`vmid`, `node`, `tags`, ports, static-vs-reserved

--- a/roles/netmon/README.md
+++ b/roles/netmon/README.md
@@ -93,4 +93,4 @@ Or include the role directly against the prober group:
 Cribl Edge receives the HEC push on `cribl_hec_input_port`
 (`group_vars/all.yml`) and routes it through the `netmon` pipeline, which stamps
 `index = netmon`. See the `cribl_edge` role and `docs/NETWORK_DIAGNOSIS.md` in
-terraform-proxmox.
+tofu-proxmox.

--- a/roles/network_quality/README.md
+++ b/roles/network_quality/README.md
@@ -11,7 +11,7 @@ co-located on the monitoring (`prometheus`) LXC alongside `prometheus_stack`:
 `irtt` (jitter/MOS) is **deferred** — see below. The role is named `network_quality`
 (not `smokeping`) so the jitter/atlas legs can be added later without a rename.
 
-See `terraform-proxmox/docs/SMOKEPING.md` for the measurement design.
+See `tofu-proxmox/docs/SMOKEPING.md` for the measurement design.
 
 ## Networking
 

--- a/roles/ntp/README.md
+++ b/roles/ntp/README.md
@@ -77,7 +77,7 @@ See `defaults/main.yml` for the authoritative list and inline rationale.
 
 Result: hosts sync from the Debian public pool and serve NTP to all internal
 RFC1918 traffic on UDP/123. Companion firewall rule lives in
-`terraform-proxmox/modules/firewall/` (see issue #285).
+`tofu-proxmox/modules/firewall/` (see issue #285).
 
 ### Internal clients (used by ansible-proxmox-apps and ansible-splunk)
 

--- a/roles/ollama/README.md
+++ b/roles/ollama/README.md
@@ -6,13 +6,13 @@ inside an LXC (CT 167 `hermes-infer`, RX 6800), and provisions **Hermes 4 14B**.
 ## Installation
 
 Ships with the `ansible-proxmox-apps` repo; no external install. The container is
-provisioned by `terraform-proxmox` and the GPU device nodes (`/dev/kfd`,
+provisioned by `tofu-proxmox` and the GPU device nodes (`/dev/kfd`,
 `/dev/dri`) are passed in by `ansible-proxmox` (role `lxc_gpu_features`) — both
 must be in place first. This role is wired into `playbooks/site.yml` against the
 `ollama_group` (containers tagged `ollama` in the tofu inventory). Tools come
 from the repo's Nix dev shell (`direnv allow`).
 
-Ordering: `terraform-proxmox` (LXC shell) → `ansible-proxmox` (GPU passthrough) →
+Ordering: `tofu-proxmox` (LXC shell) → `ansible-proxmox` (GPU passthrough) →
 **this role** (Ollama + ROCm + model) → `open_webui` (chat UI).
 
 ## What it does

--- a/roles/open_webui/README.md
+++ b/roles/open_webui/README.md
@@ -7,7 +7,7 @@ LLM, talking to **Ollama** (CT 167) and fronted by **Traefik** at
 ## Installation
 
 Ships with the `ansible-proxmox-apps` repo; no external install. The container is
-provisioned by `terraform-proxmox`. This role is wired into `playbooks/site.yml`
+provisioned by `tofu-proxmox`. This role is wired into `playbooks/site.yml`
 against the `open_webui_group` (containers tagged `open-webui` in the tofu
 inventory) and runs over the `proxmox_pct_remote` connection. Tools come from the
 repo's Nix dev shell (`direnv allow`). Deploy after the `ollama` role (its backend).

--- a/roles/openbao/README.md
+++ b/roles/openbao/README.md
@@ -80,13 +80,13 @@ This role brings OpenBao live **before** anything that reads secrets from it.
 
 1. Generate the seal key once (`openssl rand -base64 32`) and load it into
    Doppler tier-0 as `OPENBAO_STATIC_SEAL_KEY` (+ `OPENBAO_STATIC_SEAL_KEY_ID`).
-2. `terraform-proxmox` — provision the 5 OpenBao LXCs (VMID/IP/firewall).
+2. `tofu-proxmox` — provision the 5 OpenBao LXCs (VMID/IP/firewall).
 3. **this role** — install + init the cluster, mint the AppRoles.
 4. Operator — transcribe recovery shares to paper (+ Bitwarden); publish each
    AppRole's `role_id`/`secret_id` to Doppler tier-0, consumed as ambient env
    under `doppler run` — except `public`, which needs no secret-zero at all
    (see [Secret hierarchy & RBAC](#secret-hierarchy--rbac)).
-5. `terraform-proxmox` `vault-secrets` — now able to authenticate as
+5. `tofu-proxmox` `vault-secrets` — now able to authenticate as
    `terraform-apply` (read/write proof).
 
 ## Rolling expansion / migration (preserve a live cluster's data)
@@ -113,7 +113,7 @@ phases so the data replicates to the new voters before the old ones leave:
    migration: `-e openbao_bootstrap_host=openbao-02` (never a new node; and not a
    node whose host is currently unstable). `openbao_allow_fresh_init` stays
    `false`.
-3. `terraform-proxmox` apply creates the five new LXCs; then run this role with
+3. `tofu-proxmox` apply creates the five new LXCs; then run this role with
    `--limit openbao_group,localhost`.
 4. **Verify before Phase 2:** `bao operator raft list-peers` shows all 7;
    `bao operator raft autopilot state` shows 7 healthy voters; a read of a known
@@ -122,7 +122,7 @@ phases so the data replicates to the new voters before the old ones leave:
 **Phase 2 — remove the old nodes (shrink to the clean 5):**
 
 1. `bao operator raft remove-peer openbao-01` then `... openbao-02`.
-2. Drop `openbao-01`/`openbao-02` from `deployment.json`; `terraform-proxmox`
+2. Drop `openbao-01`/`openbao-02` from `deployment.json`; `tofu-proxmox`
    apply destroys the two old LXCs. Final state: 5 voters, quorum 3 — survives
    any single node, and any single Proxmox host, going down.
 
@@ -167,7 +167,7 @@ bootstrap steps short-circuit on their existence checks.
 ## Secret hierarchy & RBAC
 
 The KV v2 mount `secret/` is organized by category (canonical doc:
-`terraform-proxmox` `docs/SECRETS_HIERARCHY.md`):
+`tofu-proxmox` `docs/SECRETS_HIERARCHY.md`):
 
 ```text
 secret/infra/      proxmox/ aws/ network/   # IaC kernel — terraform-apply writes

--- a/roles/openbao_secrets/README.md
+++ b/roles/openbao_secrets/README.md
@@ -30,7 +30,7 @@ a policy can't read:
 - **KV mount**: `secret` (KV v2).
 - **One AppRole per domain**, not one shared identity — a domain's
   credentials only ever unlock that domain's own KV subtree. See
-  `terraform-proxmox` `docs/SECRETS_HIERARCHY.md` for the full RBAC table.
+  `tofu-proxmox` `docs/SECRETS_HIERARCHY.md` for the full RBAC table.
 - **Seeding**: `roles/openbao` seeds **no** values; it creates only the mount,
   policies, and AppRoles. So a domain's paths yield keys only once a writer
   populates them; until then every read is empty and the env fallback wins.
@@ -104,7 +104,7 @@ On macOS these are sourced from the operator's dedicated `openbao.keychain-db`
 keychain (72h auto-lock — the keychain's lock state is the access boundary,
 not the AppRole's own TTL) via a resolver script; on Linux guests, from a
 root-only systemd credential / `0600` EnvironmentFile. See
-`terraform-proxmox` `docs/SECRETS_HIERARCHY.md`.
+`tofu-proxmox` `docs/SECRETS_HIERARCHY.md`.
 
 ## Wiring
 

--- a/roles/plex/README.md
+++ b/roles/plex/README.md
@@ -8,7 +8,7 @@ imported media is visible — including on Roku.
 
 ## Installation
 
-Provisioned by the `plex` LXC in `terraform-proxmox` (single
+Provisioned by the `plex` LXC in `tofu-proxmox` (single
 `bulk/data` bind-mount at `/data`). Deploy via this repo:
 
 ```bash

--- a/roles/prometheus_stack/README.md
+++ b/roles/prometheus_stack/README.md
@@ -4,7 +4,7 @@ Deploys [Prometheus](https://prometheus.io/) **and** the
 [blackbox_exporter](https://github.com/prometheus/blackbox_exporter) as a **single
 Docker-in-LXC compose stack** — one project, two services. This is the **system of
 record** for the Prometheus-native network-quality monitoring stack (see
-`terraform-proxmox/docs/SMOKEPING.md`). Prometheus scrapes the co-located exporter
+`tofu-proxmox/docs/SMOKEPING.md`). Prometheus scrapes the co-located exporter
 via the multi-target `/probe` pattern, producing WAN/ISP loss, latency, and
 reachability metrics, and grows `smokeping_prober` / `irtt` / `snmp_exporter` jobs
 as those roles land.

--- a/roles/radarr/README.md
+++ b/roles/radarr/README.md
@@ -7,7 +7,7 @@ Radarr UI after deploy — it reaches Prowlarr + qBittorrent on the
 
 ## Installation
 
-Provisioned by the `radarr` LXC in `terraform-proxmox` (single
+Provisioned by the `radarr` LXC in `tofu-proxmox` (single
 `bulk/data` bind-mount at `/data`). Deploy via this repo:
 
 ```bash

--- a/roles/seerr/README.md
+++ b/roles/seerr/README.md
@@ -19,7 +19,7 @@ Seerr is **config-only** — it has no `/tank` bind-mounts and reaches the
 Wired into `playbooks/site.yml` (Phase 8c, media stack) against any host in
 `seerr_group`. The group is populated by `inventory/load_tofu.yml`
 from `containers` tagged `seerr` in the OpenTofu inventory
-(terraform-proxmox `seerr` LXC), reached over `proxmox_pct_remote`.
+(tofu-proxmox `seerr` LXC), reached over `proxmox_pct_remote`.
 
 Prerequisites:
 

--- a/roles/servarr_wiring/README.md
+++ b/roles/servarr_wiring/README.md
@@ -18,7 +18,7 @@ config-as-code tools:
 
 | Config | Owner |
 | --- | --- |
-| Root folders + qBittorrent download clients | devopsarr **`servarr-config`** tofu module (`terraform-proxmox`) |
+| Root folders + qBittorrent download clients | devopsarr **`servarr-config`** tofu module (`tofu-proxmox`) |
 | Quality profiles + custom formats + quality definitions | **`configarr`** role (TRaSH-Guides) |
 
 This role no longer POSTs root folders, download clients, or quality profiles —

--- a/roles/sonarr/README.md
+++ b/roles/sonarr/README.md
@@ -7,7 +7,7 @@ Sonarr UI after deploy — it reaches Prowlarr + qBittorrent on the
 
 ## Installation
 
-Provisioned by the `sonarr` LXC in `terraform-proxmox` (single
+Provisioned by the `sonarr` LXC in `tofu-proxmox` (single
 `bulk/data` bind-mount at `/data`). Deploy via this repo:
 
 ```bash

--- a/roles/sortarr/README.md
+++ b/roles/sortarr/README.md
@@ -20,7 +20,7 @@ registers nothing back into those apps).
 Wired into `playbooks/site.yml` (Phase 8c, media stack) against any host in
 `sortarr_group`. The group is populated by `inventory/load_tofu.yml`
 from `containers` tagged `sortarr` in the OpenTofu inventory
-(terraform-proxmox `sortarr` LXC), reached over `proxmox_pct_remote`.
+(tofu-proxmox `sortarr` LXC), reached over `proxmox_pct_remote`.
 
 Prerequisites:
 
@@ -84,12 +84,12 @@ Radarr; the Plex overlay (playback/history) is added only when
 
 ## Secrets
 
-| Variable                  | Purpose                                  | Source              |
-| ------------------------- | ----------------------------------------- | -------------------- |
-| `SONARR_API_KEY`          | Sonarr API key (read library/queue)       | environment variable |
-| `RADARR_API_KEY`          | Radarr API key (read library/queue)       | environment variable |
-| `PLEX_TOKEN`              | Optional Plex account token (overlay)     | environment variable |
-| `SORTARR_BASIC_AUTH_PASS` | Sortarr's own basic-auth password         | environment variable |
+| Variable                  | Purpose                               | Source               |
+| ------------------------- | ------------------------------------- | -------------------- |
+| `SONARR_API_KEY`          | Sonarr API key (read library/queue)   | environment variable |
+| `RADARR_API_KEY`          | Radarr API key (read library/queue)   | environment variable |
+| `PLEX_TOKEN`              | Optional Plex account token (overlay) | environment variable |
+| `SORTARR_BASIC_AUTH_PASS` | Sortarr's own basic-auth password     | environment variable |
 
 None are ever committed to git. The role's first task asserts the required
 ones are set and fails fast if any is missing.

--- a/roles/traefik/README.md
+++ b/roles/traefik/README.md
@@ -80,10 +80,10 @@ The dashboard password is **generated on the host** (not a Doppler secret) — s
 ## Fronted services
 
 The route list is **not** maintained in this role. It is the single tofu-owned
-ingress table — `terraform-proxmox` `locals.tf` `ingress_services`, surfaced as
+ingress table — `tofu-proxmox` `locals.tf` `ingress_services`, surfaced as
 `ansible_inventory.ingress` and consumed here as `tofu_data.ingress`. The
 `technitium_dns` role derives its DNS aliases from the **same** source, so a
-fronted service is added/removed in exactly one place. Add it in terraform-proxmox.
+fronted service is added/removed in exactly one place. Add it in tofu-proxmox.
 
 - **Tier 1 — media stack** (same `media_svc` VLAN as Traefik): `plex`, `seerr`
   (→ `seerr` backend), `sonarr`, `radarr`, `qbittorrent`, `prowlarr`. Reachable

--- a/roles/unifi_metrics/README.md
+++ b/roles/unifi_metrics/README.md
@@ -43,7 +43,7 @@ compose stack. Prerequisites:
   Ansible run (the `network` keychain items, same creds the tofu-unifi provider
   uses). A read-only UniFi local admin is sufficient and recommended.
 - The `cribl_edge` group deployed (provides the HEC input + `unifi_metrics`
-  index branch) and a Splunk `unifi_metrics` index (terraform-proxmox).
+  index branch) and a Splunk `unifi_metrics` index (tofu-proxmox).
 
 ## Usage
 


### PR DESCRIPTION
## Summary

- The GitHub repo formerly named `terraform-proxmox` was renamed to `tofu-proxmox`. This PR renames the repo-slug in prose/table references across tracked `.md` files.
- Docs-only: code files (`.yml`, `.tf`, `.py`, `.j2`, workflows, inventory, defaults, tasks, templates, tests) were left untouched, so no operational value (S3 keys, state paths, inventory references) was renamed.
- Also fixes a pre-existing markdownlint table-alignment issue in `roles/sortarr/README.md`, surfaced by the pre-commit hook when that file was touched.
- Infisical was investigated (read-only) as a side task and was **not** touched — see the "Infisical investigation" note below for the reviewer.

### Infisical investigation (informational only, no changes made)

Evidence that infisical is an actively wired, non-guarded deployment in this repo's config (not commented out or disabled):

- `playbooks/site.yml:852-861` — `Configure Infisical secrets-management platform` play targets `hosts: infisical_group`, runs `roles: [infisical_docker]`, tagged `infisical_docker`/`secrets`/`secrets-management`. No `when:` guard, no comment marking it disabled.
- `roles/infisical_docker/` exists in full (`tasks/main.yml`, `defaults/main.yml`, `meta/main.yml`, `handlers/main.yml`, `templates/`) — a complete Docker Compose (postgres + redis + infisical app) role.
- `inventory/load_tofu.yml:257-259` — maps hosts tagged `infisical` (from the tofu inventory) into `infisical_group`.
- `inventory/group_vars/infisical_group.yml` — active group vars for the LXC.
- `inventory/group_vars/haproxy_group.yml:19-23` — an active (uncommented) HAProxy frontend entry for `infisical`.
- `secrets.enc.yaml` — carries encrypted `INFISICAL_ENCRYPTION_KEY` / `INFISICAL_AUTH_SECRET` / `INFISICAL_DB_PASSWORD`.
- `tests/template_render/verify_templates.yml` — CI template-render assertions for the infisical compose + HAProxy backend.

Whether an actual host/tag `infisical` currently exists in the tofu-proxmox-provisioned fleet is not knowable from this repo alone (that's upstream, tofu-managed data this repo only consumes). Based on everything visible here, ansible-proxmox-apps treats infisical as a live, first-class role — not dead code. No removal was made; that decision is explicitly out of scope for this PR and gated on user confirmation.

## Test plan

- [ ] `git diff --stat` confirms only the 28 intended `.md` files changed (verified locally).
- [ ] `git grep -n 'terraform-proxmox' -- '*.md' ':(exclude)CHANGELOG.md' ':(exclude)**/adr/**'` returns no residual hits (verified locally).
- [ ] CI: markdownlint / ansible-lint / syntax-check pass.
- [ ] No qdrant/llamaindex/llms role READMEs were touched (none were in the candidate list to begin with).

Assisted-by: Claude:claude-opus-4-8[1m]

https://claude.ai/code/session_0166vNDsU1hLRFgp9CHymrjf