### PR TITLE
fix(technitium): make the v15.4 pin real (re-seed mirror, add upgrade path)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,13 @@
       "matchPackageNames": ["openproject/openproject"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "description": "Technitium is mirror-hosted, so a version bump alone is inert-to-broken: Renovate cannot re-seed the object-storage tarball, re-checksum it, or move the .NET runtime pin when a major changes target framework (15.x is net10.0, 14.x was net9.0). A major landed unattended once and left the pins pointing at a 404. Block major bumps so they stay operator-driven per the re-seed note in roles/technitium_install/defaults/main.yml; minor/patch still flow.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["technitium/dns-server"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }

--- a/roles/technitium_dns/defaults/main.yml
+++ b/roles/technitium_dns/defaults/main.yml
@@ -162,18 +162,25 @@ technitium_dns_query_log_app_name: "Log Exporter"
 technitium_dns_query_log_app_mirror_endpoint: >-
   https://s3.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}/artifacts
 # App version is pinned to the Log Exporter build compatible with the RUNNING
-# server (14.3 -> the highest store entry whose serverVersion <= ours is
-# 14.2.0 -> app 2.1). NOT the latest (3.0.1 needs server 15.3). A Renovate bump
-# is only a SIGNAL — it cannot re-host a private object. On a server upgrade the
-# operator MUST (1) pick the app version for the new serverVersion from the
-# store manifest (https://go.technitium.com/?id=44), (2) re-seed
-# artifacts/technitium/<filename> in object-storage from a clean-egress host
-# (the homelab is UDW-blocked from Technitium — use a GitHub Actions runner),
-# and (3) update the version + sha256 below. NOTE app v3.x renamed the
-# `ebableEdnsLogging` typo key below to `enableEdnsLogging` — fix that in the
-# config too on a 3.x bump.
-# renovate: datasource=docker depName=technitium/dns-server
-technitium_dns_query_log_app_version: "15.4.0"
+# server: the app has its OWN version stream, unrelated to the server tag (app
+# 3.0.1 ships with server 15.4). It is sourced from the DnsServer repo at the
+# matching server tag — Apps/LogExporterApp/LogExporterApp.csproj carries the
+# authoritative <Version>. A Renovate bump is only a SIGNAL: it cannot re-host a
+# private object, and no datasource tracks this app, so major bumps are blocked
+# in renovate.json. On a server upgrade the operator MUST (1) read <Version>
+# from the csproj at the new server tag, (2) re-seed
+# artifacts/technitium/<filename> in object-storage, and (3) update the version
+# + sha256 below.
+#
+# Neither download.technitium.com nor go.technitium.com is reachable from this
+# network, so the vendor zip cannot be mirrored directly. Build it instead —
+# `dotnet build -c Release` the csproj at the server tag inside the
+# mcr.microsoft.com/dotnet/sdk image, referencing TechnitiumLibrary{,.Net}.dll
+# and DnsServerCore.ApplicationCommon.dll extracted from the matching
+# technitium/dns-server image (those are <Private>false</Private> compile-time
+# refs, so using the image's own copies guarantees an ABI match). Zip the build
+# output flat, minus README.md, to match the vendor layout.
+technitium_dns_query_log_app_version: "3.0.1"
 technitium_dns_query_log_app_filename: "LogExporterApp-{{ technitium_dns_query_log_app_version }}.zip"
 technitium_dns_query_log_app_url: >-
   {{ technitium_dns_query_log_app_mirror_endpoint }}/technitium/{{
@@ -181,7 +188,7 @@ technitium_dns_query_log_app_url: >-
 # sha256 of the mirrored zip — documents the exact pinned build (the
 # downloadAndInstall API has no checksum param, so this is verified by the
 # operator at seed time, not enforced at install). Update with the version.
-technitium_dns_query_log_app_sha256: "53e84d2c3b8715e5fd59b415b57920bd4845ef8cb38cc935c25bddb89915c7fd"
+technitium_dns_query_log_app_sha256: "b2c32bb090e164b102185db819d97b0bf4cbe8cbe6090a5e9ffebfecce13f0c3"
 # Same stable syslog entry point the syslog_forwarder role uses (the `syslog`
 # CNAME this very role creates -> HAProxy). Never a committed literal.
 technitium_dns_query_log_syslog_host: "syslog.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"

--- a/roles/technitium_dns/tasks/query_log.yml
+++ b/roles/technitium_dns/tasks/query_log.yml
@@ -37,6 +37,13 @@
       {{ technitium_dns_query_log_app_name in
          (technitium_dns_apps_installed.json.response.apps | default([])
           | map(attribute='name') | list) }}
+    # The server renders this from the app assembly's version with trailing
+    # zero components dropped (DnsWebService.GetCleanVersion), so it compares
+    # equal to the plain pin: assembly 3.0.1.0 -> "3.0.1". Empty when absent.
+    technitium_dns_query_log_app_live_version: >-
+      {{ technitium_dns_apps_installed.json.response.apps | default([])
+         | selectattr('name', 'eq', technitium_dns_query_log_app_name)
+         | map(attribute='version') | first | default('', true) }}
   when: technitium_dns_apply | bool
 
 - name: Install the Log Exporter app from the internal object-storage mirror
@@ -58,6 +65,32 @@
   when:
     - technitium_dns_apply | bool
     - not technitium_dns_query_log_app_installed
+  no_log: true
+
+# The install above only fires when the app is ABSENT, so an already-installed
+# app would keep its old build forever. The app is compiled against the server's
+# DnsServerCore.ApplicationCommon, so a server major upgrade strands it on an
+# incompatible build — this drift-gated update is what carries it across.
+- name: Update the Log Exporter app to the pinned version
+  ansible.builtin.uri:
+    url: >-
+      {{ technitium_dns_api_url }}/api/apps/downloadAndUpdate?token={{
+      technitium_dns_api_token }}&name={{
+      technitium_dns_query_log_app_name | urlencode }}&url={{
+      technitium_dns_query_log_app_url | urlencode }}
+    method: GET
+    return_content: true
+    timeout: "{{ technitium_dns_api_timeout }}"
+  register: technitium_dns_query_log_update
+  changed_when: technitium_dns_query_log_update.json.status == "ok"
+  failed_when: >-
+    technitium_dns_query_log_update.failed or
+    technitium_dns_query_log_update.json is not defined or
+    technitium_dns_query_log_update.json.status != "ok"
+  when:
+    - technitium_dns_apply | bool
+    - technitium_dns_query_log_app_installed
+    - technitium_dns_query_log_app_live_version != technitium_dns_query_log_app_version
   no_log: true
 
 - name: Read the live Log Exporter app config

--- a/roles/technitium_install/defaults/main.yml
+++ b/roles/technitium_install/defaults/main.yml
@@ -29,12 +29,14 @@ technitium_install_api_timeout: 30
 # the DNS-secondary bring-up entirely). Instead: the .NET runtime comes from
 # Microsoft's apt repo, and the Technitium app distribution is mirrored in our
 # own object-storage (RustFS) `artifacts` bucket (public-read, non-secret
-# binaries), captured from the official `technitium/dns-server:14.3.0` image's
-# `/opt/technitium/dns` (the 14.3 / .NET 9 build). Same bare-metal layout as the
+# binaries), captured from the official `technitium/dns-server:15.4.0` image's
+# `/opt/technitium/dns` (the 15.4 / .NET 10 build). Same bare-metal layout as the
 # primary; no single-vendor-host SPOF.
 
-# ASP.NET Core runtime package (installed from the Microsoft apt repo).
-technitium_install_dotnet_pkg: "aspnetcore-runtime-9.0"
+# ASP.NET Core runtime package (installed from the Microsoft apt repo). Must
+# match the target framework the pinned server build was compiled against: 15.x
+# is net10.0, 14.x was net9.0. A major bump moves this too.
+technitium_install_dotnet_pkg: "aspnetcore-runtime-10.0"
 
 # Mirror endpoint for the Technitium app tarball. The host + port resolve from
 # the published inventory (the object-storage container) — never a committed
@@ -49,15 +51,32 @@ technitium_install_mirror_endpoint: >-
 # every bump you MUST also: (1) re-seed artifacts/technitium/ in object-storage
 # from the new official build — extract /opt/technitium/dns from the matching
 # technitium/dns-server image and tar it with `dns/` as the archive root — and
-# (2) update technitium_install_app_sha256 below to the new tarball's digest.
+# (2) update technitium_install_app_sha256 below to the new tarball's digest,
+# (3) check the image's .deps.json "tfm" and move technitium_install_dotnet_pkg
+# + the -netN suffix below if the target framework changed.
+# Renovate cannot do any of that, so major bumps are blocked in renovate.json.
 # renovate: datasource=docker depName=technitium/dns-server
 technitium_install_app_version: "15.4.0"
-technitium_install_app_filename: "technitium-dns-app-{{ technitium_install_app_version }}-net9.tgz"
+technitium_install_app_filename: "technitium-dns-app-{{ technitium_install_app_version }}-net10.tgz"
 technitium_install_app_url: "{{ technitium_install_mirror_endpoint }}/technitium/{{ technitium_install_app_filename }}"
 # sha256 of the mirror object — pins the exact build (the vendor installer
 # offered no such guarantee). Update together with the version on every re-seed.
-technitium_install_app_sha256: "c34d32e73502067dabaa1803234eb4921c3986bfe3e4bc7e070b584571a99d25"
+technitium_install_app_sha256: "c696f7ce59dc3833d6044a26042a0d0e9a5e53e375129e4e1f744eb76fc38f0e"
+
+# The API reports the running version with trailing zero components dropped
+# (DnsWebService.GetCleanVersion), but always keeps Major.Minor: 15.4.0 -> "15.4",
+# 15.4.1 -> "15.4.1". Pins mirror the Docker tag (always X.Y.Z), so normalize the
+# pin the same way to make the upgrade drift-compare idempotent. The anchored
+# two-group form is what protects Major.Minor: a bare `(\.0)+$` strip would turn
+# a future "16.0.0" into "16", which the server never reports.
+technitium_install_app_version_clean: >-
+  {{ technitium_install_app_version | regex_replace('^(\d+\.\d+)(\.0)+$', '\1') }}
 
 # Install + data dirs (match the existing primary's bare-metal layout).
 technitium_install_app_dir: "/opt/technitium"
 technitium_install_data_dir: "/etc/dns"
+# Pre-upgrade snapshot of the data dir, taken while the service is stopped. The
+# binary swap only touches app_dir, but a new major MIGRATES the config/zone
+# schema in data_dir on first start — so re-extracting the old tarball is not by
+# itself a rollback. Restoring this archive alongside it is.
+technitium_install_backup_dir: "/var/backups/technitium"

--- a/roles/technitium_install/tasks/deploy_app.yml
+++ b/roles/technitium_install/tasks/deploy_app.yml
@@ -1,0 +1,39 @@
+---
+# Deploy the pinned Technitium app build into app_dir. Shared by the fresh
+# install and the upgrade paths so both land the exact same layout.
+#
+# Callers gate this behind their own `when`, and it always replaces
+# app_dir/dns, so it reports changed whenever it runs — which is only when a
+# deploy is actually due.
+
+- name: Ensure the Technitium app directory exists
+  ansible.builtin.file:
+    path: "{{ technitium_install_app_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: Download the Technitium app from the mirror (checksum-pinned)
+  ansible.builtin.get_url:
+    url: "{{ technitium_install_app_url }}"
+    dest: /tmp/technitium-app.tgz
+    checksum: "sha256:{{ technitium_install_app_sha256 }}"
+    mode: "0644"
+
+- name: Remove the previous app build (no-op on first install)
+  # app_dir holds binaries only — all state lives in data_dir, which the unit
+  # passes to DnsServerApp.dll as an argument. Clearing it first keeps a
+  # downgrade from leaving newer stray assemblies behind to be loaded.
+  ansible.builtin.file:
+    path: "{{ technitium_install_app_dir }}/dns"
+    state: absent
+
+- name: Extract the Technitium app distribution
+  ansible.builtin.unarchive:
+    src: /tmp/technitium-app.tgz
+    dest: "{{ technitium_install_app_dir }}"
+    remote_src: true
+
+- name: Remove the downloaded tarball
+  ansible.builtin.file:
+    path: /tmp/technitium-app.tgz
+    state: absent

--- a/roles/technitium_install/tasks/main.yml
+++ b/roles/technitium_install/tasks/main.yml
@@ -23,62 +23,46 @@
   failed_when: false
   changed_when: false
 
+# The runtime tasks below are idempotent and run on EVERY converge, not just
+# the fresh-install path: a server bump onto a newer target framework (15.x is
+# net10.0, 14.x was net9.0) needs the new runtime present BEFORE the binaries
+# are swapped. Previous runtimes are deliberately left installed — .NET runs
+# side-by-side, and keeping the old one is what lets a rollback to the previous
+# build start at all.
+- name: Gather minimal facts (Debian version for the Microsoft apt repo)
+  ansible.builtin.setup:
+    gather_subset:
+      - "!all"
+      - "min"
+
+- name: Install base dependencies
+  ansible.builtin.apt:
+    name:
+      - curl
+      - ca-certificates
+      - libicu-dev
+    state: present
+    update_cache: true
+
+- name: Register the Microsoft package repository (.NET runtime source)
+  # The config .deb installs the apt source list + signing key; this
+  # replaces the dead vendor host as the runtime source.
+  ansible.builtin.apt:
+    deb: >-
+      https://packages.microsoft.com/config/debian/{{
+      ansible_facts.distribution_major_version }}/packages-microsoft-prod.deb
+
+- name: Install the ASP.NET Core runtime
+  ansible.builtin.apt:
+    name: "{{ technitium_install_dotnet_pkg }}"
+    state: present
+    update_cache: true
+
 - name: Install Technitium DNS server (bare-metal from mirror)
   when: technitium_install_check.status == -1
   block:
-    - name: Gather minimal facts (Debian version for the Microsoft apt repo)
-      ansible.builtin.setup:
-        gather_subset:
-          - "!all"
-          - "min"
-
-    - name: Install base dependencies
-      ansible.builtin.apt:
-        name:
-          - curl
-          - ca-certificates
-          - libicu-dev
-        state: present
-        update_cache: true
-
-    - name: Register the Microsoft package repository (.NET runtime source)
-      # The config .deb installs the apt source list + signing key; this
-      # replaces the dead vendor host as the runtime source.
-      ansible.builtin.apt:
-        deb: >-
-          https://packages.microsoft.com/config/debian/{{
-          ansible_facts.distribution_major_version }}/packages-microsoft-prod.deb
-
-    - name: Install the ASP.NET Core runtime
-      ansible.builtin.apt:
-        name: "{{ technitium_install_dotnet_pkg }}"
-        state: present
-        update_cache: true
-
-    - name: Ensure the Technitium app directory exists
-      ansible.builtin.file:
-        path: "{{ technitium_install_app_dir }}"
-        state: directory
-        mode: "0755"
-
-    - name: Download the Technitium app from the mirror (checksum-pinned)
-      ansible.builtin.get_url:
-        url: "{{ technitium_install_app_url }}"
-        dest: /tmp/technitium-app.tgz
-        checksum: "sha256:{{ technitium_install_app_sha256 }}"
-        mode: "0644"
-
-    - name: Extract the Technitium app distribution
-      ansible.builtin.unarchive:
-        src: /tmp/technitium-app.tgz
-        dest: "{{ technitium_install_app_dir }}"
-        remote_src: true
-        creates: "{{ technitium_install_app_dir }}/dns/DnsServerApp.dll"
-
-    - name: Remove the downloaded tarball
-      ansible.builtin.file:
-        path: /tmp/technitium-app.tgz
-        state: absent
+    - name: Deploy the pinned Technitium app build
+      ansible.builtin.include_tasks: deploy_app.yml
 
     - name: Install the dns.service systemd unit
       ansible.builtin.template:
@@ -165,6 +149,82 @@
   changed_when: false
   failed_when: technitium_install_login.json.status | default('') != "ok"
   no_log: true
+
+# The install block above only fires when the API is unreachable, so an
+# already-running server would never pick up a version bump — the pins could
+# advance while the fleet silently stayed put. This is the upgrade path. It is
+# gated on the version the server actually reports, so a converge with no bump
+# pending is a no-op. Runs here (not next to the install block) because the
+# running version comes from the authenticated login response above.
+- name: Upgrade Technitium DNS server to the pinned version
+  when:
+    - technitium_install_check.status != -1
+    - >-
+      (technitium_install_login.json.info.version | default('', true)) !=
+      (technitium_install_app_version_clean | trim)
+  block:
+    - name: Ensure the backup directory exists
+      ansible.builtin.file:
+        path: "{{ technitium_install_backup_dir }}"
+        state: directory
+        mode: "0700"
+
+    - name: Stop dns.service before swapping the app binaries
+      ansible.builtin.systemd_service:
+        name: dns.service
+        state: stopped
+
+    - name: Back up the data directory (rollback point)
+      # Taken while stopped, so the on-disk config/zones are quiescent. Named
+      # for the version being replaced — that is the build this archive pairs
+      # with if the upgrade has to be rolled back.
+      community.general.archive:
+        path: "{{ technitium_install_data_dir }}"
+        dest: >-
+          {{ technitium_install_backup_dir }}/dns-data-{{
+          technitium_install_login.json.info.version }}-{{
+          ansible_facts.date_time.epoch }}.tgz
+        format: gz
+        mode: "0600"
+
+    - name: Deploy the pinned Technitium app build
+      ansible.builtin.include_tasks: deploy_app.yml
+
+    - name: Start Technitium DNS
+      ansible.builtin.systemd_service:
+        name: dns.service
+        state: started
+
+    - name: Wait for Technitium to come back after the upgrade
+      ansible.builtin.uri:
+        url: "{{ technitium_install_api_url }}"
+        method: GET
+        status_code: [200, 301, 302]
+        timeout: "{{ technitium_install_api_timeout }}"
+      register: technitium_install_upgrade_wait
+      retries: 12
+      delay: 5
+      until: technitium_install_upgrade_wait.status in [200, 301, 302]
+
+    - name: Confirm the upgraded server reports the pinned version
+      # Answering on the port is not proof the new build loaded — a runtime
+      # mismatch fails at assembly load, not at startup. Assert the version.
+      ansible.builtin.uri:
+        url: "{{ technitium_install_api_url }}/api/user/login"
+        method: POST
+        body_format: form-urlencoded
+        body:
+          user: "{{ technitium_install_admin_user }}"
+          pass: "{{ technitium_install_admin_password }}"
+        return_content: true
+        timeout: "{{ technitium_install_api_timeout }}"
+      register: technitium_install_upgrade_verify
+      changed_when: false
+      failed_when: >-
+        (technitium_install_upgrade_verify.json.status | default('')) != "ok" or
+        (technitium_install_upgrade_verify.json.info.version | default('')) !=
+        (technitium_install_app_version_clean | trim)
+      no_log: true
 
 - name: Create API token
   # Technitium /api/user/createToken takes user/pass directly (not a


### PR DESCRIPTION
## Why

The v15.4.0 bump landed as a version string only. Nothing re-seeded the mirror
or moved the checksums, so the pins described a build that was never published.
Three defects, all masked by the same gate:

1. `technitium_install_app_sha256` was still 14.3.0's digest, and the templated
   filename resolved to an object that 404s.
2. **15.x targets `net10.0`** (14.x was `net9.0`), but the role pinned
   `aspnetcore-runtime-9.0` — the pinned runtime could not have run the build
   the version claimed.
3. The Log Exporter version was set to the *server* tag (`15.4.0`). The app has
   its own version stream (`3.0.1`), and its `sha256` was still 2.1's — pinned
   against a filename that does not exist.

None of this ever fired against the running fleet: the install path is gated on
the API being unreachable, and all three servers answer. This was a DR/rebuild
landmine, not an outage — a rebuild would have failed on the 404.

## What

**Re-seeded the mirror.** Neither vendor host (`download.technitium.com`,
`go.technitium.com`) resolves from this network, so the vendor zip cannot be
mirrored directly. The server tarball comes from the official image; the Log
Exporter is built from source at the matching server tag, against the reference
assemblies extracted from that same image (they are `<Private>false</Private>`
compile-time refs, so using the image's own copies guarantees an ABI match).
Procedure is recorded in the role defaults. **The 14.3.0 tarball stays in the
mirror as the rollback binary.**

**Added upgrade paths.** Both installs were gated on *absence* — the server on
the API being unreachable, the app on not being present — so neither could move
an already-running host. Both are now drift-gated on the version the server
actually reports, so a converge with no bump pending is a no-op.

**Runtime install now runs every converge.** An upgrade onto a new target
framework needs the runtime present *before* the swap. Old runtimes are
deliberately left installed: .NET runs side-by-side, and keeping the previous
one is what lets a rollback to the previous build start at all.

**Data-dir snapshot** is the other half of that rollback. The binary swap only
touches the app dir, but a new major migrates the config/zone schema on first
start — so re-extracting the old tarball is not by itself a rollback.

**Renovate blocks Technitium majors.** This is the root-cause fix: a bump alone
can never re-seed, re-checksum, or move the runtime pin. Majors stay
operator-driven; minor/patch still flow.

## Verification

- Both mirrored objects return **200 to an anonymous GET** and their sha256
  matches the pins in this PR.
- `ansible-lint` passes the **production** profile (0 failures, 0 warnings).
- `site.yml --syntax-check` exits clean.
- The version-compare renders correctly through Jinja for `15.4.0` → `15.4`,
  `14.3.0` → `14.3`, `15.4.1` → `15.4.1`, `16.0.0` → `16.0` (the API drops
  trailing zero components but always keeps Major.Minor).
- The built app reports `3.0.1` through the server's own version-rendering
  logic, so the drift compare is idempotent — confirmed by reflecting on the
  built assembly, not inferred.

## Not covered by CI

`molecule` cannot run locally or in CI for this role:
- `technitium_dns` is **not in the CI molecule matrix**.
- Locally, `molecule-plugins` 23.5.3 is incompatible with `ansible-core` 2.21 —
  its own vendored `create.yml`/`destroy.yml` use `when: (lookup('env','HOME'))`,
  which fails strict-boolean conditionals. This reproduces on an untouched
  scenario on `develop`, so it is pre-existing and unrelated to this change.
  Filed separately rather than worked around.

**This PR is the safe half.** It changes no live server on its own — the
upgrade only fires on a `--tags dns` converge, which is a separate supervised
step (canary → secondary → primary, with the 14.3.0 rollback rehearsed).