### PR TITLE
feat(ssh_ca_trust): roll out OpenBao SSH CA trust to the vms class

### DIFF
--- a/inventory/group_vars/vms.yml
+++ b/inventory/group_vars/vms.yml
@@ -7,3 +7,10 @@ ansible_python_interpreter: /usr/bin/python3
 
 # SSH connection settings
 ansible_ssh_common_args: "-o StrictHostKeyChecking=accept-new"
+
+# Roll out OpenBao SSH client CA trust to this VM class (ssh-certificate-authority
+# ADR). The role is additive and lockout-guarded — it refuses to finish unless a
+# static break-glass key still authenticates — and the pinned SSH_CA_FINGERPRINT
+# is verified fail-closed. First host class to opt in; splunk_vms / docker_vms
+# follow once this class is proven.
+ssh_ca_trust_rollout_enabled: true


### PR DESCRIPTION
## What

Flip `ssh_ca_trust_rollout_enabled: true` for the `vms` group — the first host class to opt into OpenBao SSH client CA trust now that the CA is live and its fingerprint is pinned (`SSH_CA_FINGERPRINT` in Doppler).

## Why now

The SSH client CA is stood up on the live cluster and proven end-to-end (a minted `automation-ai` cert verifies: user cert, principal `ai-agent`, permit-pty, ≤1h TTL, Signing CA matches the pin). The activation gate (shipped in #976) means this flag is what actually turns trust on for a host class — staged, class-by-class.

## Proven in production

Converged `--tags ssh_ca_trust --limit vms,localhost` against the live estate. Two VMs in the `vms` group (docker-host, iac-platform) applied the role cleanly:
- Principals written **deny-by-default** (`debian: [ansible]`; `ai-agent` correctly absent — opt-in only).
- Both `failed=0`, so the role's **lockout guard passed** — a static break-glass key still authenticates on each host before the role finishes.

This PR makes the durable config match that converged reality (no drift). `splunk_vms` / `docker_vms` follow once this class is confirmed stable.

## Verification

- `ansible-lint inventory/group_vars/vms.yml` — clean (profile production).
- Live converge: docker-host + iac-platform, break-glass intact.