### PR TITLE
fix(zammad): resolve real runtime deps when configuring the unpacked package

### DIFF
--- a/roles/zammad/tasks/main.yml
+++ b/roles/zammad/tasks/main.yml
@@ -295,8 +295,16 @@
       register: zammad_dbyml
       no_log: true
 
-    - name: Configure zammad (runs the postinst — migrates against the external DB)
-      ansible.builtin.command: dpkg --configure zammad
+    # dpkg --unpack skipped apt's dependency resolution, so zammad's REAL
+    # runtime deps (libpq5, libxslt1.1, curl, ...) may be missing and a bare
+    # `dpkg --configure` fails. `apt-get -f install` pulls exactly the missing
+    # deps and configures the unpacked package (running the postinst, which
+    # migrates against the external DB); the equivs dummy keeps the
+    # `postgresql` dep satisfied without a local cluster.
+    - name: Configure zammad (resolve deps + run the postinst against the external DB)
+      ansible.builtin.command: apt-get --fix-broken --yes install
+      environment:
+        DEBIAN_FRONTEND: noninteractive
       when: not zammad_configured
       changed_when: true
 


### PR DESCRIPTION
Third layer of the first-ever zammad converge (after #960, #970): the download-only + `dpkg --unpack` install path skips apt's dependency resolution, so `dpkg --configure zammad` fails with missing real deps (libpq5, libxslt1.1, curl, libimlib2, shared-mime-info). `apt-get --fix-broken --yes install` installs exactly the missing deps and configures the unpacked package in one idempotent step; the equivs dummy keeps `postgresql` satisfied.

Verification: converge `--tags zammad` post-merge (part of the restore loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6JuKQiA3nNTJ81ww1wgFo