### PR TITLE
feat(ssh_ca_trust): opt splunk_vms + docker_vms into SSH CA trust

### DIFF
--- a/inventory/group_vars/docker_vms.yml
+++ b/inventory/group_vars/docker_vms.yml
@@ -7,7 +7,7 @@ ansible_ssh_private_key_file: >-
 
 # Trust the OpenBao SSH client CA on this VM class (ssh-certificate-authority
 # ADR). Additive + lockout-guarded; pinned SSH_CA_FINGERPRINT verified
-# fail-closed. See group_vars/vms.yml — same rollout.
+# fail-closed. See inventory/group_vars/vms.yml — same rollout.
 ssh_ca_trust_rollout_enabled: true
 
 # GitHub Actions self-hosted runners — multi-repo configuration

--- a/inventory/group_vars/docker_vms.yml
+++ b/inventory/group_vars/docker_vms.yml
@@ -5,6 +5,11 @@ ansible_ssh_private_key_file: >-
   {{ lookup('env', 'PROXMOX_DKR_SSH_KEY_PATH')
   | mandatory('PROXMOX_DKR_SSH_KEY_PATH environment variable is required') }}
 
+# Trust the OpenBao SSH client CA on this VM class (ssh-certificate-authority
+# ADR). Additive + lockout-guarded; pinned SSH_CA_FINGERPRINT verified
+# fail-closed. See group_vars/vms.yml — same rollout.
+ssh_ca_trust_rollout_enabled: true
+
 # GitHub Actions self-hosted runners — multi-repo configuration
 # Each entry generates a Compose service with its own replicas.
 # docker-host VM (250): 4 CPU, 8GB RAM — per-container limits are ceilings.

--- a/inventory/group_vars/splunk_vms.yml
+++ b/inventory/group_vars/splunk_vms.yml
@@ -7,3 +7,9 @@ ansible_python_interpreter: /usr/bin/python3
 
 # SSH connection settings
 ansible_ssh_common_args: "-o StrictHostKeyChecking=accept-new"
+
+# Trust the OpenBao SSH client CA on this VM class (ssh-certificate-authority
+# ADR). Additive + lockout-guarded (a static break-glass key must still
+# authenticate before the role finishes); pinned SSH_CA_FINGERPRINT verified
+# fail-closed. See group_vars/vms.yml — same rollout.
+ssh_ca_trust_rollout_enabled: true

--- a/inventory/group_vars/splunk_vms.yml
+++ b/inventory/group_vars/splunk_vms.yml
@@ -11,5 +11,5 @@ ansible_ssh_common_args: "-o StrictHostKeyChecking=accept-new"
 # Trust the OpenBao SSH client CA on this VM class (ssh-certificate-authority
 # ADR). Additive + lockout-guarded (a static break-glass key must still
 # authenticate before the role finishes); pinned SSH_CA_FINGERPRINT verified
-# fail-closed. See group_vars/vms.yml — same rollout.
+# fail-closed. See inventory/group_vars/vms.yml — same rollout.
 ssh_ca_trust_rollout_enabled: true


### PR DESCRIPTION
## What

Flip `ssh_ca_trust_rollout_enabled: true` for the `splunk_vms` and `docker_vms` group_vars — completing the VM-side CA-trust opt-in.

## Why

The apps `ssh_ca_trust` play targets exactly `vms:splunk_vms:docker_vms`. The `vms` class already opted in and is live (docker-host + iac-platform trust the CA, https://github.com/dryvist/ansible-proxmox-apps/pull/1025). This flips the remaining two declared VM classes so every VM the trust play targets activates once it materializes in the loaded inventory.

## Verification

- `ansible-lint` — clean on both files (profile production).
- Live converge `--tags ssh_ca_trust --limit splunk_vms:docker_vms,localhost` over the automation-ansible **cert** (no static fallback) — cert path confirmed working post-#1026 fix. Those two groups currently have no materialized members in the loaded inventory, so this is the forward opt-in (the flag activates the role when the splunk VM / a docker VM is present); additive + lockout-guarded, no risk when empty.

Part of the SSH-CA fabric rollout (Vikunja #636).