### PR TITLE
feat(openbao): provision apps read tier for vikunja + namespaced zammad fields

### DIFF
--- a/inventory/group_vars/vikunja_group.yml
+++ b/inventory/group_vars/vikunja_group.yml
@@ -1,0 +1,30 @@
+---
+# Vikunja task management (issue #141) — bao-first secrets (apps domain) with an
+# env fallback, mirroring nautobot_group.yml / zammad_group.yml. Only the fields
+# with a home in secret/apps/vikunja (the openbao_vikunja_secrets promotion map)
+# are wired bao-first here; VIKUNJA_JWT_SECRET and VIKUNJA_ADMIN_PASSWORD have no
+# bao home yet, so they stay pure env lookups on the role default.
+#
+# The database password is app-namespaced (vikunja_db_password) so the flat merge
+# into bao_apps_secrets never collides with Nautobot's bare db_password. It MUST
+# match the postgres side (postgres_managed_databases reads the same
+# bao_apps_secrets.vikunja_db_password), so both ends resolve one canonical value.
+# On hosts where the apps domain was not fetched (BAO_ADDR or the apps role_id/
+# secret_id unset) bao_apps_secrets is {} and the env fallback resolves instead.
+vikunja_db_password: >-
+  {{ bao_apps_secrets.vikunja_db_password
+     | default(lookup('env', 'VIKUNJA_DB_PASSWORD'), true) }}
+
+# MCP service-account passwords bao-first (secret/apps/vikunja fields
+# svc_mcp_ro_password / svc_mcp_rw_password). Redefines the role-default list so
+# the accounts the role creates and the tokens the MCP mint step later issues
+# resolve the same canonical password. Usernames match the role defaults.
+vikunja_service_users:
+  - username: svc-mcp-ro
+    password: >-
+      {{ bao_apps_secrets.svc_mcp_ro_password
+         | default(lookup('env', 'VIKUNJA_SVC_MCP_RO_PASSWORD'), true) }}
+  - username: svc-mcp-rw
+    password: >-
+      {{ bao_apps_secrets.svc_mcp_rw_password
+         | default(lookup('env', 'VIKUNJA_SVC_MCP_RW_PASSWORD'), true) }}

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -25,7 +25,7 @@
     cribl_stream_group:cribl_edge:
     object_storage_group:
     netmon_group:prometheus_group:unifi_metrics_group:
-    postgres_group:nautobot_group:
+    postgres_group:nautobot_group:zammad_group:vikunja_group:
     sonarr_group:radarr_group:plex_group:seerr_group:sortarr_group:download_vpn_group:immich_group
   gather_facts: false
   tags:

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -129,6 +129,9 @@ openbao_vikunja_secrets:
   token_admin: VIKUNJA_MCP_TOKEN_ADMIN
   svc_mcp_ro_password: VIKUNJA_SVC_MCP_RO_PASSWORD
   svc_mcp_rw_password: VIKUNJA_SVC_MCP_RW_PASSWORD
+  # App-namespaced DB password (matches the postgres_managed_databases +
+  # vikunja_group.yml consumers reading bao_apps_secrets.vikunja_db_password).
+  vikunja_db_password: VIKUNJA_DB_PASSWORD
 
 # App service secrets GENERATED (random, generate-if-absent) in OpenBao itself,
 # replacing the retired terraform-proxmox vault-secrets root. Each app maps to
@@ -137,7 +140,12 @@ openbao_vikunja_secrets:
 # openbao_secrets then exposes these paths to the nautobot/zammad roles.
 openbao_generated_app_secrets:
   nautobot: [db_password, secret_key, superuser_password]
-  zammad: [db_password, admin_password, hermes_api_token]
+  # Zammad fields are app-namespaced (zammad_*) so the flat merge into
+  # bao_apps_secrets (openbao_secrets reads apps/nautobot + apps/zammad +
+  # apps/vikunja into one dict) never collides with Nautobot's bare
+  # db_password. The consumers already read the namespaced names
+  # (inventory/group_vars/{zammad_group,postgres_group}.yml).
+  zammad: [zammad_db_password, zammad_admin_password, zammad_hermes_api_token]
 # Random length for generated app credentials (alnum). secret_key needs more
 # entropy than a login credential, so it gets its own length (matches the 64-char
 # key the nautobot role generates locally when none is supplied).
@@ -388,6 +396,11 @@ openbao_media_approle_name: media
 # via APPS_VAULT_ROLE_ID / APPS_VAULT_SECRET_ID.
 openbao_apps_policy_name: apps
 openbao_apps_approle_name: apps
+# Apps the read-side `apps` policy grants read on = the generate-if-absent apps
+# (nautobot, zammad) PLUS vikunja, whose secret/apps/vikunja is seeded from the
+# SOPS->bao promotion map (openbao_vikunja_secrets), not generate-if-absent. The
+# apps-policy template loops this so vikunja's read grant is not silently missed.
+openbao_apps_read_apps: "{{ ((openbao_generated_app_secrets.keys() | list) + ['vikunja']) | sort }}"
 openbao_local_llm_policy_name: local-llm
 openbao_local_llm_approle_name: local-llm
 openbao_ai_saas_openrouter_policy_name: ai-saas-openrouter

--- a/roles/openbao/tasks/init.yml
+++ b/roles/openbao/tasks/init.yml
@@ -187,25 +187,19 @@
     - openbao_bootstrap_token is defined
     - (openbao_kv_mount ~ '/') not in (openbao_mounts_raw.stdout | from_json).keys()
 
-# --- App-secret seeding (write-if-changed) ----------------------------------
-# Promote Vikunja MCP service credentials (minted by the vikunja role, stored
-# in SOPS) into secret/apps/vikunja so OpenBao is their canonical home. Values
-# come from the converge environment (SOPS via `sops exec-env`), mapped by
-# openbao_vikunja_secrets. Runs only on the bootstrap host under the admin
-# token; writes only when a value differs from what is already stored.
-- name: Assemble the desired vikunja app-secret map from the converge environment
-  ansible.builtin.set_fact:
-    openbao_vikunja_desired: >-
-      {{ openbao_vikunja_desired | default({})
-         | combine({ item.key: lookup('env', item.value) }) }}
-  loop: "{{ openbao_vikunja_secrets | dict2items }}"
-  loop_control:
-    label: "{{ item.key }}"
-  no_log: true
-  when:
-    - openbao_bootstrap_token is defined
-    - lookup('env', item.value) | length > 0
-
+# --- App-secret seeding (merge-preserving, write-if-changed) -----------------
+# Promote Vikunja service credentials (minted by the vikunja role, stored in
+# SOPS) into secret/apps/vikunja so OpenBao is their canonical home. Values come
+# from the converge environment (SOPS via `sops exec-env`), mapped by
+# openbao_vikunja_secrets. Runs only on the bootstrap host under the admin token.
+#
+# MERGE-PRESERVING: the desired map is the CURRENTLY-STORED fields overlaid with
+# whatever env-derived keys this converge actually carries. A converge that
+# exposes only SOME of the mapped env vars therefore updates just those fields
+# and can never wipe the siblings a partial run doesn't know about (the old
+# whole-secret `kv put` from an env-only map would have dropped them). Idempotent:
+# no env var present, or all present values already stored -> desired == current,
+# so no write.
 - name: Read the current vikunja app secrets from OpenBao
   ansible.builtin.command:
     cmd: "bao kv get -format=json {{ openbao_kv_mount }}/apps/vikunja"
@@ -218,9 +212,30 @@
   no_log: true
   when:
     - openbao_bootstrap_token is defined
-    - (openbao_vikunja_desired | default({})) | length > 0
 
-- name: Seed or update the vikunja app secrets in OpenBao (write-if-changed)
+- name: Capture the current vikunja secret fields (empty map when the path is absent)
+  ansible.builtin.set_fact:
+    openbao_vikunja_current_data: >-
+      {{ (openbao_vikunja_current.stdout | default('{}', true) | from_json).data.data
+         | default({}, true)
+         if (openbao_vikunja_current.rc | default(1)) == 0 else {} }}
+  no_log: true
+  when: openbao_bootstrap_token is defined
+
+- name: Assemble the desired vikunja app-secret map (stored fields + converge-env overrides)
+  ansible.builtin.set_fact:
+    openbao_vikunja_desired: >-
+      {{ openbao_vikunja_desired | default(openbao_vikunja_current_data)
+         | combine({ item.key: lookup('env', item.value) }) }}
+  loop: "{{ openbao_vikunja_secrets | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  no_log: true
+  when:
+    - openbao_bootstrap_token is defined
+    - lookup('env', item.value) | length > 0
+
+- name: Seed or update the vikunja app secrets in OpenBao (merge-preserving, write-if-changed)
   ansible.builtin.command:
     argv: >-
       {{ ['bao', 'kv', 'put', openbao_kv_mount ~ '/apps/vikunja']
@@ -233,11 +248,8 @@
   changed_when: true
   when:
     - openbao_bootstrap_token is defined
-    - (openbao_vikunja_desired | default({})) | length > 0
-    - >-
-      (openbao_vikunja_current.rc | default(1)) != 0
-      or (openbao_vikunja_current.stdout | default('{}') | from_json).data.data | default({})
-         != (openbao_vikunja_desired | default({}))
+    - openbao_vikunja_desired is defined
+    - openbao_vikunja_desired != openbao_vikunja_current_data
 
 # --- App-secret generation (generate-if-absent) -----------------------------
 # Generate + seed each app's service credentials directly in OpenBao, replacing

--- a/roles/openbao/templates/ansible-converge-policy.hcl.j2
+++ b/roles/openbao/templates/ansible-converge-policy.hcl.j2
@@ -27,3 +27,25 @@ path "{{ openbao_kv_mount }}/data/ai/mcp/splunk" {
 path "{{ openbao_kv_mount }}/metadata/ai/mcp/splunk" {
   capabilities = ["read"]
 }
+
+# Transitional exact-path exception (Vikunja MCP): the converge publishes the
+# minted Vikunja MCP connection here. Same narrow create/update/read on the
+# SINGLE secret as the splunk grant above — deliberately NOT a wildcard.
+path "{{ openbao_kv_mount }}/data/ai/mcp/vikunja" {
+  capabilities = ["create", "update", "read"]
+}
+
+path "{{ openbao_kv_mount }}/metadata/ai/mcp/vikunja" {
+  capabilities = ["read"]
+}
+
+# Transitional exact-path exception (Zammad MCP): the converge publishes the
+# minted Zammad MCP connection here. Same narrow create/update/read on the
+# SINGLE secret as the splunk grant above — deliberately NOT a wildcard.
+path "{{ openbao_kv_mount }}/data/ai/mcp/zammad" {
+  capabilities = ["create", "update", "read"]
+}
+
+path "{{ openbao_kv_mount }}/metadata/ai/mcp/zammad" {
+  capabilities = ["read"]
+}

--- a/roles/openbao/templates/apps-policy.hcl.j2
+++ b/roles/openbao/templates/apps-policy.hcl.j2
@@ -1,11 +1,11 @@
 {{ ansible_managed | comment }}
 # OpenBao policy for the apps AppRole — the shared-Postgres application tier
 # (openbao_secrets domain "apps"). Read-only, generated from
-# openbao_generated_app_secrets so the policy stays in lockstep with the
-# seeded apps and never subsumes sibling domains that also live under apps/
-# (e.g. apps/media belongs to the media AppRole).
+# openbao_apps_read_apps (the generate-if-absent apps PLUS SOPS-promoted vikunja)
+# so the policy stays in lockstep with the seeded apps and never subsumes sibling
+# domains that also live under apps/ (e.g. apps/media belongs to the media AppRole).
 
-{% for app in openbao_generated_app_secrets.keys() | sort %}
+{% for app in openbao_apps_read_apps %}
 path "{{ openbao_kv_mount }}/data/apps/{{ app }}" {
   capabilities = ["read"]
 }

--- a/roles/openbao_secrets/defaults/main.yml
+++ b/roles/openbao_secrets/defaults/main.yml
@@ -82,6 +82,11 @@ openbao_secrets_domains:
       # The Hermes API token is NOT here — it lives in ai/hermes (local-llm
       # domain) so the one token has a single home shared by both sides.
       - apps/zammad
+      # Vikunja task-management (issue #141). Fields come from the SOPS->bao
+      # promotion map (roles/openbao openbao_vikunja_secrets): vikunja_db_password
+      # (app-namespaced, matches the postgres + vikunja_group consumers) plus the
+      # MCP svc-account passwords + API tokens. Merged flat into bao_apps_secrets.
+      - apps/vikunja
   - name: local-llm
     role_id_env: LOCAL_LLM_VAULT_ROLE_ID
     secret_id_env: LOCAL_LLM_VAULT_SECRET_ID


### PR DESCRIPTION
## What

Extends the shared-Postgres **apps** secrets domain to cover Vikunja and makes the Zammad generated fields collision-safe in the flat `bao_apps_secrets` merge. Pure plumbing — no live secret values, no converge run.

### Changes

- **Namespace the Zammad generated fields** (`db_password` → `zammad_db_password`, `admin_password` → `zammad_admin_password`, `hermes_api_token` → `zammad_hermes_api_token`). `openbao_secrets` flat-merges every `apps/*` path into one `bao_apps_secrets` fact, so a bare `db_password` under `apps/zammad` would collide with Nautobot's bare `db_password`. The `zammad_group.yml` / `postgres_group.yml` consumers already read the namespaced names — this brings the seeder into line. Safe: the seeder is per-path generate-if-absent, so already-seeded values are untouched.
- **Vikunja read tier.** Add `vikunja_db_password` to the SOPS→bao promotion map and a new `openbao_apps_read_apps` var (generated apps + vikunja); the `apps-policy` template loops it so `secret/apps/vikunja` gets its read grant. `openbao_secrets` now reads `apps/vikunja` in the apps domain.
- **Merge-preserving vikunja seeding.** The seeding block now builds the desired map from the currently-stored fields overlaid with the converge-env keys, so a run that exposes only some of the mapped env vars updates just those fields and can never wipe the siblings it doesn't know about. Idempotent: no change → no write.
- **ansible-converge policy:** two transitional exact-path `create/update/read` grants for `secret/ai/mcp/vikunja` and `secret/ai/mcp/zammad`, mirroring the existing splunk MCP grant (deliberately exact-path, not a wildcard).
- **site.yml:** include `zammad_group` + `vikunja_group` in the Phase 0-secrets pre-fetch so those hosts receive `bao_apps_secrets`.
- **New `inventory/group_vars/vikunja_group.yml`:** wire the DB password and the MCP service-account passwords bao-first with env fallback, mirroring `zammad_group.yml`.

## Deviation from brief

The brief assumed `openbao_vikunja_secrets` already held JWT/admin fields; it does not (it holds the MCP tokens + svc-account passwords). So `vikunja_group.yml` wires bao-first only the vars with a real home in `secret/apps/vikunja` (DB + svc passwords); `VIKUNJA_JWT_SECRET` / `VIKUNJA_ADMIN_PASSWORD` have no bao home yet and stay env-only on the role default.

## Validation

- `ansible-lint` (production profile): my changed files are clean. One pre-existing failure remains in `roles/zammad/tasks/main.yml:307` (`command-instead-of-module` on `apt-get`) — identical on `origin/develop`, untouched by this PR, and out of scope for a secrets-plumbing change.
- `yamllint`: clean on all changed YAML.
- Jinja expressions (`openbao_apps_read_apps` precedence, the merge-preserving desired-map logic) evaluated to confirm the intended results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TduAFRb5WCmy1crcz8jSrQ