### PR TITLE
fix(configarr): score Apple-TV audio policy on every quality profile

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -741,7 +741,7 @@
   roles:
     - role: plex
     # Playback visibility: a session probe that alerts on forced transcode
-    # (the audio-dropout signature) + a weekly library codec audit.
+    # + a weekly library codec audit (incident history: Zammad ticket #17040, Media).
     - role: media_monitor
 
 # Seerr request UI (Docker in LXC). Registers Sonarr/Radarr/Plex via its settings

--- a/roles/configarr/defaults/main.yml
+++ b/roles/configarr/defaults/main.yml
@@ -66,12 +66,11 @@ configarr_radarr_templates:
 
 # --- Apple-TV direct-play audio policy (global, Sonarr + Radarr) --------------
 # Prefer releases whose audio direct-plays on Apple TV so Plex never transcodes
-# audio for local playback (the real fix for the random audio dropouts — an
-# EAC3 passthrough handshake that intermittently drops on the AV chain). AC3 is
-# the most reliable Apple-TV passthrough, so it scores highest; DTS/TrueHD/FLAC/
-# PCM force a transcode and are heavily penalized (not hard-rejected, so nothing
-# becomes ungrabbable when only an incompatible release exists). Scores are
-# shared by both apps; only the TRaSH trash_ids differ per app.
+# audio for local playback. AC3 is the most reliable Apple-TV passthrough, so it
+# scores highest; DTS/TrueHD/FLAC/PCM force a transcode and are heavily
+# penalized (not hard-rejected, so nothing becomes ungrabbable when only an
+# incompatible release exists). Scores are shared by both apps; only the TRaSH
+# trash_ids differ per app. Incident history: Zammad ticket #17040 (Media).
 configarr_appletv_audio: true
 configarr_audio_scores:
   dd: 150 # AC3 / Dolby Digital — most reliable Apple-TV passthrough
@@ -123,5 +122,25 @@ configarr_radarr_audio_trash_ids:
   mp3: 6ba9033150e7896bdc9ec4b44f2b230f
   opus: a061e2e700f81932daf888599f8a8273
 # Profile names the TRaSH templates above create (assign_scores_to targets).
-configarr_sonarr_audio_profile: "WEB-1080p"
-configarr_radarr_audio_profile: "HD Bluray + WEB"
+# Every profile a series/movie can sit on gets the audio scores — a policy
+# that only covers the TRaSH-managed profile silently skips items on the
+# built-in profiles (found live: 14 series incl. the DTS-grabbing ones were
+# on the unscored "HD - 720p/1080p").
+configarr_sonarr_audio_profiles:
+  - WEB-1080p
+  - Any
+  - SD
+  - HD-720p
+  - HD-1080p
+  - Ultra-HD
+  - HD - 720p/1080p
+  - High Quality
+configarr_radarr_audio_profiles:
+  - HD Bluray + WEB
+  - Any
+  - SD
+  - HD-720p
+  - HD-1080p
+  - Ultra-HD
+  - HD - 720p/1080p
+  - High Quality

--- a/roles/configarr/templates/config.yml.j2
+++ b/roles/configarr/templates/config.yml.j2
@@ -23,8 +23,10 @@ sonarr:
       - trash_ids:
           - {{ configarr_sonarr_audio_trash_ids[codec] }}
         assign_scores_to:
-          - name: {{ configarr_sonarr_audio_profile }}
+{% for profile in configarr_sonarr_audio_profiles %}
+          - name: {{ profile }}
             score: {{ score }}
+{% endfor %}
 {% endfor %}
 {% endif %}
 
@@ -44,7 +46,9 @@ radarr:
       - trash_ids:
           - {{ configarr_radarr_audio_trash_ids[codec] }}
         assign_scores_to:
-          - name: {{ configarr_radarr_audio_profile }}
+{% for profile in configarr_radarr_audio_profiles %}
+          - name: {{ profile }}
             score: {{ score }}
+{% endfor %}
 {% endfor %}
 {% endif %}

--- a/roles/media_monitor/defaults/main.yml
+++ b/roles/media_monitor/defaults/main.yml
@@ -2,9 +2,8 @@
 # media_monitor — visibility for the media stack, deployed on the Plex host.
 # Two systemd timers:
 #   1. plex-session-probe: polls Plex /status/sessions and alerts ntfy when a
-#      client is forced to TRANSCODE (especially audio) instead of Direct Play —
-#      the live signature of the Apple-TV audio dropout this program set out to
-#      fix.
+#      client is forced to TRANSCODE (especially audio) instead of Direct Play.
+#      Incident history: Zammad ticket #17040 (Media).
 #   2. plex-codec-audit: a weekly ffprobe sweep of the library flagging any
 #      primary-audio codec that is not Apple-TV direct-play friendly, catching
 #      files that slipped past the grab-time policy (#823) and the import-time

--- a/roles/media_monitor/templates/plex-session-probe.sh.j2
+++ b/roles/media_monitor/templates/plex-session-probe.sh.j2
@@ -2,8 +2,8 @@
 # {{ ansible_managed }}
 # Plex Direct-Play session probe. Polls Plex /status/sessions and alerts ntfy
 # when a client is being forced to TRANSCODE (especially audio) instead of
-# Direct Play — the live signature of the Apple-TV audio dropout this program
-# set out to fix. Reads the server token from Preferences.xml at runtime (no
+# Direct Play (incident history: Zammad ticket #17040, Media).
+# Reads the server token from Preferences.xml at runtime (no
 # baked-in secret). Best-effort and quiet on the happy path.
 set -uo pipefail
 

--- a/roles/media_remux/defaults/main.yml
+++ b/roles/media_remux/defaults/main.yml
@@ -24,9 +24,8 @@ media_remux_group: media
 media_remux_bitrate: 640k
 
 # Codecs an Apple-TV AVR passes through reliably → left untouched. Everything
-# else (eac3, dts, truehd, flac, …) is remuxed to AC3. EAC3 is treated as
-# non-compatible on purpose: the first Apple-TV's EAC3 (Dolby Digital Plus)
-# passthrough handshake is the original fault this guard exists to prevent.
+# else (eac3, dts, truehd, flac, …) is remuxed to AC3; EAC3 is deliberately
+# non-compatible. Incident history: Zammad ticket #17040 (Media).
 media_remux_compatible_codecs_re: '^(ac3|aac)$'
 
 # ntfy alert target on remux failure — FQDN-first: the Traefik-fronted


### PR DESCRIPTION
The Apple-TV direct-play audio scores were only assigned to one quality profile per app (Sonarr WEB-1080p, Radarr HD Bluray + WEB). Items on the built-in profiles had no audio scoring, so passthrough-incompatible releases kept being selected for them. Assigns the scores to every profile in both apps.

Also replaces incident-narrative comments in configarr/media_remux/media_monitor with a reference to Zammad ticket #17040 (Media group), the system of record for the incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)