### PR TITLE
feat(zammad): seed agent overviews + document the tag taxonomy

### DIFF
--- a/roles/zammad/defaults/main.yml
+++ b/roles/zammad/defaults/main.yml
@@ -87,6 +87,44 @@ zammad_groups:
   - Hermes Agent
 # Top-level customer organization the admin belongs to.
 zammad_organization: dryvist
+
+# Agent-role overviews (saved filtered views), seeded idempotently by name.
+# Declarative keys map onto Zammad's Overview condition schema in the
+# bootstrap: open_only (state category), priority_ids, tag, updated_within_days.
+#
+# Tag taxonomy convention (controlled vocabulary, applied by seeds + agents;
+# filter with tags:"<tag>" in search or via the tag-based overviews):
+#   system:  macos screenpipe vllm-mlx llama-swap postgres zammad vikunja plex
+#            hermes splunk wireguard windowserver
+#   class:   kernel-panic oom memory wedge outage degradation data-loss
+#            config-drift auth network wifi wan monitoring-gap llm-serving
+#   series:  rc-series (the Mac-performance root-cause investigation series)
+zammad_overviews:
+  - name: Open incidents
+    link: open_incidents
+    prio: 1010
+    open_only: true
+    order_by: priority_id
+    order_direction: DESC
+  - name: Critical & high (open)
+    link: critical_high_open
+    prio: 1020
+    open_only: true
+    priority_ids: [3, 4]
+    order_by: priority_id
+    order_direction: DESC
+  - name: RC series (Mac performance)
+    link: rc_series
+    prio: 1030
+    tag: rc-series
+    order_by: created_at
+    order_direction: ASC
+  - name: Recently updated
+    link: recently_updated
+    prio: 1040
+    updated_within_days: 7
+    order_by: updated_at
+    order_direction: DESC
 zammad_extra_priority:
   id: 4
   name: 4 critical

--- a/roles/zammad/files/zammad_bootstrap.rb
+++ b/roles/zammad/files/zammad_bootstrap.rb
@@ -200,43 +200,43 @@ rescue => e
   warn "WARN: knowledge base not created automatically (#{e.class}: #{e.message}). Create it once in the UI."
 end
 
-# --- Overviews: saved filtered views so tickets stay filterable at scale -----
-# Idempotent by name. Conditions use the documented Overview condition schema.
-# Tag taxonomy convention (applied by seeds + agents; controlled vocabulary):
-#   system:  macos screenpipe vllm-mlx llama-swap postgres zammad vikunja plex
-#            hermes splunk wireguard windowserver
-#   class:   kernel-panic oom memory wedge outage degradation data-loss
-#            config-drift auth network wifi wan monitoring-gap llm-serving
-#   series:  rc-series (the Mac-performance root-cause investigation series)
-# Filter in the UI/API with tags:"<tag>" search syntax or the overviews below.
+# --- Overviews: saved filtered views, defined as DATA in zammad_overviews ----
+# (role defaults, ZAMMAD_OVERVIEWS json env). Idempotent by name. Each entry's
+# small declarative keys (open_only, priority_ids, tag, updated_within_days)
+# map onto Zammad's Overview condition schema here, so the YAML stays free of
+# Zammad internals.
 begin
+  require 'json'
+  overviews = JSON.parse(ENV['ZAMMAD_OVERVIEWS'] || '[]')
   agent_role_id = Role.find_by!(name: 'Agent').id
-  overview_defaults = {
-    roles: Role.where(id: agent_role_id), user_ids: [],
-    view: {
-      'd' => %w[title customer group state priority created_at],
-      's' => %w[title customer group state priority created_at],
-      'm' => %w[number title customer group state priority created_at],
-      'view_mode_default' => 's',
-    },
+  overview_view = {
+    'd' => %w[title customer group state priority created_at],
+    's' => %w[title customer group state priority created_at],
+    'm' => %w[number title customer group state priority created_at],
+    'view_mode_default' => 's',
   }
-  [
-    { name: 'Open incidents', prio: 1010, link: 'open_incidents',
-      condition: { 'ticket.state_id' => { operator: 'is', value: Ticket::State.by_category(:open).pluck(:id) } },
-      order: { by: 'priority_id', direction: 'DESC' } },
-    { name: 'Critical & high (open)', prio: 1020, link: 'critical_high_open',
-      condition: { 'ticket.state_id' => { operator: 'is', value: Ticket::State.by_category(:open).pluck(:id) },
-                   'ticket.priority_id' => { operator: 'is', value: [3, 4] } },
-      order: { by: 'priority_id', direction: 'DESC' } },
-    { name: 'RC series (Mac performance)', prio: 1030, link: 'rc_series',
-      condition: { 'ticket.tags' => { operator: 'contains one', value: 'rc-series' } },
-      order: { by: 'created_at', direction: 'ASC' } },
-    { name: 'Recently updated', prio: 1040, link: 'recently_updated',
-      condition: { 'ticket.updated_at' => { operator: 'within last (relative)', range: 'day', value: 7 } },
-      order: { by: 'updated_at', direction: 'DESC' } },
-  ].each do |ov|
-    next if Overview.exists?(name: ov[:name])
-    Overview.create!(overview_defaults.merge(ov))
+  overviews.each do |ov|
+    next if Overview.exists?(name: ov['name'])
+    condition = {}
+    if ov['open_only']
+      condition['ticket.state_id'] =
+        { 'operator' => 'is', 'value' => Ticket::State.by_category(:open).pluck(:id) }
+    end
+    if ov['priority_ids']
+      condition['ticket.priority_id'] = { 'operator' => 'is', 'value' => ov['priority_ids'] }
+    end
+    if ov['tag']
+      condition['ticket.tags'] = { 'operator' => 'contains one', 'value' => ov['tag'] }
+    end
+    if ov['updated_within_days']
+      condition['ticket.updated_at'] =
+        { 'operator' => 'within last (relative)', 'range' => 'day', 'value' => ov['updated_within_days'] }
+    end
+    Overview.create!(
+      name: ov['name'], link: ov['link'], prio: ov['prio'], condition: condition,
+      order: { 'by' => ov['order_by'], 'direction' => ov['order_direction'] },
+      roles: Role.where(id: agent_role_id), user_ids: [], view: overview_view
+    )
     changed = true
   end
 rescue => e

--- a/roles/zammad/files/zammad_bootstrap.rb
+++ b/roles/zammad/files/zammad_bootstrap.rb
@@ -200,4 +200,47 @@ rescue => e
   warn "WARN: knowledge base not created automatically (#{e.class}: #{e.message}). Create it once in the UI."
 end
 
+# --- Overviews: saved filtered views so tickets stay filterable at scale -----
+# Idempotent by name. Conditions use the documented Overview condition schema.
+# Tag taxonomy convention (applied by seeds + agents; controlled vocabulary):
+#   system:  macos screenpipe vllm-mlx llama-swap postgres zammad vikunja plex
+#            hermes splunk wireguard windowserver
+#   class:   kernel-panic oom memory wedge outage degradation data-loss
+#            config-drift auth network wifi wan monitoring-gap llm-serving
+#   series:  rc-series (the Mac-performance root-cause investigation series)
+# Filter in the UI/API with tags:"<tag>" search syntax or the overviews below.
+begin
+  agent_role_id = Role.find_by!(name: 'Agent').id
+  overview_defaults = {
+    roles: Role.where(id: agent_role_id), user_ids: [],
+    view: {
+      'd' => %w[title customer group state priority created_at],
+      's' => %w[title customer group state priority created_at],
+      'm' => %w[number title customer group state priority created_at],
+      'view_mode_default' => 's',
+    },
+  }
+  [
+    { name: 'Open incidents', prio: 1010, link: 'open_incidents',
+      condition: { 'ticket.state_id' => { operator: 'is', value: Ticket::State.by_category(:open).pluck(:id) } },
+      order: { by: 'priority_id', direction: 'DESC' } },
+    { name: 'Critical & high (open)', prio: 1020, link: 'critical_high_open',
+      condition: { 'ticket.state_id' => { operator: 'is', value: Ticket::State.by_category(:open).pluck(:id) },
+                   'ticket.priority_id' => { operator: 'is', value: [3, 4] } },
+      order: { by: 'priority_id', direction: 'DESC' } },
+    { name: 'RC series (Mac performance)', prio: 1030, link: 'rc_series',
+      condition: { 'ticket.tags' => { operator: 'contains one', value: 'rc-series' } },
+      order: { by: 'created_at', direction: 'ASC' } },
+    { name: 'Recently updated', prio: 1040, link: 'recently_updated',
+      condition: { 'ticket.updated_at' => { operator: 'within last (relative)', range: 'day', value: 7 } },
+      order: { by: 'updated_at', direction: 'DESC' } },
+  ].each do |ov|
+    next if Overview.exists?(name: ov[:name])
+    Overview.create!(overview_defaults.merge(ov))
+    changed = true
+  end
+rescue => e
+  warn "WARN: overviews not seeded automatically (#{e.class}: #{e.message}). Create them once in the UI."
+end
+
 puts 'ZAMMAD_BOOTSTRAP_CHANGED' if changed

--- a/roles/zammad/files/zammad_bootstrap.rb
+++ b/roles/zammad/files/zammad_bootstrap.rb
@@ -208,7 +208,7 @@ end
 begin
   require 'json'
   overviews = JSON.parse(ENV['ZAMMAD_OVERVIEWS'] || '[]')
-  agent_role_id = Role.find_by!(name: 'Agent').id
+  overview_agent_role = Role.find_by!(name: 'Agent')
   overview_view = {
     'd' => %w[title customer group state priority created_at],
     's' => %w[title customer group state priority created_at],
@@ -235,7 +235,7 @@ begin
     Overview.create!(
       name: ov['name'], link: ov['link'], prio: ov['prio'], condition: condition,
       order: { 'by' => ov['order_by'], 'direction' => ov['order_direction'] },
-      roles: Role.where(id: agent_role_id), user_ids: [], view: overview_view
+      roles: [overview_agent_role], user_ids: [], view: overview_view
     )
     changed = true
   end

--- a/roles/zammad/tasks/main.yml
+++ b/roles/zammad/tasks/main.yml
@@ -418,6 +418,7 @@
         ZAMMAD_NOTIFICATION_SENDER: "{{ zammad_notification_sender }}"
         ZAMMAD_GROUPS: "{{ zammad_groups | join(',') }}"
         ZAMMAD_ORGANIZATION: "{{ zammad_organization }}"
+        ZAMMAD_OVERVIEWS: "{{ zammad_overviews | to_json }}"
       register: zammad_bootstrap
       changed_when: "'ZAMMAD_BOOTSTRAP_CHANGED' in zammad_bootstrap.stdout"
       no_log: true


### PR DESCRIPTION
## Why

39 tickets and growing — groups alone don't support filtering (operator directive 2026-07-17). Zammad's levers are tags + overviews; neither was seeded.

## What

- `zammad_bootstrap.rb` seeds 4 agent-role overviews, idempotent by name, wrapped best-effort like the other version-sensitive extras: **Open incidents** (priority-ordered), **Critical & high (open)**, **RC series** (tag `rc-series`), **Recently updated** (7 days).
- Documents the controlled tag vocabulary (system / class / series axes) in the bootstrap so agents and seeds share one taxonomy. Tags are ticket data, not config — the existing 39 tickets are tagged by a one-off idempotent seed (110 tag applications, attributed to the `ai` service user), verified via tag search after converge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)