### PR TITLE
fix(postgres): create a replication slot per standby of the converged cluster

### DIFF
--- a/inventory/group_vars/postgres_ai_group.yml
+++ b/inventory/group_vars/postgres_ai_group.yml
@@ -9,6 +9,11 @@
 # HA: postgres-ai-1 is the primary; every other postgres_ai-tagged guest
 # reinitializes as a hot streaming standby (the role's replication path).
 postgres_primary_host: postgres-ai-1
+# This cluster's members live in postgres_ai_group, not the role's default
+# postgres_group — the primary needs it to create a replication slot per
+# standby. Without it the standby's pg_basebackup fails with
+# `replication slot "standby_postgres_ai_2" does not exist`.
+postgres_cluster_group: postgres_ai_group
 
 # Replication credential — bao-first (apps/hindsight, generated at source),
 # same env-fallback shape as the shared cluster's replication_password.

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -108,6 +108,14 @@ postgres_role: >-
      if (postgres_primary_host | length > 0 and inventory_hostname != postgres_primary_host)
      else 'primary' }}
 postgres_replication_enabled: "{{ (postgres_primary_host | length > 0) | bool }}"
+# Inventory group holding THIS cluster's members. The primary creates one
+# replication slot per standby in this group, so it must name the cluster
+# being converged — the role backs more than one (postgres_group,
+# postgres_ai_group), and a cluster whose standbys live elsewhere would get
+# no slots while its siblings' names were created against the wrong primary.
+# Not derived from the play hosts: `--limit primary` would then resolve to an
+# empty standby list and silently skip slot creation.
+postgres_cluster_group: postgres_group
 
 # The standby authenticates to the primary as this LOGIN + REPLICATION role. The
 # password is bao-first with an env fallback — never a literal.

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -349,7 +349,9 @@
         name: "standby_{{ item | regex_replace('[^A-Za-z0-9]', '_') }}"
         slot_type: physical
         state: present
-      loop: "{{ groups['postgres_group'] | default([]) | difference([postgres_primary_host]) }}"
+      loop: >-
+        {{ groups[postgres_cluster_group] | default([])
+           | difference([postgres_primary_host]) }}
       loop_control:
         label: "{{ item }}"
 


### PR DESCRIPTION
## What

Add `postgres_cluster_group` (defaults to `postgres_group`; set to `postgres_ai_group` in the ai group_vars) and loop `groups[postgres_cluster_group]` when the primary creates physical replication slots.

## Why

The primary hardcoded the shared `postgres_group` when creating a slot per standby. On the dedicated ai-VLAN cluster the standby (`postgres-ai-2`) never got a slot, so `pg_basebackup` had no slot to attach to. The fix is already live (replication works), but must land or the next clean rebuild of the ai cluster breaks again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)