### PR TITLE
feat(inventory): opt-in Nautobot GraphQL dynamic inventory

### DIFF
--- a/inventory/nautobot.yml
+++ b/inventory/nautobot.yml
@@ -1,0 +1,118 @@
+---
+# =============================================================================
+# OPT-IN Nautobot GraphQL dynamic inventory (networktocode.nautobot.gql_inventory)
+# =============================================================================
+# This is a PARALLEL inventory, NOT a replacement for inventory/load_tofu.yml.
+# The default path (inventory/hosts.yml + load_tofu.yml, wired in ansible.cfg)
+# is unchanged. Cutting over to Nautobot-sourced inventory is the deliberate
+# "migration moment" — it happens later, explicitly, by choosing `-i` (and, at
+# that point, enabling this plugin in ansible.cfg). Nothing here is referenced
+# by hosts.yml or ansible.cfg.
+#
+# WHY the groups below mirror load_tofu: so a future `-i inventory/nautobot.yml`
+# swap is drop-in — every play in site.yml targets a tag-derived `*_group`, and
+# this file reproduces that exact tag -> group mapping from Nautobot device/VM
+# tags via the `constructed` `groups` option.
+#
+# -----------------------------------------------------------------------------
+# Credentials (env, injection-agnostic — the plugin's native `env:` fallbacks):
+#   NAUTOBOT_URL    - API endpoint, shape https://nautobot.<PROXMOX_DOMAIN>
+#   NAUTOBOT_TOKEN  - Nautobot API token with read on dcim/virtualization/tags
+# An inventory plugin file cannot Jinja-template a group_var the way group_vars
+# can, so the URL is not written here — it comes from NAUTOBOT_URL at runtime.
+#
+# Token: OpenBao secret/apps/nautobot currently holds SUPERUSER creds. Inventory
+# should NOT use those — mint a dedicated read-only API token as a follow-up and
+# inject it as NAUTOBOT_TOKEN. Superuser will work in the interim but is wrong.
+#
+# -----------------------------------------------------------------------------
+# Opt-in usage (does NOT touch ansible.cfg — enable the plugin per-invocation):
+#
+#   NAUTOBOT_URL=https://nautobot.<domain> NAUTOBOT_TOKEN=<ro-token> \
+#   ANSIBLE_INVENTORY_ENABLED=networktocode.nautobot.gql_inventory \
+#     doppler run -- ansible-playbook -i inventory/nautobot.yml \
+#       playbooks/site.yml --limit <group>
+#
+# At the real cutover, add the plugin to ansible.cfg `enable_plugins` and make
+# `-i inventory/nautobot.yml` the default instead of load_tofu.
+# =============================================================================
+plugin: networktocode.nautobot.gql_inventory
+
+# api_endpoint/token intentionally omitted — resolved from NAUTOBOT_URL /
+# NAUTOBOT_TOKEN (the plugin's native env fallbacks). validate_certs stays at
+# its default (true): the endpoint is Traefik-fronted with a real certificate.
+
+# Pull name, primary IP (-> ansible_host), and tags (-> grouping) for both
+# bare-metal devices and virtual machines; Proxmox guests may be modeled as
+# either, so query both and let the tag groups sort them.
+query:
+  devices:
+    name:
+    primary_ip4:
+      host:
+    tags: name
+  virtual_machines:
+    name:
+    primary_ip4:
+      host:
+    tags: name
+
+# Reproduce load_tofu.yml's tag -> group mapping 1:1 (including the aliased
+# names: tag `smtp` -> mailpit_group, `database` -> mssql_group, `dns` ->
+# technitium_dns_group, `vpn` -> download_vpn_group, `ipam` -> phpipam_group,
+# `vectordb` -> qdrant_group, `rag` -> llamaindex_group). Left side is the exact
+# group name a site.yml play targets; right side is the Nautobot tag condition.
+#
+# ponytail: assumes `tags: name` exposes the host's `tags` var as a list of tag
+# NAME strings. If the live plugin surfaces tags as a list of dicts instead,
+# these become `tags | map(attribute='name')`. Unverifiable here (no live
+# Nautobot token) — confirm at cutover with `ansible-inventory --list --yaml`.
+groups:
+  haproxy_group: "'haproxy' in (tags | default([])) or 'loadbalancer' in (tags | default([]))"
+  cribl_edge: "'edge' in (tags | default([])) and 'cribl' in (tags | default([]))"
+  cribl_stream_group: "'stream' in (tags | default([])) and 'cribl' in (tags | default([]))"
+  mailpit_group: "'smtp' in (tags | default([]))"
+  ntfy_group: "'push' in (tags | default([]))"
+  mssql_group: "'database' in (tags | default([]))"
+  postgres_group: "'postgres' in (tags | default([]))"
+  nautobot_group: "'nautobot' in (tags | default([]))"
+  qdrant_group: "'vectordb' in (tags | default([]))"
+  llamaindex_group: "'rag' in (tags | default([]))"
+  ollama_group: "'ollama' in (tags | default([]))"
+  open_webui_group: "'open-webui' in (tags | default([]))"
+  hermes_agent_group: "'hermes-agent' in (tags | default([]))"
+  llm_fast_group: "'llm-fast' in (tags | default([]))"
+  llm_router_group: "'llm-router' in (tags | default([]))"
+  ai_orchestration_group: "'ai-orchestration' in (tags | default([]))"
+  dify_group: "'dify' in (tags | default([]))"
+  langflow_group: "'langflow' in (tags | default([]))"
+  n8n_group: "'n8n' in (tags | default([]))"
+  langgraph_group: "'langgraph' in (tags | default([]))"
+  agent_exec_group: "'agent-exec' in (tags | default([]))"
+  langfuse_group: "'langfuse' in (tags | default([]))"
+  agentgateway_group: "'agentgateway' in (tags | default([]))"
+  apt_cacher_group: "'apt-cache' in (tags | default([]))"
+  registry_group: "'registry' in (tags | default([]))"
+  minio_group: "'minio' in (tags | default([]))"
+  object_storage_group: "'object-storage' in (tags | default([]))"
+  openbao_group: "'openbao' in (tags | default([]))"
+  technitium_dns_group: "'dns' in (tags | default([]))"
+  openproject_group: "'openproject' in (tags | default([]))"
+  healthchecks_group: "'healthcheck' in (tags | default([]))"
+  netmon_group: "'netmon' in (tags | default([]))"
+  unifi_metrics_group: "'unifi_metrics' in (tags | default([]))"
+  prometheus_group: "'prometheus' in (tags | default([]))"
+  download_vpn_group: "'vpn' in (tags | default([]))"
+  sonarr_group: "'sonarr' in (tags | default([]))"
+  radarr_group: "'radarr' in (tags | default([]))"
+  plex_group: "'plex' in (tags | default([]))"
+  seerr_group: "'seerr' in (tags | default([]))"
+  sortarr_group: "'sortarr' in (tags | default([]))"
+  immich_group: "'immich' in (tags | default([]))"
+  homeassistant_group: "'homeassistant' in (tags | default([]))"
+  phpipam_group: "'ipam' in (tags | default([]))"
+  traefik_group: "'traefik' in (tags | default([]))"
+  media_group: "'media' in (tags | default([]))"
+  idrac_kvm_group: "'idrac' in (tags | default([]))"
+  vikunja_group: "'vikunja' in (tags | default([]))"
+  zammad_group: "'zammad' in (tags | default([]))"

--- a/requirements.yml
+++ b/requirements.yml
@@ -29,6 +29,9 @@ collections:
   - name: community.postgresql
     version: ">=3.4.0"  # postgres role: postgresql_user/_db/_privs idempotent role+db creation
 
+  - name: networktocode.nautobot
+    version: ">=6.2.0"  # gql_inventory plugin (inventory/nautobot.yml) — opt-in parallel inventory
+
 roles:
   # Shared inventory resolver consumed by inventory/load_tofu.yml — replaces the
   # per-repo resolution-tier copy-paste. Pinned to the release that first ships


### PR DESCRIPTION
## Summary

Adds `inventory/nautobot.yml` — a `networktocode.nautobot.gql_inventory` (GraphQL) config — as a **parallel, opt-in** inventory source. It is deliberately **not** a replacement for `load_tofu.yml`: the default path (`hosts.yml` + `load_tofu.yml`, wired in `ansible.cfg`) is untouched, and this file is **not** referenced by `hosts.yml` or `ansible.cfg`. Cutting over to Nautobot-sourced inventory is the explicit "migration moment" — it happens later, by choosing `-i inventory/nautobot.yml`.

Source-prep half of task #13's dynamic-inventory work.

## What's here

- **`requirements.yml`**: pins `networktocode.nautobot >= 6.2.0` (current latest; repo's `>=` floor pattern).
- **`inventory/nautobot.yml`**: the plugin config —
  - **Credentials from env** (the plugin's native fallbacks, injection-agnostic): `NAUTOBOT_URL` (shape `https://nautobot.<domain>`) and `NAUTOBOT_TOKEN`. An inventory plugin file can't Jinja a group_var, so the URL is not written into the file — it comes from `NAUTOBOT_URL` at runtime.
  - **GraphQL query** pulls `name`, `primary_ip4.host` (→ `ansible_host`), and `tags: name` for **both** `devices` and `virtual_machines` (Proxmox guests may be modeled as either).
  - **Grouping reproduces `load_tofu.yml`'s tag→group mapping 1:1** via the `constructed` `groups` option, including the aliased names (`smtp`→`mailpit_group`, `database`→`mssql_group`, `dns`→`technitium_dns_group`, `vpn`→`download_vpn_group`, `ipam`→`phpipam_group`, `vectordb`→`qdrant_group`, `rag`→`llamaindex_group`, and the compound `haproxy`/`loadbalancer` and `edge`+`cribl` / `stream`+`cribl` rules). A self-check asserts the 48 group names match `load_tofu` exactly, so a future `-i` swap is drop-in for every `site.yml` play.

## Grouping approach

`gql_inventory` `extends_documentation_fragment: constructed`, so it supports `groups`/`keyed_groups`/`compose`. `keyed_groups` can't produce the `_group` suffix or the aliased names, so this uses the explicit **`groups`** dict (group name → Jinja condition on the host's `tags`), which mirrors `load_tofu`'s `if <tag> in tags` logic precisely.

## Opt-in usage (no `ansible.cfg` change)

`ansible.cfg` sets `enable_plugins = yaml`, so the plugin is enabled per-invocation instead of editing the config:

```bash
NAUTOBOT_URL=https://nautobot.<domain> NAUTOBOT_TOKEN=<ro-token> \
ANSIBLE_INVENTORY_ENABLED=networktocode.nautobot.gql_inventory \
  doppler run -- ansible-playbook -i inventory/nautobot.yml playbooks/site.yml --limit <group>
```

At the real cutover, add the plugin to `enable_plugins` and make `-i inventory/nautobot.yml` the default.

## Token note (follow-up)

OpenBao `secret/apps/nautobot` currently holds **superuser** creds. Inventory should use a **dedicated read-only API token** (dcim/virtualization/tags read) minted as its own follow-up and injected as `NAUTOBOT_TOKEN`; superuser works in the interim but is wrong. Documented in the file header.

## Validation

- `ansible-lint requirements.yml inventory/nautobot.yml` — **production profile, 0 failures**.
- Plugin selection: with the plugin enabled and dummy env, `ansible-inventory --list` selects `gql_inventory` for the file (confirming the `plugin:` key + filename). Full parse needs the `netutils`/`pynautobot` runtime deps + a live token — not present in the dev shell, so a live `--list` cannot complete here (expected; noted).
- Structure + parity self-check asserts valid YAML, correct plugin key, `tags` pulled on both models, and that the `groups` set equals `load_tofu`'s tag-driven groups 1:1 — passes.

## Known ceiling

The `groups` conditions assume `tags: name` surfaces the host's `tags` var as a list of name **strings**. If the live plugin surfaces tags as a list of dicts, the conditions become `tags | map(attribute='name')` — confirm at cutover with `ansible-inventory --list --yaml` against live Nautobot. Marked with a `ponytail:` comment in the file.

## Out of scope

Host-type/base groups (`lxc_containers`, `vms`, `docker_vms`, `splunk_group`) derive from tofu host classes, not tags — they map from Nautobot device role/platform during the SSoT import (task #13's live half), noted as a follow-up. Live Nautobot converge, SSoT import, and the read-only token mint are also out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TduAFRb5WCmy1crcz8jSrQ