### PR TITLE
fix(authelia): disable notifier startup check to survive transient SMTP/DNS outage

### DIFF
--- a/roles/authelia/templates/configuration.yml.j2
+++ b/roles/authelia/templates/configuration.yml.j2
@@ -51,6 +51,9 @@ storage:
     path: "{{ authelia_db_path }}"
 
 notifier:
+  # crit-1 service must not crashloop when the SMTP relay/DNS is briefly
+  # unreachable at boot; passkey-first login never needs the notifier anyway.
+  disable_startup_check: true
   smtp:
     address: "smtp://{{ authelia_smtp_host }}:{{ authelia_smtp_port }}"
     sender: "Authelia <{{ authelia_smtp_sender }}>"


### PR DESCRIPTION
## Summary

Adds `notifier.disable_startup_check: true` to the Authelia config template.

Authelia's SMTP notifier runs a **fatal** startup check that dials the relay.
When the relay or DNS is briefly unreachable at boot, the check fails and
Authelia exits — systemd restarts it, and it crashloops. A criticality-1 auth
portal must not go fully down because a downstream (Mailpit) is momentarily
unreachable. With passkey-first login the notifier is never on the login path,
so this correctly degrades email delivery instead of the whole service.

## Incident

Observed live tonight: the guest firewall (`enable: 1`, `policy_out: DROP`)
blocks outbound DNS to the resolver VLAN, so Authelia could not resolve
`mailpit.<domain>`, and the fatal notifier check crashlooped it ~177 times.
This change stops the crashloop regardless of the notifier's reachability.

## Follow-up (separate, tofu-proxmox)

The guest firewall lacks outbound DNS egress for a DROP-policy guest — the
`outbound-internal` group's RFC1918 allowlist omits the resolver VLAN. That is
a real gap for any firewalled guest referencing an FQDN and is tracked
separately; the notifier's *email delivery* stays degraded until it lands.

## Verification

- Converged the authelia role with this change; portal answers `/api/health`.
- `ansible-lint` + template-render tests (CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)