### PR TITLE
fix(zammad): use the apt module's fixed state instead of raw apt-get

### DIFF
--- a/roles/zammad/tasks/main.yml
+++ b/roles/zammad/tasks/main.yml
@@ -305,11 +305,9 @@
     # migrates against the external DB); the equivs dummy keeps the
     # `postgresql` dep satisfied without a local cluster.
     - name: Configure zammad (resolve deps + run the postinst against the external DB)
-      ansible.builtin.command: apt-get --fix-broken --yes install
-      environment:
-        DEBIAN_FRONTEND: noninteractive
+      ansible.builtin.apt:
+        state: fixed
       when: not zammad_configured
-      changed_when: true
 
     - name: Seed the Zammad database (first configure only; seeds are create-if-missing)
       ansible.builtin.command:


### PR DESCRIPTION
The `Configure zammad` task shelled out to `apt-get --fix-broken --yes install`, which trips ansible-lint's `command-instead-of-module` rule on the required production profile — failing `Merge Gate` for every open PR in the repo, not just zammad changes.

`ansible.builtin.apt` with `state: fixed` is the module-native form of the same operation (fix-broken dependency resolution, which also runs the deferred postinst against the external DB), and the module sets the noninteractive frontend itself. Semantics preserved; `changed_when: true` dropped in favor of the module's native change reporting (the task is already gated on `not zammad_configured`).

Deliberately minimal (one task) so in-flight zammad work rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TduAFRb5WCmy1crcz8jSrQ