### PR TITLE
fix(download-vpn): route syslog via /32 in main table (immune to wg-quick rule ordering)

### DIFF
--- a/roles/download_vpn/tasks/validate.yml
+++ b/roles/download_vpn/tasks/validate.yml
@@ -217,14 +217,15 @@
     # 2026-07-17 incident: rsyslog's own outbound connection to the syslog LB
     # was nftables-accepted (killswitch.nft.j2 rule 4c) but the DEFAULT route
     # still pointed at wg0, so the RFC1918 destination was black-holed toward
-    # Proton and no logs ever reached Cribl/Splunk. mangle.nft.j2's output
-    # chain now marks new connections to the syslog LB so they take the LAN
-    # NIC via the same fwmark table as check H. Prove it here.
+    # Proton and no logs ever reached Cribl/Splunk. download-vpn-lanroute.service
+    # now installs a /32 for the LB in the MAIN table (step 3), so an ordinary
+    # UNMARKED lookup resolves out the LAN NIC. Prove it here — no mark, because
+    # the fix is deliberately mark-free (immune to wg-quick's rule ordering).
     - name: Resolve the route a NEW connection to the syslog LB would take
       vars:
         _syslog_lb: "{{ download_vpn_syslog_hosts_resolved | first | default('127.0.0.1') }}"
       ansible.builtin.command:
-        cmd: ip -4 route get {{ _syslog_lb }} mark {{ download_vpn_lanroute_mark }}
+        cmd: ip -4 route get {{ _syslog_lb }}
       register: download_vpn_syslog_route
       changed_when: false
       failed_when: false
@@ -235,11 +236,12 @@
         that:
           - "'dev ' ~ download_vpn_lan_interface in download_vpn_syslog_route.stdout"
         fail_msg: >-
-          Log shipping is silently broken: a marked connection to the syslog LB
+          Log shipping is silently broken: the route to the syslog LB
           ({{ download_vpn_syslog_hosts_resolved | first | default('127.0.0.1') }}) does not resolve out
           {{ download_vpn_lan_interface }} ({{ download_vpn_syslog_route.stdout | trim }}).
           It would be encapsulated toward the VPN and black-holed — this guest's
-          logs would never reach Cribl/Splunk. Check mangle.nft.j2's output chain.
+          logs would never reach Cribl/Splunk. Check the /32 main-table route in
+          download-vpn-lanroute.service.
         success_msg: "Syslog log-shipping egresses via the LAN NIC (reaches Cribl/Splunk)."
       when: download_vpn_syslog_hosts_resolved | default([]) | length > 0
 

--- a/roles/download_vpn/templates/download-vpn-lanroute.service.j2
+++ b/roles/download_vpn/templates/download-vpn-lanroute.service.j2
@@ -8,15 +8,18 @@ Documentation=https://github.com/JacobPEvans/ansible-proxmox-apps
 # The killswitch (not this unit) is the egress security boundary, so keeping it
 # up never enables a leak.
 #
-# PRIORITY DIRECTION (2026-07-17 fix): `ip rule` priority is LOWEST-number-first
-# — the opposite of what "higher priority" suggests in English. This rule MUST
-# use a number below wg-quick's own auto-generated catch-all (observed at 999
-# for Table=auto), or wg-quick's `default dev wg0` always matches first and
-# this table never gets a chance to fire. Confirmed live: at priority 1000
-# (the original value here, before this fix), `ip route get <lan-ip> mark
-# {{ download_vpn_lanroute_mark }}` resolved via wg0/table 51820 instead of the
-# LAN NIC — silently defeating both the pre-existing reply-routing feature and
-# the syslog log-shipping mark in mangle.nft.j2.
+# TWO mechanisms live here, because they have different robustness needs:
+#   - Syslog log shipping (step 3) → a /32 in the MAIN table. Immune to
+#     wg-quick's rule ordering (see step 3). This is what actually gets this
+#     guest's logs to Cribl/Splunk.
+#   - Web-UI reply routing (steps 1-2) → the fwmark table below. This carries a
+#     KNOWN FRAGILITY: `ip rule` priority is lowest-number-first, and wg-quick
+#     assigns its own rules (lowest-existing - 1), so a wg0 restart while our
+#     fwmark rule already exists lets wg-quick land just below it and win. On a
+#     clean boot the ordering holds (wg-quick runs first, gets high numbers);
+#     after a mid-life wg0 restart it can invert. A robust fix for the reply
+#     path (main-table RFC1918 routes, or rebuilding wg's rules) is deferred —
+#     it is not on the log-shipping path and is tracked separately.
 After=network-online.target download-vpn-wg.service
 Wants=network-online.target
 
@@ -60,10 +63,30 @@ ExecStart=/usr/bin/env ip route replace {{ net }} via {{ download_vpn_lan_gatewa
 {% endfor %}
 ExecStart=/usr/bin/env ip route replace unreachable default table {{ download_vpn_lanroute_table }}
 
-# Teardown: remove the rule, flush the table, drop the mangle marking — leaving
-# no standing non-VPN routing state.
+# 3. Log shipping: route THIS guest's syslog connection to the pipeline LB out
+#    the LAN NIC via a per-host /32 in the MAIN table. This deliberately does
+#    NOT use the fwmark table above: wg-quick assigns its own policy-rule
+#    priorities as (lowest-existing - 1), so whenever wg0 restarts while our
+#    fwmark rule already exists, wg-quick lands JUST BELOW it and wins the
+#    lookup — no fixed fwmark priority can reliably beat it (observed live
+#    2026-07-17: after a wg0 restart, wg's rules moved to 898/899 under our
+#    900 and marked syslog packets black-holed into wg0 again). A /32 in main
+#    is immune: wg-quick's own `suppress_prefixlength 0` rule consults main and
+#    suppresses ONLY default routes, so a /32 is always honored, ahead of wg's
+#    catch-all, regardless of restart ordering. The killswitch still gates what
+#    may egress (only syslog TCP to this LB is allowed), so the /32 opens no
+#    leak — it only fixes WHERE the already-permitted packets route.
+{% for _sl in download_vpn_syslog_hosts_resolved | default([]) %}
+ExecStart=/usr/bin/env ip route replace {{ _sl }}/32 via {{ download_vpn_lan_gateway }} dev {{ download_vpn_lan_interface }}
+{% endfor %}
+
+# Teardown: remove the rule, flush the table, drop the mangle marking + the
+# syslog /32s — leaving no standing non-VPN routing state.
 ExecStop=-/usr/bin/env ip rule del fwmark {{ download_vpn_lanroute_mark }} table {{ download_vpn_lanroute_table }} priority {{ download_vpn_lanroute_rule_priority }}
 ExecStop=-/usr/bin/env ip route flush table {{ download_vpn_lanroute_table }}
+{% for _sl in download_vpn_syslog_hosts_resolved | default([]) %}
+ExecStop=-/usr/bin/env ip route del {{ _sl }}/32 via {{ download_vpn_lan_gateway }} dev {{ download_vpn_lan_interface }}
+{% endfor %}
 ExecStop=-/usr/sbin/nft delete table inet vpn_lanroute
 
 [Install]

--- a/roles/download_vpn/templates/mangle.nft.j2
+++ b/roles/download_vpn/templates/mangle.nft.j2
@@ -58,38 +58,25 @@ table inet vpn_lanroute {
   chain output {
     type route hook output priority mangle;
 
-    # FIRST: tag locally-originated NEW connections to our own syslog pipeline
-    # LB with the CONNMARK, so the restore line below sets the fwmark on EVERY
-    # packet of the flow — not just the SYN. This routes rsyslog's log shipping
-    # out the LAN NIC instead of the default route into wg0 (where an RFC1918
-    # dest is unreachable and black-holed). Scoped to this exact IP+port set —
-    # never a blanket RFC1918 or "any new connection" match — so app-initiated
-    # egress (torrents, indexer fetches) is untouched and still forced through
-    # the VPN or dropped.
-    #
-    # Why CONNMARK (`ct mark`) and not `meta mark` here: the fwmark is per-packet
-    # and `ct state new` only matches the SYN. If we set the fwmark directly, the
-    # SYN would route out eth0 but the completing ACK (ct state established) would
-    # get no mark and fall back to wg0 — the handshake never completes and log
-    # shipping silently hangs (the 2026-07-17 bug this replaces). The connmark
-    # persists in conntrack, and the restore line marks every subsequent packet.
-    # It MUST precede the restore line so the SYN is re-marked in the same pass.
-{% for _sl in download_vpn_syslog_hosts_resolved | default([]) %}
-    ip daddr {{ _sl }} tcp dport {{ download_vpn_syslog_target_port }} ct state new ct mark set {{ download_vpn_lanroute_mark }}
-{% endfor %}
-
-    # Restore our connmark onto the fwmark for EVERY packet carrying it — reply
-    # packets of inbound web-UI flows (marked in prerouting) AND every packet of
-    # the syslog flow tagged just above — so the `ip rule fwmark` sends them out
-    # the LAN NIC. `type route` makes the kernel re-evaluate routing when the
+    # Restore our connmark onto the fwmark for EVERY reply packet of an inbound
+    # web-UI flow (marked in prerouting above) so the `ip rule fwmark` sends them
+    # out the LAN NIC. `type route` makes the kernel re-evaluate routing when the
     # mark changes. The `ct mark` guard means WireGuard's encapsulated UDP
     # (ct mark 0) and every unmarked app-initiated flow are left untouched.
     #
+    # NOTE: syslog log shipping is NOT marked here anymore. It used to be, but a
+    # locally-originated flow marked via the fwmark table is defeated whenever
+    # wg-quick restarts and re-numbers its policy rules below ours (2026-07-17).
+    # Syslog now uses a stable /32 route in the MAIN table instead
+    # (download-vpn-lanroute.service, step 3), which wg-quick's suppress rule
+    # honors regardless of ordering. This chain serves only the inbound web-UI
+    # reply case.
+    #
     # IPv6 INVARIANT: this rule is family-agnostic, but no v6 packet is ever
-    # marked because both marking rules above match `ip saddr`/`ip daddr`
-    # (v4-only). Keep it that way until the README "Enabling IPv6 later" runbook
-    # is followed — adding v6 marking without a v6 lanroute table (RFC-ULA-scoped,
-    # no v6 `default`) would create a v6 leak path.
+    # marked because the prerouting rule matches `ip saddr` (v4-only). Keep it
+    # that way until the README "Enabling IPv6 later" runbook is followed —
+    # adding v6 marking without a v6 lanroute table (RFC-ULA-scoped, no v6
+    # `default`) would create a v6 leak path.
     ct mark {{ download_vpn_lanroute_mark }} meta mark set {{ download_vpn_lanroute_mark }}
   }
 }


### PR DESCRIPTION
## Problem

download-vpn (the qBittorrent/Prowlarr LXC behind Proton) had been dark in
Splunk since it was built — its rsyslog disk queue had backed up to ~37M. Root
cause: the guest's syslog connection to the logging-pipeline LB was routed into
the WireGuard tunnel (`Table = auto` default route → wg0) and black-holed at
Proton, which has no route back to an RFC1918 LAN subnet.

PR #1067 fixed three real role bugs on the fwmark `vpn_lanroute` path, but the
fwmark approach still could not reliably win the route lookup: **wg-quick
assigns its own policy-rule priorities as `(lowest-existing − 1)`**, so whenever
wg0 restarts while our fwmark rule already exists, wg-quick lands just below it
and wins — no fixed fwmark priority can beat it (observed live: after a wg0
restart, wg's rules moved to 898/899 under our 900 and marked packets went back
into wg0).

## Fix

Ship this guest's syslog to the pipeline LB via a per-host **`/32` route in the
MAIN table** instead of the fwmark table. wg-quick's own
`suppress_prefixlength 0` rule consults `main` and suppresses only *default*
routes, so a `/32` is always honored ahead of wg's catch-all, regardless of
restart ordering. The killswitch still gates egress (only syslog TCP to the LB
is permitted), so the `/32` opens no leak — it only fixes *where* the
already-permitted packets route.

The mangle `output` chain no longer marks syslog; it serves only the inbound
web-UI cross-subnet reply case (unchanged). `validate.yml` now asserts the
unmarked route resolves out the LAN NIC.

## Verified live (2026-07-17)

- `ip route get <lb>` → `dev eth0 src 10.0.70.224` (LAN NIC, not wg0)
- TCP connect to the LB syslog port completes (was hanging)
- rsyslog disk queue drained ~37M → ~41K
- Splunk `index=os host=download-vpn sourcetype=syslog` receiving (961 events / 15 min)

Completes the media-stack logging validation: all six media guests now confirmed
shipping through Cribl → Splunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)