### PR TITLE
chore(secrets): drop SOPS values whose SSOT moved to OpenBao

### DIFF
--- a/secrets.enc.yaml
+++ b/secrets.enc.yaml
@@ -23,17 +23,8 @@ LANGFUSE_S3_ACCESS_KEY_ID: ENC[AES256_GCM,data:AqxfImbQgmaem7ub1sZgFmsIE7VvA2MY,
 LANGFUSE_S3_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:BvMUpdIKd1j65U9JGBSiu+HUFxy5X5RW0yaWPB25pnrcZjax7j+BgaykFOcpFNVSO7EQ038oEypuYZgXUJWEtQ==,iv:+tkAn3js4IhL+oZXCIUGJBdeq0dM6Ksbg0NRgBG+bjU=,tag:XtS5RhwAMhh6RGG564LwPg==,type:str]
 N8N_DB_PASSWORD: ENC[AES256_GCM,data:WH9+cLkFWkUFEzt8atS/hzBGr28GHjjLzZjJdO6cK+0=,iv:Weu4ZJcitkOmvYmk4npZketVMcJIhV4pxRe9qnkGbxM=,tag:IOgIUuOWFjXqMagYpPZuHw==,type:str]
 N8N_OWNER_PASSWORD: ENC[AES256_GCM,data:p0XLJdXcuthcatYT+zPeueyRqYTEuaa9,iv:ihKeV1Km+KWwmN6BTST5EASdJYv+U+rsLwgCmf2SnEg=,tag:nPzok0j/dH/S1YTretNrIw==,type:str]
-VIKUNJA_DB_PASSWORD: ENC[AES256_GCM,data:Jy+qiC6wvgTI2QBCkb4o5oh4vM9+FS70OiT6M7dhvPrw64Ddep65lPQBJKcb2/5d,iv:0HHDfT+Q35DncvnZle1rNAueSWFtdLBPs0mfMmF3NfM=,tag:Lfcquhtg6DHK5+qKLzf6yw==,type:str]
 VIKUNJA_JWT_SECRET: ENC[AES256_GCM,data:5H/XM4Q4hiLYe1dnwlC+Kw0Au2CsAYZSAq2L7jGSc8wAvPFW5sAvWrVwxxwrLubM34iRToAy2KGfnHv6Biexhw==,iv:REWG0SXVgIy0Pd6BmW+ZrV6COqxbcUcON0Yt+Aewi7k=,tag:qe3GTgSYbU8480Gda1pItw==,type:str]
 VIKUNJA_ADMIN_PASSWORD: ENC[AES256_GCM,data:oE14RtfkbF+NswJehLee5KkJeyOOH8i3XQolGuS8qVwqZ7zRYiiJ0HNCR5h8PItQ,iv:WgSwZpPSuBNf5aGNhfEoGQr3DpP3iUfm1cyfh+I4pPA=,tag:40aLFbhvcgpygU1AlGQrqw==,type:str]
-NAUTOBOT_DB_PASSWORD: ENC[AES256_GCM,data:+IhPP4X91RF+DRk7aC/A1xJezo4DY1h/SchLgEKoT5XSQu6udbmSbH6T,iv:d0Zbsy1NnD77VU7UEd8nrNBu29zT9PTcsuxmr668fDk=,tag:XTCmCA6pJkMmIzpJbuFKwQ==,type:str]
-NAUTOBOT_SECRET_KEY: ENC[AES256_GCM,data:EfxwknjptH5aBGzPAqWG6g2xK49mbipZCaC3L/sc2Ew/p7pfM91N71VXwLrToYW/WyVTVYxLOhjjW+4iJWDPOaai9vXDlEvUBlkhR50ll50iQsN/caQ=,iv:fVrUBDuWvQ+9UicWyENd8pvUnadjzne06FcpHU+GvJw=,tag:3XgLQoC322qp71/Wgn6MCQ==,type:str]
-NAUTOBOT_SUPERUSER_PASSWORD: ENC[AES256_GCM,data:mWlG6NEp431iCTDAzYQkLELzF4YIQcyDHU+q1/eozGIzIhqwatXYpxs=,iv:64rf0Es1yN19uJaTIchI4WnTEASXot7uVzjWmOWPQw0=,tag:pVtbEAVqZR7JI/5qM7N3kA==,type:str]
-VIKUNJA_SVC_MCP_RO_PASSWORD: ENC[AES256_GCM,data:os07yOeQZxdpuoNdUWf+nw1JqZt4e4XEUojRQrGvD97I2iwA3PwDxGI0jrNwECFr,iv:6QAL3/eiSS2CVLpRrc81Gygpr10R/cR754V+fqojnsc=,tag:0AWnJ/8wQofhfP55NCvqLA==,type:str]
-VIKUNJA_SVC_MCP_RW_PASSWORD: ENC[AES256_GCM,data:S47BW8xE0NYRz7xzjKW/AHS3uzd4jh1S7BZ+S/VhHmAtehwtx/pANTnAHh1sdgCu,iv:SSy2ujAPyXBmu0QJIyrwiYM2PIgJbPpzfGAMSsns06E=,tag:ouaGGSSaPOYWJ+tDt2XR4Q==,type:str]
-VIKUNJA_MCP_TOKEN_RO: ENC[AES256_GCM,data:YrKvMq4ukbzLDeutdrKq3nloRJ4zF4Az4I4AVeuiRoOPdUqHtt0wLINVtw==,iv:24iYqf9sXxy+fWhSRKk0z2+7WyIAqXCn+GKIvoCTXrs=,tag:OtYcQCmaknQRbYEOUf+KQA==,type:str]
-VIKUNJA_MCP_TOKEN_RW: ENC[AES256_GCM,data:5iHDXmuNbWEOQlhof5KjW7N0UdLnrR5B8R1/bRmuQsw9W9hyUvkA3YDMmQ==,iv:gt/MbBXXbJ1JSlg/Mg9uoMxXHNrw7uFt3JyU3GQNF3c=,tag:Qq2Xk5608W1KPXo8sQ/QBQ==,type:str]
-VIKUNJA_MCP_TOKEN_ADMIN: ENC[AES256_GCM,data:52TXlO5bpnUGTvqVJf/+Lum3eE+N7FojVj5v32JX6eh0AXl2A+4rRAF3QQ==,iv:s0COUIwf7lSCCt98wlVsTJ0Enp18cuoKAzw7ri0qDLg=,tag:IynNK3AKYi9PdF+FwY2j9w==,type:str]
 sops:
     age:
         - enc: |
@@ -45,7 +36,7 @@ sops:
             fSSlce/LFPv5+Qzn6bu04aEOlLuM2azDds00cyhyIj4ur0zXxedvSQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
-    lastmodified: "2026-07-10T16:29:36Z"
-    mac: ENC[AES256_GCM,data:iSb3xOu8/sJYnfjLksO66Hsol+8GycvBIvuQiQ3yS9ulrJ7gTFpB0fCGJWpg3AhHQncwv4M85eyJfKAXvgUfmBczn6Y2dUF/PyZBP0Fv0EcmHTVeuVdUtgLOIF9P1vQieKirv87eMNpQBF6E5MkDQIysuDJGOy2WKGXU3tbtBoo=,iv:dhSgT71t13JaQ0P7WYApBMbp91zeuVCO7SSO9QJTSvk=,tag:q/Sav6sPjYkOHhhwee/UjQ==,type:str]
+    lastmodified: "2026-07-16T22:02:12Z"
+    mac: ENC[AES256_GCM,data:CpLOFNc3twGTNA+z3oATk5rWJNx/+HjZivMGiPpTWLab1R3NW4zBlgSLycQsPz5E7EAIeeu9PkOz0JfxdVnpsztXxGwPbpNXl6AUBaS7BH1xvbHwd9Z882vO8IHlpztVbaxiqUF14OtVT4WJBljiq/2a/aS+DpzFM0ZDr4k9Luk=,iv:EItHk3WRw6bg6QseShVwywqiyC7BBdK7sYyZ5PCiOvE=,tag:+GkrnNY+m2x/uVzdWSShmw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.1


### PR DESCRIPTION
One home per secret: removes from `secrets.enc.yaml` the category of values whose canonical home is now OpenBao and whose SOPS copies are stale (the DB-role alignment converge made the OpenBao values live):

- the six vikunja fields covered by the `openbao_vikunja_secrets` promotion map (all verified present at their OpenBao path)
- the three nautobot fields (OpenBao generates these at source; the live DB now matches OpenBao, so the SOPS fallbacks would render wrong credentials)

Kept: `VIKUNJA_ADMIN_PASSWORD`, `VIKUNJA_JWT_SECRET` — not yet in OpenBao, SOPS remains their SSOT. The init.yml promotion step skips absent env vars by design, so openbao converges are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TduAFRb5WCmy1crcz8jSrQ