### PR TITLE
feat(postgres): pgBackRest WAL archiving + base backups to S3 (PITR)

### DIFF
--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -124,3 +124,60 @@ postgres_primary_fqdn: >-
 # migration to the new primary is confirmed; env-gated so it is deliberate and
 # ephemeral.
 postgres_standby_reinit: "{{ lookup('env', 'POSTGRES_STANDBY_REINIT') | default(false, true) | bool }}"
+
+# =============================================================================
+# Object-storage PITR backups (pgBackRest -> S3). A SECOND, independent tier
+# from the pg_dump layer above: pgBackRest archives WAL continuously
+# (archive_command) and takes scheduled full/incremental base backups to an
+# S3-compatible endpoint (the homelab RustFS instance; the same objects are
+# replicated to Backblaze B2 by an out-of-band job), giving point-in-time
+# recovery that logical dumps cannot. Primary-only, and OFF by default so the
+# merge is inert — flip postgres_pgbackrest_enabled at bring-up.
+#
+# Flag name: task #7 asked for `postgres_backup_enabled`, but that is already
+# the pg_dump tier's switch (default true). Repurposing it would silently
+# disable pg_dump, so this tier owns its own flag.
+postgres_pgbackrest_enabled: false
+
+# Stanza + repo layout. One stanza per cluster; the repo path is the in-bucket
+# prefix, so objects land at s3://<bucket>/postgres/<cluster_name>/... . The
+# bucket name is identical on RustFS and Backblaze B2 — B2's namespace is
+# global, so one globally-unique name satisfies the 1:1 RustFS<->B2 parity rule.
+postgres_pgbackrest_stanza: "{{ postgres_cluster_name }}"
+postgres_backup_s3_bucket: dryvist-homelab-backups
+postgres_pgbackrest_repo_path: "/postgres/{{ postgres_cluster_name }}"
+
+# S3-compatible endpoint + credentials. Injection-agnostic: the role reads env,
+# never a specific secret backend. RustFS/MinIO ignore the region but the AWS
+# SDK pgBackRest embeds requires a non-empty value, and they need path-style
+# URIs (bucket in the path, not the hostname).
+postgres_backup_s3_endpoint: "{{ lookup('env', 'POSTGRES_BACKUP_S3_ENDPOINT') | default('', true) }}"
+postgres_backup_s3_region: "{{ lookup('env', 'POSTGRES_BACKUP_S3_REGION') | default('us-east-1', true) }}"
+postgres_backup_s3_uri_style: path
+postgres_backup_s3_access_key_id: "{{ lookup('env', 'POSTGRES_BACKUP_S3_ACCESS_KEY_ID') | default('', true) }}"
+postgres_backup_s3_secret_access_key: "{{ lookup('env', 'POSTGRES_BACKUP_S3_SECRET_ACCESS_KEY') | default('', true) }}"
+
+# Retention: number of full backups to keep. pgBackRest expires the WAL that
+# predates the oldest retained full automatically, so this one knob bounds both
+# base-backup and WAL storage.
+postgres_pgbackrest_retention_full: 4
+
+# Backup schedule. pgBackRest's standard pattern is a weekly full plus daily
+# incrementals (the first backup is always promoted to full). Each entry deploys
+# a pgbackrest-backup@<type>.timer that triggers pgbackrest-backup@<type>.service.
+postgres_pgbackrest_schedules:
+  - type: full
+    on_calendar: "Sun *-*-* 01:00:00"
+  - type: incr
+    on_calendar: "Mon..Sat *-*-* 01:00:00"
+postgres_pgbackrest_randomized_delay_sec: 900
+
+# PITR restore (explicit invocation only; tags never,pgbackrest_restore). Stops
+# the cluster, restores the repo into PGDATA with --delta, and starts it to
+# replay WAL. Arm with postgres_pgbackrest_restore=true; optionally pin a target
+# with postgres_pgbackrest_restore_target (e.g. an ISO timestamp) and
+# _target_type (time/name/xid/lsn). Point a drill at a scratch cluster/stanza,
+# NEVER the live primary.
+postgres_pgbackrest_restore: false
+postgres_pgbackrest_restore_target: ""
+postgres_pgbackrest_restore_target_type: "time"

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -482,6 +482,13 @@
   when: postgres_standby_pull_pubkeys | length > 0
 
 # =============================================================================
+# Phase 5b: Object-storage PITR backups (pgBackRest -> S3). Primary-only and
+# flag-gated inside the imported file; also carries the tagged PITR restore.
+# =============================================================================
+- name: Configure object-storage PITR backups
+  ansible.builtin.import_tasks: pgbackrest.yml
+
+# =============================================================================
 # DR restore (explicit invocation only — the Database DR Standard's per-engine
 # restore path). Runs a controller-fetched dump into the named database:
 #   ansible-playbook ... --tags dr_restore \

--- a/roles/postgres/tasks/pgbackrest.yml
+++ b/roles/postgres/tasks/pgbackrest.yml
@@ -1,0 +1,185 @@
+---
+# Object-storage PITR tier: pgBackRest archives WAL continuously and takes
+# scheduled base backups to an S3-compatible endpoint (RustFS; replicated to
+# Backblaze B2 out of band). Primary-only — a standby's WAL arrives via
+# streaming, and archive_command runs on the primary. Statically imported from
+# main.yml after the cluster is up and the version fact is set, so inner block
+# tags (never,pgbackrest_restore) behave exactly like inline tasks.
+
+- name: Configure pgBackRest object-storage PITR backups
+  when:
+    - postgres_pgbackrest_enabled | bool
+    - postgres_role == 'primary'
+  block:
+    - name: Assert the pgBackRest S3 endpoint and credentials are set
+      ansible.builtin.assert:
+        that:
+          - postgres_backup_s3_endpoint | length > 0
+          - postgres_backup_s3_access_key_id | length > 0
+          - postgres_backup_s3_secret_access_key | length > 0
+        fail_msg: >-
+          pgBackRest is enabled but the S3 endpoint/credentials are unset. Set
+          POSTGRES_BACKUP_S3_ENDPOINT, POSTGRES_BACKUP_S3_ACCESS_KEY_ID, and
+          POSTGRES_BACKUP_S3_SECRET_ACCESS_KEY.
+        quiet: true
+
+    - name: Install pgBackRest
+      ansible.builtin.apt:
+        name: pgbackrest
+        state: present
+        update_cache: true
+
+    - name: Create the pgBackRest config directory
+      ansible.builtin.file:
+        path: /etc/pgbackrest
+        state: directory
+        owner: postgres
+        group: postgres
+        mode: "0750"
+
+    - name: Deploy the pgBackRest configuration
+      ansible.builtin.template:
+        src: pgbackrest.conf.j2
+        dest: /etc/pgbackrest/pgbackrest.conf
+        owner: postgres
+        group: postgres
+        mode: "0640"
+      no_log: true
+
+    - name: Configure WAL archiving GUCs for pgBackRest
+      become: true
+      become_user: postgres
+      block:
+        - name: Ensure wal_level supports archiving
+          community.postgresql.postgresql_set:
+            name: wal_level
+            value: replica
+          notify: Restart postgresql
+
+        - name: Enable WAL archiving
+          community.postgresql.postgresql_set:
+            name: archive_mode
+            value: "on"
+          notify: Restart postgresql
+
+        - name: Point archive_command at pgBackRest
+          community.postgresql.postgresql_set:
+            name: archive_command
+            value: "pgbackrest --stanza={{ postgres_pgbackrest_stanza }} archive-push %p"
+          notify: Restart postgresql
+
+    # archive_mode only takes effect after a restart, and stanza-create/check
+    # below need archiving live, so flush the restart before touching the repo.
+    - name: Apply pending archiving restart
+      ansible.builtin.meta: flush_handlers
+
+    - name: Read existing pgBackRest stanza info
+      become: true
+      become_user: postgres
+      ansible.builtin.command:
+        argv:
+          - pgbackrest
+          - --stanza={{ postgres_pgbackrest_stanza }}
+          - --output=json
+          - info
+      register: postgres_pgbackrest_info
+      changed_when: false
+      failed_when: false
+
+    - name: Create the pgBackRest stanza
+      become: true
+      become_user: postgres
+      ansible.builtin.command:
+        argv:
+          - pgbackrest
+          - --stanza={{ postgres_pgbackrest_stanza }}
+          - stanza-create
+      register: postgres_pgbackrest_stanza_create
+      changed_when: "'already exists' not in (postgres_pgbackrest_stanza_create.stderr | default(''))"
+      when: >-
+        postgres_pgbackrest_info.rc != 0
+        or (postgres_pgbackrest_stanza not in
+            (postgres_pgbackrest_info.stdout | default('[]', true)
+             | from_json | map(attribute='name') | list))
+
+    - name: Verify pgBackRest archiving is healthy
+      become: true
+      become_user: postgres
+      ansible.builtin.command:
+        argv:
+          - pgbackrest
+          - --stanza={{ postgres_pgbackrest_stanza }}
+          - check
+      changed_when: false
+
+    - name: Deploy the instanced pgBackRest backup service
+      ansible.builtin.template:
+        src: pgbackrest-backup@.service.j2
+        dest: /etc/systemd/system/pgbackrest-backup@.service
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Deploy a pgBackRest backup timer per schedule
+      ansible.builtin.template:
+        src: pgbackrest-backup@.timer.j2
+        dest: "/etc/systemd/system/pgbackrest-backup@{{ item.type }}.timer"
+        owner: root
+        group: root
+        mode: "0644"
+      loop: "{{ postgres_pgbackrest_schedules }}"
+      loop_control:
+        label: "{{ item.type }}"
+
+    - name: Enable and start each pgBackRest backup timer
+      ansible.builtin.systemd:
+        name: "pgbackrest-backup@{{ item.type }}.timer"
+        state: started
+        enabled: true
+        daemon_reload: true
+      loop: "{{ postgres_pgbackrest_schedules }}"
+      loop_control:
+        label: "{{ item.type }}"
+
+# =============================================================================
+# PITR restore (explicit invocation only — the object-storage tier's restore
+# drill). Restores the repo into PGDATA and replays WAL to the latest committed
+# transaction, or to a pinned target when postgres_pgbackrest_restore_target is
+# set:
+#   ansible-playbook ... --tags pgbackrest_restore \
+#     -e postgres_pgbackrest_enabled=true -e postgres_pgbackrest_restore=true \
+#     [-e postgres_pgbackrest_restore_target='2026-07-16 12:00:00+00']
+# Point a drill at a scratch cluster/stanza — restoring here overwrites PGDATA.
+# =============================================================================
+# Var-gated in addition to the `never` tag: the role include's `postgres` tag is
+# inherited here, so a plain `--tags postgres` converge would otherwise select
+# it; the postgres_pgbackrest_restore=false default is what keeps it inert.
+- name: Restore PostgreSQL from pgBackRest
+  when:
+    - postgres_pgbackrest_enabled | bool
+    - postgres_role == 'primary'
+    - postgres_pgbackrest_restore | bool
+  tags:
+    - never
+    - pgbackrest_restore
+  block:
+    - name: Stop the cluster before restoring
+      ansible.builtin.systemd:
+        name: "postgresql@{{ postgres_cluster_version }}-{{ postgres_cluster_name }}"
+        state: stopped
+
+    - name: Restore the repository into PGDATA (delta)
+      become: true
+      become_user: postgres
+      ansible.builtin.command:
+        argv: >-
+          {{ ['pgbackrest', '--stanza=' ~ postgres_pgbackrest_stanza, '--delta', 'restore']
+             + (['--type=' ~ postgres_pgbackrest_restore_target_type,
+                 '--target=' ~ postgres_pgbackrest_restore_target]
+                if (postgres_pgbackrest_restore_target | length > 0) else []) }}
+      changed_when: true
+
+    - name: Start the cluster to replay WAL
+      ansible.builtin.systemd:
+        name: "postgresql@{{ postgres_cluster_version }}-{{ postgres_cluster_name }}"
+        state: started

--- a/roles/postgres/templates/pgbackrest-backup@.service.j2
+++ b/roles/postgres/templates/pgbackrest-backup@.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+# {{ ansible_managed }}
+# Instanced unit: %i is the backup type (full/incr), so one service definition
+# serves every schedule. Runs as postgres over the local socket (peer auth).
+Description=pgBackRest %i backup for stanza {{ postgres_pgbackrest_stanza }}
+After=postgresql@{{ postgres_cluster_version }}-{{ postgres_cluster_name }}.service
+Wants=postgresql@{{ postgres_cluster_version }}-{{ postgres_cluster_name }}.service
+
+[Service]
+Type=oneshot
+User=postgres
+Group=postgres
+ExecStart=/usr/bin/pgbackrest --stanza={{ postgres_pgbackrest_stanza }} --type=%i backup
+# A base backup to remote S3 can take a long time; never wedge it on a timeout.
+TimeoutStartSec=0

--- a/roles/postgres/templates/pgbackrest-backup@.timer.j2
+++ b/roles/postgres/templates/pgbackrest-backup@.timer.j2
@@ -1,0 +1,12 @@
+[Unit]
+# {{ ansible_managed }}
+Description=Schedule pgBackRest {{ item.type }} backup for stanza {{ postgres_pgbackrest_stanza }}
+
+[Timer]
+Unit=pgbackrest-backup@{{ item.type }}.service
+OnCalendar={{ item.on_calendar }}
+RandomizedDelaySec={{ postgres_pgbackrest_randomized_delay_sec }}
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/roles/postgres/templates/pgbackrest.conf.j2
+++ b/roles/postgres/templates/pgbackrest.conf.j2
@@ -1,0 +1,24 @@
+# {{ ansible_managed }}
+# pgBackRest configuration for point-in-time recovery to S3-compatible storage.
+# repo1 is the homelab RustFS endpoint; the same objects are replicated to
+# Backblaze B2 out of band (identical bucket name on both sides).
+[global]
+repo1-type=s3
+repo1-s3-bucket={{ postgres_backup_s3_bucket }}
+repo1-s3-endpoint={{ postgres_backup_s3_endpoint }}
+repo1-s3-region={{ postgres_backup_s3_region }}
+repo1-s3-uri-style={{ postgres_backup_s3_uri_style }}
+repo1-s3-key={{ postgres_backup_s3_access_key_id }}
+repo1-s3-key-secret={{ postgres_backup_s3_secret_access_key }}
+repo1-path={{ postgres_pgbackrest_repo_path }}
+repo1-retention-full={{ postgres_pgbackrest_retention_full }}
+# zstd compression + parallelism keep base backups small and fast over the LAN.
+compress-type=zst
+process-max=2
+start-fast=y
+log-level-console=info
+log-level-file=detail
+
+[{{ postgres_pgbackrest_stanza }}]
+pg1-path={{ postgres_data_dir }}
+pg1-port={{ postgres_port }}


### PR DESCRIPTION
## Summary

Adds a physical **point-in-time-recovery (PITR)** tier to the `postgres` role: **pgBackRest** archives WAL continuously and takes scheduled base backups to an S3-compatible object store. This is a *second, independent* backup layer that sits alongside — not replacing — the existing `pg_dump` logical backups and the #983 streaming replication.

Source half of the P1.5 backups work. **Inert on merge** (off by default); the live converge, bucket/key provisioning, B2 replication, and restore drills are out of scope here.

## Tool choice: pgBackRest (vs wal-g)

pgBackRest wins on every axis that matters here:

- **Native package, no Docker.** Ships in Debian/PGDG apt (`pgbackrest`); the role already wires the PGDG repo, so install is one `apt` task. wal-g has no first-class Debian package (Go binary you vendor yourself), which conflicts with the repo's native-package convention.
- **Native S3 with a custom endpoint + path-style** (`repo1-s3-uri-style=path`) — exactly what RustFS/MinIO need. Same S3 client the repo's `langfuse_docker` role already points at RustFS.
- **Retention + WAL expiry in one knob** (`repo1-retention-full`), continuous WAL `archive-push`, and a real `restore --delta` + `--target` PITR path.
- **Built-in `check`/`info`** for converge-time verification.

wal-g would be more moving parts for the same outcome.

## What it does

- **Primary-only** (`postgres_role == 'primary'`, the #983 switch) — the primary owns `archive_command`; a standby's WAL arrives via streaming.
- **Master flag off by default** so the merge changes nothing until bring-up.
- **WAL archiving**: sets `wal_level=replica`, `archive_mode=on`, `archive_command=pgbackrest ... archive-push %p` (idempotent `postgresql_set`), then `stanza-create` (guarded) + `check`.
- **Scheduled base backups**: a weekly full + daily incremental (pgBackRest promotes the first backup to full) via one instanced systemd unit `pgbackrest-backup@.service` driven by per-type timers.
- **Restore path**: `tags: [never, pgbackrest_restore]` + var-gated (`postgres_pgbackrest_restore`), never automatic — stops the cluster, `restore --delta` (optionally `--type/--target`), starts it to replay WAL. This is what the restore drill exercises.

## Bucket / prefix contract

- Bucket **`dryvist-homelab-backups`** — identical on RustFS and Backblaze B2 (B2's namespace is global, so one globally-unique name satisfies the 1:1 parity rule).
- Objects under **`postgres/<cluster_name>/`** via `repo1-path` (pgBackRest's default layout preserved verbatim beneath the prefix, so replication to B2 is byte-for-byte).
- Endpoint + credentials are **read from env** (injection-agnostic): `POSTGRES_BACKUP_S3_ENDPOINT`, `POSTGRES_BACKUP_S3_ACCESS_KEY_ID`, `POSTGRES_BACKUP_S3_SECRET_ACCESS_KEY`, optional `POSTGRES_BACKUP_S3_REGION`.

## Deviation (flag name)

The task asked for a master flag named `postgres_backup_enabled`. That name is **already** the `pg_dump` tier's switch and defaults **true**; repurposing it would silently disable logical backups. This tier therefore owns a distinct flag, **`postgres_pgbackrest_enabled`** (default false). Called out in the defaults comment too.

## Validation

- `ansible-lint roles/postgres` — **production profile, 0 failures** (12 files).
- `ansible-playbook --syntax-check` on `site.yml` — passes.
- Self-check playbook asserts the restore-argv derivation (both latest and pinned-target branches) and the `<bucket>/postgres/<cluster>` object layout — passes.

## Out of scope (owned elsewhere)

Bucket creation on RustFS/B2, scoped B2 key mint into OpenBao, the RustFS→B2 replication job, vzdump guest backups, and the live converge/drills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TduAFRb5WCmy1crcz8jSrQ