### PR TITLE
feat(authelia): passkey-first SSO role + Traefik forwardAuth gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,9 @@ this repo handles app config only.
   -> Cribl Edge -> Splunk `os` index; the pipeline (Cribl) and LB (HAProxy) LXCs
   are excluded to avoid feedback loops)
 - **Technitium DNS** (LXC container)
+- **Authelia SSO** (`authelia` role — criticality-1 core service: passkey-first
+  portal + Traefik forwardAuth gate on every `sso`-flagged ingress route;
+  native binary on a mgmt-VLAN LXC, local SQLite state)
 - **apt-cacher-ng** (LXC container)
 - **Mailpit** (LXC container, SMTP relay with web UI)
 - **ntfy** (LXC container, push notification server)
@@ -163,6 +166,10 @@ documented once at
 | `SPLUNK_PASSWORD` | Splunk admin password (for E2E validation) | Doppler / SOPS |
 | `HAPROXY_STATS_PASSWORD` | HAProxy stats page password | SOPS |
 | `TECHNITIUM_DNS_API_TOKEN` | Technitium DNS API token | Doppler |
+| `AUTHELIA_JWT_SECRET` | Authelia identity-validation JWT secret | Doppler |
+| `AUTHELIA_SESSION_SECRET` | Authelia session cookie encryption secret | Doppler |
+| `AUTHELIA_STORAGE_ENCRYPTION_KEY` | Authelia SQLite at-rest encryption key (immutable after first start) | Doppler |
+| `AUTHELIA_ADMIN_PASSWORD` | Authelia bootstrap password (first login + passkey registration) | Doppler |
 | `MAILPIT_RELAY_HOST` | SMTP relay hostname | SOPS |
 | `MAILPIT_RELAY_PORT` | SMTP relay port (default 587) | SOPS |
 | `MAILPIT_RELAY_USERNAME` | SMTP relay username | SOPS |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,8 @@ this repo handles app config only.
 - **Technitium DNS** (LXC container)
 - **Authelia SSO** (`authelia` role — criticality-1 core service: passkey-first
   portal + Traefik forwardAuth gate on every `sso`-flagged ingress route;
-  native binary on a mgmt-VLAN LXC, local SQLite state)
+  native binary on a mgmt-VLAN LXC, local SQLite state. All its secrets are
+  generated-at-source on the guest — none live in Doppler/SOPS/OpenBao)
 - **apt-cacher-ng** (LXC container)
 - **Mailpit** (LXC container, SMTP relay with web UI)
 - **ntfy** (LXC container, push notification server)
@@ -166,10 +167,6 @@ documented once at
 | `SPLUNK_PASSWORD` | Splunk admin password (for E2E validation) | Doppler / SOPS |
 | `HAPROXY_STATS_PASSWORD` | HAProxy stats page password | SOPS |
 | `TECHNITIUM_DNS_API_TOKEN` | Technitium DNS API token | Doppler |
-| `AUTHELIA_JWT_SECRET` | Authelia identity-validation JWT secret | Doppler |
-| `AUTHELIA_SESSION_SECRET` | Authelia session cookie encryption secret | Doppler |
-| `AUTHELIA_STORAGE_ENCRYPTION_KEY` | Authelia SQLite at-rest encryption key (immutable after first start) | Doppler |
-| `AUTHELIA_ADMIN_PASSWORD` | Authelia bootstrap password (first login + passkey registration) | Doppler |
 | `MAILPIT_RELAY_HOST` | SMTP relay hostname | SOPS |
 | `MAILPIT_RELAY_PORT` | SMTP relay port (default 587) | SOPS |
 | `MAILPIT_RELAY_USERNAME` | SMTP relay username | SOPS |

--- a/inventory/load_tofu.yml
+++ b/inventory/load_tofu.yml
@@ -275,6 +275,11 @@
               else []
             ) +
             (
+              ['authelia_group']
+              if 'authelia' in (item.value.tags | default([]))
+              else []
+            ) +
+            (
               ['zammad_group']
               if 'zammad' in (item.value.tags | default([]))
               else []

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -889,6 +889,24 @@
     - role: zammad
 
 # =============================================================================
+# Phase 8c2: Authelia SSO portal (criticality-1 core service, auth plane)
+# Passkey-first forwardAuth provider gating every sso-flagged ingress route.
+# Must converge BEFORE Traefik so the forwardAuth backend answers when the
+# gated routes go live. Requires DNS (Phase 1a/1b) and Mailpit (notifier).
+# =============================================================================
+
+- name: Configure Authelia SSO portal
+  hosts: authelia_group
+  become: true
+  gather_facts: false
+  tags:
+    - authelia
+    - sso
+    - auth
+  roles:
+    - role: authelia
+
+# =============================================================================
 # Phase 8d: HTTPS ingress (Traefik)
 # Fronts every service web UI at https://<name>.<domain> (no ports) with a
 # wildcard Let's Encrypt cert fetched via Route53 DNS-01. On the media VLAN so

--- a/roles/authelia/README.md
+++ b/roles/authelia/README.md
@@ -21,28 +21,52 @@ opens every Traefik route whose tofu ingress row carries `sso = true`; the
 - **Mail**: identity-verification mails go to the internal SMTP relay
   (Mailpit) — open its UI to click verification links.
 
-## Secrets (Doppler / SOPS, env-injected)
+## Secrets — generated at the source, no shared store
 
-| Env var | Purpose |
-| --- | --- |
-| `AUTHELIA_JWT_SECRET` | Identity-validation JWT signing secret |
-| `AUTHELIA_SESSION_SECRET` | Session cookie encryption |
-| `AUTHELIA_STORAGE_ENCRYPTION_KEY` | SQLite at-rest encryption (immutable once set) |
-| `AUTHELIA_ADMIN_PASSWORD` | Bootstrap password for the admin user (first login + passkey registration) |
+Per the workspace generate-at-source rule, NONE of Authelia's secrets live in
+Doppler, SOPS, or OpenBao — they have no second consumer:
 
-Generate each independently (64 random chars). The storage encryption key
-cannot be changed after first start without resetting the database.
+- **JWT / session / storage-encryption secrets**: generated-if-absent on the
+  guest's persistent secrets directory and fed to the process via
+  `AUTHELIA_*_FILE` env vars in the systemd unit. Never rendered into config.
+  The storage encryption key is immutable once the database exists — the
+  create-if-absent write can never clobber it.
+- **Bootstrap password**: generated on first converge (same pattern as the
+  traefik dashboard credentials), persisted root-only at
+  `/etc/authelia/.bootstrap_password` for one-time retrieval. Read it once,
+  optionally keep it in your personal password manager (Bitwarden), and it
+  effectively retires after passkey registration. AI agents never need it —
+  machine endpoints are excluded from the SSO gate and keep their own tokens.
+
+## Installation
+
+Nothing manual — the role installs everything: the checksum-pinned release
+tarball is downloaded and verified on the controller (LXCs are firewalled
+outbound-internal-only), and the extracted binary is copied to
+`/opt/authelia` under systemd. Provisioning of the guest itself (VMID, static
+IP, firewall, ingress row) is owned by tofu-proxmox.
+
+## Usage
+
+```bash
+# Converge the portal + the gate (loader needs localhost in --limit)
+doppler run -- ansible-playbook -i inventory/hosts.yml playbooks/site.yml \
+  --tags authelia,traefik --limit authelia_group,traefik_group,localhost
+```
+
+Then complete [First-time setup](#first-time-setup). Gating is controlled
+per-route by the tofu-owned `sso` flag, not in this repo.
 
 ## Password rotation
 
 `users.yml` is seeded once (create-if-absent — the salted hash would differ
-every render). To rotate: update the Doppler secret, delete
-`/etc/authelia/users.yml` on the guest via a converge with the file absent,
-and re-run the role.
+every render). To rotate: delete `/etc/authelia/users.yml` and
+`/etc/authelia/.bootstrap_password` on the guest and re-converge; a fresh
+password is generated and persisted.
 
 ## First-time setup
 
 1. Converge (`--tags authelia` + `traefik`, with `localhost` in `--limit`).
-2. Browse to the portal, log in with the bootstrap password.
-3. Settings → Security → register a WebAuthn credential (Touch ID).
+2. Retrieve the bootstrap password from the root-only file on the guest.
+3. Browse to the portal, log in, register a WebAuthn credential (Touch ID).
 4. Subsequent logins: passkey only, "Remember me" checked.

--- a/roles/authelia/README.md
+++ b/roles/authelia/README.md
@@ -1,0 +1,48 @@
+# authelia
+
+Authelia SSO portal / Traefik forwardAuth provider — a criticality-1 core
+service (auth plane, beside ingress/DNS). One passkey login at the portal
+opens every Traefik route whose tofu ingress row carries `sso = true`; the
+`remember_me` session means roughly one login per week per browser.
+
+## How it fits
+
+- **Gate**: the `traefik` role renders an `authelia` forwardAuth middleware
+  and attaches it to every ingress route with `sso: true` (the flag is set in
+  tofu-proxmox `ingress.tf` and published through the inventory). Machine/API
+  endpoints and apps with native client auth opt out there.
+- **Login**: passkey-first (`webauthn.enable_passkey_login`) — Touch ID on the
+  registering Mac, synced to other devices via the platform keychain. The
+  bootstrap password exists only to create the account and register the first
+  passkey.
+- **State**: local SQLite on the persistent `/var/lib/authelia` mount
+  (passkey registrations survive rebuilds). Sessions are in-memory: a service
+  restart just re-prompts the browser.
+- **Mail**: identity-verification mails go to the internal SMTP relay
+  (Mailpit) — open its UI to click verification links.
+
+## Secrets (Doppler / SOPS, env-injected)
+
+| Env var | Purpose |
+| --- | --- |
+| `AUTHELIA_JWT_SECRET` | Identity-validation JWT signing secret |
+| `AUTHELIA_SESSION_SECRET` | Session cookie encryption |
+| `AUTHELIA_STORAGE_ENCRYPTION_KEY` | SQLite at-rest encryption (immutable once set) |
+| `AUTHELIA_ADMIN_PASSWORD` | Bootstrap password for the admin user (first login + passkey registration) |
+
+Generate each independently (64 random chars). The storage encryption key
+cannot be changed after first start without resetting the database.
+
+## Password rotation
+
+`users.yml` is seeded once (create-if-absent — the salted hash would differ
+every render). To rotate: update the Doppler secret, delete
+`/etc/authelia/users.yml` on the guest via a converge with the file absent,
+and re-run the role.
+
+## First-time setup
+
+1. Converge (`--tags authelia` + `traefik`, with `localhost` in `--limit`).
+2. Browse to the portal, log in with the bootstrap password.
+3. Settings → Security → register a WebAuthn credential (Touch ID).
+4. Subsequent logins: passkey only, "Remember me" checked.

--- a/roles/authelia/defaults/main.yml
+++ b/roles/authelia/defaults/main.yml
@@ -1,0 +1,71 @@
+---
+# Authelia SSO portal / Traefik forwardAuth provider — a single native Go
+# binary. Every Traefik router whose tofu ingress row has sso=true redirects
+# unauthenticated browsers here; one passkey login opens every gated UI for
+# the session lifetime. Single instance: in-memory sessions + local SQLite
+# (one/two users — no Redis, no Postgres).
+
+# --- Version / controller-staged, checksum-verified download ----------------
+# LXCs in this repo are firewalled outbound-internal-only, so the release
+# tarball is downloaded and checksum-verified on the CONTROLLER, then the
+# extracted binary is copied to the target — same pattern as roles/vikunja.
+# renovate: datasource=github-releases depName=authelia/authelia
+authelia_version: "4.39.20"
+authelia_release_tgz: "authelia-v{{ authelia_version }}-linux-amd64.tar.gz"
+authelia_release_tgz_url: >-
+  https://github.com/authelia/authelia/releases/download/v{{ authelia_version }}/{{ authelia_release_tgz }}
+authelia_release_tgz_sha256: "1f122add61752d6ef54e64ae7116bec4e026f5c0a6493498288c5a9770d92088"
+authelia_binary_name: authelia
+
+# --- System user / paths ------------------------------------------------------
+authelia_user: authelia
+authelia_group: authelia
+authelia_install_dir: /opt/authelia
+authelia_binary_path: "{{ authelia_install_dir }}/authelia"
+authelia_config_dir: /etc/authelia
+authelia_config_file: "{{ authelia_config_dir }}/configuration.yml"
+authelia_users_file: "{{ authelia_config_dir }}/users.yml"
+# SQLite + notification state live on the persistent bind mount at
+# /var/lib/authelia (provisioned by terraform-proxmox), never the ephemeral
+# rootfs — WebAuthn credential registrations must survive a rebuild.
+authelia_data_dir: /var/lib/authelia
+authelia_db_path: "{{ authelia_data_dir }}/db.sqlite3"
+
+# --- Network / domains ---------------------------------------------------------
+authelia_port: "{{ tofu_data.constants.service_ports.authelia_portal }}"
+# The ingress base domain — the session cookie is scoped to it so ONE login
+# covers every <name>.<base> UI. Must match the Traefik router FQDNs.
+authelia_cookie_domain: "{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
+authelia_portal_url: "https://authelia.{{ authelia_cookie_domain }}"
+
+# --- Sessions: login once, stay signed in for a week --------------------------
+authelia_session_expiration: "12h"
+authelia_session_inactivity: "12h"
+authelia_session_remember_me: "1w"
+
+# --- Users ---------------------------------------------------------------------
+# File backend, seeded once (create-if-absent — the live users.yml is never
+# overwritten, it accumulates WebAuthn state via the portal). The password is
+# only used to bootstrap the account; day-to-day login is the passkey.
+authelia_admin_user: jevans
+authelia_admin_display_name: "Jacob Evans"
+authelia_admin_email: "{{ authelia_admin_user }}@{{ tofu_data.domain }}"
+authelia_admin_password: "{{ lookup('env', 'AUTHELIA_ADMIN_PASSWORD') }}"
+
+# --- Secrets: injection-agnostic plain env lookups (AGENTS.md convention) ---
+authelia_jwt_secret: "{{ lookup('env', 'AUTHELIA_JWT_SECRET') }}"
+authelia_session_secret: "{{ lookup('env', 'AUTHELIA_SESSION_SECRET') }}"
+authelia_storage_encryption_key: "{{ lookup('env', 'AUTHELIA_STORAGE_ENCRYPTION_KEY') }}"
+
+# --- Notifier: the existing internal SMTP relay -------------------------------
+# Identity-verification mails (WebAuthn device registration, password reset)
+# land in the Mailpit UI.
+authelia_smtp_host: "mailpit.{{ tofu_data.domain }}"
+authelia_smtp_port: "{{ tofu_data.constants.notification_ports.mailpit_smtp }}"
+authelia_smtp_sender: "authelia@{{ tofu_data.domain }}"
+
+# --- Behaviour toggles ---------------------------------------------------------
+# false in CI/molecule/template-render: render config but no binary/systemd.
+authelia_manage_services: true
+
+authelia_api_timeout: 30

--- a/roles/authelia/defaults/main.yml
+++ b/roles/authelia/defaults/main.yml
@@ -45,17 +45,25 @@ authelia_session_remember_me: "1w"
 
 # --- Users ---------------------------------------------------------------------
 # File backend, seeded once (create-if-absent — the live users.yml is never
-# overwritten, it accumulates WebAuthn state via the portal). The password is
-# only used to bootstrap the account; day-to-day login is the passkey.
+# overwritten, it accumulates WebAuthn state via the portal). The bootstrap
+# password is generated on the host at first converge (never in Doppler /
+# OpenBao — see the generate-at-source rule in AGENTS.md) and persisted
+# root-only for one-time retrieval; day-to-day login is the passkey.
 authelia_admin_user: jevans
 authelia_admin_display_name: "Jacob Evans"
 authelia_admin_email: "{{ authelia_admin_user }}@{{ tofu_data.domain }}"
-authelia_admin_password: "{{ lookup('env', 'AUTHELIA_ADMIN_PASSWORD') }}"
+authelia_bootstrap_password_file: "{{ authelia_config_dir }}/.bootstrap_password"
 
-# --- Secrets: injection-agnostic plain env lookups (AGENTS.md convention) ---
-authelia_jwt_secret: "{{ lookup('env', 'AUTHELIA_JWT_SECRET') }}"
-authelia_session_secret: "{{ lookup('env', 'AUTHELIA_SESSION_SECRET') }}"
-authelia_storage_encryption_key: "{{ lookup('env', 'AUTHELIA_STORAGE_ENCRYPTION_KEY') }}"
+# --- Service secrets: generated at the source, no shared store ---------------
+# JWT / session / storage-encryption secrets have no second consumer, so per
+# the workspace generate-at-source rule they are generated-if-absent on the
+# guest's persistent mount and fed to Authelia via *_FILE env vars. They never
+# touch Doppler, OpenBao, or the rendered config.
+authelia_secrets_dir: "{{ authelia_data_dir }}/secrets"
+authelia_secret_files:
+  jwt_secret: "{{ authelia_secrets_dir }}/jwt_secret"
+  session_secret: "{{ authelia_secrets_dir }}/session_secret"
+  storage_key: "{{ authelia_secrets_dir }}/storage_encryption_key"
 
 # --- Notifier: the existing internal SMTP relay -------------------------------
 # Identity-verification mails (WebAuthn device registration, password reset)

--- a/roles/authelia/defaults/main.yml
+++ b/roles/authelia/defaults/main.yml
@@ -73,7 +73,8 @@ authelia_smtp_port: "{{ tofu_data.constants.notification_ports.mailpit_smtp }}"
 authelia_smtp_sender: "authelia@{{ tofu_data.domain }}"
 
 # --- Behaviour toggles ---------------------------------------------------------
-# false in CI/molecule/template-render: render config but no binary/systemd.
+# false in CI/molecule contexts: skips systemd unit install/start and the live
+# health check only (binary staging and config render still run).
 authelia_manage_services: true
 
 authelia_api_timeout: 30

--- a/roles/authelia/handlers/main.yml
+++ b/roles/authelia/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Restart authelia
+  ansible.builtin.systemd:
+    name: authelia
+    state: restarted
+    daemon_reload: true
+  when: authelia_manage_services | bool

--- a/roles/authelia/meta/main.yml
+++ b/roles/authelia/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  author: JacobPEvans
+  description: >-
+    Authelia SSO portal / Traefik forwardAuth provider — native single Go
+    binary, passkey-first login, local SQLite state. Criticality-1 core
+    service: one login gates every sso-flagged ingress route.
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+  galaxy_tags:
+    - authelia
+    - sso
+    - authentication
+dependencies: []

--- a/roles/authelia/tasks/main.yml
+++ b/roles/authelia/tasks/main.yml
@@ -69,16 +69,32 @@
     ansible_become: false
   run_once: true
 
+# Extract into a VERSIONED staging dir: the tarball's binary is named bare
+# `authelia`, so an unversioned creates-guard would keep copying a stale
+# binary after a version bump (the vikunja role dodges this only because its
+# binary name embeds the version).
+- name: Create versioned staging dir on controller
+  ansible.builtin.file:
+    path: "/tmp/authelia-v{{ authelia_version }}"
+    state: directory
+    mode: "0755"
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  run_once: true
+
 - name: Extract the Authelia binary on controller
   ansible.builtin.unarchive:
     src: "/tmp/{{ authelia_release_tgz }}"
-    dest: /tmp
+    dest: "/tmp/authelia-v{{ authelia_version }}"
     remote_src: true
     include:
       - "{{ authelia_binary_name }}"
     # unarchive re-extracts (and reports changed) every run without this guard;
     # the tarball is checksum-pinned, so an existing extract is always current.
-    creates: "/tmp/{{ authelia_binary_name }}"
+    creates: "/tmp/authelia-v{{ authelia_version }}/{{ authelia_binary_name }}"
   delegate_to: localhost
   connection: local
   become: false
@@ -88,7 +104,7 @@
 
 - name: Copy the Authelia binary to the target
   ansible.builtin.copy:
-    src: "/tmp/{{ authelia_binary_name }}"
+    src: "/tmp/authelia-v{{ authelia_version }}/{{ authelia_binary_name }}"
     dest: "{{ authelia_binary_path }}"
     owner: root
     group: root

--- a/roles/authelia/tasks/main.yml
+++ b/roles/authelia/tasks/main.yml
@@ -1,0 +1,178 @@
+---
+# Authelia native install. The controller stages the checksum-verified release
+# tarball (LXCs here are firewalled outbound-internal-only and cannot reach
+# GitHub), extracts the single binary, and copies it to the target — same
+# controller-staging pattern as roles/vikunja and roles/openbao.
+
+- name: Validate Authelia secrets are set
+  ansible.builtin.assert:
+    that:
+      - authelia_jwt_secret | length > 0
+      - authelia_session_secret | length > 0
+      - authelia_storage_encryption_key | length > 0
+      - authelia_admin_password | length > 0
+    fail_msg: >-
+      AUTHELIA_JWT_SECRET / AUTHELIA_SESSION_SECRET /
+      AUTHELIA_STORAGE_ENCRYPTION_KEY / AUTHELIA_ADMIN_PASSWORD must all be
+      set before first deploy. Add via: doppler secrets set
+      AUTHELIA_JWT_SECRET=<64 random chars> ... (generate each independently).
+    quiet: true
+  no_log: true
+
+- name: Create authelia system group
+  ansible.builtin.group:
+    name: "{{ authelia_group }}"
+    system: true
+    state: present
+
+- name: Create authelia system user
+  ansible.builtin.user:
+    name: "{{ authelia_user }}"
+    group: "{{ authelia_group }}"
+    system: true
+    shell: /usr/sbin/nologin
+    home: "{{ authelia_install_dir }}"
+    create_home: false
+    state: present
+
+- name: Create Authelia directories
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: "{{ item.owner }}"
+    group: "{{ authelia_group }}"
+    mode: "{{ item.mode }}"
+  loop:
+    - { path: "{{ authelia_install_dir }}", owner: root, mode: "0755" }
+    - { path: "{{ authelia_config_dir }}", owner: root, mode: "0750" }
+    - { path: "{{ authelia_data_dir }}", owner: "{{ authelia_user }}", mode: "0750" }
+  loop_control:
+    label: "{{ item.path }}"
+
+# ansible_become: false on the delegated tasks is REQUIRED — Ansible inherits
+# the play's become: true on delegated tasks regardless of task-level become,
+# which fails with "sudo: a password is required" on the controller.
+- name: Stage the Authelia release tarball on controller (checksum-verified)
+  ansible.builtin.get_url:
+    url: "{{ authelia_release_tgz_url }}"
+    dest: "/tmp/{{ authelia_release_tgz }}"
+    checksum: "sha256:{{ authelia_release_tgz_sha256 }}"
+    mode: "0644"
+    force: true
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  run_once: true
+
+- name: Extract the Authelia binary on controller
+  ansible.builtin.unarchive:
+    src: "/tmp/{{ authelia_release_tgz }}"
+    dest: /tmp
+    remote_src: true
+    include:
+      - "{{ authelia_binary_name }}"
+    # unarchive re-extracts (and reports changed) every run without this guard;
+    # the tarball is checksum-pinned, so an existing extract is always current.
+    creates: "/tmp/{{ authelia_binary_name }}"
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  run_once: true
+
+- name: Copy the Authelia binary to the target
+  ansible.builtin.copy:
+    src: "/tmp/{{ authelia_binary_name }}"
+    dest: "{{ authelia_binary_path }}"
+    owner: root
+    group: root
+    mode: "0755"
+  notify: Restart authelia
+
+- name: Render Authelia config
+  ansible.builtin.template:
+    src: configuration.yml.j2
+    dest: "{{ authelia_config_file }}"
+    owner: root
+    group: "{{ authelia_group }}"
+    mode: "0640"
+  no_log: true
+  notify: Restart authelia
+
+# --- Users file: seed once, never overwrite ----------------------------------
+# The live users.yml is bootstrap-only state: the portal appends WebAuthn
+# passkey registrations to the STORAGE (SQLite), but the password hash in
+# users.yml must not be clobbered on every converge (the hash is salted, so a
+# re-render would always differ). Create-if-absent, like the traefik dashboard
+# htpasswd. To change the password: delete the file and re-converge.
+- name: Check whether the users database already exists
+  ansible.builtin.stat:
+    path: "{{ authelia_users_file }}"
+  register: authelia_users_stat
+
+- name: Hash the bootstrap password
+  ansible.builtin.command:
+    argv:
+      - "{{ authelia_binary_path }}"
+      - crypto
+      - hash
+      - generate
+      - argon2
+      - --password
+      - "{{ authelia_admin_password }}"
+  register: authelia_hash_out
+  when: not authelia_users_stat.stat.exists
+  changed_when: false
+  no_log: true
+
+- name: Seed the users database (create-if-absent)
+  ansible.builtin.template:
+    src: users.yml.j2
+    dest: "{{ authelia_users_file }}"
+    owner: root
+    group: "{{ authelia_group }}"
+    mode: "0640"
+  vars:
+    # `authelia crypto hash generate` prints "Digest: <hash>".
+    authelia_admin_password_hash: "{{ authelia_hash_out.stdout | regex_replace('^Digest:\\s*', '') }}"
+  when: not authelia_users_stat.stat.exists
+  no_log: true
+  notify: Restart authelia
+
+- name: Install the authelia systemd unit
+  ansible.builtin.template:
+    src: authelia.service.j2
+    dest: /etc/systemd/system/authelia.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart authelia
+  when: authelia_manage_services | bool
+
+- name: Enable and start Authelia
+  ansible.builtin.systemd:
+    name: authelia
+    state: started
+    enabled: true
+    daemon_reload: true
+  when: authelia_manage_services | bool
+
+# Flush so a config/unit/binary change is live before the health check.
+- name: Apply any pending Authelia restart
+  ansible.builtin.meta: flush_handlers
+
+- name: Wait for Authelia to answer its health endpoint
+  ansible.builtin.uri:
+    url: "http://localhost:{{ authelia_port }}/api/health"
+    method: GET
+    status_code: [200]
+    timeout: "{{ authelia_api_timeout }}"
+  register: authelia_health
+  until: authelia_health.status == 200
+  retries: 10
+  delay: 3
+  changed_when: false
+  when: authelia_manage_services | bool

--- a/roles/authelia/tasks/main.yml
+++ b/roles/authelia/tasks/main.yml
@@ -4,21 +4,6 @@
 # GitHub), extracts the single binary, and copies it to the target — same
 # controller-staging pattern as roles/vikunja and roles/openbao.
 
-- name: Validate Authelia secrets are set
-  ansible.builtin.assert:
-    that:
-      - authelia_jwt_secret | length > 0
-      - authelia_session_secret | length > 0
-      - authelia_storage_encryption_key | length > 0
-      - authelia_admin_password | length > 0
-    fail_msg: >-
-      AUTHELIA_JWT_SECRET / AUTHELIA_SESSION_SECRET /
-      AUTHELIA_STORAGE_ENCRYPTION_KEY / AUTHELIA_ADMIN_PASSWORD must all be
-      set before first deploy. Add via: doppler secrets set
-      AUTHELIA_JWT_SECRET=<64 random chars> ... (generate each independently).
-    quiet: true
-  no_log: true
-
 - name: Create authelia system group
   ansible.builtin.group:
     name: "{{ authelia_group }}"
@@ -46,8 +31,26 @@
     - { path: "{{ authelia_install_dir }}", owner: root, mode: "0755" }
     - { path: "{{ authelia_config_dir }}", owner: root, mode: "0750" }
     - { path: "{{ authelia_data_dir }}", owner: "{{ authelia_user }}", mode: "0750" }
+    - { path: "{{ authelia_secrets_dir }}", owner: "{{ authelia_user }}", mode: "0700" }
   loop_control:
     label: "{{ item.path }}"
+
+# --- Service secrets: generate-at-source, no shared store --------------------
+# force:false = create-if-absent; an existing secret is never rewritten, so
+# converges stay stable and the storage encryption key (immutable once the
+# SQLite db exists) can never be clobbered. Lives on the persistent mount.
+- name: Generate service secrets (create-if-absent, guest-local)
+  ansible.builtin.copy:
+    content: "{{ lookup('community.general.random_string', length=64, special=false) }}"
+    dest: "{{ item.value }}"
+    force: false
+    owner: "{{ authelia_user }}"
+    group: "{{ authelia_group }}"
+    mode: "0600"
+  loop: "{{ authelia_secret_files | dict2items }}"
+  loop_control:
+    label: "{{ item.value }}"
+  no_log: true
 
 # ansible_become: false on the delegated tasks is REQUIRED — Ansible inherits
 # the play's become: true on delegated tasks regardless of task-level become,
@@ -107,40 +110,58 @@
 # passkey registrations to the STORAGE (SQLite), but the password hash in
 # users.yml must not be clobbered on every converge (the hash is salted, so a
 # re-render would always differ). Create-if-absent, like the traefik dashboard
-# htpasswd. To change the password: delete the file and re-converge.
+# htpasswd: the bootstrap password is GENERATED here (never Doppler/OpenBao —
+# generate-at-source rule) and persisted root-only for one-time retrieval; the
+# operator may then keep it in their personal password manager. To rotate:
+# delete users.yml + the password file and re-converge.
 - name: Check whether the users database already exists
   ansible.builtin.stat:
     path: "{{ authelia_users_file }}"
   register: authelia_users_stat
 
-- name: Hash the bootstrap password
-  ansible.builtin.command:
-    argv:
-      - "{{ authelia_binary_path }}"
-      - crypto
-      - hash
-      - generate
-      - argon2
-      - --password
-      - "{{ authelia_admin_password }}"
-  register: authelia_hash_out
+- name: Seed the users database (first run only)
   when: not authelia_users_stat.stat.exists
-  changed_when: false
-  no_log: true
+  block:
+    - name: Generate the bootstrap password
+      ansible.builtin.set_fact:
+        authelia_bootstrap_password: "{{ lookup('community.general.random_string', length=24, special=false) }}"
+      no_log: true
 
-- name: Seed the users database (create-if-absent)
-  ansible.builtin.template:
-    src: users.yml.j2
-    dest: "{{ authelia_users_file }}"
-    owner: root
-    group: "{{ authelia_group }}"
-    mode: "0640"
-  vars:
-    # `authelia crypto hash generate` prints "Digest: <hash>".
-    authelia_admin_password_hash: "{{ authelia_hash_out.stdout | regex_replace('^Digest:\\s*', '') }}"
-  when: not authelia_users_stat.stat.exists
-  no_log: true
-  notify: Restart authelia
+    - name: Persist the bootstrap password for one-time retrieval (root-only)
+      ansible.builtin.copy:
+        content: "{{ authelia_admin_user }}:{{ authelia_bootstrap_password }}\n"
+        dest: "{{ authelia_bootstrap_password_file }}"
+        owner: root
+        group: root
+        mode: "0600"
+      no_log: true
+
+    - name: Hash the bootstrap password
+      ansible.builtin.command:
+        argv:
+          - "{{ authelia_binary_path }}"
+          - crypto
+          - hash
+          - generate
+          - argon2
+          - --password
+          - "{{ authelia_bootstrap_password }}"
+      register: authelia_hash_out
+      changed_when: false
+      no_log: true
+
+    - name: Seed the users database (create-if-absent)
+      ansible.builtin.template:
+        src: users.yml.j2
+        dest: "{{ authelia_users_file }}"
+        owner: root
+        group: "{{ authelia_group }}"
+        mode: "0640"
+      vars:
+        # `authelia crypto hash generate` prints "Digest: <hash>".
+        authelia_admin_password_hash: "{{ authelia_hash_out.stdout | regex_replace('^Digest:\\s*', '') }}"
+      no_log: true
+      notify: Restart authelia
 
 - name: Install the authelia systemd unit
   ansible.builtin.template:

--- a/roles/authelia/templates/authelia.service.j2
+++ b/roles/authelia/templates/authelia.service.j2
@@ -1,0 +1,17 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Authelia SSO portal / forwardAuth provider
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ authelia_user }}
+Group={{ authelia_group }}
+WorkingDirectory={{ authelia_install_dir }}
+ExecStart={{ authelia_binary_path }} --config {{ authelia_config_file }}
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/authelia/templates/authelia.service.j2
+++ b/roles/authelia/templates/authelia.service.j2
@@ -9,6 +9,11 @@ Type=simple
 User={{ authelia_user }}
 Group={{ authelia_group }}
 WorkingDirectory={{ authelia_install_dir }}
+# Secrets are guest-generated files (generate-at-source rule) — fed via the
+# *_FILE variables so the rendered config contains no secret material.
+Environment=AUTHELIA_IDENTITY_VALIDATION_RESET_PASSWORD_JWT_SECRET_FILE={{ authelia_secret_files.jwt_secret }}
+Environment=AUTHELIA_SESSION_SECRET_FILE={{ authelia_secret_files.session_secret }}
+Environment=AUTHELIA_STORAGE_ENCRYPTION_KEY_FILE={{ authelia_secret_files.storage_key }}
 ExecStart={{ authelia_binary_path }} --config {{ authelia_config_file }}
 Restart=on-failure
 RestartSec=3

--- a/roles/authelia/templates/configuration.yml.j2
+++ b/roles/authelia/templates/configuration.yml.j2
@@ -2,8 +2,9 @@
 # Authelia configuration — passkey-first SSO portal + Traefik forwardAuth
 # provider. Single instance: in-memory session provider (a restart re-prompts
 # the browser; acceptable for a homelab) and local SQLite on the persistent
-# data mount. Secrets are rendered inline (0640 root:authelia), same treatment
-# as the vikunja config.
+# data mount. NO secrets live in this file — the JWT/session/storage secrets
+# are guest-generated files fed via AUTHELIA_*_FILE env vars in the systemd
+# unit (generate-at-source rule; no shared secret store involved).
 
 theme: auto
 
@@ -12,10 +13,6 @@ server:
 
 log:
   level: info
-
-identity_validation:
-  reset_password:
-    jwt_secret: "{{ authelia_jwt_secret }}"
 
 authentication_backend:
   file:
@@ -37,7 +34,6 @@ access_control:
       policy: one_factor
 
 session:
-  secret: "{{ authelia_session_secret }}"
   cookies:
     - domain: "{{ authelia_cookie_domain }}"
       authelia_url: "{{ authelia_portal_url }}"
@@ -51,7 +47,6 @@ regulation:
   ban_time: "5m"
 
 storage:
-  encryption_key: "{{ authelia_storage_encryption_key }}"
   local:
     path: "{{ authelia_db_path }}"
 

--- a/roles/authelia/templates/configuration.yml.j2
+++ b/roles/authelia/templates/configuration.yml.j2
@@ -1,0 +1,63 @@
+{{ ansible_managed | comment }}
+# Authelia configuration — passkey-first SSO portal + Traefik forwardAuth
+# provider. Single instance: in-memory session provider (a restart re-prompts
+# the browser; acceptable for a homelab) and local SQLite on the persistent
+# data mount. Secrets are rendered inline (0640 root:authelia), same treatment
+# as the vikunja config.
+
+theme: auto
+
+server:
+  address: "tcp://0.0.0.0:{{ authelia_port }}"
+
+log:
+  level: info
+
+identity_validation:
+  reset_password:
+    jwt_secret: "{{ authelia_jwt_secret }}"
+
+authentication_backend:
+  file:
+    path: "{{ authelia_users_file }}"
+
+# Passkey-first login: a discoverable WebAuthn credential is a full first
+# factor, so day-to-day login is one Touch ID prompt — no password typed.
+webauthn:
+  disable: false
+  enable_passkey_login: true
+
+access_control:
+  default_policy: deny
+  rules:
+    # Every Traefik-fronted UI under the ingress base domain. one_factor is
+    # the passkey (passkey login satisfies one_factor); step-up to
+    # two_factor per-domain later if wanted.
+    - domain: "*.{{ authelia_cookie_domain }}"
+      policy: one_factor
+
+session:
+  secret: "{{ authelia_session_secret }}"
+  cookies:
+    - domain: "{{ authelia_cookie_domain }}"
+      authelia_url: "{{ authelia_portal_url }}"
+      expiration: "{{ authelia_session_expiration }}"
+      inactivity: "{{ authelia_session_inactivity }}"
+      remember_me: "{{ authelia_session_remember_me }}"
+
+regulation:
+  max_retries: 3
+  find_time: "2m"
+  ban_time: "5m"
+
+storage:
+  encryption_key: "{{ authelia_storage_encryption_key }}"
+  local:
+    path: "{{ authelia_db_path }}"
+
+notifier:
+  smtp:
+    address: "smtp://{{ authelia_smtp_host }}:{{ authelia_smtp_port }}"
+    sender: "Authelia <{{ authelia_smtp_sender }}>"
+    # The internal relay accepts unauthenticated plain SMTP.
+    disable_require_tls: true

--- a/roles/authelia/templates/users.yml.j2
+++ b/roles/authelia/templates/users.yml.j2
@@ -1,0 +1,12 @@
+{{ ansible_managed | comment }}
+# Bootstrap users database — SEEDED ONCE (create-if-absent; a converge never
+# overwrites it). Passkeys registered via the portal live in the SQLite
+# storage, not here. To rotate the password: delete this file and re-converge.
+users:
+  {{ authelia_admin_user }}:
+    disabled: false
+    displayname: "{{ authelia_admin_display_name }}"
+    password: "{{ authelia_admin_password_hash }}"
+    email: "{{ authelia_admin_email }}"
+    groups:
+      - admins

--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -89,7 +89,7 @@
 # (default http), insecure_tls (self-signed backend, e.g. Splunk / Proxmox),
 # sticky + health_check (pool session affinity + per-node health checks). Every
 # row is normalised here to {name, fqdn, servers[], scheme, insecure_tls,
-# sticky, health_check} so the template stays dumb (and fixture-testable):
+# sticky, health_check, sso} so the template stays dumb (and fixture-testable):
 #   - fqdn    = base domain itself when apex, else <name>.<base domain>
 #   - servers = one <scheme>://<host-or-ip>:<port> url per backend (or the
 #               single ip), so single and multi-backend rows render uniformly.
@@ -109,7 +109,8 @@
           'scheme': item.scheme | default('http'),
           'insecure_tls': item.insecure_tls | default(false),
           'sticky': item.sticky | default(false),
-          'health_check': item.health_check | default(false)
+          'health_check': item.health_check | default(false),
+          'sso': item.sso | default(false)
         }]
       }}
   loop: "{{ traefik_ingress_routes }}"

--- a/roles/traefik/templates/dynamic.yml.j2
+++ b/roles/traefik/templates/dynamic.yml.j2
@@ -2,6 +2,13 @@
    inventory (traefik_routes, built in tasks/main.yml). Each router requests the
    single wildcard *.{{ traefik_base_domain }} cert so Traefik issues it once and
    serves it for every host. Managed by Ansible (traefik role). Do not edit. #}
+{# The Authelia forwardAuth middleware dials the authelia BACKEND url directly
+   (its ingress-row server), never authelia.<domain> — that FQDN CNAMEs back to
+   Traefik itself and would loop. Routes opt in via the tofu-owned sso flag;
+   when no authelia route exists in the inventory nothing is gated (safe
+   pre-cutover rollout). #}
+{% set authelia_routes = traefik_routes | selectattr('name', 'equalto', 'authelia') | list %}
+{% set sso_enabled = authelia_routes | length > 0 %}
 http:
   routers:
 {% for route in traefik_routes %}
@@ -10,6 +17,10 @@ http:
       service: {{ route.name }}
       entryPoints:
         - websecure
+{% if sso_enabled and route.sso | default(false) %}
+      middlewares:
+        - authelia
+{% endif %}
       tls:
         certResolver: letsencrypt
         domains:
@@ -69,10 +80,22 @@ http:
     insecure-backend:
       insecureSkipVerify: true
 {% endif %}
-{% if traefik_dashboard_enabled %}
+{% if traefik_dashboard_enabled or sso_enabled %}
 
   middlewares:
+{% if traefik_dashboard_enabled %}
     dashboard-auth:
       basicAuth:
         usersFile: "{{ traefik_dashboard_users_file }}"
+{% endif %}
+{% if sso_enabled %}
+    authelia:
+      forwardAuth:
+        address: "{{ authelia_routes[0].servers[0] }}/api/authz/forward-auth"
+        authResponseHeaders:
+          - Remote-User
+          - Remote-Groups
+          - Remote-Email
+          - Remote-Name
+{% endif %}
 {% endif %}

--- a/roles/traefik/templates/dynamic.yml.j2
+++ b/roles/traefik/templates/dynamic.yml.j2
@@ -17,7 +17,9 @@ http:
       service: {{ route.name }}
       entryPoints:
         - websecure
-{% if sso_enabled and route.sso | default(false) %}
+{# route.name != 'authelia': the portal must never gate itself (auth loop),
+   even if its inventory row is ever mis-flagged sso: true. #}
+{% if sso_enabled and route.name != 'authelia' and route.sso | default(false) %}
       middlewares:
         - authelia
 {% endif %}

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1023,7 +1023,11 @@
     traefik_ingress_routes:
       - { name: plex, ip: "192.0.2.10", port: 32400 }
       # HTTPS backend with a self-signed cert (e.g. Splunk Web) -> insecure_tls.
-      - { name: splunk, ip: "192.0.2.12", port: 8000, scheme: https, insecure_tls: true }
+      # sso: true -> the router gets the authelia forwardAuth middleware.
+      - { name: splunk, ip: "192.0.2.12", port: 8000, scheme: https, insecure_tls: true, sso: true }
+      # The Authelia portal row itself (never sso-gated); its backend url is
+      # what the forwardAuth middleware dials.
+      - { name: authelia, ip: "192.0.2.14", port: 9091 }
       # Proxmox cluster-UI apex: load-balanced pool over the node FQDNs, sticky
       # + health-checked, https to self-signed node backends.
       - name: proxmox
@@ -1057,7 +1061,8 @@
               'scheme': item.scheme | default('http'),
               'insecure_tls': item.insecure_tls | default(false),
               'sticky': item.sticky | default(false),
-              'health_check': item.health_check | default(false)
+              'health_check': item.health_check | default(false),
+              'sso': item.sso | default(false)
             }]
           }}
       loop: "{{ traefik_ingress_routes }}"
@@ -1172,6 +1177,25 @@
         fail_msg: >-
           dynamic.yml.j2 apex service wrong: pool size/urls, sticky cookie,
           healthCheck, or serversTransport not rendered as expected.
+
+    - name: Assert the sso flag gates exactly the flagged routers via forwardAuth
+      ansible.builtin.assert:
+        that:
+          # sso: true -> the router carries the authelia middleware.
+          - "'authelia' in _traefik_dynamic_yaml.http.routers.splunk.middlewares"
+          # Unflagged routers (and the portal itself) carry none.
+          - "'middlewares' not in _traefik_dynamic_yaml.http.routers.plex"
+          - "'middlewares' not in _traefik_dynamic_yaml.http.routers.authelia"
+          # The middleware dials the portal BACKEND url (never the public FQDN,
+          # which CNAMEs back to Traefik and would loop).
+          - >-
+            _traefik_dynamic_yaml.http.middlewares.authelia.forwardAuth.address
+            == "http://192.0.2.14:9091/api/authz/forward-auth"
+          - "'Remote-User' in _traefik_dynamic_yaml.http.middlewares.authelia.forwardAuth.authResponseHeaders"
+        fail_msg: >-
+          dynamic.yml.j2 sso gating wrong: middleware missing on a flagged
+          router, present on an unflagged one, or the forwardAuth address does
+          not target the portal backend.
 
     - name: Assert HTTPS backend gets an https URL + insecure-backend serversTransport
       ansible.builtin.assert:


### PR DESCRIPTION
## What

- New `roles/authelia`: criticality-1 SSO portal / Traefik forwardAuth provider. Controller-staged, checksum-pinned native binary under systemd; WebAuthn passkey-first login; in-memory sessions (12h/12h, 1-week remember-me); local SQLite on the persistent data mount; SMTP notifier via the internal relay; bootstrap user seeded create-if-absent with an argon2 hash generated on the host.
- `roles/traefik`: renders an `authelia` forwardAuth middleware (dialing the portal backend URL — the public FQDN CNAMEs back to Traefik and would loop) and attaches it to every router whose ingress row publishes `sso: true`.
- Inventory loader: `authelia_group` from the `authelia` tag; new site.yml play ordered before Traefik.
- Template-render tests assert the gating matrix (flagged router gated, unflagged + portal not, correct forwardAuth address).

## Rollout safety

The middleware only attaches when the inventory rows carry `sso: true`, so this merges cleanly before or after the upstream tofu apply that publishes the flag.

## Verification

- `ansible-lint`: 0 failures (production profile) on all touched files.
- `tests/template_render/verify_templates.yml`: 166 ok / 0 failed.
- `site.yml --syntax-check`: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)