### PR TITLE
fix(site): OpenBao secrets pre-fetch must run on every tagged converge

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -26,9 +26,14 @@
     postgres_group:nautobot_group:zammad_group:vikunja_group:
     sonarr_group:radarr_group:plex_group:seerr_group:sortarr_group:download_vpn_group:immich_group
   gather_facts: false
+  # `always`: every consumer role resolves its secrets bao-first, so a tagged
+  # converge (--tags zammad, --tags nautobot, ...) MUST still run this play —
+  # under the old `openbao_secrets, ai` tags a tagged converge skipped the
+  # fetch and templated empty passwords (zammad database.yml, 2026-07-16).
+  # The role still skips cleanly when BAO_ADDR / a domain's AppRole envs are
+  # unset, so `always` costs nothing in env-less runs.
   tags:
-    - openbao_secrets
-    - ai
+    - always
   tasks:
     - name: Fetch each resource-domain's KV subtree via its own AppRole
       ansible.builtin.include_role:


### PR DESCRIPTION
Fourth layer of the zammad restore: `--tags zammad` (or any app tag) skipped the Phase-0 OpenBao pre-fetch play (tagged `openbao_secrets, ai`), so `bao_apps_secrets` was `{}` and `database.yml` rendered with an **empty password** → silent Rails boot abort (`fe_sendauth: no password supplied` proven via direct PG connect from the guest). The APPS AppRole itself reads `apps/zammad` fine (verified live).

`tags: always` on the pre-fetch play; it still skips cleanly when BAO_ADDR / AppRole envs are absent. This also protects every other bao-first app converge (`--tags nautobot`, `--tags vikunja`, ...) from the same empty-secret render.

Verification: converge `--tags zammad` post-merge renders a working database.yml (restore loop continues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6JuKQiA3nNTJ81ww1wgFo