### PR TITLE
feat(llm_router): add deepseek-v4-flash OpenRouter alias; bump hermes bundle to v0.4.0

### DIFF
--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -48,7 +48,7 @@ hermes_agent_installer_path: "/usr/local/lib/hermes-agent-installer-{{ hermes_ag
 # autonomous-base.md + the Hermes variant — no vendored copy to drift.
 # Bump the tag deliberately: renovate opens the PR on each nix-hermes release;
 # a bad ref fails the converge loudly at the controller build step.
-hermes_agent_bundle_flake_ref: "github:dryvist/nix-hermes/nix-hermes-v0.2.0#hermes-bundle"
+hermes_agent_bundle_flake_ref: "github:dryvist/nix-hermes/nix-hermes-v0.4.0#hermes-bundle"
 
 # --- Brain: the LiteLLM router (the fabric front door, OpenAI-compatible /v1) ---
 # Reached by its neutral Traefik FQDN — never a hardcoded IP. The router routes by

--- a/roles/llm_router/defaults/main.yml
+++ b/roles/llm_router/defaults/main.yml
@@ -197,6 +197,11 @@ llm_router_openrouter_models:
     model: nvidia/nemotron-3-ultra-550b-a55b:free
     key_field: nvidia-nemotron-3-ultra-550b-a55b-free
     context_window: 1000000
+  # Cheap paid egress: efficiency-optimized MoE, $0.09/$0.18 per 1M tokens.
+  - alias: deepseek-v4-flash
+    model: deepseek/deepseek-v4-flash
+    key_field: deepseek-deepseek-v4-flash
+    context_window: 1000000
 
 # --- Routing behaviour -------------------------------------------------------
 # Load-balance across same-name deployments; cool a failed one down so traffic

--- a/roles/openbao_secrets/defaults/main.yml
+++ b/roles/openbao_secrets/defaults/main.yml
@@ -96,9 +96,9 @@ openbao_secrets_domains:
       - ai/open-webui  # OPEN_WEBUI_SECRET_KEY, OPEN_WEBUI_OPENAI_API_KEY
       - ai/hermes      # GH_PAT_WRITE_PROJECT_ISSUES, HERMES_GITHUB_APP_{ID,INSTALLATION_ID,
                        #   PRIVATE_KEY}. The old account-wide OPENROUTER_API_KEY
-                       #   parked here is SUPERSEDED by the per-model keys in
-                       #   ai/saas/openrouter below — retire it (bao kv delete
-                       #   field) once the per-model keys are seeded.
+                       #   was transferred to the deepseek-deepseek-v4-flash
+                       #   per-model field in ai/saas/openrouter and removed
+                       #   from this path (2026-07-16).
       - ai/saas/openrouter  # Paid-SaaS provider key area (ai/saas/<provider>).
                        #   One field per OpenRouter MODEL (field name = model
                        #   slug, e.g. nvidia-nemotron-3-ultra-550b-a55b-free),


### PR DESCRIPTION
## Summary
- Second per-model OpenRouter egress alias: `deepseek-v4-flash` → `deepseek/deepseek-v4-flash` (1M context, cheap paid). Key field `deepseek-deepseek-v4-flash` is already seeded in the SaaS key area — the old account-wide OpenRouter key in `ai/hermes` was transferred there and removed; the `openbao_secrets` comment now records that.
- Bumps `hermes_agent_bundle_flake_ref` to `nix-hermes-v0.4.0`, whose composed SOUL.md tells every Hermes instantiation about the OpenRouter aliases (dryvist/nix-hermes#13).

## Verification
- `ansible-lint` production profile clean on the changed roles.
- Render contract for the OpenRouter tier already covered by `tests/template_render` (entry renders only when its key resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUqvNUuZP36gQMRgb7dcEn