### PR TITLE
fix(authelia): make passkey enrolment reachable (two_factor policy + filesystem notifier)

### DIFF
--- a/roles/authelia/defaults/main.yml
+++ b/roles/authelia/defaults/main.yml
@@ -74,12 +74,12 @@ authelia_secret_files:
   session_secret: "{{ authelia_secrets_dir }}/session_secret"
   storage_key: "{{ authelia_secrets_dir }}/storage_encryption_key"
 
-# --- Notifier: the existing internal SMTP relay -------------------------------
-# Identity-verification mails (WebAuthn device registration, password reset)
-# land in the Mailpit UI.
-authelia_smtp_host: "mailpit.{{ tofu_data.domain }}"
-authelia_smtp_port: "{{ tofu_data.constants.notification_ports.mailpit_smtp }}"
-authelia_smtp_sender: "authelia@{{ tofu_data.domain }}"
+# --- Notifier: local filesystem, not SMTP -------------------------------------
+# One-time codes for passkey enrolment and password reset are written to this
+# file on the persistent mount, not emailed. Auth-critical flows must not depend
+# on mail/DNS reachability in a single-user homelab; the operator reads the code
+# directly. Lives on the persistent mount so it survives a rebuild.
+authelia_notification_file: "{{ authelia_data_dir }}/notification.txt"
 
 # --- Behaviour toggles ---------------------------------------------------------
 # false in CI/molecule contexts: skips systemd unit install/start and the live

--- a/roles/authelia/templates/configuration.yml.j2
+++ b/roles/authelia/templates/configuration.yml.j2
@@ -18,11 +18,15 @@ authentication_backend:
   file:
     path: "{{ authelia_users_file }}"
 
-# Passkey-first login: a discoverable WebAuthn credential is a full first
-# factor, so day-to-day login is one Touch ID prompt — no password typed.
+# Passkey-first login: a discoverable WebAuthn credential logs the user in with
+# one Touch ID prompt, no password typed. A passkey alone is only one_factor by
+# default, so uv_two_factors lets a user-verifying passkey (Touch ID performs
+# user verification) satisfy the two_factor policy on its own — otherwise the
+# two_factor routes below would still demand a password after the passkey.
 webauthn:
   disable: false
   enable_passkey_login: true
+  experimental_enable_passkey_uv_two_factors: true
 
 access_control:
   default_policy: deny
@@ -35,11 +39,12 @@ access_control:
       resources:
         - "^/api(?:/.*)?$"
 {% endfor %}
-    # Every Traefik-fronted UI under the ingress base domain. one_factor is
-    # the passkey (passkey login satisfies one_factor); step-up to
-    # two_factor per-domain later if wanted.
+    # Every Traefik-fronted UI under the ingress base domain. two_factor is
+    # required so Authelia exposes passkey/WebAuthn enrolment at all (it hides
+    # it when nothing needs a second factor); a UV passkey satisfies it in one
+    # Touch ID gesture via webauthn.experimental_enable_passkey_uv_two_factors.
     - domain: "*.{{ authelia_cookie_domain }}"
-      policy: one_factor
+      policy: two_factor
 
 session:
   cookies:

--- a/roles/authelia/templates/configuration.yml.j2
+++ b/roles/authelia/templates/configuration.yml.j2
@@ -59,11 +59,11 @@ storage:
     path: "{{ authelia_db_path }}"
 
 notifier:
-  # crit-1 service must not crashloop when the SMTP relay/DNS is briefly
-  # unreachable at boot; passkey-first login never needs the notifier anyway.
+  # crit-1 service must not crashloop when a downstream is briefly unreachable
+  # at boot; passkey-first login never touches the notifier anyway.
   disable_startup_check: true
-  smtp:
-    address: "smtp://{{ authelia_smtp_host }}:{{ authelia_smtp_port }}"
-    sender: "Authelia <{{ authelia_smtp_sender }}>"
-    # The internal relay accepts unauthenticated plain SMTP.
-    disable_require_tls: true
+  # Filesystem backend, not SMTP: auth-critical flows (passkey enrolment's
+  # one-time code, password reset) must not depend on mail/DNS reachability in
+  # a single-user homelab. The code is written here and read by the operator.
+  filesystem:
+    filename: "{{ authelia_notification_file }}"


### PR DESCRIPTION
## Summary

Two fixes that together make passkey-first SSO actually usable. Both root-caused
against the live deployment tonight.

### 1. `two_factor` policy — enrolment was invisible

Authelia **hides WebAuthn/passkey enrolment entirely** when no access-control
rule requires a second factor. With every route on `one_factor`, the settings
page reported *"There are no protected applications that require a second factor
method"* and offered nothing to register — so a passkey could never be enrolled,
and passkey-first login was unreachable.

Also sets `webauthn.experimental_enable_passkey_uv_two_factors`: a passkey alone
counts as `one_factor` per Authelia's docs, so without this the `two_factor`
routes would prompt for a password *after* the passkey, defeating passwordless
login. Touch ID performs user verification, so it satisfies `two_factor` in one
gesture.

Both keys validated against the live `authelia v4.39.20` binary.

### 2. Filesystem notifier — enrolment needed email

Authelia emails a one-time code to authorize adding a passkey. Routing that via
SMTP made auth-critical enrolment depend on mail + DNS reachability; a
DROP-policy guest that can't resolve the relay can't enrol at all (observed).
The filesystem backend writes the code to the persistent mount instead, removing
email/DNS from the auth-critical path.

## Verification

- Converged live: `two_factor` config produced the **WebAuthn Credentials → ADD**
  enrolment UI (previously absent).
- Service `active`, `NRestarts=0`, `/api/health` 200.
- Rebased onto develop; preserves #1049's `/api` bypass rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)