### PR TITLE
feat(postgres): primary/standby replication roles with standby bootstrap

### DIFF
--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -74,6 +74,37 @@ postgres_backup_retention_days: 14
 # never a committed literal). Empty -> no trust installed.
 postgres_standby_pull_pubkeys: "{{ lookup('env', 'POSTGRES_STANDBY_SSH_PUBKEYS') | default('', true) }}"
 
+# --- Streaming replication (primary/standby) ---------------------------------
+# postgres_role selects the converge shape. `primary` (default) is the current
+# single-node path: 303000 keeps converging byte-identically. `standby`
+# bootstraps this node from a primary with pg_basebackup and provisions no
+# roles/databases (they arrive over the stream).
+postgres_role: primary
+
+# On the PRIMARY: the standby's FQDN. Empty (default) adds no replication
+# wiring, so an ordinary primary converge is unchanged. Set it to open a
+# `host replication` pg_hba entry for the standby (a hostname, per the FQDN
+# rule) and turn on the replication GUCs + replicator role below.
+postgres_replication_standby_host: ""
+
+# On the STANDBY: the primary's FQDN to clone from. Required when role=standby.
+postgres_replication_primary_host: ""
+
+# Replication login role (LOGIN + REPLICATION). Injection-agnostic: the
+# password is a plain env lookup and the secrets backend supplies it. The
+# fail-loud assert fires only when replication is actually enabled, so a
+# non-replicating converge needs no env var.
+postgres_replication_user: replicator
+postgres_replication_password: "{{ lookup('env', 'POSTGRES_REPLICATOR_PASSWORD') | default('', true) }}"
+
+# Optional physical replication slot. Empty = no slot (the standby streams
+# without one). Set the same name on primary and standby to pin a slot so the
+# primary retains WAL for a disconnected standby.
+postgres_replication_slot: ""
+
+# Streaming capacity. 10 covers a few standbys plus concurrent base backups.
+postgres_max_wal_senders: 10
+
 # DR restore inputs (docs/DATABASE_DR_STANDARD.md in ansible-proxmox; tagged
 # `never,dr_restore` — runs only on explicit invocation). `_dump` is a
 # CONTROLLER-side path (fetched from the replicated archive or the Tier-2

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -165,6 +165,99 @@
   register: postgres_cluster_config_file
   failed_when: not postgres_cluster_config_file.stat.exists
 
+# =============================================================================
+# Phase 2b: Standby bootstrap (postgres_role == 'standby')
+# The Debian postinst always pre-creates a fresh cluster at PGDATA, so "empty
+# PGDATA" never holds literally. The guard is therefore: clone only when there
+# is no standby.signal (an established standby is left alone — idempotent
+# rebuild) AND the pre-existing cluster holds zero user databases (a former
+# primary's data is never destroyed). pg_basebackup -R writes standby.signal +
+# primary_conninfo; role/database provisioning is skipped (Phase 4 is gated).
+# =============================================================================
+- name: Bootstrap this node as a streaming standby
+  when: postgres_role == 'standby'
+  block:
+    - name: Check for an existing standby.signal
+      ansible.builtin.stat:
+        path: "{{ postgres_data_dir }}/standby.signal"
+      register: postgres_standby_signal
+
+    - name: Clone from the primary when no standby is established yet
+      when: not postgres_standby_signal.stat.exists
+      block:
+        - name: Require the primary FQDN and replicator password for the clone
+          ansible.builtin.assert:
+            that:
+              - postgres_replication_primary_host | length > 0
+              - postgres_replication_password | length > 0
+            fail_msg: >-
+              postgres_role=standby needs postgres_replication_primary_host and
+              POSTGRES_REPLICATOR_PASSWORD (env) set before it can pg_basebackup.
+            quiet: true
+
+        - name: Ensure the freshly-installed cluster is up so it can be inspected
+          ansible.builtin.systemd:
+            name: "postgresql@{{ postgres_cluster_version }}-{{ postgres_cluster_name }}"
+            state: started
+
+        - name: Count user databases in the pre-existing cluster
+          become: true
+          become_user: postgres
+          community.postgresql.postgresql_query:
+            db: postgres
+            query: >-
+              SELECT count(*) AS n FROM pg_database
+              WHERE datistemplate = false AND datname <> 'postgres'
+          register: postgres_preexisting_userdbs
+
+        - name: Refuse to clone over a cluster that already holds user data
+          ansible.builtin.assert:
+            that: postgres_preexisting_userdbs.query_result[0].n | int == 0
+            fail_msg: >-
+              {{ postgres_data_dir }} already contains user databases; refusing
+              to overwrite it with a base backup. Remove the data deliberately
+              if this node is meant to become a standby.
+            quiet: true
+
+        - name: Stop the cluster so PGDATA can be replaced by the base backup
+          ansible.builtin.systemd:
+            name: "postgresql@{{ postgres_cluster_version }}-{{ postgres_cluster_name }}"
+            state: stopped
+
+        - name: Empty PGDATA for pg_basebackup
+          ansible.builtin.file:
+            path: "{{ postgres_data_dir }}"
+            state: "{{ item }}"
+            owner: postgres
+            group: postgres
+            mode: "0700"
+          loop:
+            - absent
+            - directory
+
+        - name: Base-backup PGDATA from the primary (streaming, self-configuring)
+          become: true
+          become_user: postgres
+          ansible.builtin.command:
+            argv: >-
+              {{ ['pg_basebackup',
+                  '--host', postgres_replication_primary_host,
+                  '--username', postgres_replication_user,
+                  '--pgdata', postgres_data_dir,
+                  '--wal-method', 'stream',
+                  '--write-recovery-conf']
+                 + (['--slot', postgres_replication_slot]
+                    if postgres_replication_slot | length > 0 else []) }}
+            creates: "{{ postgres_data_dir }}/standby.signal"
+          environment:
+            PGPASSWORD: "{{ postgres_replication_password }}"
+          no_log: true
+
+        - name: Start the cluster as a standby
+          ansible.builtin.systemd:
+            name: "postgresql@{{ postgres_cluster_version }}-{{ postgres_cluster_name }}"
+            state: started
+
 - name: Ensure the PostgreSQL cluster service is started and enabled
   ansible.builtin.systemd:
     name: "postgresql@{{ postgres_cluster_version }}-{{ postgres_cluster_name }}"
@@ -200,6 +293,68 @@
         value: "{{ postgres_password_encryption }}"
       notify: Reload postgresql
 
+# =============================================================================
+# Phase 3b: Primary replication config (postgres_role == 'primary' with a
+# standby FQDN set). wal_level/max_wal_senders need a restart, folded into the
+# flush below. The replicator role + hostname pg_hba entry let exactly the named
+# standby stream. Off by default (empty standby host), so a plain primary is
+# untouched.
+# =============================================================================
+- name: Configure the primary for streaming replication
+  become: true
+  become_user: postgres
+  when:
+    - postgres_role == 'primary'
+    - postgres_replication_standby_host | length > 0
+  vars:
+    ansible_ssh_pipelining: true
+  block:
+    - name: Require the replicator password before enabling replication
+      ansible.builtin.assert:
+        that: postgres_replication_password | length > 0
+        fail_msg: >-
+          postgres_replication_standby_host is set but POSTGRES_REPLICATOR_PASSWORD
+          (env) is empty; refusing to create a passwordless replication role.
+        quiet: true
+
+    - name: Set wal_level to replica
+      community.postgresql.postgresql_set:
+        name: wal_level
+        value: replica
+      notify: Restart postgresql
+
+    - name: Set max_wal_senders
+      community.postgresql.postgresql_set:
+        name: max_wal_senders
+        value: "{{ postgres_max_wal_senders }}"
+      notify: Restart postgresql
+
+    - name: Ensure the replicator login/replication role exists
+      community.postgresql.postgresql_user:
+        name: "{{ postgres_replication_user }}"
+        password: "{{ postgres_replication_password }}"
+        role_attr_flags: LOGIN,REPLICATION
+        state: present
+      no_log: true
+
+    - name: Ensure the physical replication slot exists
+      community.postgresql.postgresql_slot:
+        name: "{{ postgres_replication_slot }}"
+        slot_type: physical
+        state: present
+      when: postgres_replication_slot | length > 0
+
+    - name: Allow the standby to stream replication (hostname pg_hba, scram)
+      community.postgresql.postgresql_pg_hba:
+        dest: "{{ postgres_conf_dir }}/pg_hba.conf"
+        contype: host
+        databases: replication
+        users: "{{ postgres_replication_user }}"
+        source: "{{ postgres_replication_standby_host }}"
+        method: scram-sha-256
+        state: present
+      notify: Reload postgresql
+
 # Apply a pending restart NOW so the remote listener + scram are live before we
 # create roles and run the health check (handlers otherwise flush at play end).
 - name: Apply pending PostgreSQL restart/reload
@@ -209,10 +364,13 @@
 # Phase 4: Roles, databases, and host-based auth
 # Credentials come from the source secret store; apply them on each run so an
 # app cutover can rotate from bootstrap SOPS values without manual SQL.
+# Primary only: a standby is read-only and receives roles/databases over the
+# replication stream, so provisioning them there would fail.
 # =============================================================================
 - name: Provision managed roles and databases
   become: true
   become_user: postgres
+  when: postgres_role == 'primary'
   block:
     - name: Ensure each managed login role exists with the source password
       community.postgresql.postgresql_user:


### PR DESCRIPTION
## What

Adds primary/standby streaming-replication awareness to the `postgres` role.
Scope is `roles/postgres` only — no `group_vars`, `site.yml`, or other roles.

A `postgres_role` variable (default `primary`) selects the converge shape:

- **primary** (default) — unchanged single-node behavior. With
  `postgres_replication_standby_host` empty, the converge is byte-identical to
  today. Set that variable (to the standby's FQDN) to enable the primary
  replication wiring: `wal_level=replica`, `max_wal_senders`, a
  `LOGIN`/`REPLICATION` replicator role, an optional physical replication
  slot, and a `host replication` pg_hba entry keyed on the standby's
  **hostname** (per the FQDN convention).
- **standby** — bootstraps the node from the primary with `pg_basebackup`
  (`-R -X stream`, plus the slot when configured), then skips all
  role/database provisioning (those arrive over the stream).

## Safety

The standby bootstrap **never overwrites a cluster that already holds user
data**. It clones only when there is no `standby.signal` and a live count
confirms zero user databases; otherwise it fails loud. An established standby
(has `standby.signal`) is left untouched, so re-converge is idempotent.

The replicator password is injection-agnostic (plain `POSTGRES_REPLICATOR_PASSWORD`
env lookup). A fail-loud assert fires only when replication is actually
enabled, so existing non-replicating converges need no new env var.

## Verification

- `ansible-lint roles/postgres/` — passes, production profile, 0 findings.
- `ansible-playbook --syntax-check playbooks/site.yml` — passes.

Not converged — provisioning and cutover are sequenced separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TduAFRb5WCmy1crcz8jSrQ