### PR TITLE
feat(postgres): streaming replication with a single-switch primary cutover

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -168,3 +168,13 @@ bao_media_secrets: {}
 # `apps` domain — shared-Postgres app secrets (Nautobot #138: db_password,
 # secret_key, superuser_password under secret/apps/nautobot).
 bao_apps_secrets: {}
+
+# Shared-Postgres primary host — the SINGLE switch for the streaming-replication
+# topology (issue #138). Empty = single-primary (today): every postgres-tagged
+# guest is its own primary and apps reach the DB by the stable `postgres` name.
+# Set it to the primary guest's inventory hostname (e.g. `postgres-apps`) to cut
+# over in one move: that guest stays primary, every OTHER postgres-tagged guest
+# reinitializes as a hot standby streaming from it, and the apps repoint at the
+# primary. Env-driven so the cutover is a deliberate, ephemeral flip — no
+# committed edit. The postgres role and the app *_db_host both read this.
+postgres_primary_host: "{{ lookup('env', 'POSTGRES_PRIMARY_HOST') | default('', true) }}"

--- a/inventory/group_vars/nautobot_group.yml
+++ b/inventory/group_vars/nautobot_group.yml
@@ -9,10 +9,13 @@ nautobot_web_port: >-
   {{ (hostvars['localhost']['tofu_data']['constants']['service_ports']['nautobot_web'])
      | default(8080) }}
 
-# Postgres has no ingress; reach it by its guest FQDN on the data VLAN. The
-# guest DNS zone is tofu_data.domain and the hostname is fixed at `postgres`
-# by the container (a stable service identifier, not a hard-coded address).
-nautobot_db_host: "postgres.{{ hostvars['localhost']['tofu_data']['domain'] }}"
+# Postgres has no ingress; reach it by the primary guest's FQDN. Tracks the
+# shared postgres_primary_host switch (group_vars/all): unset -> the stable
+# `postgres` name (today); set to the apps-tier primary at cutover -> that name.
+# A guest hostname is a stable service identifier here, not a hard-coded address.
+nautobot_db_host: >-
+  {{ (postgres_primary_host if (postgres_primary_host | default('', true) | length > 0) else 'postgres')
+     }}.{{ hostvars['localhost']['tofu_data']['domain'] }}
 nautobot_db_password: >-
   {{ bao_apps_secrets.db_password
      | default(lookup('env', 'NAUTOBOT_DB_PASSWORD'), true) }}

--- a/inventory/group_vars/zammad_group.yml
+++ b/inventory/group_vars/zammad_group.yml
@@ -11,10 +11,13 @@ zammad_web_port: >-
   {{ (hostvars['localhost']['tofu_data']['constants']['service_ports']['zammad_web'])
      | default(8080) }}
 
-# Postgres has no ingress; reach it by its guest FQDN on the data VLAN. The
-# guest DNS zone is tofu_data.domain and the hostname is fixed at `postgres`
-# by the container (a stable service identifier, not a hard-coded address).
-zammad_db_host: "postgres.{{ hostvars['localhost']['tofu_data']['domain'] }}"
+# Postgres has no ingress; reach it by the primary guest's FQDN. Tracks the
+# shared postgres_primary_host switch (group_vars/all): unset -> the stable
+# `postgres` name (today); set to the apps-tier primary at cutover -> that name.
+# A guest hostname is a stable service identifier here, not a hard-coded address.
+zammad_db_host: >-
+  {{ (postgres_primary_host if (postgres_primary_host | default('', true) | length > 0) else 'postgres')
+     }}.{{ hostvars['localhost']['tofu_data']['domain'] }}
 zammad_db_password: >-
   {{ bao_apps_secrets.zammad_db_password
      | default(lookup('env', 'ZAMMAD_DB_PASSWORD'), true) }}

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -81,3 +81,46 @@ postgres_standby_pull_pubkeys: "{{ lookup('env', 'POSTGRES_STANDBY_SSH_PUBKEYS')
 # database for the mandatory restore drill.
 postgres_dr_restore_db: ""
 postgres_dr_restore_dump: ""
+
+# =============================================================================
+# Streaming replication (issue #138). Disabled by default: with
+# postgres_primary_host empty this role behaves exactly as a single primary and
+# creates every managed database here. Set postgres_primary_host (group_vars/all,
+# env POSTGRES_PRIMARY_HOST) to the primary guest's inventory hostname to enable
+# — the primary then gains a replication role + slot + pg_hba line, and every
+# OTHER postgres-tagged guest reinitializes as a hot standby streaming from it.
+# =============================================================================
+# Floor for postgres_primary_host so the role resolves standalone (group_vars/all
+# overrides with the env value). A host is the primary when no primary is named,
+# or when it IS the named primary; anything else is a standby.
+postgres_primary_host: ""
+postgres_role: >-
+  {{ 'standby'
+     if (postgres_primary_host | length > 0 and inventory_hostname != postgres_primary_host)
+     else 'primary' }}
+postgres_replication_enabled: "{{ (postgres_primary_host | length > 0) | bool }}"
+
+# The standby authenticates to the primary as this LOGIN + REPLICATION role. The
+# password is bao-first with an env fallback — never a literal.
+postgres_replication_user: replicator
+postgres_replication_password: >-
+  {{ bao_apps_secrets.replication_password
+     | default(lookup('env', 'POSTGRES_REPLICATION_PASSWORD'), true) }}
+# One physical slot per standby, so the primary retains WAL while a standby is
+# down instead of relying on wal_keep_size guesswork.
+postgres_replication_slot: "standby_{{ inventory_hostname | regex_replace('[^A-Za-z0-9]', '_') }}"
+# CIDR the primary accepts replication connections from (the standby's subnet).
+# Same env-derived pg_hba pattern as the app client_cidrs — pg_hba needs a CIDR,
+# not an FQDN, so this is the one legitimate place for one, and even here it is
+# env-sourced. The demoted standby (CT 303000) lives on the data VLAN.
+postgres_replication_cidr: "{{ lookup('env', 'NETWORK_CIDR_DATA') | default('', true) }}"
+# The primary's FQDN the standby streams from — by name, never an address.
+postgres_primary_fqdn: >-
+  {{ lookup('env', 'POSTGRES_PRIMARY_FQDN')
+     | default(postgres_primary_host ~ '.' ~ (tofu_data.domain | default('')), true) }}
+# Data-loss interlock. The standby bootstrap REFUSES to wipe a populated PGDATA
+# unless this is true, so a stray role flip can never destroy a live primary. A
+# fresh/empty standby bootstraps with no interlock. Set true ONLY after the
+# migration to the new primary is confirmed; env-gated so it is deliberate and
+# ephemeral.
+postgres_standby_reinit: "{{ lookup('env', 'POSTGRES_STANDBY_REINIT') | default(false, true) | bool }}"

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -172,6 +172,104 @@
     enabled: true
 
 # =============================================================================
+# Phase 2b: Standby bootstrap (streaming replication, issue #138)
+# Only a replication standby with no standby.signal yet. Reinitializes PGDATA
+# from a fresh pg_basebackup of the primary, then the cluster comes back up in
+# standby mode (pg_basebackup --write-recovery-conf drops standby.signal +
+# primary_conninfo). Idempotent: once standby.signal exists this is skipped.
+# Converge the PRIMARY first so its replication role + slot exist — a stray
+# out-of-order run cannot corrupt data: the basebackup lands in a temp dir and
+# only replaces PGDATA on success, and the interlock below refuses to touch a
+# populated PGDATA unless the demotion is explicitly confirmed.
+# =============================================================================
+- name: Bootstrap the streaming standby
+  when:
+    - postgres_replication_enabled | bool
+    - postgres_role == 'standby'
+  block:
+    - name: Check whether this guest is already a standby
+      ansible.builtin.stat:
+        path: "{{ postgres_data_dir }}/standby.signal"
+      register: postgres_standby_signal
+
+    - name: Reinitialize PGDATA as a streaming standby
+      when: not postgres_standby_signal.stat.exists
+      block:
+        # postgres_existing_data_version (Phase 2) stat'd PGDATA/PG_VERSION.
+        - name: Refuse to wipe populated data without an explicit reinit
+          ansible.builtin.fail:
+            msg: >-
+              {{ postgres_data_dir }} already holds a PostgreSQL cluster and
+              this guest is being demoted to a standby. Reinitializing wipes it.
+              Set postgres_standby_reinit=true (env POSTGRES_STANDBY_REINIT)
+              only AFTER confirming its data is migrated to
+              {{ postgres_primary_fqdn }}.
+          when:
+            - postgres_existing_data_version.stat.exists
+            - not (postgres_standby_reinit | bool)
+
+        - name: Write the replicator .pgpass for the postgres user
+          ansible.builtin.copy:
+            # `>` folds the split back to one line and keeps a single trailing
+            # newline; the fold-space lands inside `{{ ... }}` so it is inert.
+            dest: /var/lib/postgresql/.pgpass
+            content: >
+              {{ postgres_primary_fqdn }}:{{ postgres_port }}:replication:{{ postgres_replication_user
+              }}:{{ postgres_replication_password }}
+            owner: postgres
+            group: postgres
+            mode: "0600"
+          no_log: true
+
+        - name: Verify the primary is reachable before touching PGDATA
+          ansible.builtin.command:
+            argv:
+              - pg_isready
+              - --host={{ postgres_primary_fqdn }}
+              - --port={{ postgres_port }}
+              - --timeout=10
+          changed_when: false
+
+        - name: Stop the cluster before reinitializing PGDATA
+          ansible.builtin.systemd:
+            name: "postgresql@{{ postgres_cluster_version }}-{{ postgres_cluster_name }}"
+            state: stopped
+
+        - name: Remove any stale basebackup staging directory
+          ansible.builtin.file:
+            path: "{{ postgres_data_root }}/.ansible-standby-basebackup"
+            state: absent
+
+        - name: Take a base backup from the primary
+          become: true
+          become_user: postgres
+          ansible.builtin.command:
+            argv:
+              - pg_basebackup
+              - --pgdata={{ postgres_data_root }}/.ansible-standby-basebackup
+              - --wal-method=stream
+              - --slot={{ postgres_replication_slot }}
+              - --write-recovery-conf
+              - --checkpoint=fast
+              - --no-password
+              - --host={{ postgres_primary_fqdn }}
+              - --port={{ postgres_port }}
+              - --username={{ postgres_replication_user }}
+          changed_when: true
+
+        - name: Replace PGDATA with the base backup
+          ansible.builtin.shell:
+            cmd: >-
+              rm -rf {{ postgres_data_dir }} &&
+              mv {{ postgres_data_root }}/.ansible-standby-basebackup {{ postgres_data_dir }}
+          changed_when: true
+
+        - name: Start the cluster in standby mode
+          ansible.builtin.systemd:
+            name: "postgresql@{{ postgres_cluster_version }}-{{ postgres_cluster_name }}"
+            state: started
+
+# =============================================================================
 # Phase 3: Cluster configuration (idempotent GUCs)
 # postgresql_set only writes when the value differs, so the idempotence run is
 # clean. listen_addresses/port need a restart; password_encryption reloads.
@@ -206,13 +304,70 @@
   ansible.builtin.meta: flush_handlers
 
 # =============================================================================
+# Phase 3b: Primary replication config (streaming replication, issue #138)
+# Primary-only. Creates the replication login role, one physical slot per
+# standby (so WAL is retained while a standby is down), and the replication
+# pg_hba line. Converge the primary before any standby so these exist when the
+# standby's pg_basebackup connects.
+# =============================================================================
+- name: Configure the replication primary
+  become: true
+  become_user: postgres
+  when:
+    - postgres_replication_enabled | bool
+    - postgres_role == 'primary'
+  block:
+    - name: Ensure wal_level supports replication
+      community.postgresql.postgresql_set:
+        name: wal_level
+        value: replica
+      notify: Restart postgresql
+
+    - name: Ensure the replication login role exists
+      community.postgresql.postgresql_user:
+        name: "{{ postgres_replication_user }}"
+        password: "{{ postgres_replication_password }}"
+        role_attr_flags: LOGIN,REPLICATION
+        state: present
+      no_log: true
+
+    - name: Ensure a physical replication slot exists for each standby
+      community.postgresql.postgresql_slot:
+        name: "standby_{{ item | regex_replace('[^A-Za-z0-9]', '_') }}"
+        slot_type: physical
+        state: present
+      loop: "{{ groups['postgres_group'] | default([]) | difference([postgres_primary_host]) }}"
+      loop_control:
+        label: "{{ item }}"
+
+    - name: Allow the replicator to connect from the standby subnet (scram)
+      community.postgresql.postgresql_pg_hba:
+        dest: "{{ postgres_conf_dir }}/pg_hba.conf"
+        contype: host
+        databases: replication
+        users: "{{ postgres_replication_user }}"
+        source: "{{ postgres_replication_cidr }}"
+        method: scram-sha-256
+        state: present
+      when: postgres_replication_cidr | length > 0
+      notify: Reload postgresql
+
+- name: Apply pending replication restart/reload
+  ansible.builtin.meta: flush_handlers
+  when: postgres_replication_enabled | bool
+
+# =============================================================================
 # Phase 4: Roles, databases, and host-based auth
 # Credentials come from the source secret store; apply them on each run so an
 # app cutover can rotate from bootstrap SOPS values without manual SQL.
+# Primary-only: a standby is read-only and inherits every role and database
+# through streaming (they are catalog state carried in the WAL), so running
+# these writes there would fail against the read-only replica.
 # =============================================================================
 - name: Provision managed roles and databases
   become: true
   become_user: postgres
+  when: postgres_role == 'primary'
   block:
     - name: Ensure each managed login role exists with the source password
       community.postgresql.postgresql_user:


### PR DESCRIPTION
## What

Adds primary→standby streaming replication to the shared `postgres` role and
gates the whole topology behind one switch: `postgres_primary_host`
(`group_vars/all`, env `POSTGRES_PRIMARY_HOST`).

- **Empty (default)** → today's single-primary behavior, byte-for-byte. Merging
  this changes nothing live.
- **Set to the primary guest's inventory hostname** (e.g. `postgres-apps`) → the
  named guest stays primary; every other `postgres`-tagged guest reinitializes
  as a hot standby streaming from it; the apps' `db_host` repoints at the primary.

## How it works

| Concern | Mechanism |
| --- | --- |
| Role selection | `postgres_role` derives `primary`/`standby` from `postgres_primary_host` vs `inventory_hostname` |
| Primary setup (Phase 3b) | `replicator` LOGIN,REPLICATION role · one physical slot per standby · `host replication` pg_hba scoped to the standby subnet · `wal_level=replica` |
| Standby bootstrap (Phase 2b) | `pg_basebackup --write-recovery-conf` into a temp dir, swapped into PGDATA on success; auth via a `0600` `.pgpass`; idempotent once `standby.signal` exists |
| Data-loss interlock | the standby refuses to wipe a **populated** PGDATA unless `postgres_standby_reinit=true` (env) confirms the demotion |
| App repoint | `nautobot`/`zammad` `db_host` track the same switch (`postgres` today → named primary at cutover) |
| Managed DBs | Phase 4 is now primary-only; the standby inherits roles/DBs through the WAL stream |

## New env inputs (injected, never committed)

- `POSTGRES_PRIMARY_HOST` — the cutover switch.
- `POSTGRES_REPLICATION_PASSWORD` (or `bao_apps_secrets.replication_password`) — the `replicator` role password.
- `NETWORK_CIDR_DATA` — the standby subnet the primary accepts replication from (pg_hba needs a CIDR).
- `POSTGRES_STANDBY_REINIT` — the one-shot data-loss interlock for demoting a populated guest.

## Cutover runbook (live steps — run once the new primary CT exists)

These require the apps-tier primary guest to be provisioned (its tofu entry is a
separate PR) and converged. **Converge the primary before the standby.**

1. **Provision + converge the new primary** (no switch yet): it comes up empty
   and creates the app roles/databases.
2. **Migrate app data**, during a short write-freeze on the apps:
   `pg_dump -Fc` the `nautobot` and `vikunja` databases from the current
   primary, restore into the new primary (`pg_restore --clean --if-exists`, or
   the role's `--tags dr_restore`). Zammad is a fresh deploy — no migration.
3. **Flip the switch**: set `POSTGRES_PRIMARY_HOST` to the new primary's
   hostname, set `POSTGRES_REPLICATION_PASSWORD` / `NETWORK_CIDR_DATA`, and
   converge `--limit <new-primary>,localhost` — it gains the replicator role,
   slot, and pg_hba line.
4. **Demote the old guest**: with `POSTGRES_STANDBY_REINIT=true` (the interlock
   is required because it holds data), converge `--limit <old-guest>,localhost`.
   It reinitializes from a base backup of the new primary and comes up streaming.
5. **Repoint + restart apps** (they now resolve the new `db_host` from the same
   switch), then **verify replication**: on the primary
   `SELECT client_addr, state, replay_lag FROM pg_stat_replication;`, on the
   standby `SELECT pg_is_in_recovery();` and the `pg_last_wal_replay_lsn` lag.

## Verification

- `ansible-lint` (production profile) — pass.
- `ansible-playbook --syntax-check playbooks/site.yml` — pass.
- Jinja derivations (role selection, `db_host` switch, `.pgpass` fold) checked to render correctly.

The live cutover steps above are **not** exercised here (they need the running
primary/standby); this PR delivers the role + switch that makes them a var flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TduAFRb5WCmy1crcz8jSrQ
