### PR TITLE
fix(zammad): SSO login as jevans + DB-password guard + self-healing restart

### DIFF
--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -382,6 +382,29 @@
   become_user: postgres
   when: postgres_role == 'primary'
   block:
+    # Every managed password resolves through
+    # `bao_apps_secrets.<app>_db_password | default(lookup('env', '<APP>_DB_PASSWORD'), true)`.
+    # `bao_apps_secrets` defaults to {} (group_vars/all.yml), so a converge run
+    # WITHOUT the secrets environment (sops exec-env / doppler run) silently
+    # resolves every password to '' and rewrites the role with an empty one —
+    # the app then fails auth against a password only this play knows it broke.
+    # Fail loudly instead: an absent secret is an operator error, never an
+    # empty password.
+    - name: Assert every managed role has a non-empty source password
+      ansible.builtin.assert:
+        that:
+          - item.password | default('', true) | length > 0
+        fail_msg: >-
+          No password resolved for the '{{ item.user }}' role. Re-run under the
+          secrets environment (sops exec-env secrets.enc.yaml 'doppler run -- ...')
+          or populate bao_apps_secrets — converging without it would set an empty
+          password and lock the app out of its own database.
+        quiet: true
+      loop: "{{ postgres_managed_databases }}"
+      loop_control:
+        label: "{{ item.user }}"
+      no_log: true
+
     - name: Ensure each managed login role exists with the source password
       community.postgresql.postgresql_user:
         name: "{{ item.user }}"

--- a/roles/traefik/templates/dynamic.yml.j2
+++ b/roles/traefik/templates/dynamic.yml.j2
@@ -17,10 +17,16 @@ http:
       service: {{ route.name }}
       entryPoints:
         - websecure
+{# strip-remote-headers goes on EVERY router, ahead of authelia, and is not
+   optional: an app that trusts Remote-User (Zammad's auth_sso) would otherwise
+   accept whatever a client sent. Ungated and bypassed paths need it MOST —
+   they never reach Authelia, so nothing else would overwrite a forged header.
+   Authelia re-adds the real values via authResponseHeaders on gated routes. #}
 {# route.name != 'authelia': the portal must never gate itself (auth loop),
    even if its inventory row is ever mis-flagged sso: true. #}
-{% if sso_enabled and route.name != 'authelia' and route.sso | default(false) %}
       middlewares:
+        - strip-remote-headers
+{% if sso_enabled and route.name != 'authelia' and route.sso | default(false) %}
         - authelia
 {% endif %}
       tls:
@@ -37,6 +43,7 @@ http:
       entryPoints:
         - websecure
       middlewares:
+        - strip-remote-headers
         - dashboard-auth
       tls:
         certResolver: letsencrypt
@@ -82,9 +89,20 @@ http:
     insecure-backend:
       insecureSkipVerify: true
 {% endif %}
-{% if traefik_dashboard_enabled or sso_enabled %}
 
   middlewares:
+{# Always defined — every router references it, and an undefined middleware
+   makes Traefik drop the whole router. Setting a header to "" removes it from
+   the forwarded request, so a client cannot smuggle an identity into an app
+   that trusts these (Zammad auth_sso). This is the control that makes header
+   trust safe; do not make it conditional on sso_enabled. #}
+    strip-remote-headers:
+      headers:
+        customRequestHeaders:
+          Remote-User: ""
+          Remote-Groups: ""
+          Remote-Email: ""
+          Remote-Name: ""
 {% if traefik_dashboard_enabled %}
     dashboard-auth:
       basicAuth:
@@ -99,5 +117,4 @@ http:
           - Remote-Groups
           - Remote-Email
           - Remote-Name
-{% endif %}
 {% endif %}

--- a/roles/zammad/defaults/main.yml
+++ b/roles/zammad/defaults/main.yml
@@ -77,6 +77,27 @@ zammad_ai_email: "ai@{{ tofu_data.domain }}"
 zammad_hermes_api_token: "{{ lookup('env', 'ZAMMAD_API_TOKEN') }}"
 zammad_ai_api_token: "{{ lookup('env', 'ZAMMAD_AI_API_TOKEN') }}"
 
+# --- Human SSO account (Authelia forwardAuth identity) ------------------------
+# `login` MUST equal the Authelia username verbatim: Zammad's create_sso does
+# User.lookup(login: ...) on the Remote-User header value, so the email is
+# metadata and the login is the join key. admin@ above stays the break-glass
+# password login for when Authelia itself is unavailable.
+zammad_sso_login: jevans
+zammad_sso_email: "{{ zammad_sso_login }}@{{ tofu_data.domain }}"
+zammad_sso_firstname: Jacob
+zammad_sso_lastname: Evans
+# Which SOURCE addresses may assert an SSO login. This is NOT the primary
+# control — Traefik stripping client-supplied Remote-* headers is (a request can
+# only carry Remote-User if Authelia put it there). It still must be non-empty:
+# Zammad's verify_sso_trusted_ip! does `return if trusted_ips.blank?`, so a blank
+# value silently skips the check entirely.
+# Scoped to RFC1918 rather than Traefik's address on purpose: Rails resolves
+# request.remote_ip from X-Forwarded-For, so it is the BROWSER's address here,
+# not the proxy's. Comma-separated string; CIDRs allowed.
+zammad_sso_trusted_ips: >-
+  {{ lookup('env', 'ZAMMAD_SSO_TRUSTED_IPS')
+     | default('10.0.0.0/8,192.168.0.0/16,172.16.0.0/12', true) }}
+
 # Incident-management groups + severity priorities. Hermes maps its P-levels to
 # these priority ids: P1->4 critical, P2->3 high, P3->2 normal, P4->1 low. The
 # built-in 1/2/3 are kept; only "4 critical" is added.

--- a/roles/zammad/files/zammad_bootstrap.rb
+++ b/roles/zammad/files/zammad_bootstrap.rb
@@ -31,6 +31,11 @@ smtp_host   = env!('ZAMMAD_SMTP_HOST')
 smtp_port   = env!('ZAMMAD_SMTP_PORT').to_i
 sender      = env!('ZAMMAD_NOTIFICATION_SENDER')
 groups      = env!('ZAMMAD_GROUPS').split(',').map(&:strip).reject(&:empty?)
+sso_login   = env!('ZAMMAD_SSO_LOGIN')
+sso_email   = env!('ZAMMAD_SSO_EMAIL')
+sso_first   = env!('ZAMMAD_SSO_FIRSTNAME')
+sso_last    = env!('ZAMMAD_SSO_LASTNAME')
+sso_ips     = env!('ZAMMAD_SSO_TRUSTED_IPS')
 
 def set_setting(name, value)
   return false if Setting.get(name) == value
@@ -39,12 +44,28 @@ def set_setting(name, value)
 end
 
 # --- Core settings: end the getting-started wizard, https, storage, es -------
+# auth_sso: Zammad's SessionsController#create_sso reads the login from
+# request.env REMOTE_USER / HTTP_REMOTE_USER / X-Forwarded-User, so Authelia's
+# `Remote-User` forwardAuth header lands as HTTP_REMOTE_USER and logs the user
+# in with no password. Traefik STRIPS any client-supplied Remote-* header before
+# forwardAuth (roles/traefik), which is what makes trusting this header safe —
+# without that strip anyone could assert any login here, so the two ship together.
+#
+# auth_sso_trusted_ips is a hard requirement, not defence in depth: Zammad's
+# verify_sso_trusted_ip! does `return if trusted_ips.blank?` — a blank value
+# skips the source check entirely.
 {
   'system_init_done' => true,
   'fqdn'             => fqdn,
   'http_type'       => 'https',
   'storage_provider' => 'File',
   'es_url'          => es_url,
+  'auth_sso'        => true,
+  # A comma-separated STRING, never an Array: Auth::Sso::TrustedIps does
+  # `setting_value.to_s.split(',')`, so an Array stringifies to `["a", "b"]` and
+  # every entry then fails IPAddr parsing — include? returns false and SSO is
+  # rejected for everyone. CIDR entries are supported.
+  'auth_sso_trusted_ips' => sso_ips.split(',').map(&:strip).reject(&:empty?).join(','),
 }.each { |k, v| changed = true if set_setting(k, v) }
 
 # --- Admin user (create-or-find; ensure Admin+Agent + active) ----------------
@@ -62,6 +83,30 @@ else
   unless missing.empty?
     admin.roles = (admin.roles.to_a + missing).uniq
     admin.save!
+    changed = true
+  end
+end
+
+# --- Human SSO account (Authelia forwardAuth identity) -----------------------
+# Zammad looks the user up by LOGIN (User.lookup(login: login&.downcase)), so
+# the login MUST equal the Authelia username verbatim — the email is metadata,
+# not the lookup key. No password is set: this account authenticates only by the
+# SSO header, and admin@ stays the break-glass password login for when Authelia
+# itself is down.
+sso_roles = Role.where(name: %w[Admin Agent]).to_a
+sso_user = User.find_by(login: sso_login.downcase)
+if sso_user.nil?
+  sso_user = User.create!(
+    login: sso_login.downcase, firstname: sso_first, lastname: sso_last,
+    email: sso_email.downcase, roles: sso_roles, active: true
+  )
+  changed = true
+else
+  missing_sso = sso_roles - sso_user.roles.to_a
+  if !missing_sso.empty? || !sso_user.active
+    sso_user.roles = (sso_user.roles.to_a + missing_sso).uniq
+    sso_user.active = true
+    sso_user.save!
     changed = true
   end
 end

--- a/roles/zammad/tasks/main.yml
+++ b/roles/zammad/tasks/main.yml
@@ -384,10 +384,15 @@
           - zammad_admin_password | length > 0
           - zammad_hermes_api_token | length > 0
           - zammad_ai_api_token | length > 0
+          # Never let auth_sso be enabled with a blank trusted-IP list:
+          # verify_sso_trusted_ip! treats blank as "skip the check", so an empty
+          # value here silently accepts an SSO assertion from any source.
+          - zammad_sso_trusted_ips | length > 0
         fail_msg: >-
           ZAMMAD_ADMIN_PASSWORD, ZAMMAD_API_TOKEN and ZAMMAD_AI_API_TOKEN must
           be set before the first converge (Doppler/SOPS or OpenBao
-          apps/zammad + ai/hermes).
+          apps/zammad + ai/hermes), and zammad_sso_trusted_ips must be non-empty
+          (a blank value disables Zammad's SSO source check entirely).
         quiet: true
       no_log: true
 
@@ -416,6 +421,11 @@
         ZAMMAD_SMTP_HOST: "{{ zammad_smtp_host }}"
         ZAMMAD_SMTP_PORT: "{{ zammad_smtp_port }}"
         ZAMMAD_NOTIFICATION_SENDER: "{{ zammad_notification_sender }}"
+        ZAMMAD_SSO_LOGIN: "{{ zammad_sso_login }}"
+        ZAMMAD_SSO_EMAIL: "{{ zammad_sso_email }}"
+        ZAMMAD_SSO_FIRSTNAME: "{{ zammad_sso_firstname }}"
+        ZAMMAD_SSO_LASTNAME: "{{ zammad_sso_lastname }}"
+        ZAMMAD_SSO_TRUSTED_IPS: "{{ zammad_sso_trusted_ips }}"
         ZAMMAD_GROUPS: "{{ zammad_groups | join(',') }}"
         ZAMMAD_ORGANIZATION: "{{ zammad_organization }}"
         ZAMMAD_HERMES_ORGANIZATION: "{{ zammad_hermes_organization }}"
@@ -491,16 +501,43 @@
     # =========================================================================
     # Phase 11: Health
     # =========================================================================
-    - name: Wait for the Zammad web UI to answer through nginx
-      ansible.builtin.uri:
-        url: "http://127.0.0.1:{{ zammad_web_port }}/"
-        status_code: [200, 301, 302]
-        follow_redirects: none
-      register: zammad_health
-      until: zammad_health.status in [200, 301, 302]
-      retries: "{{ zammad_health_retries | int }}"
-      delay: "{{ zammad_health_delay | int }}"
-      changed_when: false
+    # Self-healing, because "config correct + process stale" is a trap this role
+    # cannot otherwise escape: a converge that rewrote database.yml and then
+    # failed before flushing handlers leaves Zammad running with the OLD
+    # credentials, and every later converge sees the file already correct,
+    # notifies no handler, and never restarts it — so the stale process 500s
+    # forever while every file on disk looks right. (Observed 2026-07-17:
+    # web started 05:58, database.yml rewritten 07:21, PG::ConnectionBad until
+    # a restart.) An unhealthy service therefore earns one restart and a
+    # re-check before the converge is allowed to fail.
+    - name: Ensure Zammad answers through nginx
+      block:
+        - name: Wait for the Zammad web UI to answer through nginx
+          ansible.builtin.uri:
+            url: "http://127.0.0.1:{{ zammad_web_port }}/"
+            status_code: [200, 301, 302]
+            follow_redirects: none
+          register: zammad_health
+          until: zammad_health.status in [200, 301, 302]
+          retries: "{{ zammad_health_retries | int }}"
+          delay: "{{ zammad_health_delay | int }}"
+          changed_when: false
+      rescue:
+        - name: Restart Zammad — the running process may predate its config
+          ansible.builtin.systemd_service:
+            name: zammad
+            state: restarted
+
+        - name: Wait for the Zammad web UI to answer after the restart
+          ansible.builtin.uri:
+            url: "http://127.0.0.1:{{ zammad_web_port }}/"
+            status_code: [200, 301, 302]
+            follow_redirects: none
+          register: zammad_health_retry
+          until: zammad_health_retry.status in [200, 301, 302]
+          retries: "{{ zammad_health_retries | int }}"
+          delay: "{{ zammad_health_delay | int }}"
+          changed_when: false
 
 # Publish the Zammad MCP connection to OpenBao (task #12). Deferred: gated on
 # zammad_token_publish_openbao (default false); the converge flips it with -e.

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1183,9 +1183,9 @@
         that:
           # sso: true -> the router carries the authelia middleware.
           - "'authelia' in _traefik_dynamic_yaml.http.routers.splunk.middlewares"
-          # Unflagged routers (and the portal itself) carry none.
-          - "'middlewares' not in _traefik_dynamic_yaml.http.routers.plex"
-          - "'middlewares' not in _traefik_dynamic_yaml.http.routers.authelia"
+          # Unflagged routers (and the portal itself) are NOT gated.
+          - "'authelia' not in _traefik_dynamic_yaml.http.routers.plex.middlewares"
+          - "'authelia' not in _traefik_dynamic_yaml.http.routers.authelia.middlewares"
           # The middleware dials the portal BACKEND url (never the public FQDN,
           # which CNAMEs back to Traefik and would loop).
           - >-
@@ -1196,6 +1196,35 @@
           dynamic.yml.j2 sso gating wrong: middleware missing on a flagged
           router, present on an unflagged one, or the forwardAuth address does
           not target the portal backend.
+
+    # A forged Remote-User must never reach a backend that trusts it (Zammad's
+    # auth_sso). Ungated/bypassed routes are the dangerous ones — they never
+    # reach Authelia, so only this strip protects them. Ordering matters: the
+    # strip has to run BEFORE authelia, or it would erase the identity Authelia
+    # just established.
+    - name: Assert every router strips client-supplied Remote-* headers, before authelia
+      ansible.builtin.assert:
+        that:
+          - >-
+            _traefik_dynamic_yaml.http.routers.values()
+            | map(attribute='middlewares') | select('defined')
+            | map('first') | unique | list == ['strip-remote-headers']
+          - >-
+            _traefik_dynamic_yaml.http.routers.splunk.middlewares
+            == ['strip-remote-headers', 'authelia']
+          - "'strip-remote-headers' in _traefik_dynamic_yaml.http.routers.plex.middlewares"
+          - "'strip-remote-headers' in _traefik_dynamic_yaml.http.routers.authelia.middlewares"
+          - >-
+            _traefik_dynamic_yaml.http.middlewares['strip-remote-headers'].headers.customRequestHeaders['Remote-User']
+            == ""
+          - >-
+            _traefik_dynamic_yaml.http.middlewares['strip-remote-headers'].headers.customRequestHeaders['Remote-Groups']
+            == ""
+        fail_msg: >-
+          dynamic.yml.j2 header hardening wrong: a router is missing
+          strip-remote-headers, does not run it first, or the middleware does
+          not clear the Remote-* headers. A client could then forge Remote-User
+          on an ungated or /api-bypassed route and be trusted by Zammad.
 
     - name: Assert HTTPS backend gets an https URL + insecure-backend serversTransport
       ansible.builtin.assert:


### PR DESCRIPTION
## Summary

Makes durable the fixes already converged onto the live guests tonight for the
Zammad **503 "no available server"** outage and true SSO as `jevans`. Three
defects, all root-caused against the live guest.

### 1. The outage — stale processes, not bad config

Zammad's running processes started **05:58**; the `database.yml` that fixed the
DB password was rewritten at **07:21**. They held the *old* credentials and
500'd on every request while every file on disk looked correct. A converge could
never self-heal (file already right → no handler → no restart); Traefik
health-checked the 500 and pulled the backend → 503. Fix: the health check now
wraps in `block`/`rescue` — an unhealthy service earns one restart + re-check.

### 2. The silent footgun behind it

`bao_apps_secrets` defaults to `{}`; both Postgres and Zammad fall back to an env
var, so a converge **without** the secrets environment resolves the password to
an **empty string** and rewrites the role with it. Now `postgres` asserts every
managed password is non-empty and **fails loudly**.

### 3. True SSO as `jevans` (+ mandatory header hardening)

- `auth_sso=true`; a `jevans` Admin+Agent user keyed by **login** (Zammad's
  `create_sso` does `User.lookup(login:)` on the `Remote-User` value).
- `auth_sso_trusted_ips` as a **comma-separated CIDR string** — an Array
  stringifies wrong and a blank value skips the check entirely, so the role
  asserts it non-empty. Verified against Zammad's own source + live v4.39.20.
- **Traefik strips client-supplied `Remote-*` FIRST on every router** — gated,
  ungated, and `/api`-bypassed alike. Without this the #1049 `/api` bypass would
  let anyone send `Remote-User: admin@...` and be trusted. **Verified live: a
  forged header to `/api` returns `Authentication required`, not admin.**

## Why this PR matters now

The header-strip is currently **live on the guest but not in `develop`**, so the
next Traefik converge from develop would silently re-open the spoofing hole. This
PR closes that divergence.

## Verification (against the live guest)

- Zammad 200 on `:3000`/`:8080`, 302 → authelia through Traefik, no health-check failures.
- `jevans` active with Admin+Agent; `auth_sso=true`; trusted-IPs a CIDR string.
- Spoofing test: forged `Remote-User` → `Authentication required`.
- `ansible-lint` (production profile) + 168 template-render assertions pass; ruby `-c` syntax OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)