### PR TITLE
fix(technitium): read the running version from session/get, not login

### DIFF
--- a/roles/technitium_install/tasks/main.yml
+++ b/roles/technitium_install/tasks/main.yml
@@ -150,17 +150,33 @@
   failed_when: technitium_install_login.json.status | default('') != "ok"
   no_log: true
 
+- name: Read the running server version
+  # /api/user/login does NOT carry an info block — only /api/user/session/get
+  # reports info.version. Reading the version off the login response yields an
+  # undefined attribute, so the upgrade gate can never compare a real version.
+  ansible.builtin.uri:
+    url: >-
+      {{ technitium_install_api_url }}/api/user/session/get?token={{
+      technitium_install_login.json.token }}
+    method: GET
+    return_content: true
+    timeout: "{{ technitium_install_api_timeout }}"
+  register: technitium_install_session
+  changed_when: false
+  failed_when: technitium_install_session.json.status | default('') != "ok"
+  no_log: true
+
 # The install block above only fires when the API is unreachable, so an
 # already-running server would never pick up a version bump — the pins could
 # advance while the fleet silently stayed put. This is the upgrade path. It is
 # gated on the version the server actually reports, so a converge with no bump
 # pending is a no-op. Runs here (not next to the install block) because the
-# running version comes from the authenticated login response above.
+# running version comes from the authenticated session lookup above.
 - name: Upgrade Technitium DNS server to the pinned version
   when:
     - technitium_install_check.status != -1
     - >-
-      (technitium_install_login.json.info.version | default('', true)) !=
+      (technitium_install_session.json.info.version | default('', true)) !=
       (technitium_install_app_version_clean | trim)
   block:
     - name: Ensure the backup directory exists
@@ -182,7 +198,7 @@
         path: "{{ technitium_install_data_dir }}"
         dest: >-
           {{ technitium_install_backup_dir }}/dns-data-{{
-          technitium_install_login.json.info.version }}-{{
+          technitium_install_session.json.info.version | default('unknown', true) }}-{{
           ansible_facts.date_time.epoch }}.tgz
         format: gz
         mode: "0600"
@@ -206,9 +222,9 @@
       delay: 5
       until: technitium_install_upgrade_wait.status in [200, 301, 302]
 
-    - name: Confirm the upgraded server reports the pinned version
-      # Answering on the port is not proof the new build loaded — a runtime
-      # mismatch fails at assembly load, not at startup. Assert the version.
+    - name: Log in to the upgraded server
+      # A fresh login: the pre-upgrade session token does not survive the
+      # restart, so it cannot be reused to read the new version.
       ansible.builtin.uri:
         url: "{{ technitium_install_api_url }}/api/user/login"
         method: POST
@@ -216,6 +232,21 @@
         body:
           user: "{{ technitium_install_admin_user }}"
           pass: "{{ technitium_install_admin_password }}"
+        return_content: true
+        timeout: "{{ technitium_install_api_timeout }}"
+      register: technitium_install_upgrade_login
+      changed_when: false
+      failed_when: technitium_install_upgrade_login.json.status | default('') != "ok"
+      no_log: true
+
+    - name: Confirm the upgraded server reports the pinned version
+      # Answering on the port is not proof the new build loaded — a runtime
+      # mismatch fails at assembly load, not at startup. Assert the version.
+      ansible.builtin.uri:
+        url: >-
+          {{ technitium_install_api_url }}/api/user/session/get?token={{
+          technitium_install_upgrade_login.json.token }}
+        method: GET
         return_content: true
         timeout: "{{ technitium_install_api_timeout }}"
       register: technitium_install_upgrade_verify


### PR DESCRIPTION
## Problem

PR #993 added the Technitium upgrade path but read the running version from the
wrong endpoint. Verified against a live 14.3 server:

- `/api/user/login` → `{displayName, username, totpEnabled, server, status}` — **no `info` block**
- `/api/user/session/get` → includes `info.version: "14.3"`

## Impact

`technitium_install_login.json.info.version` is an undefined attribute. Two failures:

1. **Gate always true** — `default('', true)` makes it compare `'' != '15.4'`, so an upgrade always looks pending.
2. **Upgrade aborts with the server stopped** — the rollback-archive filename interpolates the same attribute *after* `dns.service` is stopped. Jinja raises on the undefined attribute, leaving a stopped DNS server and no binary swap.

## Fix

Add an authenticated `session/get` lookup and source the version from it in all three places: upgrade gate, archive name, post-upgrade assertion. The post-upgrade check re-logs in first — the pre-upgrade session token does not survive the restart.

## Why CI missed it

No Molecule scenario runs a real Technitium server, so the API response shape is never exercised. Caught by probing the live fleet before rollout.

## Verification

- `ansible-lint roles/technitium_install/` → passed, 0 failures (profile `production`)
- Live probe confirms `session/get` reports `14.3` on all three servers