### PR TITLE
feat(zammad): dedicated Hermes customer org for blast-radius isolation

### DIFF
--- a/roles/zammad/defaults/main.yml
+++ b/roles/zammad/defaults/main.yml
@@ -90,6 +90,11 @@ zammad_groups:
   - Media
 # Top-level customer organization the admin belongs to.
 zammad_organization: dryvist
+# Dedicated non-shared org for the Hermes agent: the zammad-incidents skill
+# files tickets without a customer, so Zammad makes the hermes user the
+# customer and the ticket inherits this org — the 24/7 auto-filed noise stays
+# in its own container, bulk-manageable without touching anything else.
+zammad_hermes_organization: Hermes
 
 # Agent-role overviews (saved filtered views), seeded idempotently by name.
 # Declarative keys map onto Zammad's Overview condition schema in the
@@ -126,6 +131,12 @@ zammad_overviews:
     link: recently_updated
     prio: 1040
     updated_within_days: 7
+    order_by: updated_at
+    order_direction: DESC
+  - name: Hermes (auto-filed)
+    link: hermes_auto
+    prio: 1050
+    organization: Hermes
     order_by: updated_at
     order_direction: DESC
 zammad_extra_priority:

--- a/roles/zammad/files/zammad_bootstrap.rb
+++ b/roles/zammad/files/zammad_bootstrap.rb
@@ -72,19 +72,25 @@ end
 # human-only. No password is set: these accounts are API-token-only and cannot
 # log in via the web UI.
 agent_role = [Role.find_by!(name: 'Agent')]
+# hermes also carries Customer: the zammad-incidents skill omits the customer
+# field, so Zammad makes the token's user the ticket customer — which routes
+# every Hermes-filed ticket into the dedicated Hermes org (blast-radius
+# isolation for a 24/7 autonomous filer).
+hermes_roles = [Role.find_by!(name: 'Agent'), Role.find_by!(name: 'Customer')]
 service_users = [
-  [hermes_email, 'Hermes', 'Agent'],
-  [ai_email, 'AI', 'Assistant'],
-].map do |email, first, last|
+  [hermes_email, 'Hermes', 'Agent', hermes_roles],
+  [ai_email, 'AI', 'Assistant', agent_role],
+].map do |email, first, last, desired_roles|
   u = User.find_by(email: email.downcase)
   if u.nil?
     u = User.create!(login: email.downcase, firstname: first, lastname: last,
-                     email: email.downcase, roles: agent_role, active: true)
+                     email: email.downcase, roles: desired_roles, active: true)
     changed = true
-  elsif u.roles.to_a != agent_role || !u.active
-    # Reconcile drift: service accounts are Agent-only and active — strip any
-    # elevated role that snuck on outside this bootstrap.
-    u.update!(roles: agent_role, active: true)
+  elsif u.roles.to_a.sort_by(&:id) != desired_roles.sort_by(&:id) || !u.active
+    # Reconcile drift: service accounts carry exactly their desired roles and
+    # stay active — strip any elevated role that snuck on outside this
+    # bootstrap.
+    u.update!(roles: desired_roles, active: true)
     changed = true
   end
   u
@@ -98,7 +104,10 @@ if kb_perm && !agent_role.first.permissions.include?(kb_perm)
   changed = true
 end
 
-# --- Top-level organization (create-or-find; all our users belong to it) -----
+# --- Organizations ------------------------------------------------------------
+# Top-level org holds the humans + the interactive-AI account; hermes gets its
+# OWN non-shared org so its 24/7 auto-filed tickets live in a separate
+# container (filter, bulk-manage, or purge them without touching the rest).
 org_name = ENV['ZAMMAD_ORGANIZATION']
 if org_name && !org_name.empty?
   org = Organization.find_by(name: org_name)
@@ -106,9 +115,23 @@ if org_name && !org_name.empty?
     org = Organization.create!(name: org_name, shared: true, active: true)
     changed = true
   end
-  ([admin] + service_users).each do |u|
+  [admin, service_users[1]].each do |u|
     next if u.organization_id == org.id
     u.update!(organization_id: org.id)
+    changed = true
+  end
+end
+
+hermes_org_name = ENV['ZAMMAD_HERMES_ORGANIZATION']
+if hermes_org_name && !hermes_org_name.empty?
+  hermes_org = Organization.find_by(name: hermes_org_name)
+  if hermes_org.nil?
+    hermes_org = Organization.create!(name: hermes_org_name, shared: false, active: true,
+                                      note: 'Container for tickets auto-filed by the Hermes agent')
+    changed = true
+  end
+  unless service_users[0].organization_id == hermes_org.id
+    service_users[0].update!(organization_id: hermes_org.id)
     changed = true
   end
 end
@@ -231,6 +254,10 @@ begin
     if ov['updated_within_days']
       condition['ticket.updated_at'] =
         { 'operator' => 'within last (relative)', 'range' => 'day', 'value' => ov['updated_within_days'] }
+    end
+    if ov['organization']
+      condition['ticket.organization_id'] =
+        { 'operator' => 'is', 'value' => [Organization.find_by!(name: ov['organization']).id] }
     end
     Overview.create!(
       name: ov['name'], link: ov['link'], prio: ov['prio'], condition: condition,

--- a/roles/zammad/files/zammad_bootstrap.rb
+++ b/roles/zammad/files/zammad_bootstrap.rb
@@ -86,7 +86,7 @@ service_users = [
     u = User.create!(login: email.downcase, firstname: first, lastname: last,
                      email: email.downcase, roles: desired_roles, active: true)
     changed = true
-  elsif u.roles.to_a.sort_by(&:id) != desired_roles.sort_by(&:id) || !u.active
+  elsif u.role_ids.sort != desired_roles.map(&:id).sort || !u.active
     # Reconcile drift: service accounts carry exactly their desired roles and
     # stay active — strip any elevated role that snuck on outside this
     # bootstrap.
@@ -108,6 +108,7 @@ end
 # Top-level org holds the humans + the interactive-AI account; hermes gets its
 # OWN non-shared org so its 24/7 auto-filed tickets live in a separate
 # container (filter, bulk-manage, or purge them without touching the rest).
+hermes_user, ai_user = service_users
 org_name = ENV['ZAMMAD_ORGANIZATION']
 if org_name && !org_name.empty?
   org = Organization.find_by(name: org_name)
@@ -115,7 +116,7 @@ if org_name && !org_name.empty?
     org = Organization.create!(name: org_name, shared: true, active: true)
     changed = true
   end
-  [admin, service_users[1]].each do |u|
+  [admin, ai_user].each do |u|
     next if u.organization_id == org.id
     u.update!(organization_id: org.id)
     changed = true
@@ -130,8 +131,8 @@ if hermes_org_name && !hermes_org_name.empty?
                                       note: 'Container for tickets auto-filed by the Hermes agent')
     changed = true
   end
-  unless service_users[0].organization_id == hermes_org.id
-    service_users[0].update!(organization_id: hermes_org.id)
+  unless hermes_user.organization_id == hermes_org.id
+    hermes_user.update!(organization_id: hermes_org.id)
     changed = true
   end
 end
@@ -256,8 +257,12 @@ begin
         { 'operator' => 'within last (relative)', 'range' => 'day', 'value' => ov['updated_within_days'] }
     end
     if ov['organization']
-      condition['ticket.organization_id'] =
-        { 'operator' => 'is', 'value' => [Organization.find_by!(name: ov['organization']).id] }
+      ov_org = Organization.find_by(name: ov['organization'])
+      if ov_org.nil?
+        warn "WARN: organization '#{ov['organization']}' not found — skipping overview '#{ov['name']}'."
+        next
+      end
+      condition['ticket.organization_id'] = { 'operator' => 'is', 'value' => [ov_org.id] }
     end
     Overview.create!(
       name: ov['name'], link: ov['link'], prio: ov['prio'], condition: condition,

--- a/roles/zammad/tasks/main.yml
+++ b/roles/zammad/tasks/main.yml
@@ -418,6 +418,7 @@
         ZAMMAD_NOTIFICATION_SENDER: "{{ zammad_notification_sender }}"
         ZAMMAD_GROUPS: "{{ zammad_groups | join(',') }}"
         ZAMMAD_ORGANIZATION: "{{ zammad_organization }}"
+        ZAMMAD_HERMES_ORGANIZATION: "{{ zammad_hermes_organization }}"
         ZAMMAD_OVERVIEWS: "{{ zammad_overviews | to_json }}"
       register: zammad_bootstrap
       changed_when: "'ZAMMAD_BOOTSTRAP_CHANGED' in zammad_bootstrap.stdout"


### PR DESCRIPTION
## Why

Hermes runs 24/7 and auto-files incidents (operator directive 2026-07-17: it must be able to "blow up its own stuff without affecting everything else"). Today every ticket shares one org and the seeded customer, so Hermes noise is not structurally separable.

## How it works

The `zammad-incidents` skill (dryvist/nix-hermes) creates tickets **without a customer field**; Zammad then makes the token's user the customer, and the ticket inherits the customer's organization. So isolation is purely server-side config:

- `hermes` user gains the **Customer** role (now Agent+Customer) and moves to a dedicated **non-shared `Hermes` org** (`zammad_hermes_organization` default). Every Hermes-filed ticket lands in that container — filterable, bulk-manageable, purgeable without touching anything else.
- `ai` + admin stay in `dryvist`.
- Role reconcile becomes per-user desired-roles (hermes = Agent+Customer, ai = Agent) so drift still gets stripped.
- New declarative overview key `organization` + seeded **"Hermes (auto-filed)"** overview.

## Verification plan (post-merge converge)

File a canary ticket with the hermes token omitting customer → assert customer=hermes, organization=Hermes, visible in the new overview; then close the canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)