### PR TITLE
fix(syslog_forwarder): set global workDirectory so imfile config validates

### DIFF
--- a/roles/syslog_forwarder/defaults/main.yml
+++ b/roles/syslog_forwarder/defaults/main.yml
@@ -42,3 +42,10 @@ syslog_forwarder_program_routes: []
 # a file-only logger (e.g. qbittorrent-nox).
 # Format: [{file: <abs path>, tag: <programname>}].
 syslog_forwarder_imfile_inputs: []
+
+# Debian's rsyslog package default (matches the base /etc/rsyslog.conf
+# $WorkDirectory). The config-validate step checks the rendered drop-in
+# standalone, so imfile's own working-dir requirement isn't satisfied by the
+# base file's directive already being in scope — restating it here is required,
+# not redundant.
+syslog_forwarder_imfile_work_directory: /var/spool/rsyslog

--- a/roles/syslog_forwarder/templates/10-forward-cribl.conf.j2
+++ b/roles/syslog_forwarder/templates/10-forward-cribl.conf.j2
@@ -10,6 +10,10 @@
 # imfile inputs: tail file-only loggers into rsyslog. Each input's tag becomes
 # the $programname, so these lines flow through the catch-all (or a matching
 # program route) to the syslog target.
+# global() restates the base config's $WorkDirectory: the deploy-time config
+# validation checks this drop-in standalone, so imfile can't see the base
+# file's directive and fails validation without its own.
+global(workDirectory="{{ syslog_forwarder_imfile_work_directory }}")
 module(load="imfile")
 {% for _in in syslog_forwarder_imfile_inputs %}
 input(type="imfile"

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1269,6 +1269,7 @@
     syslog_forwarder_imfile_inputs:
       - file: /data/.qbittorrent-profile/qBittorrent/data/logs/qbittorrent.log
         tag: qbittorrent
+    syslog_forwarder_imfile_work_directory: /var/spool/rsyslog
     _sf_template_dir: "../../roles/syslog_forwarder/templates"
 
   tasks:
@@ -1327,6 +1328,16 @@
           - "'load=' ~ '\"imfile\"' in _sf"
           - "'qbittorrent.log' in _sf"
         fail_msg: imfile input for the file-only logger did not render.
+
+    - name: Assert imfile's global workDirectory renders and precedes the module load
+      ansible.builtin.assert:
+        that:
+          - "'workDirectory=' ~ '\"/var/spool/rsyslog\"' in _sf"
+          - "_sf.index('workDirectory=') < _sf.index('load=' ~ '\"imfile\"')"
+        fail_msg: >-
+          global(workDirectory=...) must render before module(load="imfile") or
+          the standalone config-validate step fails (imfile has no working dir
+          in scope without it).
 
     - name: Syslog forwarder template rendering PASSED
       ansible.builtin.debug:


### PR DESCRIPTION
Follow-up to #1056: the rendered drop-in fails rsyslog config validation whenever `syslog_forwarder_imfile_inputs` is non-empty (confirmed live on download-vpn — the config never got applied because validation rejected it). Root cause: the ansible validate step checks the rendered file standalone, so the base config's `$WorkDirectory` isn't visible to imfile's own requirement. Fix: restate it via `global(workDirectory=...)` inside the drop-in, guarded by the same conditional.

Verified: `rsyslogd -N1` on the exact rendered fragment now exits 0 (was exit 1 without the fix). ansible-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)