### PR TITLE
docs(openbao): mandate secrets engines over manual credential control

### DIFF
--- a/.claude/rules/openbao-plugins-first.md
+++ b/.claude/rules/openbao-plugins-first.md
@@ -1,0 +1,90 @@
+---
+name: openbao-plugins-first
+description: OpenBao secrets engines are mandatory - never manual credential control
+globs:
+  - "roles/openbao/**"
+  - "roles/openbao_secrets/**"
+  - "playbooks/**openbao**"
+---
+
+# OpenBao: Plugins First, Always
+
+## Principle
+
+**If a resource has an OpenBao secrets engine, that engine is the only way its
+credentials may be produced.** A credential a human minted, typed, pasted, or
+stored in KV is *manual control*, and manual control is banned wherever an
+engine exists.
+
+**GitHub and AWS both have engines here, and both are enabled.** A static PAT
+or a static AWS access key is therefore never the answer for either — not as a
+default, not as a starting point, and not as a "temporary step until the engine
+is wired up."
+
+Upstream catalog: <https://github.com/openbao/openbao-plugins>
+
+## Why
+
+An engine-minted credential is short-lived, attributable to the run that asked
+for it, revocable by lease, and impossible to leak durably. A static credential
+is the opposite on all four counts: it lives until someone remembers to rotate
+it, it is attributable only to whoever pasted it in, revoking it breaks every
+unrelated consumer sharing it, and one transcript or log line leaks it forever.
+
+The engines are already paid for — installed, version-pinned, checksum- and
+signature-verified, and mounted. Reaching past a working engine for KV
+re-introduces every property the engine was adopted to eliminate.
+
+## What is already enabled — check before you build
+
+| Resource | Engine | Mount | Mint from |
+| --- | --- | --- | --- |
+| GitHub | `vault-plugin-secrets-github` | `github` | `github/token/<permission_set>` |
+| AWS | `openbao-plugins` secrets-aws | `aws` | `aws/sts/<role>` |
+
+Both default to enabled (`openbao_github_engine_enabled`,
+`openbao_aws_engine_enabled` in `roles/openbao/defaults/main.yml`).
+
+**GitHub — do not build a new grant.** The `github-mint` base-capability policy
+(`templates/github-mint-policy.hcl.j2`) already grants
+`github/token/<permission_set>` for every administrator-defined permission set,
+and already composes with the KV leaves. An identity that needs a GitHub token
+attaches `github-mint`. It does not get a new policy template, and it does not
+get a KV path.
+
+**AWS — same shape.** Consumers read `aws/sts/<role>` for short-lived STS
+credentials. Never plumb `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`.
+
+## Rules
+
+- **Never seed a credential into KV that an engine can mint.** `secret/github/*`
+  holding PATs is the canonical violation. Reviewers reject it on sight.
+- **Never add a KV-read policy for GitHub.** Attach `github-mint` instead.
+- **A new resource gets a catalog check first.** Search
+  [openbao/openbao-plugins](https://github.com/openbao/openbao-plugins) before
+  designing anything. An engine that exists upstream but is not enabled here is
+  a gap to close, not a licence to use KV.
+- **KV is for values nothing can mint** — app config, third-party secrets with
+  no engine, bootstrap material. That is its whole job.
+- **The exception must be argued, with evidence.** If an engine genuinely cannot
+  serve a purpose (a real GitHub App permission gap, say), the evidence is a
+  cited API/docs limitation in the PR body. "The App probably can't do this" is
+  not evidence, and an unevidenced assumption is not an exception.
+- **A human-in-the-loop gate is not a reason to go static.** Gating *who may
+  ask* is an auth/policy concern; it never changes *how the credential is
+  produced*.
+
+## Applying this
+
+Before any OpenBao change, answer in the PR body:
+
+1. Which resource's credentials does this touch?
+2. Does an engine for it exist — enabled here, or upstream in `openbao-plugins`?
+3. If yes: which mount path mints it, and which existing policy grants that?
+4. If you are adding KV or a policy granting KV read for that resource: why can
+   the engine not do this, with a citation?
+
+Cannot answer 3 without inventing something new? You are almost certainly
+duplicating a grant that already exists. Re-read
+`roles/openbao/defaults/main.yml` — the base policies and capability leaves
+cover more than they look like they do.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,29 @@ never bake a specific backend (OpenBao, Doppler, SOPS) into a role default.
 The secrets architecture (which store holds what, per-domain RBAC, the
 workstation consumption path) is documented on the docs site, not here.
 
+### OpenBao: always use the plugin, never manual credential control
+
+**Read [`.claude/rules/openbao-plugins-first.md`](.claude/rules/openbao-plugins-first.md)
+before making any OpenBao change of any kind.** It is the binding rule, not a
+suggestion, and it is short.
+
+The one-line version: if a resource has an OpenBao **secrets engine**, that
+engine is the only way its credentials may be produced. A credential a human
+minted, typed, pasted, or stored in KV is manual control and is banned wherever
+an engine exists. **GitHub and AWS both have engines here and are already
+enabled** — so a static PAT or a static AWS access key is never the answer,
+never a starting point, and never a "temporary" step.
+
+| Resource | Engine (enabled by default) | Mint from | Never |
+| --- | --- | --- | --- |
+| GitHub | `vault-plugin-secrets-github` @ `github` | `github/token/<permission_set>` (attach the existing `github-mint` policy) | a PAT in `secret/github/*` |
+| AWS | [`openbao-plugins`](https://github.com/openbao/openbao-plugins) secrets-aws @ `aws` | `aws/sts/<role>` | a static access key |
+
+Adding a **new** resource? Check
+[openbao/openbao-plugins](https://github.com/openbao/openbao-plugins) for an
+engine first. An engine that exists upstream and is not enabled here is a gap to
+close, not a reason to reach for KV.
+
 ## Commands
 
 ```bash

--- a/roles/openbao/README.md
+++ b/roles/openbao/README.md
@@ -6,6 +6,14 @@ static-key auto-unseal** (no cloud KMS). After the cluster is live the role
 provisions a KV v2 mount, the secret hierarchy, the RBAC policies, and one
 AppRole per resource-domain identity (see [Secret hierarchy & RBAC](#secret-hierarchy--rbac)).
 
+> **Before changing anything here, read
+> [`.claude/rules/openbao-plugins-first.md`](../../.claude/rules/openbao-plugins-first.md).**
+> Secrets engines are mandatory wherever one exists: GitHub tokens are minted
+> from `github/token/<permission_set>` (attach the existing `github-mint`
+> policy) and AWS credentials from `aws/sts/<role>`. A static PAT or access key
+> stored in KV is manual credential control and is rejected. KV is only for
+> values no engine can mint.
+
 ## Architecture
 
 - **5-voter Raft HA** (quorum 3): every node carries a `retry_join` for each peer

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -630,6 +630,13 @@ openbao_base_approles:
 openbao_approles: "{{ openbao_base_approles + openbao_ai_apply_approles }}"
 # Policy templates rendered + written on the bootstrap host. Each entry maps a
 # policy name to its template; add a row to grow the RBAC surface.
+#
+# BEFORE ADDING A ROW, read .claude/rules/openbao-plugins-first.md. A policy
+# granting KV read for a resource that has a secrets engine is manual credential
+# control and is rejected. GitHub has one (mount `github`) and AWS has one (mount
+# `aws`), both enabled by default. A GitHub token grant is ALWAYS the existing
+# `github-mint` capability policy attached via token_policies — never a new
+# template, never a secret/github/* path. AWS is always aws/sts/<role>.
 openbao_base_policies:
   - name: terrakube-iac-platform
     template: terrakube-workspace-policy.hcl.j2


### PR DESCRIPTION
# Mandate OpenBao secrets engines over manual credential control

## Why

Nothing in this repo said "use the secrets engine." So #1012 (now draft) provisioned
AppRoles whose only capability was reading a **hand-seeded static PAT** out of KV — for
GitHub, whose engine has been enabled and minting per-run tokens this whole time. The
rule was real but unwritten, which means unenforced.

## The rule

**If a resource has an OpenBao secrets engine, that engine is the only way its
credentials may be produced.** A credential a human minted, typed, pasted, or stored in
KV is manual control, and manual control is banned wherever an engine exists.

**GitHub and AWS both have engines here, and both are enabled** — a static PAT or a
static AWS access key is never the answer, never a starting point, and never a
"temporary step until the engine is wired up."

| Resource | Engine | Mount | Mint from | Never |
| --- | --- | --- | --- | --- |
| GitHub | `vault-plugin-secrets-github` | `github` | `github/token/<permission_set>` — attach the existing `github-mint` policy | a PAT in `secret/github/*` |
| AWS | [`openbao-plugins`](https://github.com/openbao/openbao-plugins) secrets-aws | `aws` | `aws/sts/<role>` | a static access key |

New resource? Check [openbao/openbao-plugins](https://github.com/openbao/openbao-plugins)
first. An engine that exists upstream but isn't enabled here is a gap to close, not a
licence to use KV. KV keeps its real job: values nothing can mint.

## Where it lands — so no future agent can miss it

Placed at the points an agent actually passes through, not just where docs live:

- **`.claude/rules/openbao-plugins-first.md`** — the binding rule. `globs`-scoped to
  `roles/openbao/**` + `roles/openbao_secrets/**`, so it auto-loads exactly when those
  are touched.
- **`AGENTS.md`** → Secrets Management. `CLAUDE.md` already does `@AGENTS.md`, so this is
  in context every session, every agent, no discovery step.
- **`roles/openbao/README.md`** — a callout above the fold.
- **The `openbao_base_policies` comment** — the literal line where a KV-read policy would
  get added. Guard at the point of temptation.

## Design notes

**Names the existing answer, not just the ban.** The rule points at `github-mint`
(already rendered, already attached to apply-tier actors) so the next agent *reuses* it
rather than rebuilding it — which is what #1012 did wrong. A prohibition without the
alternative just gets creatively routed around.

**Exceptions need evidence.** If an App genuinely can't serve a purpose, the PR body
carries a cited API/docs limitation. "The App probably can't do this" is an assumption,
and an assumption is not an exception.

**Closes the loophole explicitly:** a human-in-the-loop gate is an auth concern and never
a reason to go static — gating *who may ask* doesn't change *how the credential is made*.

## Verification

Every factual claim in the rule was checked against the tree, not recalled:

- `openbao_github_engine_enabled: true` (:232), `openbao_aws_engine_enabled: true` (:173),
  `openbao_github_mount: github` (:233)
- `github-mint` → `github-mint-policy.hcl.j2` is in the rendered policy list (:485); the
  template grants `{{ mount }}/token/{{ permission_set.name }}` for every set
- `aws/sts/*` paths in live use (:379, :381)
- `defaults/main.yml` parses (174 keys); both relative doc links resolve; ansible-lint via
  pre-commit passed

Docs only — no policy, engine, or AppRole behaviour changes.

Refs #1012

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<https://claude.ai/code/session_01RC6muwSosdFeLz3iBEJp57>
