### PR TITLE
feat(zammad): per-actor AI service accounts for a real audit trail

### DIFF
--- a/inventory/group_vars/zammad_group.yml
+++ b/inventory/group_vars/zammad_group.yml
@@ -45,6 +45,14 @@ zammad_hermes_api_token: >-
   {{ bao_local_llm_secrets.ZAMMAD_API_TOKEN
      | default(lookup('env', 'ZAMMAD_API_TOKEN'), true) }}
 
+# API token for the interactive-AI service account (Claude Code / Codex
+# sessions — a separate Zammad user from both hermes and the human admin, so
+# the activity stream attributes writes to the real actor). Canonical home is
+# apps/zammad alongside the other Zammad secrets; bao-first, env fallback.
+zammad_ai_api_token: >-
+  {{ bao_apps_secrets.zammad_ai_api_token
+     | default(lookup('env', 'ZAMMAD_AI_API_TOKEN'), true) }}
+
 # Outbound notification email relays through the existing Mailpit LXC (SMTP on
 # notification_ports.mailpit_smtp). Reached by its guest FQDN — no auth, no TLS
 # on the internal relay. Notifications land in the Mailpit web UI, not real mail.

--- a/roles/zammad/defaults/main.yml
+++ b/roles/zammad/defaults/main.yml
@@ -60,16 +60,22 @@ zammad_es_port: 9200
 zammad_es_url: "http://{{ zammad_es_host }}:{{ zammad_es_port }}"
 zammad_es_heap: 2g
 
-# --- Admin + Hermes API token -------------------------------------------------
-# Admin account seeded once (idempotent create-or-find). The Hermes API token
-# is seeded into a persistent api Token row so the agent can open/update
-# tickets; its value comes from the secret store (group_vars, bao-first).
+# --- Admin + per-actor AI service accounts ------------------------------------
+# Admin account seeded once (idempotent create-or-find) and stays HUMAN-ONLY.
+# Each machine actor gets its own Agent-role, token-only user (no password
+# login) so Zammad's activity stream attributes every write to the real actor:
+#   hermes = the autonomous Hermes agent
+#   ai     = interactive AI sessions (Claude Code, Codex, ...)
+# Token values come from the secret store (group_vars, bao-first).
 zammad_admin_user: admin
 zammad_admin_email: "{{ zammad_admin_user }}@{{ tofu_data.domain }}"
 zammad_admin_firstname: Zammad
 zammad_admin_lastname: Admin
 zammad_admin_password: "{{ lookup('env', 'ZAMMAD_ADMIN_PASSWORD') }}"
+zammad_hermes_email: "hermes@{{ tofu_data.domain }}"
+zammad_ai_email: "ai@{{ tofu_data.domain }}"
 zammad_hermes_api_token: "{{ lookup('env', 'ZAMMAD_API_TOKEN') }}"
+zammad_ai_api_token: "{{ lookup('env', 'ZAMMAD_AI_API_TOKEN') }}"
 
 # Incident-management groups + severity priorities. Hermes maps its P-levels to
 # these priority ids: P1->4 critical, P2->3 high, P3->2 normal, P4->1 low. The

--- a/roles/zammad/files/zammad_bootstrap.rb
+++ b/roles/zammad/files/zammad_bootstrap.rb
@@ -5,9 +5,10 @@
 # no drift prints nothing and stays idempotent.
 #
 # Essential seeding (settings, admin, per-actor service accounts + API tokens,
-# Incidents group, severities) fails loudly. The version-sensitive extras (Mailpit notification channel, the
-# knowledge base) are wrapped so a model-API drift warns but never aborts the
-# converge — both have a one-click manual fallback in the UI.
+# Incidents group, severities) fails loudly. The version-sensitive extras
+# (Mailpit notification channel, knowledge base) are wrapped so a model-API
+# drift warns but never aborts the converge — both have a one-click manual
+# fallback in the UI.
 
 changed = false
 UserInfo.current_user_id = 1 # act as the system user for created_by/updated_by
@@ -80,6 +81,11 @@ service_users = [
     u = User.create!(login: email.downcase, firstname: first, lastname: last,
                      email: email.downcase, roles: agent_role, active: true)
     changed = true
+  elsif u.roles.to_a != agent_role || !u.active
+    # Reconcile drift: service accounts are Agent-only and active — strip any
+    # elevated role that snuck on outside this bootstrap.
+    u.update!(roles: agent_role, active: true)
+    changed = true
   end
   u
 end
@@ -147,8 +153,8 @@ token_prefs = { 'permission' => %w[ticket.agent knowledge_base.editor] }
     t = Token.create!(action: 'api', name: name, persistent: true,
                       user_id: user.id, preferences: token_prefs)
     changed = true
-  elsif t.user_id != user.id || t.preferences != token_prefs
-    t.update!(user_id: user.id, preferences: token_prefs)
+  elsif t.user_id != user.id || t.preferences != token_prefs || !t.persistent
+    t.update!(user_id: user.id, preferences: token_prefs, persistent: true)
     changed = true
   end
   if t.token != value

--- a/roles/zammad/files/zammad_bootstrap.rb
+++ b/roles/zammad/files/zammad_bootstrap.rb
@@ -4,8 +4,8 @@
 # mutates state, so the Ansible task can report changed accurately; a re-run with
 # no drift prints nothing and stays idempotent.
 #
-# Essential seeding (settings, admin, API token, Incidents group, severities)
-# fails loudly. The version-sensitive extras (Mailpit notification channel, the
+# Essential seeding (settings, admin, per-actor service accounts + API tokens,
+# Incidents group, severities) fails loudly. The version-sensitive extras (Mailpit notification channel, the
 # knowledge base) are wrapped so a model-API drift warns but never aborts the
 # converge — both have a one-click manual fallback in the UI.
 
@@ -18,11 +18,14 @@ def env!(key)
   v
 end
 
-fqdn        = env!('ZAMMAD_FQDN')
-es_url      = env!('ZAMMAD_ES_URL')
-admin_email = env!('ZAMMAD_ADMIN_EMAIL')
-admin_pass  = env!('ZAMMAD_ADMIN_PASSWORD')
-api_token   = env!('ZAMMAD_API_TOKEN')
+fqdn         = env!('ZAMMAD_FQDN')
+es_url       = env!('ZAMMAD_ES_URL')
+admin_email  = env!('ZAMMAD_ADMIN_EMAIL')
+admin_pass   = env!('ZAMMAD_ADMIN_PASSWORD')
+api_token    = env!('ZAMMAD_API_TOKEN')
+ai_api_token = env!('ZAMMAD_AI_API_TOKEN')
+hermes_email = env!('ZAMMAD_HERMES_EMAIL')
+ai_email     = env!('ZAMMAD_AI_EMAIL')
 smtp_host   = env!('ZAMMAD_SMTP_HOST')
 smtp_port   = env!('ZAMMAD_SMTP_PORT').to_i
 sender      = env!('ZAMMAD_NOTIFICATION_SENDER')
@@ -62,7 +65,34 @@ else
   end
 end
 
-# --- Top-level organization (create-or-find; admin belongs to it) ------------
+# --- Dedicated AI service accounts (per-actor audit trail) -------------------
+# Every machine actor gets its OWN Agent-role user so the activity stream and
+# ticket history attribute writes to the real actor — the admin account stays
+# human-only. No password is set: these accounts are API-token-only and cannot
+# log in via the web UI.
+agent_role = [Role.find_by!(name: 'Agent')]
+service_users = [
+  [hermes_email, 'Hermes', 'Agent'],
+  [ai_email, 'AI', 'Assistant'],
+].map do |email, first, last|
+  u = User.find_by(email: email.downcase)
+  if u.nil?
+    u = User.create!(login: email.downcase, firstname: first, lastname: last,
+                     email: email.downcase, roles: agent_role, active: true)
+    changed = true
+  end
+  u
+end
+
+# Agents need knowledge_base.editor for their tokens to carry that scope; the
+# default Agent role does not always include it.
+kb_perm = Permission.find_by(name: 'knowledge_base.editor')
+if kb_perm && !agent_role.first.permissions.include?(kb_perm)
+  agent_role.first.permissions << kb_perm
+  changed = true
+end
+
+# --- Top-level organization (create-or-find; all our users belong to it) -----
 org_name = ENV['ZAMMAD_ORGANIZATION']
 if org_name && !org_name.empty?
   org = Organization.find_by(name: org_name)
@@ -70,23 +100,24 @@ if org_name && !org_name.empty?
     org = Organization.create!(name: org_name, shared: true, active: true)
     changed = true
   end
-  unless admin.organization_id == org.id
-    admin.update!(organization_id: org.id)
+  ([admin] + service_users).each do |u|
+    next if u.organization_id == org.id
+    u.update!(organization_id: org.id)
     changed = true
   end
 end
 
-# --- Incident groups (create-or-find; make admin a full agent in each) -------
+# --- Incident groups (create-or-find; admin + service users get full access) -
 groups.each do |gname|
   group = Group.find_by(name: gname)
   if group.nil?
     group = Group.create!(name: gname, active: true)
     changed = true
   end
-  # Grant the admin full access to the group so it can own/route incidents.
-  unless admin.group_ids_access('full').include?(group.id)
-    admin.group_names_access_map = admin.group_names_access_map.merge(group.name => ['full'])
-    admin.save!
+  ([admin] + service_users).each do |u|
+    next if u.group_ids_access('full').include?(group.id)
+    u.group_names_access_map = u.group_names_access_map.merge(group.name => ['full'])
+    u.save!
     changed = true
   end
 end
@@ -97,27 +128,31 @@ if Ticket::Priority.find_by(id: 4).nil? && Ticket::Priority.find_by(name: '4 cri
   changed = true
 end
 
-# --- Hermes API token (persistent api token seeded with the supplied value;
-# reconciled if it already exists but was rotated in OpenBao/Doppler) --------
+# --- API tokens (persistent, seeded with supplied values; reconciled on
+# rotation in OpenBao/Doppler). Each token belongs to ITS OWN service user —
+# never the admin — and carries only Agent-level scopes.
 # Two hard-won constraints (first live bring-up, 2026-07-16):
 #   1. Token.create!/update! REGENERATE the token value via callbacks —
-#      update_column is the only way the supplied secret actually persists.
+#      update_column is the only way the supplied secret actually persists,
+#      so the value is re-asserted LAST, after any update!.
 #   2. An api token with empty preferences has NO permission scopes and every
 #      HTTP request is rejected "Authentication required".
-hermes_token_prefs = { 'permission' => %w[admin ticket.agent knowledge_base.editor] }
-hermes_token = Token.find_by(action: 'api', name: 'hermes')
-if hermes_token.nil?
-  hermes_token = Token.create!(action: 'api', name: 'hermes', persistent: true,
-                               user_id: admin.id, preferences: hermes_token_prefs)
-  hermes_token.update_column(:token, api_token)
-  changed = true
-else
-  if hermes_token.token != api_token
-    hermes_token.update_column(:token, api_token)
+token_prefs = { 'permission' => %w[ticket.agent knowledge_base.editor] }
+[
+  ['hermes', service_users[0], api_token],
+  ['ai', service_users[1], ai_api_token],
+].each do |name, user, value|
+  t = Token.find_by(action: 'api', name: name)
+  if t.nil?
+    t = Token.create!(action: 'api', name: name, persistent: true,
+                      user_id: user.id, preferences: token_prefs)
+    changed = true
+  elsif t.user_id != user.id || t.preferences != token_prefs
+    t.update!(user_id: user.id, preferences: token_prefs)
     changed = true
   end
-  if hermes_token.preferences != hermes_token_prefs
-    hermes_token.update!(preferences: hermes_token_prefs)
+  if t.token != value
+    t.update_column(:token, value)
     changed = true
   end
 end

--- a/roles/zammad/tasks/main.yml
+++ b/roles/zammad/tasks/main.yml
@@ -372,8 +372,9 @@
         - nginx
 
     # =========================================================================
-    # Phase 9: Idempotent bootstrap (settings incl. es_url, admin, Hermes token,
-    # Incidents group, P1-P4 severities, Mailpit channel, KB). The ruby prints
+    # Phase 9: Idempotent bootstrap (settings incl. es_url, admin, per-actor
+    # AI service accounts + their tokens, Incidents group, P1-P4 severities,
+    # Mailpit channel, KB). The ruby prints
     # ZAMMAD_BOOTSTRAP_CHANGED on drift. Runs BEFORE the search-index rebuild so
     # es_url is set first.
     # =========================================================================
@@ -382,9 +383,11 @@
         that:
           - zammad_admin_password | length > 0
           - zammad_hermes_api_token | length > 0
+          - zammad_ai_api_token | length > 0
         fail_msg: >-
-          ZAMMAD_ADMIN_PASSWORD and ZAMMAD_API_TOKEN must be set before the
-          first converge (Doppler/SOPS or OpenBao apps/zammad + ai/hermes).
+          ZAMMAD_ADMIN_PASSWORD, ZAMMAD_API_TOKEN and ZAMMAD_AI_API_TOKEN must
+          be set before the first converge (Doppler/SOPS or OpenBao
+          apps/zammad + ai/hermes).
         quiet: true
       no_log: true
 
@@ -407,6 +410,9 @@
         ZAMMAD_ADMIN_LASTNAME: "{{ zammad_admin_lastname }}"
         ZAMMAD_ADMIN_PASSWORD: "{{ zammad_admin_password }}"
         ZAMMAD_API_TOKEN: "{{ zammad_hermes_api_token }}"
+        ZAMMAD_AI_API_TOKEN: "{{ zammad_ai_api_token }}"
+        ZAMMAD_HERMES_EMAIL: "{{ zammad_hermes_email }}"
+        ZAMMAD_AI_EMAIL: "{{ zammad_ai_email }}"
         ZAMMAD_SMTP_HOST: "{{ zammad_smtp_host }}"
         ZAMMAD_SMTP_PORT: "{{ zammad_smtp_port }}"
         ZAMMAD_NOTIFICATION_SENDER: "{{ zammad_notification_sender }}"


### PR DESCRIPTION
## Why

The first live bring-up attached the hermes API token to the **human admin account** with `admin` scope, and seeding ran as the anonymous system user — Zammad's activity stream could not attribute writes to the real actor (operator finding, 2026-07-17).

## What

- Dedicated Agent-role, token-only users: `hermes` (autonomous agent) and `ai` (interactive AI sessions). No password login; admin becomes human-only.
- The `hermes` token moves to the hermes user; both tokens carry `ticket.agent` + `knowledge_base.editor` only (no more `admin` scope).
- Agent role is granted `knowledge_base.editor` (not guaranteed by default) so the token scope is effective.
- Token values re-asserted via `update_column` LAST (Token callbacks regenerate values on create!/update!).
- New secret `zammad_ai_api_token` — already seeded in OpenBao `apps/zammad` (v5); bao-first with env fallback, asserted before bootstrap.

## Verification

- `ruby -c` syntax OK; `ansible-lint` production profile passed on all touched files.
- Post-merge converge will be verified by calling `/users/me` with each token and confirming it maps to its own user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)