### PR TITLE
fix(zammad): build the schema before seeding on first configure

### DIFF
--- a/roles/zammad/tasks/main.yml
+++ b/roles/zammad/tasks/main.yml
@@ -309,6 +309,16 @@
         state: fixed
       when: not zammad_configured
 
+    # The postinst's own "Updating db" step does not reliably build the schema
+    # on an EMPTY external database (observed: configure succeeds, 496
+    # migrations still pending, db:seed then aborts on the missing schema) —
+    # migrate explicitly before seeding.
+    - name: Build the Zammad schema (first configure only)
+      ansible.builtin.command:
+        cmd: "zammad run rake db:migrate"
+      when: not zammad_configured
+      changed_when: true
+
     - name: Seed the Zammad database (first configure only; seeds are create-if-missing)
       ansible.builtin.command:
         cmd: "zammad run rake db:seed"


### PR DESCRIPTION
Fifth layer of the first-ever zammad converge (after #960/#970/#973/#1007): with a working DB connection the postinst 'Updating db' step completed WITHOUT building the schema on the empty external database — 496 migrations still pending, and `rake db:seed` then aborted. Run `rake db:migrate` explicitly before `db:seed` on the first configure.

Verification: converge `--tags zammad` post-merge (restore loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6JuKQiA3nNTJ81ww1wgFo