### PR TITLE
feat(ssh): fail-loud cert fallback + strict pinned host-key verification

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,10 @@
 [defaults]
 inventory = inventory/hosts.yml
 roles_path = roles
-host_key_checking = False
+# Host identities are verified against the reviewed pinned known_hosts that
+# scripts/run-ansible.sh materializes from SSH_KNOWN_HOSTS (Doppler). A rebuilt
+# guest fails closed until re-harvested. LXC converges use pct, not SSH.
+host_key_checking = True
 deprecation_warnings = True
 retry_files_enabled = False
 forks = 5

--- a/inventory/group_vars/splunk_vms.yml
+++ b/inventory/group_vars/splunk_vms.yml
@@ -5,8 +5,10 @@
 ansible_user: debian
 ansible_python_interpreter: /usr/bin/python3
 
-# SSH connection settings
-ansible_ssh_common_args: "-o StrictHostKeyChecking=accept-new"
+# Host-key verification comes from the wrapper-materialized pinned known_hosts
+# (ANSIBLE_SSH_COMMON_ARGS via scripts/run-ansible.sh) — no per-group override.
+# NOTE: when a splunk VM next materializes, harvest its host key into Doppler
+# SSH_KNOWN_HOSTS before converging it over SSH (fail-closed until then).
 
 # Trust the OpenBao SSH client CA on this VM class (ssh-certificate-authority
 # ADR). Additive + lockout-guarded (a static break-glass key must still

--- a/inventory/group_vars/vms.yml
+++ b/inventory/group_vars/vms.yml
@@ -5,8 +5,8 @@
 ansible_user: debian
 ansible_python_interpreter: /usr/bin/python3
 
-# SSH connection settings
-ansible_ssh_common_args: "-o StrictHostKeyChecking=accept-new"
+# Host-key verification comes from the wrapper-materialized pinned known_hosts
+# (ANSIBLE_SSH_COMMON_ARGS via scripts/run-ansible.sh) — no per-group override.
 
 # Roll out OpenBao SSH client CA trust to this VM class (ssh-certificate-authority
 # ADR). The role is additive and lockout-guarded — it refuses to finish unless a

--- a/scripts/run-ansible.sh
+++ b/scripts/run-ansible.sh
@@ -68,8 +68,11 @@ fi
 # Pin host identities: materialize the reviewed known_hosts (Doppler
 # SSH_KNOWN_HOSTS, harvested over authenticated channels) and verify strictly.
 # A rebuilt guest gets a new host key and fails closed until re-harvested —
-# that is the intended tradeoff. Without the pin ambient, ssh falls back to
-# the user's own known_hosts + interactive confirmation.
+# that is the intended tradeoff. These pinned options are PREPENDED and
+# OpenSSH uses the first value per option, so appended caller extras cannot
+# weaken them; GlobalKnownHostsFile is disabled so only the pin is consulted.
+# Without the pin ambient, non-interactive runs fail closed for any host not
+# already in the user's own known_hosts.
 if [[ -n ${SSH_KNOWN_HOSTS:-} ]]; then
   if [[ -z $CERT_DIR ]]; then
     CERT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ansible-sshkh.XXXXXX")
@@ -77,7 +80,7 @@ if [[ -n ${SSH_KNOWN_HOSTS:-} ]]; then
   fi
   printf '%s\n' "$SSH_KNOWN_HOSTS" > "$CERT_DIR/known_hosts"
   chmod 600 "$CERT_DIR/known_hosts"
-  export ANSIBLE_SSH_COMMON_ARGS="-o UserKnownHostsFile=$CERT_DIR/known_hosts -o StrictHostKeyChecking=yes${ANSIBLE_SSH_COMMON_ARGS:+ $ANSIBLE_SSH_COMMON_ARGS}"
+  export ANSIBLE_SSH_COMMON_ARGS="-o UserKnownHostsFile=$CERT_DIR/known_hosts -o GlobalKnownHostsFile=/dev/null -o StrictHostKeyChecking=yes${ANSIBLE_SSH_COMMON_ARGS:+ $ANSIBLE_SSH_COMMON_ARGS}"
 fi
 
 ansible-playbook "$PLAYBOOK" "$@"

--- a/scripts/run-ansible.sh
+++ b/scripts/run-ansible.sh
@@ -48,13 +48,36 @@ mint_ssh_cert() {
   export PROXMOX_SSH_KEY_PATH="$CERT_DIR/id"
 }
 
-if [[ -n ${BAO_ADDR:-} && -n ${OPENBAO_APPROLE_ANSIBLE_ROLE_ID:-} && -n ${OPENBAO_APPROLE_ANSIBLE_SECRET_ID:-} ]] \
-  && mint_ssh_cert; then
+if [[ -n ${BAO_ADDR:-} && -n ${OPENBAO_APPROLE_ANSIBLE_ROLE_ID:-} && -n ${OPENBAO_APPROLE_ANSIBLE_SECRET_ID:-} ]]; then
+  # FAIL-LOUD: when the cert env is present, a mint failure is an error — never
+  # silently ride the static key (that masked a dead cert path once already).
+  # Break-glass = run WITHOUT the BAO env, with PROXMOX_SSH_KEY_PATH set.
+  if ! mint_ssh_cert; then
+    echo "ERROR: OpenBao SSH cert mint FAILED and the cert env is present — refusing" >&2
+    echo "the silent static-key fallback. Fix the cert path, or unset the OPENBAO_APPROLE_ANSIBLE_*" >&2
+    echo "env and set PROXMOX_SSH_KEY_PATH to deliberately use the static break-glass key." >&2
+    exit 1
+  fi
   echo "Using a short-lived SSH certificate from the OpenBao CA (automation-ansible)."
 elif [[ -z ${PROXMOX_SSH_KEY_PATH:-} ]]; then
   echo "ERROR: no SSH auth available — set BAO_ADDR + OPENBAO_APPROLE_ANSIBLE_* for cert" >&2
   echo "minting, or PROXMOX_SSH_KEY_PATH for the static break-glass key." >&2
   exit 1
+fi
+
+# Pin host identities: materialize the reviewed known_hosts (Doppler
+# SSH_KNOWN_HOSTS, harvested over authenticated channels) and verify strictly.
+# A rebuilt guest gets a new host key and fails closed until re-harvested —
+# that is the intended tradeoff. Without the pin ambient, ssh falls back to
+# the user's own known_hosts + interactive confirmation.
+if [[ -n ${SSH_KNOWN_HOSTS:-} ]]; then
+  if [[ -z $CERT_DIR ]]; then
+    CERT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ansible-sshkh.XXXXXX")
+    chmod 700 "$CERT_DIR"
+  fi
+  printf '%s\n' "$SSH_KNOWN_HOSTS" > "$CERT_DIR/known_hosts"
+  chmod 600 "$CERT_DIR/known_hosts"
+  export ANSIBLE_SSH_COMMON_ARGS="-o UserKnownHostsFile=$CERT_DIR/known_hosts -o StrictHostKeyChecking=yes${ANSIBLE_SSH_COMMON_ARGS:+ $ANSIBLE_SSH_COMMON_ARGS}"
 fi
 
 ansible-playbook "$PLAYBOOK" "$@"


### PR DESCRIPTION
## What (SSH-CA Phase D prep — twin of ansible-proxmox#425)

1. **Fail-loud cert fallback**: a mint failure with the OpenBao env present now errors instead of silently riding the static key — the silent fallback masked the dead cert path in #1026. Break-glass is explicit: run without `OPENBAO_APPROLE_ANSIBLE_*`.
2. **Strict pinned host-key verification**: `run-ansible.sh` materializes the reviewed known_hosts (Doppler `SSH_KNOWN_HOSTS`, harvested over authenticated channels) with `StrictHostKeyChecking=yes`; `ansible.cfg` `host_key_checking = True`; the per-group `accept-new` overrides (dead config under the old global `False`) removed. Rebuilt guests fail closed until re-harvested.

## Verified live

- docker-host + iac-platform converge over an **automation-ansible cert** against ONLY the pinned file under strict checking — docker-host's user-default known_hosts entry is stale/mismatched, so success **proves** the pinned file was in use.
- Negative: a mismatched host key is refused (`Host key verification failed` → UNREACHABLE).
- `ansible-lint` (production) + `shellcheck` clean.

Splunk-VM note: no splunk VM is in the loaded inventory today; when one materializes, harvest its host key into `SSH_KNOWN_HOSTS` first (fail-closed until then, per the group_vars note).