### PR TITLE
feat(zammad): add Media group for user-facing media incidents

### DIFF
--- a/roles/zammad/defaults/main.yml
+++ b/roles/zammad/defaults/main.yml
@@ -85,6 +85,9 @@ zammad_groups:
   - Homelab Infrastructure
   - AI/LLM Serving
   - Hermes Agent
+  # User-facing media stack (Plex playback, *arr pipeline) — related to but
+  # distinct from Homelab Infrastructure.
+  - Media
 # Top-level customer organization the admin belongs to.
 zammad_organization: dryvist
 zammad_extra_priority:


### PR DESCRIPTION
Adds a "Media" group to the seeded Zammad groups — the user-facing media component, related to but distinct from Homelab Infrastructure. Already live-converged during the 2026-07-17 maintenance window (group id 6). Context: Zammad ticket #17040.

🤖 Generated with [Claude Code](https://claude.com/claude-code)