### PR TITLE
feat(openbao): add github-read/github-admin token-provider AppRoles

### DIFF
--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -354,6 +354,26 @@ openbao_terraform_apply_policy_name: terraform-apply
 openbao_terraform_apply_approle_name: terraform-apply
 openbao_flow_lock_policy_name: flow-lock
 openbao_flow_lock_approle_name: flow-lock
+# GitHub token providers for the workstation git/gh path — the OpenBao-backed
+# replacement for the local tiered-PAT keychain services. nix-darwin's
+# `openbao-github-creds` logs in with one of these and reads the stored token
+# from secret/github/<purpose>; the AppRole it picks IS the tier boundary:
+#
+#   github-read   -> secret/github/repo-write   default, secret-zero in the
+#                                               everyday Doppler config
+#   github-admin  -> secret/github/*            elevated (personal-admin,
+#                                               org-admin, actions-secrets,
+#                                               classic-admin, visicore);
+#                                               secret-zero only in the
+#                                               privileged Doppler config
+#
+# Deliberately NOT members of openbao_ai_domains: a standing PAT must never be
+# an AI-agent credential. Agents mint a per-run GitHub App token via
+# `github-mint` instead. See templates/github-token-policy.hcl.j2.
+openbao_github_read_policy_name: github-read
+openbao_github_read_approle_name: github-read
+openbao_github_admin_policy_name: github-admin
+openbao_github_admin_approle_name: github-admin
 # Terrakube native workload identity. The API signs a short-lived JWT per job;
 # OpenBao verifies it through internal OIDC discovery and binds the exact
 # organization/workspace `sub` claim before issuing a short-lived token.
@@ -568,6 +588,17 @@ openbao_base_approles:
     policy: "{{ openbao_hermes_write_policy_name }}"
   - name: "{{ openbao_public_approle_name }}"
     policy: "{{ openbao_public_policy_name }}"
+  # GitHub token providers: standing, ambient READ tiers consumed by
+  # nix-darwin's `openbao-github-creds` on the workstation. Their role_id /
+  # secret_id are operator-held in Doppler (github-read in the everyday config,
+  # github-admin only in the privileged one) and injected as ambient env, same
+  # shape as ai-orchestrator. manage_secret_id stays true (default): a git push
+  # must not need a human to wrap a secret_id first.
+  - name: "{{ openbao_github_read_approle_name }}"
+    policy: "{{ openbao_github_read_policy_name }}"
+  - name: "{{ openbao_github_admin_approle_name }}"
+    policy: "{{ openbao_github_admin_policy_name }}"
+    token_ttl: 30m  # elevated identity gets a short token TTL
   # ai-orchestrator: role_id/secret_id are operator-held in Doppler tier-0
   # (services BAO_AI_ORCHESTRATOR_ROLE_ID / _SECRET_ID), consumed as ambient env.
   # This AppRole already exists LIVE with a non-expiring secret_id in active
@@ -681,6 +712,14 @@ openbao_base_policies:
     template: hermes-write-policy.hcl.j2
   - name: "{{ openbao_public_policy_name }}"
     template: public-policy.hcl.j2
+  # GitHub token providers (workstation git/gh). One template, two tiers; the
+  # purpose_glob IS the privilege boundary — see github-token-policy.hcl.j2.
+  - name: "{{ openbao_github_read_policy_name }}"
+    template: github-token-policy.hcl.j2
+    purpose_glob: repo-write
+  - name: "{{ openbao_github_admin_policy_name }}"
+    template: github-token-policy.hcl.j2
+    purpose_glob: "*"
   - name: "{{ openbao_ai_orchestrator_policy_name }}"
     template: ai-orchestrator-policy.hcl.j2
   # ai-readonly / ai-elevated / ai-apply-<svc> no longer own standalone policies —

--- a/roles/openbao/templates/github-token-policy.hcl.j2
+++ b/roles/openbao/templates/github-token-policy.hcl.j2
@@ -1,0 +1,35 @@
+{{ ansible_managed | comment }}
+# OpenBao policy for a GitHub TOKEN-PROVIDER AppRole — the workstation git/gh
+# path (nix-darwin's `openbao-github-creds`), NOT the AI-agent path. Rendered
+# once per tier via `purpose_glob`:
+#
+#   github-read   purpose_glob: repo-write   the always-on default tier
+#   github-admin  purpose_glob: "*"          the elevated tiers
+#
+# Read-only by construction: these identities fetch a stored GitHub token, they
+# never write one. Seeding secret/github/* is an operator action, not something
+# the consumer can do.
+#
+# WHY THIS IS NOT A `read-github` kv-capability LEAF. The base capability
+# template grants a whole subtree, which would expose EVERY purpose (including
+# the admin PATs) to any actor attaching the leaf — and the read-all rollup
+# would hand standing PATs to ai-readonly/ai-elevated. AI agents must mint a
+# per-run GitHub App token via `github-mint` instead; a standing PAT is never
+# an agent credential. Keeping these policies out of openbao_ai_domains is the
+# enforcement.
+#
+# TIER SPLIT IS ENFORCED BY THE PATH, NOT BY TRUST. github-read names exactly
+# one purpose, so its secret-zero — which ships in the default Doppler config
+# and is therefore reachable by any plain shell — cannot read an admin PAT even
+# if the caller asks for one. The elevated secret-zero lives in a
+# more-privileged Doppler config, so pulling an admin token stays a deliberate
+# `doppler run --config <admin>` step. That path scoping replaces the old
+# elevate-access keychain unlock as the "elevated needs a deliberate act" gate.
+
+path "{{ openbao_kv_mount }}/data/github/{{ item.purpose_glob }}" {
+  capabilities = ["read"]
+}
+
+path "{{ openbao_kv_mount }}/metadata/github/{{ item.purpose_glob }}" {
+  capabilities = ["read", "list"]
+}


### PR DESCRIPTION
## Why

`openbao-github-creds` (dryvist/nix-darwin#1699) logs in with an AppRole named by its
`GITHUB_READ` / `GITHUB_ADMIN` env prefix and reads a token from `secret/github/<purpose>`.
Neither AppRole existed in this role, so every invocation failed closed at the secret-zero
check — the wrapper shipped with nothing behind it. This provisions both tiers so the
migration off the local per-tier keychain services has a target.

Verified before this change: the role defines ~20 AppRoles, none for GitHub, and no
`secret/github/` path appears anywhere in `roles/`.

## What

- `templates/github-token-policy.hcl.j2` — one read-only template, parameterized by
  `purpose_glob` (same shape as `terrakube-workspace-policy.hcl.j2` + `workspace:`).
- Two policies + two AppRoles wired through the existing `openbao_base_policies` /
  `openbao_base_approles` lists. No new render machinery.

| AppRole | Reads | Secret-zero lives in |
| --- | --- | --- |
| `github-read` | `secret/github/repo-write` only | everyday config |
| `github-admin` | `secret/github/*` | privileged config only |

## Design notes

**The `purpose_glob` is the privilege boundary, not trust.** `github-read` names exactly one
purpose, so its always-reachable secret-zero cannot read an admin token even if the caller
asks for one. Elevation stays a deliberate act because the elevated secret-zero is only
injected by the privileged config.

**Deliberately not a `read-github` kv-capability leaf.** A leaf grants a whole subtree and
would auto-join the `read-all` rollup — handing standing PATs to `ai-readonly` / `ai-elevated`.
Agents mint a per-run GitHub App token via `github-mint` instead; a standing PAT is never an
agent credential. Keeping these out of `openbao_ai_domains` is the enforcement.

**`manage_secret_id` stays default (true).** A git push must not require a human to wrap a
secret_id first. `github-admin` gets `token_ttl: 30m`, mirroring `ai-orchestrator`'s
short-TTL treatment of a broader identity.

## Verification

- Template render test: `github-read` → `secret/{data,metadata}/github/repo-write`;
  `github-admin` → `secret/{data,metadata}/github/*`; asserted the read tier is granted
  no wildcard path.
- `ansible-lint` via pre-commit passed; `defaults/main.yml` parses.
- Not yet converged — this PR only defines the roles. Post-merge: promote to `main`,
  converge, publish each role_id/secret_id to its Doppler config, seed
  `secret/github/<purpose>`, then verify `openbao-github-creds token repo-write`.

Refs dryvist/nix-darwin#1699

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RC6muwSosdFeLz3iBEJp57