### PR TITLE
test(ssh_ca_trust): add molecule scenario for the activation gate

### DIFF
--- a/.github/workflows/_molecule.yml
+++ b/.github/workflows/_molecule.yml
@@ -35,6 +35,7 @@ jobs:
           - keepalived
           - postgres
           - nautobot
+          - ssh_ca_trust
 
     steps:
       - name: Checkout code
@@ -107,6 +108,8 @@ jobs:
           #                  fallbacks; technitium_dns_apply=false, no live API)
           #   openbao     -> none (static seal key stubbed in converge;
           #                  service + bootstrap gated off under Docker)
+          #   ssh_ca_trust -> none (activation gate held closed in both
+          #                  converge cases; no live OpenBao CA fetch)
           MSSQL_SA_PASSWORD: ${{ steps.doppler.outputs.MSSQL_SA_PASSWORD }}
           QBITTORRENT_ADMIN_PASSWORD: ${{ steps.doppler.outputs.QBITTORRENT_ADMIN_PASSWORD }}
         run: molecule test -s "$MOLECULE_SCENARIO"

--- a/molecule/ssh_ca_trust/converge.yml
+++ b/molecule/ssh_ca_trust/converge.yml
@@ -1,0 +1,31 @@
+---
+# Molecule converge for ssh_ca_trust (VM/guest half).
+#
+# Exercises the two-condition activation gate's NO-OP paths only: no pin, and
+# pin-without-rollout (the stray-env defense, #1013 / P0). Both must produce
+# zero changes with no OpenBao reachable — every task in tasks/main.yml is
+# gated behind `when: ssh_ca_trust_enabled | bool`, so a closed gate touches
+# nothing (no fetch attempted, no files written).
+#
+# The pin+rollout-both-true "activates" path needs a live/mocked OpenBao CA
+# endpoint this scenario does not stand up; verify.yml instead asserts the
+# gate FORMULA directly for that case (see verify.yml header).
+
+- name: Converge
+  hosts: all
+  become: true
+  gather_facts: true
+
+  tasks:
+    - name: Converge — no pin, rollout default (expect no-op)
+      ansible.builtin.include_role:
+        name: ssh_ca_trust
+      vars:
+        ssh_ca_trust_ca_fingerprint: ""
+
+    - name: Converge — pin present, rollout OFF (expect no-op)
+      ansible.builtin.include_role:
+        name: ssh_ca_trust
+      vars:
+        ssh_ca_trust_ca_fingerprint: "SHA256:fakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfak"
+        ssh_ca_trust_rollout_enabled: false

--- a/molecule/ssh_ca_trust/molecule.yml
+++ b/molecule/ssh_ca_trust/molecule.yml
@@ -1,0 +1,51 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: ssh-ca-trust-test
+    # No stable version tags available; geerlingguy only publishes :latest
+    image: geerlingguy/docker-debian12-ansible:latest
+    privileged: true
+    command: ""
+    pre_build_image: true
+    tmpfs:
+      - /run
+      - /tmp
+      - /run/lock
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    groups:
+      - ssh_ca_trust_group
+      - lxc_containers
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
+
+verifier:
+  name: ansible
+
+scenario:
+  name: ssh_ca_trust
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - cleanup
+    - destroy

--- a/molecule/ssh_ca_trust/prepare.yml
+++ b/molecule/ssh_ca_trust/prepare.yml
@@ -1,0 +1,15 @@
+---
+# Molecule preparation for the ssh_ca_trust scenario.
+
+- name: Prepare
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Wait for container to be ready
+      ansible.builtin.wait_for_connection:
+        timeout: 30
+
+    - name: Gather facts
+      ansible.builtin.setup:

--- a/molecule/ssh_ca_trust/verify.yml
+++ b/molecule/ssh_ca_trust/verify.yml
@@ -6,16 +6,21 @@
 #    to expose ssh_ca_trust_principals and assert the deny-by-default
 #    principals map: `debian: [ansible]` only, `ai-agent` absent unless a
 #    group opts in via an override.
-# 3. Asserts the activation-gate FORMULA for the pin+rollout-both-true case,
-#    matching defaults/main.yml verbatim — this scenario does not stand up a
-#    live/mocked OpenBao endpoint to exercise the real fetch/write path, so a
-#    future edit to the boolean logic is what this assertion protects
-#    against. See PR description for what is/isn't covered.
+# 3. Asserts the role's OWN ssh_ca_trust_enabled (loaded from defaults/main.yml
+#    via vars_files below, then re-templated under overridden inputs) for all
+#    three gate combinations — not a hand-copied formula — so drift in the
+#    real boolean logic breaks this test. The pin+rollout-both-true path is
+#    exercised only through this derived var: this scenario does not stand up
+#    a live/mocked OpenBao endpoint to exercise the real fetch/write path. See
+#    PR description for what is/isn't covered.
 
 - name: Verify
   hosts: all
   become: true
   gather_facts: false
+
+  vars_files:
+    - ../../roles/ssh_ca_trust/defaults/main.yml
 
   tasks:
     - name: Stat the CA trust artifacts (should not exist — gate stayed closed both times)
@@ -47,29 +52,29 @@
           - "'ai-agent' not in (ssh_ca_trust_principals.debian | default([]))"
         fail_msg: "ssh_ca_trust_principals default drifted from the deny-by-default map"
 
-    - name: Assert the activation-gate formula opens when both conditions hold
+    - name: Assert the role's own gate opens when both conditions hold
       ansible.builtin.assert:
         that:
-          - (ca_fp | length > 0) and (rollout | bool)
-        fail_msg: "gate formula did not evaluate true with pin+rollout both set"
+          - ssh_ca_trust_enabled | bool
+        fail_msg: "ssh_ca_trust_enabled did not open with pin+rollout both set"
       vars:
-        ca_fp: "SHA256:fakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfak"
-        rollout: true
+        ssh_ca_trust_ca_fingerprint: "SHA256:test"
+        ssh_ca_trust_rollout_enabled: true
 
-    - name: Assert the activation-gate formula stays closed when rollout is off
+    - name: Assert the role's own gate stays closed when rollout is off
       ansible.builtin.assert:
         that:
-          - not ((ca_fp | length > 0) and (rollout | bool))
-        fail_msg: "gate formula opened with rollout OFF"
+          - not (ssh_ca_trust_enabled | bool)
+        fail_msg: "ssh_ca_trust_enabled opened with rollout OFF"
       vars:
-        ca_fp: "SHA256:fakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfak"
-        rollout: false
+        ssh_ca_trust_ca_fingerprint: "SHA256:test"
+        ssh_ca_trust_rollout_enabled: false
 
-    - name: Assert the activation-gate formula stays closed with no pin
+    - name: Assert the role's own gate stays closed with no pin
       ansible.builtin.assert:
         that:
-          - not ((ca_fp | length > 0) and (rollout | bool))
-        fail_msg: "gate formula opened with no pin"
+          - not (ssh_ca_trust_enabled | bool)
+        fail_msg: "ssh_ca_trust_enabled opened with no pin"
       vars:
-        ca_fp: ""
-        rollout: true
+        ssh_ca_trust_ca_fingerprint: ""
+        ssh_ca_trust_rollout_enabled: true

--- a/molecule/ssh_ca_trust/verify.yml
+++ b/molecule/ssh_ca_trust/verify.yml
@@ -1,0 +1,75 @@
+---
+# Molecule verification for ssh_ca_trust (VM/guest half).
+#
+# 1. Confirms neither no-op converge case wrote any CA trust artifact.
+# 2. Re-imports the role (no side effects — gate stays closed with defaults)
+#    to expose ssh_ca_trust_principals and assert the deny-by-default
+#    principals map: `debian: [ansible]` only, `ai-agent` absent unless a
+#    group opts in via an override.
+# 3. Asserts the activation-gate FORMULA for the pin+rollout-both-true case,
+#    matching defaults/main.yml verbatim — this scenario does not stand up a
+#    live/mocked OpenBao endpoint to exercise the real fetch/write path, so a
+#    future edit to the boolean logic is what this assertion protects
+#    against. See PR description for what is/isn't covered.
+
+- name: Verify
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Stat the CA trust artifacts (should not exist — gate stayed closed both times)
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      loop:
+        - /etc/ssh/trusted-user-ca-keys.pem
+        - /etc/ssh/principals
+        - /etc/ssh/sshd_config.d/99-openbao-ca.conf
+      register: ssh_ca_trust_artifacts
+
+    - name: Assert no CA trust file was ever written
+      ansible.builtin.assert:
+        that:
+          - not item.stat.exists
+        fail_msg: "{{ item.item }} exists — the activation gate did not stay closed"
+      loop: "{{ ssh_ca_trust_artifacts.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+
+    - name: Re-import the role to expose its default principals map
+      ansible.builtin.import_role:
+        name: ssh_ca_trust
+
+    - name: Assert the deny-by-default principals map
+      ansible.builtin.assert:
+        that:
+          - "ssh_ca_trust_principals == {'debian': ['ansible']}"
+          - "'ai-agent' not in (ssh_ca_trust_principals.debian | default([]))"
+        fail_msg: "ssh_ca_trust_principals default drifted from the deny-by-default map"
+
+    - name: Assert the activation-gate formula opens when both conditions hold
+      ansible.builtin.assert:
+        that:
+          - (ca_fp | length > 0) and (rollout | bool)
+        fail_msg: "gate formula did not evaluate true with pin+rollout both set"
+      vars:
+        ca_fp: "SHA256:fakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfak"
+        rollout: true
+
+    - name: Assert the activation-gate formula stays closed when rollout is off
+      ansible.builtin.assert:
+        that:
+          - not ((ca_fp | length > 0) and (rollout | bool))
+        fail_msg: "gate formula opened with rollout OFF"
+      vars:
+        ca_fp: "SHA256:fakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfak"
+        rollout: false
+
+    - name: Assert the activation-gate formula stays closed with no pin
+      ansible.builtin.assert:
+        that:
+          - not ((ca_fp | length > 0) and (rollout | bool))
+        fail_msg: "gate formula opened with no pin"
+      vars:
+        ca_fp: ""
+        rollout: true


### PR DESCRIPTION
## Summary
- `ssh_ca_trust` (VM/guest half) shipped with no molecule scenario, sibling to the same gap in `ansible-proxmox` that let a hard-fail activation gate bug reach production.
- Adds `molecule/ssh_ca_trust/`, mirroring the repo's convention exactly (`geerlingguy/docker-debian12-ansible` image, cgroup/tmpfs setup, wired into the CI scenario matrix).

## What the scenario covers
- **Real role converges** (not mocks) for both no-op paths of the two-condition activation gate (`ssh_ca_trust_enabled = (fingerprint set) and (rollout_enabled)`):
  1. no pin, rollout default → no-op
  2. pin present, rollout OFF → still a no-op (stray-env defense)
  - `verify.yml` asserts none of the three CA-trust artifacts were ever written.
- **Deny-by-default principals map**: re-imports the role (still a no-op) to expose `ssh_ca_trust_principals` and asserts it is exactly `debian: [ansible]`, with `ai-agent` absent.
- **What is NOT covered for real**: the pin+rollout-both-true "activates" path, since exercising the CA fetch/write chain for real needs a live or mocked OpenBao endpoint, which this scenario deliberately does not stand up. Instead `verify.yml` asserts the activation-gate **formula** directly (mirroring `defaults/main.yml` verbatim) for all three input combinations.
- Adds `ssh_ca_trust` to the CI scenario matrix in `.github/workflows/_molecule.yml` (every other scenario in this repo is matrix-wired; this keeps that invariant).

## Lint
- `ansible-lint` (production profile): 0 failures, 0 warnings, both scoped to the new files and full-repo (680 files).
- `yamllint`: clean.

Closes #1013

## Test plan
- [ ] CI: the `Molecule` workflow's new `ssh_ca_trust` matrix job runs and passes.