### PR TITLE
feat(postgres): pgvector support + dedicated ai-VLAN memory cluster wiring

### DIFF
--- a/inventory/group_vars/postgres_ai_group.yml
+++ b/inventory/group_vars/postgres_ai_group.yml
@@ -1,0 +1,47 @@
+---
+# Dedicated ai-VLAN native PostgreSQL cluster backing the Hindsight
+# agent-memory service — separate from the shared-apps cluster
+# (postgres_group) because the memory plane must live entirely on the ai
+# VLAN. Same postgres role, same multi-tier DR standard (nightly pg_dump on
+# the persistent mount, standby-node archive pull via its own
+# postgres_standby_jobs entry, Tier-2 cloud upload).
+
+# HA: postgres-ai-1 is the primary; every other postgres_ai-tagged guest
+# reinitializes as a hot streaming standby (the role's replication path).
+postgres_primary_host: postgres-ai-1
+
+# Replication credential — bao-first (apps/hindsight, generated at source),
+# same env-fallback shape as the shared cluster's replication_password.
+postgres_replication_password: >-
+  {{ bao_apps_secrets.hindsight_replication_password
+     | default(lookup('env', 'HINDSIGHT_REPLICATION_PASSWORD'), true) }}
+
+# CIDR the primary accepts replication connections from (the standby lives
+# on the same ai VLAN). Env-derived — pg_hba needs a CIDR, not an FQDN.
+postgres_replication_cidr: "{{ lookup('env', 'NETWORK_CIDR_AI') | default('', true) }}"
+
+# Narrow the listener to the guest's own reservation address (derived
+# from the tofu inventory, never a literal). Falls back to the permissive role
+# default only when the reservation fact is absent (e.g. a molecule run, which
+# sets its own value anyway).
+# NB the space after the comma: postgres normalizes list GUCs to ", " — a
+# space-less value never matches SHOW output, so postgresql_set re-applies and
+# restarts the cluster on every converge.
+postgres_listen_addresses: >-
+  {{ ('localhost, ' ~ container_reserved_ip)
+     if (container_reserved_ip | default('', true) | length > 0)
+     else '*' }}
+
+# Databases on this cluster. Credential is bao-first (apps/hindsight,
+# generated at source); client_cidr is the ai VLAN — the Hindsight API
+# replicas are the only consumers, and this is the one legitimate place for
+# an (env-derived) CIDR since pg_hba cannot take an FQDN. pgvector ships as
+# a PGDG package via extensions:[vector].
+postgres_managed_databases:
+  - name: hindsight
+    user: hindsight
+    password: >-
+      {{ bao_apps_secrets.hindsight_db_password
+         | default(lookup('env', 'HINDSIGHT_DB_PASSWORD'), true) }}
+    client_cidr: "{{ lookup('env', 'NETWORK_CIDR_AI') | default('', true) }}"
+    extensions: [vector]

--- a/inventory/load_tofu.yml
+++ b/inventory/load_tofu.yml
@@ -140,6 +140,11 @@
               else []
             ) +
             (
+              ['postgres_ai_group']
+              if 'postgres_ai' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
               ['nautobot_group']
               if 'nautobot' in (item.value.tags | default([]))
               else []

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -23,7 +23,7 @@
     cribl_stream_group:cribl_edge:
     object_storage_group:
     netmon_group:prometheus_group:unifi_metrics_group:
-    postgres_group:nautobot_group:zammad_group:vikunja_group:
+    postgres_group:postgres_ai_group:hindsight_group:nautobot_group:zammad_group:vikunja_group:
     sonarr_group:radarr_group:plex_group:seerr_group:sortarr_group:download_vpn_group:immich_group
   gather_facts: false
   # `always`: every consumer role resolves its secrets bao-first, so a tagged
@@ -572,6 +572,19 @@
   gather_facts: true
   tags:
     - postgres
+    - database
+  roles:
+    - role: postgres
+
+- name: Configure ai-VLAN PostgreSQL (Hindsight memory cluster)
+  hosts: postgres_ai_group
+  become: true
+  gather_facts: true
+  # serial keeps the converge primary-then-standby: the standby's basebackup
+  # needs a running, already-converged primary.
+  serial: 1
+  tags:
+    - postgres_ai
     - database
   roles:
     - role: postgres

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -151,6 +151,12 @@ openbao_generated_app_secrets:
   # puts it in .pgpass). Bare name is safe in the flat bao_apps_secrets merge —
   # no other app path carries a replication_password field.
   postgres: [replication_password]
+  # Hindsight agent-memory service (ai VLAN): its dedicated ai-VLAN Postgres
+  # cluster's DB + replication credentials plus the Control Plane UI access
+  # key. App-namespaced for the flat bao_apps_secrets merge. The service's LLM
+  # key is NOT here — it reuses ai/llm's LLM_ROUTER_MASTER_KEY (local-llm
+  # domain), same router credential every ai-VLAN consumer uses.
+  hindsight: [hindsight_db_password, hindsight_replication_password, hindsight_cp_access_key]
 # Random length for generated app credentials (alnum). secret_key needs more
 # entropy than a login credential, so it gets its own length (matches the 64-char
 # key the nautobot role generates locally when none is supplied).

--- a/roles/openbao_secrets/defaults/main.yml
+++ b/roles/openbao_secrets/defaults/main.yml
@@ -91,6 +91,10 @@ openbao_secrets_domains:
       # roles/openbao openbao_generated_app_secrets.postgres); consumed by the
       # postgres role on both the primary and the standby.
       - apps/postgres
+      # Hindsight agent-memory (ai VLAN): DB + replication credentials for its
+      # dedicated Postgres cluster and the Control Plane access key (generated
+      # at source by openbao_generated_app_secrets.hindsight; app-namespaced).
+      - apps/hindsight
   - name: local-llm
     role_id_env: LOCAL_LLM_VAULT_ROLE_ID
     secret_id_env: LOCAL_LLM_VAULT_SECRET_ID

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -57,7 +57,16 @@ postgres_pgdg_repo: >-
 #   client_cidr - CIDR the user may connect from (the app's LXC subnet); the
 #                 ONLY place an IP literal is legitimate (pg_hba needs a CIDR,
 #                 not an FQDN), and even then it is env-derived, not hard-coded.
+#   extensions  - optional list of PostgreSQL extensions to enable in the
+#                 database (e.g. [vector]); the matching PGDG package is
+#                 installed via postgres_extension_packages below.
 postgres_managed_databases: []
+
+# Extension name -> PGDG apt package suffix (postgresql-<major>-<suffix>).
+# Only extensions that ship as separate PGDG packages need an entry; contrib
+# extensions resolve to the empty string and skip the package install.
+postgres_extension_packages:
+  vector: pgvector
 
 # pg_dump backups via a systemd timer, written to the persistent mount.
 postgres_backup_enabled: true

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -94,6 +94,8 @@
   loop: >-
     {{ postgres_managed_databases | map(attribute='extensions', default=[])
        | flatten | unique | select('in', postgres_extension_packages) | list }}
+  # Contrib extensions map to an empty suffix — nothing to apt-install.
+  when: postgres_extension_packages[item] | length > 0
 
 - name: Check whether the PostgreSQL cluster config exists
   ansible.builtin.stat:

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -84,6 +84,17 @@
       did not expose a server major version: {{ postgres_psql_version.stdout }}
   when: postgres_cluster_version | string | length == 0
 
+# Extension packages must be present on primary AND standbys (the standby
+# replays the catalog state but still needs the shared library on disk).
+- name: Install PGDG extension packages required by managed databases
+  ansible.builtin.apt:
+    name: >-
+      postgresql-{{ postgres_cluster_version }}-{{ postgres_extension_packages[item] }}
+    state: present
+  loop: >-
+    {{ postgres_managed_databases | map(attribute='extensions', default=[])
+       | flatten | unique | select('in', postgres_extension_packages) | list }}
+
 - name: Check whether the PostgreSQL cluster config exists
   ansible.builtin.stat:
     path: "{{ postgres_conf_dir }}"
@@ -408,6 +419,17 @@
       loop_control:
         label: "{{ item.name }}"
       no_log: true
+
+    - name: Enable each managed database's extensions
+      community.postgresql.postgresql_ext:
+        db: "{{ item.0.name }}"
+        name: "{{ item.1 }}"
+        state: present
+      loop: >-
+        {{ postgres_managed_databases
+           | subelements('extensions', skip_missing=True) }}
+      loop_control:
+        label: "{{ item.0.name }}: {{ item.1 }}"
 
     - name: Allow each managed user to connect from its client CIDR (scram)
       community.postgresql.postgresql_pg_hba:


### PR DESCRIPTION
## Summary
- `postgres` role: generic `extensions: [vector]` support per managed database — installs the matching PGDG package (`postgresql-<major>-pgvector`) on primary **and** standbys, enables the extension on the primary via `community.postgresql.postgresql_ext`.
- New `postgres_ai_group` (tofu tag `postgres_ai`): a dedicated ai-VLAN Postgres cluster for the Hindsight agent-memory service, reusing the role's streaming-replication HA (`postgres-ai-1` primary + hot standby) and the full DR standard unchanged.
- Secrets: `apps/hindsight` generated-at-source (DB password, replication password, Control Plane access key), fetched via the existing apps domain.
- `site.yml`: new `postgres_ai` phase (serial: 1, primary-then-standby); pre-fetch play covers `postgres_ai_group` + `hindsight_group`.

Part of the Hindsight standalone-memory-service campaign (tofu-proxmox#675 upstream; hindsight_docker role PR follows).

## Test plan
- `ansible-lint` production profile: 0 failures on 221 files.
- Molecule postgres scenario in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BgTn2CxMJmyY9yKXndsNaq