### PR TITLE
feat(zammad): seed the org + incident groups and make the hermes token usable

### DIFF
--- a/roles/zammad/defaults/main.yml
+++ b/roles/zammad/defaults/main.yml
@@ -76,6 +76,11 @@ zammad_hermes_api_token: "{{ lookup('env', 'ZAMMAD_API_TOKEN') }}"
 # built-in 1/2/3 are kept; only "4 critical" is added.
 zammad_groups:
   - Incidents
+  - Homelab Infrastructure
+  - AI/LLM Serving
+  - Hermes Agent
+# Top-level customer organization the admin belongs to.
+zammad_organization: dryvist
 zammad_extra_priority:
   id: 4
   name: 4 critical

--- a/roles/zammad/files/zammad_bootstrap.rb
+++ b/roles/zammad/files/zammad_bootstrap.rb
@@ -62,6 +62,20 @@ else
   end
 end
 
+# --- Top-level organization (create-or-find; admin belongs to it) ------------
+org_name = ENV['ZAMMAD_ORGANIZATION']
+if org_name && !org_name.empty?
+  org = Organization.find_by(name: org_name)
+  if org.nil?
+    org = Organization.create!(name: org_name, shared: true, active: true)
+    changed = true
+  end
+  unless admin.organization_id == org.id
+    admin.update!(organization_id: org.id)
+    changed = true
+  end
+end
+
 # --- Incident groups (create-or-find; make admin a full agent in each) -------
 groups.each do |gname|
   group = Group.find_by(name: gname)
@@ -85,13 +99,27 @@ end
 
 # --- Hermes API token (persistent api token seeded with the supplied value;
 # reconciled if it already exists but was rotated in OpenBao/Doppler) --------
+# Two hard-won constraints (first live bring-up, 2026-07-16):
+#   1. Token.create!/update! REGENERATE the token value via callbacks —
+#      update_column is the only way the supplied secret actually persists.
+#   2. An api token with empty preferences has NO permission scopes and every
+#      HTTP request is rejected "Authentication required".
+hermes_token_prefs = { 'permission' => %w[admin ticket.agent knowledge_base.editor] }
 hermes_token = Token.find_by(action: 'api', name: 'hermes')
 if hermes_token.nil?
-  Token.create!(action: 'api', name: 'hermes', persistent: true, user_id: admin.id, token: api_token)
+  hermes_token = Token.create!(action: 'api', name: 'hermes', persistent: true,
+                               user_id: admin.id, preferences: hermes_token_prefs)
+  hermes_token.update_column(:token, api_token)
   changed = true
-elsif hermes_token.token != api_token
-  hermes_token.update!(token: api_token)
-  changed = true
+else
+  if hermes_token.token != api_token
+    hermes_token.update_column(:token, api_token)
+    changed = true
+  end
+  if hermes_token.preferences != hermes_token_prefs
+    hermes_token.update!(preferences: hermes_token_prefs)
+    changed = true
+  end
 end
 
 # --- Outbound email via the Mailpit relay (best-effort; manual UI fallback) --

--- a/roles/zammad/tasks/main.yml
+++ b/roles/zammad/tasks/main.yml
@@ -411,6 +411,7 @@
         ZAMMAD_SMTP_PORT: "{{ zammad_smtp_port }}"
         ZAMMAD_NOTIFICATION_SENDER: "{{ zammad_notification_sender }}"
         ZAMMAD_GROUPS: "{{ zammad_groups | join(',') }}"
+        ZAMMAD_ORGANIZATION: "{{ zammad_organization }}"
       register: zammad_bootstrap
       changed_when: "'ZAMMAD_BOOTSTRAP_CHANGED' in zammad_bootstrap.stdout"
       no_log: true


### PR DESCRIPTION
## Why

The first live bring-up needed hand-repair in three places the bootstrap did not cover. Without this, a rebuild reproduces a half-seeded instance whose API rejects every request — so the fixes are codified here rather than left as one-off live edits.

## Changes

- Seed the top-level `dryvist` organization and place the admin in it.
- Add the estate's incident groups (`Homelab Infrastructure`, `AI/LLM Serving`, `Hermes Agent`) alongside the `Incidents` catch-all.
- Two token defects found the hard way:
  - Zammad's `Token` callbacks **regenerate the token value** on `create!`/`update!`, so a supplied secret never persists — `update_column` is the only path that stores the intended value. Symptom: the token in the secret store never matches the one Zammad accepts.
  - A token with **empty `preferences` has no permission scopes**, so every API call is rejected `"Authentication required"` even with a valid token.

Both remain create-or-find / reconcile-if-drifted, so the play stays idempotent.

## Verification

- Bootstrap is idempotent by construction (find-or-create; `changed` only on real writes).
- Token behavior confirmed live: with `preferences` set and the value written via `update_column`, the hermes token authenticates and can list groups, states, and users.
- Full converge re-verification of this branch is pending the Zammad DB credential reconciliation tracked in Zammad (Homelab Infrastructure) — the guest currently 500s on `password authentication failed`, which is unrelated to this diff.

Incident: Zammad (Homelab Infrastructure).