### PR TITLE
fix(technitium): converge onto the apt .NET layout, gate the binary swap, pin the official Log Exporter

### DIFF
--- a/roles/technitium_dns/defaults/main.yml
+++ b/roles/technitium_dns/defaults/main.yml
@@ -161,26 +161,27 @@ technitium_dns_query_log_app_name: "Log Exporter"
 # bucket over 443 with a valid wildcard cert the resolver already trusts.
 technitium_dns_query_log_app_mirror_endpoint: >-
   https://s3.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}/artifacts
-# App version is pinned to the Log Exporter build compatible with the RUNNING
-# server: the app has its OWN version stream, unrelated to the server tag (app
-# 3.0.1 ships with server 15.4). It is sourced from the DnsServer repo at the
-# matching server tag — Apps/LogExporterApp/LogExporterApp.csproj carries the
-# authoritative <Version>. A Renovate bump is only a SIGNAL: it cannot re-host a
-# private object, and no datasource tracks this app, so major bumps are blocked
-# in renovate.json. On a server upgrade the operator MUST (1) read <Version>
-# from the csproj at the new server tag, (2) re-seed
-# artifacts/technitium/<filename> in object-storage, and (3) update the version
-# + sha256 below.
+# The app has its OWN version stream and is NOT coupled to the server tag. A
+# server upgrade does NOT require an app upgrade: this exact 2.1 build (the
+# official vendor zip mirrored below) was verified running on server 14.3 AND
+# on 15.4 — same zip, app loads, one DNS app class registered. The DNS app API
+# (DnsServerCore.ApplicationCommon) is stable across the 14->15 major, so do
+# not bump this pin just because the server moved.
 #
-# Neither download.technitium.com nor go.technitium.com is reachable from this
-# network, so the vendor zip cannot be mirrored directly. Build it instead —
-# `dotnet build -c Release` the csproj at the server tag inside the
-# mcr.microsoft.com/dotnet/sdk image, referencing TechnitiumLibrary{,.Net}.dll
-# and DnsServerCore.ApplicationCommon.dll extracted from the matching
-# technitium/dns-server image (those are <Private>false</Private> compile-time
-# refs, so using the image's own copies guarantees an ABI match). Zip the build
-# output flat, minus README.md, to match the vendor layout.
-technitium_dns_query_log_app_version: "3.0.1"
+# DO NOT hand-build this app from source. It was tried: a locally built 3.0.1
+# (the <Version> in Apps/LogExporterApp/LogExporterApp.csproj at tag v15.4.0)
+# installs and reports status ok, but its assembly fails to load on the server
+# with SecurityException "Invalid assembly public key" thrown out of
+# Technitium's own DnsApplicationAssemblyLoadContext.Load fallback loop. The
+# app then registers ZERO app classes and query-log export silently stops —
+# while /api/apps/list still reports the app as installed, so nothing looks
+# wrong. Only mirror official vendor-built zips here.
+#
+# Because neither download.technitium.com nor go.technitium.com is reachable
+# from this network, a NEW app version can only be pinned once its official zip
+# has been obtained out-of-band and re-seeded into artifacts/technitium/. Until
+# then this pin stays where it is. Renovate cannot track or re-host it.
+technitium_dns_query_log_app_version: "2.1"
 technitium_dns_query_log_app_filename: "LogExporterApp-{{ technitium_dns_query_log_app_version }}.zip"
 technitium_dns_query_log_app_url: >-
   {{ technitium_dns_query_log_app_mirror_endpoint }}/technitium/{{
@@ -188,7 +189,7 @@ technitium_dns_query_log_app_url: >-
 # sha256 of the mirrored zip — documents the exact pinned build (the
 # downloadAndInstall API has no checksum param, so this is verified by the
 # operator at seed time, not enforced at install). Update with the version.
-technitium_dns_query_log_app_sha256: "b2c32bb090e164b102185db819d97b0bf4cbe8cbe6090a5e9ffebfecce13f0c3"
+technitium_dns_query_log_app_sha256: "53e84d2c3b8715e5fd59b415b57920bd4845ef8cb38cc935c25bddb89915c7fd"
 # Same stable syslog entry point the syslog_forwarder role uses (the `syslog`
 # CNAME this very role creates -> HAProxy). Never a committed literal.
 technitium_dns_query_log_syslog_host: "syslog.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"

--- a/roles/technitium_dns/tasks/query_log.yml
+++ b/roles/technitium_dns/tasks/query_log.yml
@@ -68,9 +68,11 @@
   no_log: true
 
 # The install above only fires when the app is ABSENT, so an already-installed
-# app would keep its old build forever. The app is compiled against the server's
-# DnsServerCore.ApplicationCommon, so a server major upgrade strands it on an
-# incompatible build — this drift-gated update is what carries it across.
+# app would keep its old build forever; this drift-gated update carries a
+# re-pinned version across. It is NOT needed to follow a server upgrade — the
+# DNS app API is stable across majors and the pinned build is verified on both
+# 14.3 and 15.4 (see defaults/main.yml). Firing only on drift is what keeps the
+# converge idempotent.
 - name: Update the Log Exporter app to the pinned version
   ansible.builtin.uri:
     url: >-
@@ -92,6 +94,49 @@
     - technitium_dns_query_log_app_installed
     - technitium_dns_query_log_app_live_version != technitium_dns_query_log_app_version
   no_log: true
+
+# A broken app build is INVISIBLE to every check above: downloadAndInstall /
+# downloadAndUpdate return status ok as long as the zip unpacks, and the app
+# keeps showing up in /api/apps/list. But if its assembly fails to load, the
+# server registers zero app classes, reports the version as "0.0", and silently
+# exports nothing — query logs just stop reaching the syslog pipeline with no
+# error anywhere. A self-built 3.0.1 zip did exactly this on 15.4. Re-read the
+# list after install/update and fail loudly on that state.
+- name: Re-read the DNS app list after install or update
+  ansible.builtin.uri:
+    url: "{{ technitium_dns_api_url }}/api/apps/list?token={{ technitium_dns_api_token }}"
+    method: GET
+    return_content: true
+    timeout: "{{ technitium_dns_api_timeout }}"
+  register: technitium_dns_apps_verify
+  changed_when: false
+  failed_when: >-
+    technitium_dns_apps_verify.failed or
+    technitium_dns_apps_verify.json is not defined or
+    technitium_dns_apps_verify.json.status != "ok"
+  when: technitium_dns_apply | bool
+  no_log: true
+
+- name: Require the Log Exporter app to have actually loaded
+  vars:
+    technitium_dns_query_log_app_entry: >-
+      {{ technitium_dns_apps_verify.json.response.apps | default([])
+         | selectattr('name', 'eq', technitium_dns_query_log_app_name)
+         | first | default({}, true) }}
+  ansible.builtin.assert:
+    that:
+      - technitium_dns_query_log_app_entry.dnsApps | default([]) | length > 0
+      - technitium_dns_query_log_app_entry.version | default('0.0') != "0.0"
+    fail_msg: >-
+      The '{{ technitium_dns_query_log_app_name }}' app is installed but loaded
+      NO app classes (version reported as
+      '{{ technitium_dns_query_log_app_entry.version | default('none') }}').
+      Its assembly failed to load, so query-log export is silently dead on this
+      host. The pinned zip is not a working build for this server — check the
+      DNS server log for an assembly load exception, and pin a version whose
+      OFFICIAL vendor-built zip is mirrored (never a hand-built one).
+    quiet: true
+  when: technitium_dns_apply | bool
 
 - name: Read the live Log Exporter app config
   ansible.builtin.uri:

--- a/roles/technitium_install/defaults/main.yml
+++ b/roles/technitium_install/defaults/main.yml
@@ -33,10 +33,30 @@ technitium_install_api_timeout: 30
 # `/opt/technitium/dns` (the 15.4 / .NET 10 build). Same bare-metal layout as the
 # primary; no single-vendor-host SPOF.
 
-# ASP.NET Core runtime package (installed from the Microsoft apt repo). Must
-# match the target framework the pinned server build was compiled against: 15.x
-# is net10.0, 14.x was net9.0. A major bump moves this too.
-technitium_install_dotnet_pkg: "aspnetcore-runtime-10.0"
+# ASP.NET Core runtime packages (from the Microsoft apt repo, reached through
+# apt-cacher-ng's packages.microsoft.com CONNECT passthrough). The FIRST entry
+# must match the target framework the pinned server build was compiled against:
+# 15.x is net10.0, 14.x was net9.0. A major bump moves that entry.
+#
+# The previous runtime stays in the list on purpose. .NET runs side-by-side, and
+# a rollback to the previous server build only starts if ITS framework is still
+# installed — dropping the old entry would silently disarm the rollback path.
+technitium_install_dotnet_pkgs:
+  - "aspnetcore-runtime-10.0"
+  - "aspnetcore-runtime-9.0"
+
+# The framework version 'dotnet --list-runtimes' must report before the binaries
+# are swapped. Derived from the pinned build's runtimeconfig.json "frameworks"
+# entry (15.4.0 requires Microsoft.AspNetCore.App 10.0.0).
+technitium_install_dotnet_framework_major: "10"
+
+# Where the apt-managed .NET lives. The fleet was originally built by
+# Technitium's official install.sh, which drops a self-managed tarball runtime in
+# /opt/dotnet and points /usr/bin/dotnet at it. Since .NET 7 the muxer only
+# probes frameworks under its OWN root, so an apt runtime under /usr/lib/dotnet
+# is invisible to an /opt/dotnet muxer. The role converges onto the apt layout.
+technitium_install_dotnet_apt_root: /usr/lib/dotnet
+technitium_install_dotnet_legacy_root: /opt/dotnet
 
 # Mirror endpoint for the Technitium app tarball. The host + port resolve from
 # the published inventory (the object-storage container) — never a committed
@@ -52,8 +72,9 @@ technitium_install_mirror_endpoint: >-
 # from the new official build — extract /opt/technitium/dns from the matching
 # technitium/dns-server image and tar it with `dns/` as the archive root — and
 # (2) update technitium_install_app_sha256 below to the new tarball's digest,
-# (3) check the image's .deps.json "tfm" and move technitium_install_dotnet_pkg
-# + the -netN suffix below if the target framework changed.
+# (3) check the image's .deps.json "tfm" and move the first
+# technitium_install_dotnet_pkgs entry, technitium_install_dotnet_framework_major,
+# and the -netN suffix below if the target framework changed.
 # Renovate cannot do any of that, so major bumps are blocked in renovate.json.
 # renovate: datasource=docker depName=technitium/dns-server
 technitium_install_app_version: "15.4.0"

--- a/roles/technitium_install/defaults/main.yml
+++ b/roles/technitium_install/defaults/main.yml
@@ -53,9 +53,11 @@ technitium_install_dotnet_framework_major: "10"
 # Where the apt-managed .NET lives. The fleet was originally built by
 # Technitium's official install.sh, which drops a self-managed tarball runtime in
 # /opt/dotnet and points /usr/bin/dotnet at it. Since .NET 7 the muxer only
-# probes frameworks under its OWN root, so an apt runtime under /usr/lib/dotnet
+# probes frameworks under its OWN root, so an apt runtime under /usr/share/dotnet
 # is invisible to an /opt/dotnet muxer. The role converges onto the apt layout.
-technitium_install_dotnet_apt_root: /usr/lib/dotnet
+# Verified live on Debian 13: the MS apt packages install the muxer + shared
+# frameworks under /usr/share/dotnet (NOT /usr/lib/dotnet).
+technitium_install_dotnet_apt_root: /usr/share/dotnet
 technitium_install_dotnet_legacy_root: /opt/dotnet
 
 # Mirror endpoint for the Technitium app tarball. The host + port resolve from

--- a/roles/technitium_install/tasks/main.yml
+++ b/roles/technitium_install/tasks/main.yml
@@ -52,11 +52,64 @@
       https://packages.microsoft.com/config/debian/{{
       ansible_facts.distribution_major_version }}/packages-microsoft-prod.deb
 
-- name: Install the ASP.NET Core runtime
+- name: Check whether /usr/bin/dotnet is the legacy tarball muxer
+  ansible.builtin.stat:
+    path: /usr/bin/dotnet
+  register: technitium_install_legacy_muxer
+
+- name: Retire the legacy tarball .NET muxer symlink
+  # The fleet was built by Technitium's official install.sh: a tarball runtime in
+  # /opt/dotnet with /usr/bin/dotnet symlinked to it, owned by no package. The
+  # apt dotnet-host package ships /usr/bin/dotnet itself, so the unowned symlink
+  # is removed first — that way dpkg lays down its own link cleanly instead of us
+  # depending on its overwrite semantics for a file no package owns.
+  # Removing it cannot disturb a RUNNING server: the unit resolves ExecStart at
+  # start time, and the apt install below restores the path before any restart.
+  ansible.builtin.file:
+    path: /usr/bin/dotnet
+    state: absent
+  when:
+    - technitium_install_legacy_muxer.stat.islnk | default(false)
+    - technitium_install_dotnet_legacy_root in
+      (technitium_install_legacy_muxer.stat.lnk_target | default(''))
+
+- name: Install the ASP.NET Core runtimes
+  # Routed through apt-cacher-ng like every other apt call on these guests: the
+  # Microsoft repo is HTTPS-only, so the proxy tunnels it via the CONNECT
+  # passthrough the apt_cacher_ng role configures for packages.microsoft.com.
   ansible.builtin.apt:
-    name: "{{ technitium_install_dotnet_pkg }}"
+    name: "{{ technitium_install_dotnet_pkgs }}"
     state: present
     update_cache: true
+
+- name: Read the frameworks the active muxer can resolve
+  ansible.builtin.command:
+    cmd: /usr/bin/dotnet --list-runtimes
+  register: technitium_install_runtimes
+  changed_when: false
+  # check mode cannot install the repo or the packages, so the muxer legitimately
+  # has nothing to report yet — don't fail the dry-run on it.
+  failed_when: false
+
+- name: Require the pinned build's framework before touching the server
+  # THE safety gate. The binaries are swapped while dns.service is stopped, and a
+  # framework mismatch fails at assembly load — i.e. AFTER the old build is gone.
+  # Asserting here means a runtime that the muxer cannot see stops the play with
+  # DNS still serving, instead of stranding a stopped server with no rollback.
+  ansible.builtin.assert:
+    that:
+      - >-
+        'Microsoft.AspNetCore.App ' ~ technitium_install_dotnet_framework_major
+        in technitium_install_runtimes.stdout | default('')
+    fail_msg: >-
+      /usr/bin/dotnet does not expose Microsoft.AspNetCore.App
+      {{ technitium_install_dotnet_framework_major }}.x, which
+      {{ technitium_install_app_version }} requires. Resolved muxer:
+      {{ technitium_install_legacy_muxer.stat.lnk_target | default('/usr/bin/dotnet') }}.
+      Runtimes seen: {{ technitium_install_runtimes.stdout_lines | default([]) }}.
+      Refusing to swap binaries — the server is still running the old build.
+    quiet: true
+  when: not ansible_check_mode
 
 - name: Install Technitium DNS server (bare-metal from mirror)
   when: technitium_install_check.status == -1

--- a/roles/technitium_install/templates/dns.service.j2
+++ b/roles/technitium_install/templates/dns.service.j2
@@ -1,7 +1,8 @@
 {{ ansible_managed | comment }}
 # Technitium DNS Server — bare-metal .NET install. The app distribution is
-# mirrored from MinIO (technitium_install role); the runtime is the ASP.NET Core
-# runtime from the Microsoft apt repo. Layout matches the existing primary.
+# mirrored from object storage (technitium_install role); the runtime is the
+# ASP.NET Core runtime from the Microsoft apt repo, so /usr/bin/dotnet is the
+# apt dotnet-host muxer and resolves frameworks under {{ technitium_install_dotnet_apt_root }}.
 [Unit]
 Description=Technitium DNS Server
 After=network.target


### PR DESCRIPTION
# fix(technitium): converge onto the apt .NET layout, gate the binary swap, pin the official Log Exporter

Final fixes in the v15.4 chain. Both found by running the rollout against the
live canary (`pi-hole`) instead of trusting the role — Molecule runs no real
Technitium server, so API response shapes and host layout are never exercised
by CI.

## Commit 1 — converge onto the apt .NET layout and gate the binary swap

`apt install aspnetcore-runtime-10.0` failed with `No package matching`. Probing
the canary showed the role assumed a fleet that does not exist:

| Role assumed | Fleet actually has |
| --- | --- |
| Microsoft apt repo registered | no MS source at all |
| apt-managed aspnetcore runtime | no apt dotnet packages |
| runtime resolvable by `dotnet` | `.NET 9` tarball under `/opt/dotnet` |

`/usr/bin/dotnet` -> `/opt/dotnet/dotnet` (owned by no package), no `DOTNET_ROOT`
in the unit, app is framework-dependent. These servers were built by Technitium's
official `install.sh`, which ships its own runtime — so the apt path had **never
run**. Same reason the whole converge was inert.

Since .NET 7 the muxer only probes frameworks under its **own** root, so an apt
runtime is invisible to an `/opt/dotnet` muxer. 15.4.0 requires
`Microsoft.AspNetCore.App 10.0.0`.

**Without this** a converge would: install a runtime nothing can see -> stop
`dns.service` -> swap in 15.4 -> fail at assembly load -> time out -> leave DNS
**down**.

Changes:

- **Install both runtimes** — `10.0` to run 15.4, **`9.0` so a 14.3 rollback still
  starts**. Dropping the old entry silently disarms rollback.
- **Retire the unowned `/usr/bin/dotnet` symlink** before the apt install so dpkg
  lays down its own link, rather than relying on overwrite semantics for a file
  no package owns. Safe on a running server — ExecStart resolves at start time.
- **Assert the muxer reports the required framework BEFORE stopping
  `dns.service`.** A runtime the muxer cannot see now stops the play with DNS
  still serving, instead of stranding a stopped server.

## Commit 2 — pin the official Log Exporter build, catch silent app-load failure

The role hand-built the Log Exporter app from source and pinned `3.0.1`, on the
premise that the app is compiled against the server's
`DnsServerCore.ApplicationCommon`, so a server major upgrade strands it on an
incompatible build.

**That premise is false.** The official prebuilt `2.1` zip loads cleanly on server
14.3 **and** 15.4 — verified live by installing it onto the canary after its 15.4
upgrade. The DNS app API is stable across the major.

The self-built `3.0.1` was **actively broken**: it installs, returns `status: ok`,
and keeps appearing in `/api/apps/list`, but its assembly fails to load with
`SecurityException: Invalid assembly public key (0x8013141E)` thrown out of
Technitium's own `DnsApplicationAssemblyLoadContext.Load` fallback loop. The app
then registers **zero** DNS app classes and **query-log export silently stops** —
no error surfaces anywhere. The only visible symptom was the drift gate firing on
every converge forever, because the server reports an unloaded app's version as
`0.0`, and `0.0` never equals the pin.

Ruled out by evidence, so nobody re-treads it:

- Not DLL corruption — the shipped `Serilog.Sinks.Syslog.dll` is byte-identical to
  the official NuGet `net8.0` asset.
- Not a `dotnet build` vs `dotnet publish` deps.json layout problem — the working
  2.1 zip has the identical shape (`lib/netX` runtime paths, `type=package`, flat
  DLLs, bundled `.pdb`).
- Not the `assemblyVersion=0.0.0.0` recorded for that dependency — 2.1 records it
  too; the NuGet package genuinely ships it.

Changes:

- **Pin the official mirrored 2.1 zip** + its sha256. Only vendor-built zips get
  mirrored; a new version needs its official zip obtained out-of-band first, since
  the vendor hosts are unreachable from this network.
- **Assert the app actually loaded** after install/update (non-empty `dnsApps`,
  version != `0.0`). This is the check whose absence let a dead exporter look
  healthy.
- **Correct the apt .NET root** to `/usr/share/dotnet` (verified live on Debian 13).

## apt-cacher-ng

apt reaches `packages.microsoft.com` through the cache's CONNECT passthrough —
verified live on the cache host (`PassThroughPattern` carries the MS host, service
active). The canary already has `/etc/apt/apt.conf.d/00proxy`. This deliberately
rules out a `dotnet-install.sh` tarball, which would bypass the cache.

## Verification

- `ansible-lint roles/technitium_install/ roles/technitium_dns/` -> passed, 0
  failures (production profile)
- Canary converge on `pi-hole`: upgraded 14.3 -> **15.4**, `dns.service` active,
  `dig` resolves, runtime migrated to `/usr/share/dotnet` with both 9.0 and 10.0
  present (rollback viable), rollback archive written under
  `/var/backups/technitium`
- Log Exporter restored on the canary: **2.1, one app class loaded** — matching
  both un-upgraded servers
- Re-converge idempotence: the Log Exporter update task now **skips**; the new
  guard reports `ok`

## Known gaps (not introduced here, not fixed here)

- `Create API token` and `Configure upstream forwarders` still use
  `changed_when: status == "ok"`, so they report `changed` on every run. Worse,
  the token task mints a **new non-expiring** token each converge — the fleet has
  accumulated 74 / 83 / 17 `ansible-automation` tokens. Deserves its own PR.
