### PR TITLE
feat(vikunja): mint MCP service-user API tokens and publish to OpenBao

### DIFF
--- a/roles/vikunja/defaults/main.yml
+++ b/roles/vikunja/defaults/main.yml
@@ -63,3 +63,48 @@ vikunja_service_users:
     password: "{{ lookup('env', 'VIKUNJA_SVC_MCP_RW_PASSWORD') }}"
 
 vikunja_api_timeout: 30
+
+# --- MCP API tokens -> OpenBao (issue #141) ---------------------------------
+# Mint a long-lived Vikunja API token per MCP service user and publish the
+# shared connection to OpenBao secret/ai/mcp/vikunja. Mirrors ansible-splunk's
+# splunk_docker manage_one_user pattern: mint-if-absent + sibling-preserving
+# KV-v2 write, gated on a publish flag. Inert by default — the converge enables
+# it with -e '{"vikunja_token_publish_openbao": true}' once a write-capable
+# OpenBao AppRole (BAO_ADDR/BAO_TOKEN) is in the CONTROLLER environment.
+vikunja_token_publish_openbao: false
+vikunja_token_openbao_addr: "{{ lookup('env', 'BAO_ADDR') | default('', true) }}"
+vikunja_token_openbao_token: "{{ lookup('env', 'BAO_TOKEN') | default('', true) }}"
+vikunja_token_openbao_mount: "secret"
+vikunja_token_openbao_path: "ai/mcp/vikunja"
+vikunja_url_openbao_key: "VIKUNJA_MCP_URL"
+
+# Shared MCP connection URL published alongside the tokens. Derived from the
+# role's own ingress wiring (vikunja_public_url — the FQDN Vikunja uses for
+# links/CORS) so the client-facing base can never drift from it; + the API base.
+vikunja_mcp_url: "{{ vikunja_public_url | regex_replace('/+$', '') }}/api/v1"
+
+# Minted token lifetime. Rotation is a re-mint: delete the mcp-<user> token in
+# Vikunja and re-converge.
+vikunja_token_expiry_days: 365
+
+# Route groups (GET /api/v1/routes keys) the MCP tokens may act on. RO tokens
+# get the read_* actions on these groups; RW tokens get every action. Bounded
+# to the task-management surface — never the whole route set (which includes
+# user, migration, and token-management routes). Group keys and actions are
+# validated against the live route set at mint time, so an unknown name here is
+# skipped, not fatal.
+vikunja_mcp_token_scopes:
+  - tasks
+  - projects
+  - labels
+  - filters
+
+# Service users that receive an MCP token, the tier each gets, and the OpenBao
+# field its token publishes to. Passwords come from vikunja_service_users.
+vikunja_mcp_token_users:
+  - username: svc-mcp-ro
+    readonly: true
+    kv_field: VIKUNJA_MCP_TOKEN_RO
+  - username: svc-mcp-rw
+    readonly: false
+    kv_field: VIKUNJA_MCP_TOKEN_RW

--- a/roles/vikunja/tasks/main.yml
+++ b/roles/vikunja/tasks/main.yml
@@ -187,3 +187,23 @@
            | regex_search('(?:^|\\s|\\|)' ~ item.username ~ '(?:\\s|\\||$)'))
   changed_when: true
   no_log: true
+
+# Mint per-user MCP API tokens and publish the shared connection to OpenBao.
+# Deferred by default: the converge flips the flag with
+# -e '{"vikunja_token_publish_openbao": true}' once a write-capable OpenBao
+# AppRole (BAO_ADDR/BAO_TOKEN) is in the controller environment.
+- name: Mint MCP API tokens and publish to OpenBao
+  ansible.builtin.include_tasks: mcp_tokens.yml
+  when: vikunja_token_publish_openbao | bool
+  tags: vikunja_mcp_tokens
+
+- name: Note MCP token minting is deferred
+  ansible.builtin.debug:
+    msg: >-
+      Vikunja MCP token minting is deferred (vikunja_token_publish_openbao is
+      off). Service users exist; enable with
+      -e '{"vikunja_token_publish_openbao": true}' plus a write-capable OpenBao
+      AppRole (BAO_ADDR/BAO_TOKEN) to mint mcp-<user> tokens and publish
+      {{ vikunja_url_openbao_key }} + per-tier tokens to
+      {{ vikunja_token_openbao_mount }}/{{ vikunja_token_openbao_path }}.
+  when: not (vikunja_token_publish_openbao | bool)

--- a/roles/vikunja/tasks/mcp_token_one.yml
+++ b/roles/vikunja/tasks/mcp_token_one.yml
@@ -1,0 +1,105 @@
+---
+# Ensure ONE MCP service user has a live API token and publish it (with the
+# shared connection URL) to OpenBao. Included per item from mcp_tokens.yml with
+# loop_var: vikunja_mcp_user ({ username, readonly, kv_field }). The token is
+# minted on behalf of the user logging in (PUT /tokens uses that user's JWT).
+
+- name: "Log in to Vikunja as {{ vikunja_mcp_user.username }}"
+  ansible.builtin.uri:
+    url: "http://localhost:{{ vikunja_port }}/api/v1/login"
+    method: POST
+    body_format: json
+    body:
+      username: "{{ vikunja_mcp_user.username }}"
+      password: >-
+        {{ (vikunja_service_users
+            | selectattr('username', 'equalto', vikunja_mcp_user.username)
+            | first).password }}
+    status_code: [200]
+  register: vikunja_mcp_login
+  no_log: true
+
+- name: "List existing API tokens for {{ vikunja_mcp_user.username }}"
+  ansible.builtin.uri:
+    url: "http://localhost:{{ vikunja_port }}/api/v1/tokens"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ vikunja_mcp_login.json.token }}"
+    status_code: [200]
+  register: vikunja_mcp_token_list
+  no_log: true
+
+# The list omits the secret value (returned exactly once at creation), so a live
+# token titled mcp-<user> means "already provisioned" — do not re-mint.
+- name: "Detect a live mcp token for {{ vikunja_mcp_user.username }}"
+  ansible.builtin.set_fact:
+    vikunja_mcp_token_exists: >-
+      {{ (vikunja_mcp_token_list.json | default([], true))
+         | selectattr('title', 'defined')
+         | selectattr('title', 'equalto', 'mcp-' ~ vikunja_mcp_user.username)
+         | list | length > 0 }}
+
+- name: "Mint API token for {{ vikunja_mcp_user.username }}"
+  ansible.builtin.uri:
+    url: "http://localhost:{{ vikunja_port }}/api/v1/tokens"
+    method: PUT
+    headers:
+      Authorization: "Bearer {{ vikunja_mcp_login.json.token }}"
+    body_format: json
+    body:
+      title: "mcp-{{ vikunja_mcp_user.username }}"
+      permissions: "{{ vikunja_ro_permissions if vikunja_mcp_user.readonly else vikunja_rw_permissions }}"
+      expires_at: >-
+        {{ '%Y-%m-%dT%H:%M:%SZ'
+           | strftime((now(utc=true).timestamp() | int) + (vikunja_token_expiry_days | int * 86400), utc=true) }}
+    status_code: [200, 201]
+  register: vikunja_mcp_token_mint
+  when: not vikunja_mcp_token_exists
+  no_log: true
+
+- name: "Read current OpenBao secret at {{ vikunja_token_openbao_path }}"
+  ansible.builtin.uri:
+    url: "{{ vikunja_token_openbao_addr }}/v1/{{ vikunja_token_openbao_mount }}/data/{{ vikunja_token_openbao_path }}"
+    method: GET
+    headers:
+      X-Vault-Token: "{{ vikunja_token_openbao_token }}"
+    validate_certs: false
+    status_code: [200, 404]
+  register: vikunja_bao_current
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  no_log: true
+
+# KV v2 replaces the whole secret, so merge canonical fields over current data
+# to preserve siblings. The URL (non-secret) is written whenever it is missing
+# or stale; the token is added only when freshly minted (Vikunja returns it
+# exactly once). Guarding the write on an actual delta keeps the task
+# idempotent — once URL + token are present, later converges no-op here.
+- name: "Publish MCP connection to OpenBao for {{ vikunja_mcp_user.username }}"
+  ansible.builtin.uri:
+    url: "{{ vikunja_token_openbao_addr }}/v1/{{ vikunja_token_openbao_mount }}/data/{{ vikunja_token_openbao_path }}"
+    method: POST
+    headers:
+      X-Vault-Token: "{{ vikunja_token_openbao_token }}"
+    body_format: json
+    body:
+      data: >-
+        {{ (vikunja_bao_current.json | default({}, true)).get('data', {}).get('data', {})
+           | combine({vikunja_url_openbao_key: vikunja_mcp_url})
+           | combine({vikunja_mcp_user.kv_field: vikunja_mcp_token_mint.json.token}
+                     if (vikunja_mcp_token_mint is not skipped) else {}) }}
+    validate_certs: false
+    status_code: [200, 204]
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  when: >-
+    vikunja_mcp_token_mint is not skipped
+    or (vikunja_bao_current.json | default({}, true)).get('data', {}).get('data', {}).get(vikunja_url_openbao_key)
+       != vikunja_mcp_url
+  no_log: true

--- a/roles/vikunja/tasks/mcp_tokens.yml
+++ b/roles/vikunja/tasks/mcp_tokens.yml
@@ -1,0 +1,84 @@
+---
+# Mint a long-lived Vikunja API token for each MCP service user and publish the
+# shared connection (URL + per-tier tokens) to OpenBao secret/ai/mcp/vikunja.
+#
+# Mirrors ansible-splunk roles/splunk_docker/tasks/manage_one_user.yml:
+#   * mint only when absent (idempotent — Vikunja returns the key exactly once)
+#   * sibling-preserving KV-v2 read-modify-write
+#   * no_log on every secret-bearing task
+# Included from tasks/main.yml only when vikunja_token_publish_openbao is true.
+# The converge enables it with -e '{"vikunja_token_publish_openbao": true}';
+# BAO_ADDR/BAO_TOKEN must be in the CONTROLLER environment.
+#
+# Permissions are built from the LIVE GET /api/v1/routes response, never
+# hardcoded: Vikunja's PermissionsAreValid rejects any group/action not in the
+# current route set, and the route-group keys are derived from URL paths (so
+# they shift across versions). Building from the running instance keeps the
+# minted permissions valid by construction.
+
+- name: Assert OpenBao write credentials are present
+  ansible.builtin.assert:
+    that:
+      - vikunja_token_openbao_addr | length > 0
+      - vikunja_token_openbao_token | length > 0
+    fail_msg: >-
+      vikunja_token_publish_openbao is on but BAO_ADDR/BAO_TOKEN are unset.
+      Provide a write-capable OpenBao AppRole in the converge environment.
+    quiet: true
+
+- name: Log in to Vikunja as admin to read the token route catalogue
+  ansible.builtin.uri:
+    url: "http://localhost:{{ vikunja_port }}/api/v1/login"
+    method: POST
+    body_format: json
+    body:
+      username: "{{ vikunja_admin_user }}"
+      password: "{{ vikunja_admin_password }}"
+    status_code: [200]
+  register: vikunja_admin_login
+  no_log: true
+
+- name: Fetch the API token route catalogue
+  ansible.builtin.uri:
+    url: "http://localhost:{{ vikunja_port }}/api/v1/routes"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ vikunja_admin_login.json.token }}"
+    status_code: [200]
+  register: vikunja_routes
+  no_log: true
+
+- name: Determine in-scope Vikunja route groups
+  ansible.builtin.set_fact:
+    vikunja_scoped_groups: "{{ vikunja_mcp_token_scopes | select('in', vikunja_routes.json) | list }}"
+
+# read_all/read_one are the only read actions; create/update/delete are writes.
+# RW grants every action on a scoped group; RO grants only the read_* actions,
+# dropping any group left with none.
+- name: Build read-write and read-only permission maps
+  ansible.builtin.set_fact:
+    vikunja_rw_permissions: >-
+      {{ dict(vikunja_scoped_groups
+              | zip(vikunja_scoped_groups | map('extract', vikunja_routes.json) | map('list'))) }}
+    vikunja_ro_permissions: >-
+      {{ dict(vikunja_scoped_groups
+              | zip(vikunja_scoped_groups | map('extract', vikunja_routes.json)
+                    | map('list') | map('select', 'match', 'read') | map('list')))
+         | dict2items | rejectattr('value', 'eq', []) | items2dict }}
+
+- name: Assert MCP token permission scopes resolved
+  ansible.builtin.assert:
+    that:
+      - vikunja_rw_permissions | length > 0
+      - vikunja_ro_permissions | length > 0
+    fail_msg: >-
+      No Vikunja route groups matched vikunja_mcp_token_scopes
+      ({{ vikunja_mcp_token_scopes | join(', ') }}) in GET /api/v1/routes.
+    quiet: true
+
+- name: Mint and publish MCP tokens per service user
+  ansible.builtin.include_tasks: mcp_token_one.yml
+  loop: "{{ vikunja_mcp_token_users }}"
+  loop_control:
+    loop_var: vikunja_mcp_user
+    label: "{{ vikunja_mcp_user.username }}"


### PR DESCRIPTION
## What

Adds MCP API-token provisioning to the `vikunja` role: mints a long-lived Vikunja API token for each MCP service user and publishes the shared connection to OpenBao `secret/ai/mcp/vikunja`.

- **`svc-mcp-ro`** → read-only token → `VIKUNJA_MCP_TOKEN_RO`
- **`svc-mcp-rw`** → read-write token → `VIKUNJA_MCP_TOKEN_RW`
- **`VIKUNJA_MCP_URL`** → the shared API base, derived from the role's own ingress FQDN (`vikunja_public_url`) so it can't drift from what Vikunja advertises for links/CORS.

## How

Mirrors the `ansible-splunk` `splunk_docker` `manage_one_user` pattern:

- **Mint-if-absent** — a live token titled `mcp-<user>` is treated as already-provisioned; Vikunja returns the secret exactly once at creation.
- **Sibling-preserving KV-v2 write** — read-modify-write merges the canonical fields over current data; the non-secret URL is written when missing/stale, the token only when freshly minted. Guarded on an actual delta so re-converges no-op.
- **`no_log`** on every secret-bearing task; `assert` guards fail loud when the publish flag is on but `BAO_ADDR`/`BAO_TOKEN` are absent.

**Token permissions are built from the live `GET /api/v1/routes` catalogue, not hardcoded.** Vikunja's server-side validation rejects any group/action outside the current route set, and the route-group keys are derived from URL paths (so they shift across versions). Read tiers get the `read_*` actions; write tiers get every action. Scopes are bounded to the task-management surface (`tasks`/`projects`/`labels`/`filters`) — never the whole route set (which includes user, migration, and token-management routes).

## Deferred by default

`vikunja_token_publish_openbao: false`. Nothing is minted until the converge enables it with `-e '{"vikunja_token_publish_openbao": true}'` and a write-capable OpenBao AppRole is present in the controller environment. When off, a debug task explains the deferral.

## Verification

- `ansible-lint roles/vikunja` — passes on the **production** profile (0 failures).
- Role syntax-check — passes.
- Permission-map derivation self-check (mocked `/routes`) — asserts RO=read-only, RW=all-actions, out-of-scope/unknown groups dropped. Passes.
- Vikunja token API route/verb/payload verified against the pinned `v2.3.0` OpenAPI spec and Go source (`PermissionsAreValid`).

Does **not** merge, converge, or call OpenBao/Vikunja live. Does not touch `roles/openbao`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TduAFRb5WCmy1crcz8jSrQ