### PR TITLE
fix(download_vpn): route syslog log-shipping via LAN, not the VPN tunnel

### DIFF
--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -147,6 +147,17 @@ download_vpn_syslog_target_port: "{{ tofu_data.constants.syslog_ports.linux }}"
 # new egress path. See templates/mangle.nft.j2 + download-vpn-lanroute.service.j2.
 download_vpn_lanroute_table: 100
 download_vpn_lanroute_mark: "0x1"
+# MUST be a lower number than wg-quick's own auto-generated catch-all rule
+# ("not fwmark <wg-hash> lookup <wg-table>", observed at priority 999 for this
+# wg0 interface) — ip rule evaluates lowest-number-first, and the first rule
+# whose table produces ANY matching route (even a bare `default`) wins. Table
+# 51820's `default dev wg0` always matches, so if this rule sits at priority
+# 1000 (as it did until 2026-07-17) it never gets a chance to fire: every
+# mark-{{ download_vpn_lanroute_mark }} packet — replies AND the syslog
+# log-shipping connection in mangle.nft.j2 — silently fell through to wg0
+# instead of the LAN NIC. Confirmed via `ip route get <lan-target> mark
+# {{ download_vpn_lanroute_mark }}` resolving `dev wg0` instead of eth0.
+download_vpn_lanroute_rule_priority: 900
 # Reply-routing scope. Legitimate marked replies only ever target RFC1918 LAN
 # clients (e.g. the Traefik mgmt VLAN), NEVER public IPs. The lanroute table
 # therefore routes ONLY these ranges out the LAN NIC and installs an `unreachable`

--- a/roles/download_vpn/tasks/main.yml
+++ b/roles/download_vpn/tasks/main.yml
@@ -504,7 +504,12 @@
     owner: root
     group: root
     mode: "0644"
-  notify: Reload systemd
+  # NOT "Reload systemd" (daemon_reload only) — this is a Type=oneshot,
+  # RemainAfterExit=yes unit, so `state: started` on an already-active oneshot
+  # is a no-op regardless of daemon_reload; a unit-file change (e.g. the
+  # 2026-07-17 ip-rule-priority fix) would silently never take effect on a
+  # live host without an explicit restart.
+  notify: Restart download-vpn lanroute
 
 - name: Enable + start LAN-reply policy routing
   ansible.builtin.systemd:

--- a/roles/download_vpn/tasks/validate.yml
+++ b/roles/download_vpn/tasks/validate.yml
@@ -213,6 +213,34 @@
           `default via` clearnet route) in that table.
         success_msg: "LAN-reply policy routing present + fail-closed (no clearnet default)."
 
+    # --- H2. syslog log-shipping egress actually routes via LAN, not wg0 -----
+    # 2026-07-17 incident: rsyslog's own outbound connection to the syslog LB
+    # was nftables-accepted (killswitch.nft.j2 rule 4c) but the DEFAULT route
+    # still pointed at wg0, so the RFC1918 destination was black-holed toward
+    # Proton and no logs ever reached Cribl/Splunk. mangle.nft.j2's output
+    # chain now marks new connections to the syslog LB so they take the LAN
+    # NIC via the same fwmark table as check H. Prove it here.
+    - name: Resolve the route a NEW connection to the syslog LB would take
+      ansible.builtin.command:
+        cmd: ip -4 route get {{ download_vpn_syslog_hosts_resolved[0] }} mark {{ download_vpn_lanroute_mark }}
+      register: download_vpn_syslog_route
+      changed_when: false
+      failed_when: false
+      when: download_vpn_syslog_hosts_resolved | default([]) | length > 0
+
+    - name: Assert syslog log-shipping egresses via the LAN NIC, not wg0
+      ansible.builtin.assert:
+        that:
+          - "'dev ' ~ download_vpn_lan_interface in download_vpn_syslog_route.stdout"
+        fail_msg: >-
+          Log shipping is silently broken: a marked connection to the syslog LB
+          ({{ download_vpn_syslog_hosts_resolved[0] }}) does not resolve out
+          {{ download_vpn_lan_interface }} ({{ download_vpn_syslog_route.stdout | trim }}).
+          It would be encapsulated toward the VPN and black-holed — this guest's
+          logs would never reach Cribl/Splunk. Check mangle.nft.j2's output chain.
+        success_msg: "Syslog log-shipping egresses via the LAN NIC (reaches Cribl/Splunk)."
+      when: download_vpn_syslog_hosts_resolved | default([]) | length > 0
+
     # --- I. marked-path leak check (closes the validator blind spot) --------
     # Checks A-G probe only UNMARKED traffic, so they never exercise the table
     # that the lanroute fwmark rule selects. Prove that a packet carrying the

--- a/roles/download_vpn/tasks/validate.yml
+++ b/roles/download_vpn/tasks/validate.yml
@@ -221,8 +221,10 @@
     # chain now marks new connections to the syslog LB so they take the LAN
     # NIC via the same fwmark table as check H. Prove it here.
     - name: Resolve the route a NEW connection to the syslog LB would take
+      vars:
+        _syslog_lb: "{{ download_vpn_syslog_hosts_resolved | first | default('127.0.0.1') }}"
       ansible.builtin.command:
-        cmd: ip -4 route get {{ download_vpn_syslog_hosts_resolved[0] }} mark {{ download_vpn_lanroute_mark }}
+        cmd: ip -4 route get {{ _syslog_lb }} mark {{ download_vpn_lanroute_mark }}
       register: download_vpn_syslog_route
       changed_when: false
       failed_when: false
@@ -234,7 +236,7 @@
           - "'dev ' ~ download_vpn_lan_interface in download_vpn_syslog_route.stdout"
         fail_msg: >-
           Log shipping is silently broken: a marked connection to the syslog LB
-          ({{ download_vpn_syslog_hosts_resolved[0] }}) does not resolve out
+          ({{ download_vpn_syslog_hosts_resolved | first | default('127.0.0.1') }}) does not resolve out
           {{ download_vpn_lan_interface }} ({{ download_vpn_syslog_route.stdout | trim }}).
           It would be encapsulated toward the VPN and black-holed — this guest's
           logs would never reach Cribl/Splunk. Check mangle.nft.j2's output chain.

--- a/roles/download_vpn/templates/download-vpn-lanroute.service.j2
+++ b/roles/download_vpn/templates/download-vpn-lanroute.service.j2
@@ -1,12 +1,22 @@
 [Unit]
 Description=download-vpn LAN-reply policy routing (cross-subnet web UI reachability)
 Documentation=https://github.com/JacobPEvans/ansible-proxmox-apps
-# Order after wg0 so wg-quick's own fwmark policy rules already exist and we
-# layer a higher-priority rule above them; network-online ensures the LAN NIC is
-# configured. Deliberately NOT Requires=download-vpn-wg.service: this reply
-# routing is independent of the tunnel, so the web UIs stay reachable for
-# debugging even during a VPN outage. The killswitch (not this unit) is the
-# egress security boundary, so keeping it up never enables a leak.
+# Order after wg0 so wg-quick's own fwmark policy rules already exist; network-
+# online ensures the LAN NIC is configured. Deliberately NOT
+# Requires=download-vpn-wg.service: this reply routing is independent of the
+# tunnel, so the web UIs stay reachable for debugging even during a VPN outage.
+# The killswitch (not this unit) is the egress security boundary, so keeping it
+# up never enables a leak.
+#
+# PRIORITY DIRECTION (2026-07-17 fix): `ip rule` priority is LOWEST-number-first
+# — the opposite of what "higher priority" suggests in English. This rule MUST
+# use a number below wg-quick's own auto-generated catch-all (observed at 999
+# for Table=auto), or wg-quick's `default dev wg0` always matches first and
+# this table never gets a chance to fire. Confirmed live: at priority 1000
+# (the original value here, before this fix), `ip route get <lan-ip> mark
+# {{ download_vpn_lanroute_mark }}` resolved via wg0/table 51820 instead of the
+# LAN NIC — silently defeating both the pre-existing reply-routing feature and
+# the syslog log-shipping mark in mangle.nft.j2.
 After=network-online.target download-vpn-wg.service
 Wants=network-online.target
 
@@ -43,8 +53,8 @@ ExecStartPre=/usr/sbin/nft -f {{ download_vpn_mangle_ruleset_path }}
 #    packet that somehow carries the mark but is destined for the public internet
 #    finds no route here and fails CLOSED — clearnet egress via the LAN table is
 #    structurally impossible, not merely policy-gated by the killswitch.
-ExecStartPre=-/usr/bin/env ip rule del fwmark {{ download_vpn_lanroute_mark }} table {{ download_vpn_lanroute_table }} priority 1000
-ExecStart=/usr/bin/env ip rule add fwmark {{ download_vpn_lanroute_mark }} table {{ download_vpn_lanroute_table }} priority 1000
+ExecStartPre=-/usr/bin/env ip rule del fwmark {{ download_vpn_lanroute_mark }} table {{ download_vpn_lanroute_table }} priority {{ download_vpn_lanroute_rule_priority }}
+ExecStart=/usr/bin/env ip rule add fwmark {{ download_vpn_lanroute_mark }} table {{ download_vpn_lanroute_table }} priority {{ download_vpn_lanroute_rule_priority }}
 {% for net in download_vpn_lanroute_reply_networks %}
 ExecStart=/usr/bin/env ip route replace {{ net }} via {{ download_vpn_lan_gateway }} dev {{ download_vpn_lan_interface }} table {{ download_vpn_lanroute_table }}
 {% endfor %}
@@ -52,7 +62,7 @@ ExecStart=/usr/bin/env ip route replace unreachable default table {{ download_vp
 
 # Teardown: remove the rule, flush the table, drop the mangle marking — leaving
 # no standing non-VPN routing state.
-ExecStop=-/usr/bin/env ip rule del fwmark {{ download_vpn_lanroute_mark }} table {{ download_vpn_lanroute_table }} priority 1000
+ExecStop=-/usr/bin/env ip rule del fwmark {{ download_vpn_lanroute_mark }} table {{ download_vpn_lanroute_table }} priority {{ download_vpn_lanroute_rule_priority }}
 ExecStop=-/usr/bin/env ip route flush table {{ download_vpn_lanroute_table }}
 ExecStop=-/usr/sbin/nft delete table inet vpn_lanroute
 

--- a/roles/download_vpn/templates/mangle.nft.j2
+++ b/roles/download_vpn/templates/mangle.nft.j2
@@ -58,26 +58,38 @@ table inet vpn_lanroute {
   chain output {
     type route hook output priority mangle;
 
-    # Restore ONLY our mark onto reply packets so the `ip rule fwmark` sends
-    # them out the LAN NIC. `type route` makes the kernel re-evaluate routing
-    # when the mark changes. The `ct mark` guard means WireGuard's encapsulated
-    # UDP (ct mark 0) and every app-initiated flow are left untouched.
+    # FIRST: tag locally-originated NEW connections to our own syslog pipeline
+    # LB with the CONNMARK, so the restore line below sets the fwmark on EVERY
+    # packet of the flow — not just the SYN. This routes rsyslog's log shipping
+    # out the LAN NIC instead of the default route into wg0 (where an RFC1918
+    # dest is unreachable and black-holed). Scoped to this exact IP+port set —
+    # never a blanket RFC1918 or "any new connection" match — so app-initiated
+    # egress (torrents, indexer fetches) is untouched and still forced through
+    # the VPN or dropped.
+    #
+    # Why CONNMARK (`ct mark`) and not `meta mark` here: the fwmark is per-packet
+    # and `ct state new` only matches the SYN. If we set the fwmark directly, the
+    # SYN would route out eth0 but the completing ACK (ct state established) would
+    # get no mark and fall back to wg0 — the handshake never completes and log
+    # shipping silently hangs (the 2026-07-17 bug this replaces). The connmark
+    # persists in conntrack, and the restore line marks every subsequent packet.
+    # It MUST precede the restore line so the SYN is re-marked in the same pass.
+{% for _sl in download_vpn_syslog_hosts_resolved | default([]) %}
+    ip daddr {{ _sl }} tcp dport {{ download_vpn_syslog_target_port }} ct state new ct mark set {{ download_vpn_lanroute_mark }}
+{% endfor %}
+
+    # Restore our connmark onto the fwmark for EVERY packet carrying it — reply
+    # packets of inbound web-UI flows (marked in prerouting) AND every packet of
+    # the syslog flow tagged just above — so the `ip rule fwmark` sends them out
+    # the LAN NIC. `type route` makes the kernel re-evaluate routing when the
+    # mark changes. The `ct mark` guard means WireGuard's encapsulated UDP
+    # (ct mark 0) and every unmarked app-initiated flow are left untouched.
     #
     # IPv6 INVARIANT: this rule is family-agnostic, but no v6 packet is ever
-    # marked because the prerouting rule above matches `ip saddr` (v4-only). Keep
-    # it that way until the README "Enabling IPv6 later" runbook is followed —
-    # adding v6 marking without a v6 lanroute table (RFC-ULA-scoped, no v6
-    # `default`) would create a v6 leak path.
+    # marked because both marking rules above match `ip saddr`/`ip daddr`
+    # (v4-only). Keep it that way until the README "Enabling IPv6 later" runbook
+    # is followed — adding v6 marking without a v6 lanroute table (RFC-ULA-scoped,
+    # no v6 `default`) would create a v6 leak path.
     ct mark {{ download_vpn_lanroute_mark }} meta mark set {{ download_vpn_lanroute_mark }}
-
-    # Mark NEW locally-originated connections to our own syslog pipeline LB so
-    # they route out the LAN NIC too (same `ip rule fwmark` as above), instead
-    # of following the default route into wg0 where an RFC1918 destination is
-    # unreachable. Scoped to this exact IP+port set — never a blanket RFC1918
-    # or "any new connection" match, so app-initiated egress (torrents, indexer
-    # fetches) is untouched and still forced through the VPN or dropped.
-{% for _sl in download_vpn_syslog_hosts_resolved | default([]) %}
-    ip daddr {{ _sl }} tcp dport {{ download_vpn_syslog_target_port }} ct state new meta mark set {{ download_vpn_lanroute_mark }}
-{% endfor %}
   }
 }

--- a/roles/download_vpn/templates/mangle.nft.j2
+++ b/roles/download_vpn/templates/mangle.nft.j2
@@ -13,18 +13,30 @@
   subnet, so it is black-holed and the client times out. Same-subnet replies
   work only because that /24 is a connected route on the LAN NIC.
 
+  A second, narrower case of the same problem: rsyslog on THIS guest
+  self-initiates a connection to the internal syslog pipeline LB
+  (killswitch.nft.j2 rule 4c already ACCEPTs it) — but an nftables accept
+  doesn't change routing, and the default route still points at wg0, so the
+  SYN is encapsulated toward Proton and black-holed there too (confirmed
+  2026-07-17: `ip route get <lb-ip>` resolved via wg0/table 51820, TCP connect
+  hung). The mark below (output chain, matched by dest LB IP+port only) fixes
+  this the same way, WITHOUT touching the "apps never self-initiate non-VPN
+  egress" invariant — it is scoped to our own log-shipping target, never to
+  general RFC1918 or public destinations.
+
   FIX: tag the *inbound* connections we want reachable with a connmark, restore
   that mark onto their *reply* packets, and (via the companion `ip rule fwmark`)
   route only those replies out the LAN NIC. See download-vpn-lanroute.service.
 
   SECURITY INVARIANT (unchanged): this never lets the apps INITIATE non-VPN
-  egress. Only packets belonging to an already-marked inbound connection get the
-  mark; app-initiated flows (torrents, indexer fetches, DNS) are never marked, so
-  they still resolve via wg0 — or are dropped by the killswitch if wg0 is down.
-  The `ct mark {{ download_vpn_lanroute_mark }}` guard on the output chain is
-  load-bearing: an unconditional `meta mark set ct mark` would also clobber
-  WireGuard's own fwmark on its encapsulated UDP (ct mark 0), recursively routing
-  the handshake into the tunnel and breaking the VPN.
+  egress to the public internet. Only packets belonging to an already-marked
+  inbound connection, OR a new connection to our own syslog LB specifically,
+  get the mark; app-initiated flows (torrents, indexer fetches, DNS) are never
+  marked, so they still resolve via wg0 — or are dropped by the killswitch if
+  wg0 is down. The `ct mark {{ download_vpn_lanroute_mark }}` guard on the
+  output chain is load-bearing: an unconditional `meta mark set ct mark` would
+  also clobber WireGuard's own fwmark on its encapsulated UDP (ct mark 0),
+  recursively routing the handshake into the tunnel and breaking the VPN.
 -#}
 {#
   Declare-then-flush so a re-apply replaces the ruleset instead of merging
@@ -57,5 +69,15 @@ table inet vpn_lanroute {
     # adding v6 marking without a v6 lanroute table (RFC-ULA-scoped, no v6
     # `default`) would create a v6 leak path.
     ct mark {{ download_vpn_lanroute_mark }} meta mark set {{ download_vpn_lanroute_mark }}
+
+    # Mark NEW locally-originated connections to our own syslog pipeline LB so
+    # they route out the LAN NIC too (same `ip rule fwmark` as above), instead
+    # of following the default route into wg0 where an RFC1918 destination is
+    # unreachable. Scoped to this exact IP+port set — never a blanket RFC1918
+    # or "any new connection" match, so app-initiated egress (torrents, indexer
+    # fetches) is untouched and still forced through the VPN or dropped.
+{% for _sl in download_vpn_syslog_hosts_resolved | default([]) %}
+    ip daddr {{ _sl }} tcp dport {{ download_vpn_syslog_target_port }} ct state new meta mark set {{ download_vpn_lanroute_mark }}
+{% endfor %}
   }
 }


### PR DESCRIPTION
## Summary
- rsyslog's own connection to the syslog pipeline LB was nftables-accepted but still routed via wg0 (the VPN tunnel), where the internal LB IP is unreachable — logs from this guest never reached Cribl/Splunk.
- Root cause (confirmed via direct routing-table inspection on the live host): the `vpn_lanroute` policy-routing rule's `ip rule` priority (1000) is numerically *lower precedence* than wg-quick's own auto-generated catch-all rule (observed at priority 999) — `ip rule` evaluates lowest-number-first, so wg-quick's rule always won the race. This silently defeated not just the new syslog mark added here, but the pre-existing qBittorrent/Prowlarr cross-subnet WebUI reply-routing feature too (never previously proven with a live functional test).
- Also fixed the systemd-unit-deploy task notifying `Reload systemd` (daemon_reload only) instead of `Restart download-vpn lanroute` — for a `Type=oneshot, RemainAfterExit=yes` unit, `state: started` is a no-op once already active, so this unit-file change would never take live effect without an explicit restart.

## Changes
- `mangle.nft.j2`: mark new connections to the syslog LB (exact IP+port match) for LAN routing, same mechanism as the existing reply-routing feature.
- `defaults/main.yml`: new `download_vpn_lanroute_rule_priority: 900` (was a hardcoded `1000` in the template).
- `download-vpn-lanroute.service.j2`: use the new priority var; corrected the misleading "higher-priority" comment.
- `tasks/main.yml`: fixed the unit-deploy task's notify target.
- `tasks/validate.yml`: new functional assertion — `ip route get <syslog-lb> mark <lanroute-mark>` must resolve via the LAN interface, not wg0.

## Verification
Confirmed live on download-vpn (pve2, LXC 725140) after converging + a one-time catch-up restart:
- `ip rule` now shows the fwmark rule at priority 900 (ahead of wg-quick's 999).
- `ip -4 route get 10.0.40.21 mark 0x1` resolves `via 10.0.70.1 dev eth0 table 100` (was `dev wg0 table 51820`).

End-to-end delivery to Splunk is still blocked separately by an ongoing UDW gateway outage (cross-VLAN routing from this guest's LAN NIC is currently down independent of this fix — confirmed via ping: same-VLAN gateway reachable, cross-VLAN LB unreachable). That is tracked in Zammad ticket #17041, not this PR.

## Test plan
- [x] `ansible-lint` clean (production profile) on all changed files.
- [x] Converged `--tags download_vpn` against the live host; unit file + nftables rule both rendered and validated (`nft -c -f`) cleanly.
- [x] Live `ip rule` / `ip route get` verification (see above).
- [ ] End-to-end Splunk arrival — blocked on the separate UDW outage, will re-verify once that's resolved.