### PR TITLE
chore(authelia): remove one-time bootstrap password once a passkey is enrolled

### DIFF
--- a/roles/authelia/tasks/main.yml
+++ b/roles/authelia/tasks/main.yml
@@ -213,3 +213,30 @@
   delay: 3
   changed_when: false
   when: authelia_manage_services | bool
+
+# The bootstrap password exists only to bootstrap the very first login before a
+# passkey is enrolled. Once the admin has a registered passkey it is dead weight
+# — a standing password credential on a passkey-first portal — so remove it.
+# Fail-safe by design: the file is removed ONLY on a positive credential match,
+# so a failed/absent list just keeps the (root-only 0600) file rather than
+# risking a lockout.
+- name: Check whether the admin has enrolled a passkey
+  ansible.builtin.command:
+    cmd: >-
+      {{ authelia_binary_path }} storage user webauthn list {{ authelia_admin_user }}
+      --config {{ authelia_config_file }}
+  environment:
+    AUTHELIA_STORAGE_ENCRYPTION_KEY_FILE: "{{ authelia_secret_files.storage_key }}"
+  register: authelia_webauthn_list
+  changed_when: false
+  failed_when: false
+  no_log: true
+  when: authelia_manage_services | bool
+
+- name: Remove the one-time bootstrap password once a passkey is enrolled
+  ansible.builtin.file:
+    path: "{{ authelia_bootstrap_password_file }}"
+    state: absent
+  when:
+    - authelia_manage_services | bool
+    - authelia_webauthn_list.stdout | default('') is regex('\n\s*\d+\s')


### PR DESCRIPTION
## Summary

The Authelia bootstrap password exists only to bootstrap the very first login
before a passkey is registered. Once the admin has an enrolled WebAuthn
credential it is dead weight — a standing password credential on a passkey-first
portal — and today it lingers on the guest indefinitely (observed after the
`jevans` passkey was enrolled tonight).

This adds a role task that removes `.bootstrap_password` once a passkey exists,
via the `authelia storage user webauthn list` CLI. **Fail-safe:** the file is
removed only on a positive credential match, so a failed or empty listing keeps
the (root-only `0600`) file rather than risking a lockout.

## Verification

- `ansible-lint` (production profile) passes.
- Idempotent: no-op when the file is already gone; keeps the file when no passkey
  is enrolled yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)