### PR TITLE
fix(postgres): name the pgBackRest stanza for the host, not the cluster

### DIFF
--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -139,13 +139,17 @@ postgres_standby_reinit: "{{ lookup('env', 'POSTGRES_STANDBY_REINIT') | default(
 # disable pg_dump, so this tier owns its own flag.
 postgres_pgbackrest_enabled: false
 
-# Stanza + repo layout. One stanza per cluster; the repo path is the in-bucket
-# prefix, so objects land at s3://<bucket>/postgres/<cluster_name>/... . The
-# bucket name is identical on RustFS and Backblaze B2 — B2's namespace is
+# Stanza + repo layout. The stanza is named for the HOST, not the cluster: every
+# Debian host names its cluster `main`, so deriving from postgres_cluster_name
+# gave each host the same stanza AND the same repo path, colliding them in one
+# shared repo (#1017). The repo path is the in-bucket prefix, so objects land at
+# s3://<bucket>/postgres/<inventory_hostname>/... — one prefix per host.
+#
+# The bucket name is identical on RustFS and Backblaze B2 — B2's namespace is
 # global, so one globally-unique name satisfies the 1:1 RustFS<->B2 parity rule.
-postgres_pgbackrest_stanza: "{{ postgres_cluster_name }}"
+postgres_pgbackrest_stanza: "{{ inventory_hostname }}"
 postgres_backup_s3_bucket: dryvist-homelab-backups
-postgres_pgbackrest_repo_path: "/postgres/{{ postgres_cluster_name }}"
+postgres_pgbackrest_repo_path: "/postgres/{{ postgres_pgbackrest_stanza }}"
 
 # S3-compatible endpoint + credentials. Injection-agnostic: the role reads env,
 # never a specific secret backend. RustFS/MinIO ignore the region but the AWS

--- a/roles/postgres/tasks/pgbackrest.yml
+++ b/roles/postgres/tasks/pgbackrest.yml
@@ -1,7 +1,9 @@
 ---
 # Object-storage PITR tier: pgBackRest archives WAL continuously and takes
-# scheduled base backups to an S3-compatible endpoint (RustFS; replicated to
-# Backblaze B2 out of band). Primary-only — a standby's WAL arrives via
+# scheduled base backups to an S3-compatible endpoint (repo1 = RustFS, and the
+# offsite repo2 when enabled — pgBackRest writes both itself; an out-of-band
+# mirror used to fill that role and silently copied a truncated subset, #1027).
+# Primary-only — a standby's WAL arrives via
 # streaming, and archive_command runs on the primary. Statically imported from
 # main.yml after the cluster is up and the version fact is set, so inner block
 # tags (never,pgbackrest_restore) behave exactly like inline tasks.
@@ -95,7 +97,7 @@
     # reports the stanza as present if it exists in ANY repo, so enabling repo2
     # on an existing host skipped creation and left the offsite repo
     # uninitialized. And `info` exits 0 with a stub for a missing stanza, so on a
-    # fresh host the gate never fired at all (#1017).
+    # fresh host the gate never fired at all (#1037).
     - name: Create the pgBackRest stanza in every configured repo
       become: true
       become_user: postgres
@@ -107,8 +109,8 @@
       register: postgres_pgbackrest_stanza_create
       changed_when: >-
         'already exists' not in
-        (postgres_pgbackrest_stanza_create.stdout | default('')
-         ~ postgres_pgbackrest_stanza_create.stderr | default(''))
+        ((postgres_pgbackrest_stanza_create.stdout | default(''))
+         ~ (postgres_pgbackrest_stanza_create.stderr | default('')))
 
     # `check` validates archiving against every configured repo, so enabling
     # repo2 extends this gate to the offsite copy automatically. Do NOT swap it


### PR DESCRIPTION
Every Debian host names its cluster `main`, so the stanza and repo path derived from `postgres_cluster_name` were identical on every host — colliding them in one shared repo (#1017).

The live hosts already run per-host stanzas as a manual workaround, so the **source had drifted from reality**: a converge would have created a second, empty stanza and repointed `archive_command` at it, orphaning the backups this tier just proved restorable.

Verified against both live hosts — the rendered stanza and repo path now equal the live `pgbackrest.conf` on each (`postgres`, `postgres-apps`), so a converge **adopts** the existing repos rather than replacing them.

Closes #1017.