### PR TITLE
fix(traefik): honor per-route health_check_path from ingress contract

### DIFF
--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -110,6 +110,7 @@
           'insecure_tls': item.insecure_tls | default(false),
           'sticky': item.sticky | default(false),
           'health_check': item.health_check | default(false),
+          'health_check_path': item.health_check_path | default('/'),
           'sso': item.sso | default(false)
         }]
       }}

--- a/roles/traefik/templates/dynamic.yml.j2
+++ b/roles/traefik/templates/dynamic.yml.j2
@@ -63,9 +63,15 @@ http:
           - url: "{{ url }}"
 {% endfor %}
 {% if route.health_check | default(false) %}
+{# health_check_path comes from the tofu ingress contract. A hardcoded "/"
+   ejects every server of any backend whose root is not 200 - an API that only
+   answers on /health looks entirely down. Default "/" keeps legacy routes
+   byte-identical. Keep comments at column 0, never indented inside the emitted
+   block: the stripped comment leaves its leading whitespace behind and
+   corrupts the YAML. #}
         healthCheck:
           scheme: "{{ route.scheme | default('http') }}"
-          path: "/"
+          path: "{{ route.health_check_path | default('/') }}"
           interval: "10s"
           timeout: "5s"
 {% endif %}


### PR DESCRIPTION
## What

Carry `health_check_path` from the tofu ingress contract through the traefik router builder into the rendered dynamic config, defaulting to `/`.

## Why

The router builder's key allowlist in `roles/traefik/tasks/main.yml` silently dropped `health_check_path`, and `dynamic.yml.j2` hardcoded `path: "/"`. Any backend whose root is not 200 (an API answering only on `/health`) had every server ejected from its pool — `hindsight.<domain>` served **503 no available server**. Default `/` keeps every legacy route byte-identical.

## Validation

Rendered the real template against a fixture: YAML parses, hindsight route emits `path: /health`, legacy routes byte-identical, no whitespace leakage. Live converge `--tags traefik` restored the pool to 200. The multi-line Jinja `{# #}` comment is anchored at column 0 — an indented comment leaks whitespace and corrupts the YAML (root cause of a prior full-ingress outage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)