### PR TITLE
fix(hermes_agent): controller bundle tasks must unset the ansible_become var

### DIFF
--- a/roles/hermes_agent/tasks/assert.yml
+++ b/roles/hermes_agent/tasks/assert.yml
@@ -156,6 +156,12 @@
   ansible.builtin.command:
     cmd: nix --version
   delegate_to: localhost
+  # become must be disabled via the VARIABLE, not just the keyword: group_vars
+  # sets the connection var ansible_become: true, and connection vars outrank
+  # task keywords — with only the keyword this task sudo-prompts on the
+  # controller and kills the converge.
   become: false
+  vars:
+    ansible_become: false
   run_once: true
   changed_when: false

--- a/roles/hermes_agent/tasks/main.yml
+++ b/roles/hermes_agent/tasks/main.yml
@@ -183,7 +183,10 @@
   ansible.builtin.command:
     cmd: nix build --no-link --print-out-paths "{{ hermes_agent_bundle_flake_ref }}"
   delegate_to: localhost
+  # See assert.yml: the ansible_become connection var outranks the keyword.
   become: false
+  vars:
+    ansible_become: false
   run_once: true
   register: hermes_agent_bundle_build
   changed_when: false


### PR DESCRIPTION
The #958 bundle build's localhost-delegated tasks set `become: false` as a task keyword, but `group_vars/all.yml` sets the **connection variable** `ansible_become: true` — and connection vars outrank task keywords. On a controller without passwordless sudo, every `--tags hermes_agent` converge dies at `Assert the controller has nix` with `sudo: a password is required` (reproduced twice today).

Fix: `vars: ansible_become: false` on both delegated tasks (assert + build).

Verification: `--tags hermes_agent` converge passes the assert on this controller (run post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6JuKQiA3nNTJ81ww1wgFo