### PR TITLE
feat(zammad): publish MCP connection to OpenBao secret/ai/mcp/zammad

### DIFF
--- a/roles/zammad/defaults/main.yml
+++ b/roles/zammad/defaults/main.yml
@@ -114,3 +114,21 @@ zammad_elastic_repo: >-
 zammad_api_timeout: 30
 zammad_health_retries: 30
 zammad_health_delay: 10
+
+# --- MCP connection publish -> OpenBao (task #12) ----------------------------
+# Publish the shared Zammad MCP connection (URL + Hermes API token) to OpenBao
+# secret/ai/mcp/zammad for doppler-mcp to inject into the Zammad MCP server.
+# Inert by default — the converge enables it with
+# -e '{"zammad_token_publish_openbao": true}' once a write-capable OpenBao
+# AppRole (BAO_ADDR/BAO_TOKEN) is in the CONTROLLER environment.
+zammad_token_publish_openbao: false
+zammad_token_openbao_addr: "{{ lookup('env', 'BAO_ADDR') | default('', true) }}"
+zammad_token_openbao_token: "{{ lookup('env', 'BAO_TOKEN') | default('', true) }}"
+zammad_token_openbao_mount: "secret"
+zammad_token_openbao_path: "ai/mcp/zammad"
+zammad_url_openbao_key: "ZAMMAD_MCP_URL"
+zammad_token_openbao_key: "ZAMMAD_MCP_TOKEN"
+# MCP connection URL — the Zammad API base. The MCP server needs /api/v1 IN the
+# URL value (nix-ai catalog finding). Reuses the role's own ingress FQDN so it
+# can't drift from the host Zammad advertises for links.
+zammad_mcp_url: "https://{{ zammad_ui_fqdn }}/api/v1"

--- a/roles/zammad/tasks/main.yml
+++ b/roles/zammad/tasks/main.yml
@@ -442,3 +442,10 @@
       retries: "{{ zammad_health_retries | int }}"
       delay: "{{ zammad_health_delay | int }}"
       changed_when: false
+
+# Publish the Zammad MCP connection to OpenBao (task #12). Deferred: gated on
+# zammad_token_publish_openbao (default false); the converge flips it with -e.
+- name: Publish Zammad MCP connection to OpenBao
+  ansible.builtin.include_tasks: publish_mcp.yml
+  when: zammad_token_publish_openbao | bool
+  tags: zammad_mcp_publish

--- a/roles/zammad/tasks/publish_mcp.yml
+++ b/roles/zammad/tasks/publish_mcp.yml
@@ -1,0 +1,70 @@
+---
+# Publish the shared Zammad MCP connection (API base URL + the seeded Hermes API
+# token) to OpenBao secret/ai/mcp/zammad. Mirrors the OpenBao half of
+# roles/vikunja's publisher: flag-gated, sibling-preserving KV-v2
+# read-modify-write, no_log, delegated to the controller where BAO_* live.
+#
+# Zammad's token is SEEDED, not minted — zammad_bootstrap.rb runs
+# Token.create!(... token: ZAMMAD_API_TOKEN) with a value supplied from OpenBao,
+# so there is nothing to mint here; the token is already in hand as
+# zammad_hermes_api_token.
+# ponytail: reuses the existing admin 'hermes' api token as the MCP token
+# (promote-existing-credential rule — a 2nd consumer of a token that already
+# exists). Upgrade path for MCP least-privilege: a dedicated svc-mcp Zammad user
+# + its own Token.create! in zammad_bootstrap.rb, published to this same field.
+
+- name: Assert OpenBao write credentials are present for the MCP publish
+  ansible.builtin.assert:
+    that:
+      - zammad_token_openbao_addr | length > 0
+      - zammad_token_openbao_token | length > 0
+    fail_msg: >-
+      zammad_token_publish_openbao is on but BAO_ADDR/BAO_TOKEN are unset.
+      Provide a write-capable OpenBao AppRole in the converge environment.
+    quiet: true
+
+- name: Read current OpenBao secret at {{ zammad_token_openbao_path }}
+  ansible.builtin.uri:
+    url: "{{ zammad_token_openbao_addr }}/v1/{{ zammad_token_openbao_mount }}/data/{{ zammad_token_openbao_path }}"
+    method: GET
+    headers:
+      X-Vault-Token: "{{ zammad_token_openbao_token }}"
+    validate_certs: false
+    status_code: [200, 404]
+  register: zammad_bao_current
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  no_log: true
+
+# KV v2 replaces the whole secret, so merge the canonical fields over current
+# data to preserve siblings. Delta-guarded so a converge with no change no-ops.
+- name: Publish the Zammad MCP connection to OpenBao
+  ansible.builtin.uri:
+    url: "{{ zammad_token_openbao_addr }}/v1/{{ zammad_token_openbao_mount }}/data/{{ zammad_token_openbao_path }}"
+    method: POST
+    headers:
+      X-Vault-Token: "{{ zammad_token_openbao_token }}"
+    body_format: json
+    body:
+      data: >-
+        {{ (zammad_bao_current.json | default({}, true)).get('data', {}).get('data', {})
+           | combine({
+               zammad_url_openbao_key: zammad_mcp_url,
+               zammad_token_openbao_key: zammad_hermes_api_token
+             }) }}
+    validate_certs: false
+    status_code: [200, 204]
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  when: >-
+    (zammad_bao_current.json | default({}, true)).get('data', {}).get('data', {}).get(zammad_url_openbao_key)
+      != zammad_mcp_url
+    or (zammad_bao_current.json | default({}, true)).get('data', {}).get('data', {}).get(zammad_token_openbao_key)
+      != zammad_hermes_api_token
+  no_log: true


### PR DESCRIPTION
## What

Publishes the shared Zammad MCP connection (`ZAMMAD_MCP_URL` + `ZAMMAD_MCP_TOKEN`) to OpenBao `secret/ai/mcp/zammad`, so `doppler-mcp` can inject it into the Zammad MCP server (nix-ai catalog entry, dryvist/nix-ai#1254).

- New `roles/zammad/tasks/publish_mcp.yml`
- Defaults for the publish flag, OpenBao coordinates, and the MCP URL
- One appended include at the end of `roles/zammad/tasks/main.yml` (kept to a single top-level task to minimize rebase impact on the in-flight Zammad-deploy work)

## How

**Zammad's token is seeded, not minted.** `zammad_bootstrap.rb` runs `Token.create!(... token: ZAMMAD_API_TOKEN)` with a value supplied from the secret store — so unlike the Vikunja publisher (which mints via REST), there is nothing to mint here. The token is already in hand as `zammad_hermes_api_token`.

The publisher is therefore the **OpenBao half** of the Vikunja publisher:

- Flag-gated on `zammad_token_publish_openbao` (default **false**).
- `assert` fails loud if the flag is on but `BAO_ADDR`/`BAO_TOKEN` are unset.
- Sibling-preserving KV-v2 read-modify-write (merge canonical fields over current data), `no_log` on every secret-bearing task, delegated to the controller where `BAO_*` live.
- **Delta-guarded**: the write only fires when the stored URL or token differs, so a re-converge no-ops (verified by a self-check).

`ZAMMAD_MCP_URL` = `https://{{ zammad_ui_fqdn }}/api/v1` — reuses the role's own ingress FQDN so it can't drift, and keeps `/api/v1` in the URL value (the MCP server requires it).

**Token choice:** reuses the existing admin `hermes` API token as the MCP token (a second consumer of a credential that already exists). A `ponytail:` comment records the least-privilege upgrade path — a dedicated `svc-mcp` Zammad user with its own token in `zammad_bootstrap.rb`.

## Deliberately deferred / out of scope

- Does **not** touch `roles/openbao` (the `ai/mcp/zammad` grant is provisioned separately) or `zammad_bootstrap.rb`.
- Converge/verify follows the Zammad first-deploy; the converge enables the publish with `-e '{"zammad_token_publish_openbao": true}'`.

## Validation

- `ansible-lint roles/zammad` — passes on the **production** profile (0 failures).
- Role syntax-check passes (the `apt_repository` deprecation warning is pre-existing on develop, unrelated to this change).
- Self-check of the merge + delta-guard confirms siblings are preserved, both fields are set, and the guard is idempotent (no-op when current, publishes when stale/absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TduAFRb5WCmy1crcz8jSrQ