### PR TITLE
fix(traefik): fail the converge if Traefik rejects the rendered dynamic config

### DIFF
--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -156,3 +156,42 @@
     enabled: true
     daemon_reload: true
   when: traefik_manage_services | bool
+
+# --- Post-deploy: verify Traefik actually ACCEPTED the dynamic config --------
+# Traefik's file provider hot-reloads dynamic.yml and, on a parse/build error,
+# logs it and SILENTLY KEEPS THE LAST-GOOD CONFIG (or none) — every backing
+# host then 404s with no signal. A rendered config that CI's YAML-parse guard
+# somehow still let through (or an env-specific breakage) would otherwise land
+# live and stay invisible until someone notices the outage. Flush the pending
+# restart, then fail the converge loudly if the file provider rejected the
+# config, instead of reporting a green run over a dead ingress.
+- name: Apply the pending Traefik restart before verifying the config loaded
+  ansible.builtin.meta: flush_handlers
+
+- name: Give Traefik's file provider a moment to (re)load the dynamic config
+  ansible.builtin.wait_for:
+    timeout: 5
+  when: traefik_manage_services | bool
+
+- name: Read the recent Traefik journal for file-provider errors
+  ansible.builtin.command:
+    cmd: journalctl -u traefik --no-pager --since "-30 seconds"
+  register: _traefik_journal
+  changed_when: false
+  failed_when: false
+  when: traefik_manage_services | bool
+
+- name: Fail loudly if Traefik rejected the rendered dynamic config
+  ansible.builtin.assert:
+    that:
+      # "collecting file configs" is Traefik's wrapper for ANY file-provider
+      # config error (YAML parse, unknown key, ...); it never appears on a clean
+      # load, so its presence means the live routers were NOT updated.
+      - "'collecting file configs' not in _traefik_journal.stdout"
+    fail_msg: >-
+      Traefik's file provider REJECTED the rendered dynamic config — the live
+      routers are stale and every host behind Traefik will 404. Fix
+      dynamic.yml.j2 and re-converge. Recent journal:
+      {{ _traefik_journal.stdout_lines[-12:] | join('\n') }}
+    success_msg: "Traefik accepted the dynamic config (file provider loaded clean)."
+  when: traefik_manage_services | bool


### PR DESCRIPTION
## Summary
On 2026-07-17 a broken `dynamic.yml` (a stale render that a merged template fix was never converged over) sat live for hours and took **all** Traefik ingress down — every host 404'd — while the converge that deployed it reported success. Root cause of the silence: Traefik's file provider hot-reloads `dynamic.yml` and, on a parse/build error, logs it and **silently keeps the last-good config**. Nothing in the role verified the live provider actually accepted the config.

## What this does NOT need (already covered)
The CI YAML-parse guard already exists — `tests/template_render/verify_templates.yml` renders `dynamic.yml.j2` and runs it through `from_yaml` (added in #996), and a negative test confirms it raises on the exact leaked-Jinja-comment corruption. So template-**source** corruption already fails CI. This PR is the complementary **live** check.

## Change
After starting Traefik, flush the pending restart and fail the converge loudly if the Traefik journal shows a file-provider error (`collecting file configs` — Traefik's wrapper for any dynamic-config parse/build failure, never present on a clean load). A green converge can no longer sit on top of a dead ingress.

- Live-only (`traefik_manage_services`); there is no `molecule/traefik` scenario and the template-render test doesn't execute `tasks/main.yml`, so CI is unaffected.

## Test plan
- [x] `ansible-lint` clean (production profile).
- [x] Confirmed no molecule scenario runs the traefik role's `tasks/main.yml` (traefik only appears as a host-group label in `molecule/keepalived`).
- [ ] Live: on the next traefik converge, a valid config passes silently; a deliberately-broken `dynamic.yml.j2` fails the converge with the journal tail.