### PR TITLE
feat(openbao): generate the shared-apps postgres replication credential

### DIFF
--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -146,6 +146,11 @@ openbao_generated_app_secrets:
   # db_password. The consumers already read the namespaced names
   # (inventory/group_vars/{zammad_group,postgres_group}.yml).
   zammad: [zammad_db_password, zammad_admin_password, zammad_hermes_api_token]
+  # Streaming-replication credential for the shared-apps Postgres pair (the
+  # postgres role's primary creates the replicator login with it; the standby
+  # puts it in .pgpass). Bare name is safe in the flat bao_apps_secrets merge —
+  # no other app path carries a replication_password field.
+  postgres: [replication_password]
 # Random length for generated app credentials (alnum). secret_key needs more
 # entropy than a login credential, so it gets its own length (matches the 64-char
 # key the nautobot role generates locally when none is supplied).

--- a/roles/openbao_secrets/defaults/main.yml
+++ b/roles/openbao_secrets/defaults/main.yml
@@ -87,6 +87,10 @@ openbao_secrets_domains:
       # (app-namespaced, matches the postgres + vikunja_group consumers) plus the
       # MCP svc-account passwords + API tokens. Merged flat into bao_apps_secrets.
       - apps/vikunja
+      # Shared-apps Postgres replication credential (generated at source by
+      # roles/openbao openbao_generated_app_secrets.postgres); consumed by the
+      # postgres role on both the primary and the standby.
+      - apps/postgres
   - name: local-llm
     role_id_env: LOCAL_LLM_VAULT_ROLE_ID
     secret_id_env: LOCAL_LLM_VAULT_SECRET_ID


### PR DESCRIPTION
Adds the streaming-replication credential for the shared-apps Postgres pair to the OpenBao plumbing:

- `roles/openbao/defaults/main.yml`: `postgres: [replication_password]` in `openbao_generated_app_secrets` — seeded generate-if-absent at `secret/apps/postgres`, and the `apps` policy loop picks the path up automatically via `openbao_apps_read_apps`.
- `roles/openbao_secrets/defaults/main.yml`: `apps/postgres` added to the apps domain path list so `bao_apps_secrets.replication_password` resolves bao-first for the postgres role (primary creates the replicator login; standby writes .pgpass).

The bare field name is collision-safe in the flat apps-domain merge (no other app path carries `replication_password`).

Refs #138 (streaming replication).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TduAFRb5WCmy1crcz8jSrQ