### PR TITLE
fix(postgres): bind the address the guest holds, not the one it was assigned

### DIFF
--- a/inventory/group_vars/postgres_ai_group.yml
+++ b/inventory/group_vars/postgres_ai_group.yml
@@ -28,14 +28,17 @@ postgres_replication_cidr: "{{ lookup('env', 'NETWORK_CIDR_AI') | default('', tr
 # memory plane down (standby basebackup + both API replicas lose the primary)
 # with the cluster still reporting healthy. Falls back to the permissive role
 # default only when the fact is absent (e.g. a molecule run, which sets its
-# own value anyway).
+# own value anyway) — hence the safe-navigation default({}): a guest with no
+# default route has no ansible_default_ipv4 at all, and the fallback has to
+# survive that rather than raise.
 # NB the space after the comma: postgres normalizes list GUCs to ", " — a
 # space-less value never matches SHOW output, so postgresql_set re-applies and
-# restarts the cluster on every converge.
+# restarts the cluster on every converge. The {%- -%} markers matter for the
+# same reason: without them the folded scalar leaks a leading space into the
+# value and it never matches SHOW either.
 postgres_listen_addresses: >-
-  {{ ('localhost, ' ~ ansible_default_ipv4.address)
-     if (ansible_default_ipv4.address | default('', true) | length > 0)
-     else '*' }}
+  {%- set ip = (ansible_default_ipv4 | default({})).address | default('', true) -%}
+  {{ ('localhost, ' ~ ip) if (ip | length > 0) else '*' }}
 
 # Databases on this cluster. Credential is bao-first (apps/hindsight,
 # generated at source); client_cidr is the ai VLAN — the Hindsight API

--- a/inventory/group_vars/postgres_ai_group.yml
+++ b/inventory/group_vars/postgres_ai_group.yml
@@ -20,16 +20,21 @@ postgres_replication_password: >-
 # on the same ai VLAN). Env-derived — pg_hba needs a CIDR, not an FQDN.
 postgres_replication_cidr: "{{ lookup('env', 'NETWORK_CIDR_AI') | default('', true) }}"
 
-# Narrow the listener to the guest's own reservation address (derived
-# from the tofu inventory, never a literal). Falls back to the permissive role
-# default only when the reservation fact is absent (e.g. a molecule run, which
-# sets its own value anyway).
+# Narrow the listener to the address the guest ACTUALLY holds, discovered at
+# runtime. It must never be derived from an intended/reserved address: these
+# guests are ip=dhcp, IPAM ownership lives in Nautobot, and postgres silently
+# skips a listen_addresses entry it cannot bind. Binding an address the guest
+# does not hold therefore degrades to localhost-only and takes the whole
+# memory plane down (standby basebackup + both API replicas lose the primary)
+# with the cluster still reporting healthy. Falls back to the permissive role
+# default only when the fact is absent (e.g. a molecule run, which sets its
+# own value anyway).
 # NB the space after the comma: postgres normalizes list GUCs to ", " — a
 # space-less value never matches SHOW output, so postgresql_set re-applies and
 # restarts the cluster on every converge.
 postgres_listen_addresses: >-
-  {{ ('localhost, ' ~ container_reserved_ip)
-     if (container_reserved_ip | default('', true) | length > 0)
+  {{ ('localhost, ' ~ ansible_default_ipv4.address)
+     if (ansible_default_ipv4.address | default('', true) | length > 0)
      else '*' }}
 
 # Databases on this cluster. Credential is bao-first (apps/hindsight,

--- a/inventory/group_vars/postgres_group.yml
+++ b/inventory/group_vars/postgres_group.yml
@@ -1,18 +1,20 @@
 ---
 # Shared native PostgreSQL (issue #138) — backs Nautobot now, Vikunja/EspoCRM
 # later. Secrets resolve bao-first (apps domain) with an env fallback; the
-# listener is narrowed to the data-VLAN reservation address.
+# listener is narrowed to the guest's live data-VLAN address.
 
-# Narrow the listener to the guest's own data-VLAN reservation address (derived
-# from the tofu inventory, never a literal). Falls back to the permissive role
-# default only when the reservation fact is absent (e.g. a molecule run, which
-# sets its own value anyway).
+# Narrow the listener to the address the guest ACTUALLY holds, discovered at
+# runtime — never an intended/reserved address. postgres silently skips a
+# listen_addresses entry it cannot bind, so any drift between the reservation
+# and the live lease degrades the cluster to localhost-only while it still
+# reports healthy. Falls back to the permissive role default only when the
+# fact is absent (e.g. a molecule run, which sets its own value anyway).
 # NB the space after the comma: postgres normalizes list GUCs to ", " — a
 # space-less value never matches SHOW output, so postgresql_set re-applies and
 # restarts the cluster on every converge.
 postgres_listen_addresses: >-
-  {{ ('localhost, ' ~ container_reserved_ip)
-     if (container_reserved_ip | default('', true) | length > 0)
+  {{ ('localhost, ' ~ ansible_default_ipv4.address)
+     if (ansible_default_ipv4.address | default('', true) | length > 0)
      else '*' }}
 
 # Databases on this shared cluster. Each password is bao-first

--- a/inventory/group_vars/postgres_group.yml
+++ b/inventory/group_vars/postgres_group.yml
@@ -8,14 +8,17 @@
 # listen_addresses entry it cannot bind, so any drift between the reservation
 # and the live lease degrades the cluster to localhost-only while it still
 # reports healthy. Falls back to the permissive role default only when the
-# fact is absent (e.g. a molecule run, which sets its own value anyway).
+# fact is absent (e.g. a molecule run, which sets its own value anyway) —
+# hence the safe-navigation default({}): a guest with no default route has no
+# ansible_default_ipv4 at all, and the fallback has to survive that.
 # NB the space after the comma: postgres normalizes list GUCs to ", " — a
 # space-less value never matches SHOW output, so postgresql_set re-applies and
-# restarts the cluster on every converge.
+# restarts the cluster on every converge. The {%- -%} markers matter for the
+# same reason: without them the folded scalar leaks a leading space into the
+# value and it never matches SHOW either.
 postgres_listen_addresses: >-
-  {{ ('localhost, ' ~ ansible_default_ipv4.address)
-     if (ansible_default_ipv4.address | default('', true) | length > 0)
-     else '*' }}
+  {%- set ip = (ansible_default_ipv4 | default({})).address | default('', true) -%}
+  {{ ('localhost, ' ~ ip) if (ip | length > 0) else '*' }}
 
 # Databases on this shared cluster. Each password is bao-first
 # (secret/apps/<app>) with an env fallback; each client_cidr is the app LXC's


### PR DESCRIPTION
## Problem

`postgres_listen_addresses` was derived from `container_reserved_ip` — the **intended** address from the tofu inventory. But these guests are `ip=dhcp`, and IPAM ownership belongs to Nautobot, so an intended address is not a fact about the guest.

postgres **silently skips** a `listen_addresses` entry it cannot bind. When the live lease and the intended address disagree, the cluster degrades to localhost-only while still reporting healthy — no error, no failed unit.

That is exactly what took the new ai-VLAN memory cluster down:

```
listen_addresses = localhost, 10.0.50.53   # what postgres was told to bind
inet 10.0.50.224                           # what the guest actually holds
→ LISTEN 127.0.0.1:5432 only
```

The standby's basebackup failed `pg_isready` against the primary, and both Hindsight API replicas would never have connected.

## Fix

Derive from `ansible_default_ipv4.address` — what the guest actually holds. Both plays already `gather_facts: true`.

This deliberately does **not** add a DHCP reservation to pin the intended address: that would mean hard-coding IPs, and Nautobot owns IPAM regardless.

## Blast radius — verified no-op for the shared cluster

Both shared-cluster guests hold exactly their reserved address, so the rendered GUC is byte-identical and `postgresql_set` sees no diff (no restart):

| guest | reserved | actually holds |
| --- | --- | --- |
| postgres | 10.0.30.51 | 10.0.30.51 |
| postgres-apps | 10.0.60.56 | 10.0.60.56 |

Only the ai-VLAN guests change — which is the bug being fixed. Applied to both group_vars because it is one pattern with one root cause; the shared cluster has the same latent trap today and only avoids it by luck of the lease matching.