### PR TITLE
feat(object_storage): private versioned dryvist-homelab-backups bucket

### DIFF
--- a/roles/object_storage/defaults/main.yml
+++ b/roles/object_storage/defaults/main.yml
@@ -67,6 +67,11 @@ object_storage_aws_env:
 #   served it — the build fetches via plain get_url with no auth); the artifact
 #   is gated by the internal-network boundary, not a bucket ACL, exactly like the
 #   other buckets. Operator-staged.
+# - dryvist-homelab-backups: the guest/database backup target (pgBackRest and the
+#   guest vzdump S3 sync leg write here). PRIVATE — no `policy` key, so it never
+#   gets the anonymous-read document; backups must never be world-readable on the
+#   internal network. Versioned like the others for on-site anti-deletion; the
+#   same 1:1-named bucket mirrors to Backblaze B2 with object lock out of band.
 object_storage_default_buckets:
   - name: splunk-addons
     policy: download
@@ -76,6 +81,8 @@ object_storage_default_buckets:
     versioning: true
   - name: idrac
     policy: download
+    versioning: true
+  - name: dryvist-homelab-backups
     versioning: true
 
 # Lifecycle: expire noncurrent object versions after this many days, bounding


### PR DESCRIPTION
## What

Adds `dryvist-homelab-backups` to the object_storage (RustFS) role's default bucket list. This is the target for the homelab's guest and database backups.

## Contract

- **Private.** No `policy` key, so the role's anonymous-read (`download`) policy tasks skip it entirely — the filter only selects buckets whose `policy == download`. Backups must never be world-readable on the internal network, unlike the artifact-mirror buckets.
- **Versioned.** `versioning: true` gives on-site anti-deletion (overwrites and deletes leave recoverable prior versions).
- **Lifecycle-bounded.** Inherits the shared noncurrent-version expiration ceiling; the role has no per-bucket lifecycle knob, so it matches its siblings.

The same bucket name mirrors 1:1 to off-site immutable object storage (object lock) out of band, so the name is deliberately globally unique.

## Scope

Defaults-only, one bucket entry plus a comment. The role's existing create/versioning/lifecycle tasks already handle any `versioning: true` bucket, so no task changes are needed. `ansible-lint` passes (production profile, 0 failures).

Part of the backup design for the shared apps data platform (task #7).