### PR TITLE
feat(authelia): bypass the SSO gate for token-authenticated /api paths

### DIFF
--- a/roles/authelia/defaults/main.yml
+++ b/roles/authelia/defaults/main.yml
@@ -38,6 +38,15 @@ authelia_port: "{{ tofu_data.constants.service_ports.authelia_portal }}"
 authelia_cookie_domain: "{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
 authelia_portal_url: "https://authelia.{{ authelia_cookie_domain }}"
 
+# Domains whose /api/ paths bypass the SSO gate. These apps enforce their own
+# API token auth on every /api request; the forwardAuth portal can never be
+# satisfied by a non-browser client, so without a bypass an sso-flagged route
+# blocks all machine consumers (a 401 from the app's own WWW-Authenticate,
+# observed on the first token client 2026-07-17). Browser UIs stay behind the
+# portal — the bypass matches only ^/api/.
+authelia_api_bypass_domains:
+  - "zammad.{{ authelia_cookie_domain }}"
+
 # --- Sessions: login once, stay signed in for a week --------------------------
 authelia_session_expiration: "12h"
 authelia_session_inactivity: "12h"

--- a/roles/authelia/templates/configuration.yml.j2
+++ b/roles/authelia/templates/configuration.yml.j2
@@ -33,7 +33,7 @@ access_control:
     - domain: "{{ bypass_domain }}"
       policy: bypass
       resources:
-        - "^/api/.*$"
+        - "^/api(?:/.*)?$"
 {% endfor %}
     # Every Traefik-fronted UI under the ingress base domain. one_factor is
     # the passkey (passkey login satisfies one_factor); step-up to

--- a/roles/authelia/templates/configuration.yml.j2
+++ b/roles/authelia/templates/configuration.yml.j2
@@ -27,6 +27,14 @@ webauthn:
 access_control:
   default_policy: deny
   rules:
+{% for bypass_domain in authelia_api_bypass_domains %}
+    # {{ bypass_domain }} authenticates /api itself (per-request token); the
+    # portal cannot satisfy a non-browser client. UI paths stay gated below.
+    - domain: "{{ bypass_domain }}"
+      policy: bypass
+      resources:
+        - "^/api/.*$"
+{% endfor %}
     # Every Traefik-fronted UI under the ingress base domain. one_factor is
     # the passkey (passkey login satisfies one_factor); step-up to
     # two_factor per-domain later if wanted.


### PR DESCRIPTION
An `sso`-flagged route sends every request through the forwardAuth portal, which a non-browser API client can never satisfy — the app's own per-request token auth is unreachable from outside. Verified live: the app answers 200 to the same token on its local listener and through its own nginx, while the ingress path returns the app-level 401 challenge.

This adds `authelia_api_bypass_domains` — an access-control bypass list rendered above the catch-all `one_factor` rule, matching only `^/api/.*$`. Browser UI paths stay behind the portal. Seeded with the one route flagged `sso` today.