### PR TITLE
chore(secrets): drop retired INFISICAL_* values

### DIFF
--- a/secrets.enc.yaml
+++ b/secrets.enc.yaml
@@ -2,9 +2,6 @@ OPENPROJECT_SECRET_KEY_BASE: ENC[AES256_GCM,data:Ah3kmzdQefQ5aQoe6oPTZ05anOvnXGJ
 PLEX_CLAIM_TOKEN: ENC[AES256_GCM,data:OnuFaeXBKlLqR0BisS/hFewFtPExjeErFJM=,iv:TjOkZzYHsU/fhJpzKHdyQ82Q4oQ6mwjkEWcw2ccwMuc=,tag:bQUhkmsmcuuq6EZ9RrCPyg==,type:str]
 OBJECT_STORAGE_ROOT_USER: ENC[AES256_GCM,data:RUMATWA29iMlVCpRIfJbYLrm4LA7308e,iv:QBWFRAqmfOuQkBT/BJ5ITdaUfYETaLNGAUYT7x4CQ0w=,tag:Nh1GypebpFMulE3CH+buYg==,type:str]
 OBJECT_STORAGE_ROOT_PASSWORD: ENC[AES256_GCM,data:xyx58P9PljoA4eiH4On9Ibg4x/a7HnSfFB4IpikB7hOu1lkynvXemXYTqVyEWBeLUl/7hH4vfSeGPRe3VmJk1Q==,iv:IrPhi+5fy+0a4BiEX7ylOdSV5uYnzqz5Ox1LevbVxWw=,tag:YEuL/e6SJxFNIlGLdSp+tg==,type:str]
-INFISICAL_ENCRYPTION_KEY: ENC[AES256_GCM,data:RnXExKRXc4k/MTb/V4+wZKte2jrOZhCMDnkhd+1gLV4mbZ5gclWOyhp9wkOkq3KxlErkaQvYlZonNEdob/bgVQ==,iv:92ixGdjoXAcO2KPye3qEZtrYyrfYTzB58qfuh3ugO84=,tag:0ZaoUGk6/JMEoHn8qSF5HQ==,type:str]
-INFISICAL_AUTH_SECRET: ENC[AES256_GCM,data:U6JE6lqAyDzJ/PkFGIJFv45ySnve6zgzFFBSkDZw/iFnFnvjKhNZ84VexRJ4ZkmTEaZr/F4jIIkoF6OpoLHyyA==,iv:rjbhGeUK029g5ggLVy9nTBh1o7yZaQiJZkpDCrPyPKU=,tag:gaojjh1SIY99zrqHmACGfg==,type:str]
-INFISICAL_DB_PASSWORD: ENC[AES256_GCM,data:rj1B0pLDjCMgxRioFab3Bu4DHcwUdq2XgYmq7PGNdgQ=,iv:Tx1OUC605rd0yWC2ZL11GX/RUIWxp2vmsz55qEvooOY=,tag:ufu/XfhNAAbgFVPvybiI8Q==,type:str]
 PHPIPAM_DB_PASSWORD: ENC[AES256_GCM,data:sMNx+650PU92f01I1HDMAhdqNdNjWBm2REz60haQZsI=,iv:O/uopDZQmssAsPRQWsqVG6TY1b+iT6pSoruNwB36IZg=,tag:rxXrMMkxxVfls9K1XSESMQ==,type:str]
 PHPIPAM_DB_ROOT_PASSWORD: ENC[AES256_GCM,data:gC+LNPaVJ9GB0aydX56+SC9x9jhKYhyEGha0wxNQFno=,iv:UdoH0uyl7FxFqbN58NtZTYEMnXFbRZ5tjG2v+pIMgHA=,tag:7u2N0DYNij8wd934kmOk5Q==,type:str]
 DIFY_DB_PASSWORD: ENC[AES256_GCM,data:3evBWNs4gPRmiuSivT56f8+htX/8AL7W85VyJe9KsiPML1bfRgoe3D5TtUCcbwne,iv:H8fkR3GLuTlnVl6Z7QtmjFYL7tprTtHB5LT2GHultu8=,tag:ISjtls1TOqaTQeTBFyGFAA==,type:str]
@@ -36,7 +33,7 @@ sops:
             fSSlce/LFPv5+Qzn6bu04aEOlLuM2azDds00cyhyIj4ur0zXxedvSQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
-    lastmodified: "2026-07-16T22:02:12Z"
-    mac: ENC[AES256_GCM,data:CpLOFNc3twGTNA+z3oATk5rWJNx/+HjZivMGiPpTWLab1R3NW4zBlgSLycQsPz5E7EAIeeu9PkOz0JfxdVnpsztXxGwPbpNXl6AUBaS7BH1xvbHwd9Z882vO8IHlpztVbaxiqUF14OtVT4WJBljiq/2a/aS+DpzFM0ZDr4k9Luk=,iv:EItHk3WRw6bg6QseShVwywqiyC7BBdK7sYyZ5PCiOvE=,tag:+GkrnNY+m2x/uVzdWSShmw==,type:str]
+    lastmodified: "2026-07-16T23:15:20Z"
+    mac: ENC[AES256_GCM,data:Ur1aD6mvasTNU0+M4e2UiUhhqwQHcMiVM/WgEgKBm7oHttMkeznOvtuZRB1tjq+6HAEsOyd9B6ChHn7JWjs4gxgl8q0md9gtQD/252aBmfvdETHB2Wk7p8BS2xpdlrVOl5iggUvt7agUMSDlwhE8k9mgQO90ekzKz1/fOpFwSpw=,iv:blHqM+oUh4mhw49jX8qBktNODJiQDwYTQydq2sfyhQk=,tag:mHmt/p4JRX+BhXzxByNhpA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.1


### PR DESCRIPTION
Removes the 3 retired INFISICAL_* values via sops unset (#978 removed the role; guest is gone from desired state). Verified: file decrypts cleanly, 0 INFISICAL keys remain.