### PR TITLE
feat(agent_sandbox): egress boundary for ad-hoc autonomous agent containers

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -616,6 +616,22 @@
       when: github_runner_admin_token is defined or github_runner_token is defined
 
 # =============================================================================
+# Phase 7a: Agent Sandbox Egress Boundary
+# Internal `agents` docker network + allowlisting CONNECT proxy on the
+# docker-host VM. Agent containers themselves are launched ad hoc by
+# dryvist/nix-agent-sandbox (`agent run --host`), never by Ansible.
+# =============================================================================
+
+- name: Deploy agent sandbox egress boundary
+  hosts: docker_vms
+  become: true
+  gather_facts: false
+  tags:
+    - agent_sandbox
+  roles:
+    - role: agent_sandbox
+
+# =============================================================================
 # Phase 7b: iDRAC KVM HTML5 Viewer
 # domistyle/idrac6-based viewers (R410 + R710) on dedicated LXC 251.
 # Credentials come from Doppler IDRAC_R*_HOST/USER/PASSWORD env vars.

--- a/roles/agent_sandbox/README.md
+++ b/roles/agent_sandbox/README.md
@@ -1,0 +1,58 @@
+# agent_sandbox
+
+Egress boundary for autonomous agent containers
+([dryvist/nix-agent-sandbox](https://github.com/dryvist/nix-agent-sandbox))
+on the docker-host VM:
+
+- `agents` docker network with `internal: true` — members have **no route
+  out**; Docker itself enforces the default-deny.
+- A squid CONNECT proxy (`agent-squid`, alias `proxy:3128` on that network)
+  is the sole dual-homed member; its domain allowlist is the only egress
+  policy. Converge ends with live allow/deny probes from inside the network.
+
+Agent containers are **not** managed by Ansible: the nix-agent-sandbox
+`agent run --host <docker-host>` launcher spawns them ad hoc with plain
+`docker run --network agents` — no IaC run per container.
+
+## Installation
+
+Included via the `Deploy agent sandbox egress boundary` play in
+`playbooks/site.yml` (hosts: `docker_vms`). Converge just this role:
+
+```sh
+ansible-playbook playbooks/site.yml --tags agent_sandbox --diff
+```
+
+## Usage
+
+From a workstation with the nix-agent-sandbox CLI:
+
+```sh
+BAO_ADDR=https://openbao.<domain> \
+  agent run --host <docker-host-fqdn> --profile dev \
+  --repo dryvist/some-repo "task prompt"
+```
+
+The launcher attaches the container to `agents` and points
+`HTTP(S)_PROXY` at `http://proxy:3128`; everything not on the allowlist is
+denied by squid, and everything else has no route at all.
+
+## Allowlist maintenance
+
+`agent_sandbox_egress_domains` mirrors nix-agent-sandbox `lib.egressDomains`
+(the source of truth). Regenerate after upstream changes:
+
+```sh
+nix eval github:dryvist/nix-agent-sandbox#lib.egressDomains --json
+```
+
+`agent_sandbox_internal_domains` appends in-network FQDNs (the OpenBao
+ingress route) at converge time from ambient `PROXMOX_SUBDOMAIN` — the
+sensitive domain is never committed.
+
+## Later hardening
+
+Docker's `internal: true` is the enforcement point. If containers ever get
+host networking or the compose definition drifts, host nftables rules
+dropping forwarded traffic from the `agents` subnet (except to the proxy)
+are the belt-and-braces follow-up; not implemented in v1.

--- a/roles/agent_sandbox/defaults/main.yml
+++ b/roles/agent_sandbox/defaults/main.yml
@@ -1,0 +1,46 @@
+---
+# Egress boundary for autonomous agent containers (dryvist/nix-agent-sandbox)
+# on the docker-host VM. Creates an internal-only docker network whose sole
+# route out is an allowlisting CONNECT proxy; `agent run --host` attaches
+# fresh containers to it with plain `docker run` — no IaC in the loop.
+
+agent_sandbox_dir: /opt/agent-sandbox
+agent_sandbox_squid_image: "ubuntu/squid:6.10-24.04_beta"
+agent_sandbox_probe_image: "curlimages/curl:8.15.0"
+agent_sandbox_proxy_container: agent-squid
+# Network + alias names are the contract with the nix-agent-sandbox launcher
+# (its AGENT_NETWORK / AGENT_PROXY_URL defaults: agents / http://proxy:3128).
+agent_sandbox_network: agents
+agent_sandbox_egress_network: agents-egress
+agent_sandbox_proxy_alias: proxy
+agent_sandbox_proxy_port: 3128
+
+# Committed mirror of dryvist/nix-agent-sandbox `lib.egressDomains` — that
+# repo is the source of truth. Regenerate with:
+#   nix eval github:dryvist/nix-agent-sandbox#lib.egressDomains --json
+agent_sandbox_egress_domains:
+  modelApis:
+    - api.anthropic.com
+    - api.openai.com
+    - chatgpt.com
+    - generativelanguage.googleapis.com
+    - cloudcode-pa.googleapis.com
+  github:
+    - github.com
+    - api.github.com
+    - objects.githubusercontent.com
+    - raw.githubusercontent.com
+    - ghcr.io
+    - pkg-containers.githubusercontent.com
+  nix:
+    - cache.nixos.org
+    - channels.nixos.org
+    - install.determinate.systems
+  internal: []
+
+# In-network FQDNs appended at converge time (the OpenBao ingress route for
+# task-profile secret fetch + GitHub token minting). The sensitive domain is
+# ambient env, never a committed literal — same pattern as the openbao role's
+# Terrakube issuer.
+agent_sandbox_internal_domains:
+  - "openbao.{{ lookup('env', 'PROXMOX_SUBDOMAIN') | default('local', true) }}"

--- a/roles/agent_sandbox/handlers/main.yml
+++ b/roles/agent_sandbox/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart agent sandbox proxy
+  community.docker.docker_compose_v2:
+    project_src: "{{ agent_sandbox_dir }}"
+    state: present
+    recreate: always

--- a/roles/agent_sandbox/tasks/main.yml
+++ b/roles/agent_sandbox/tasks/main.yml
@@ -1,0 +1,80 @@
+---
+# Agent sandbox egress boundary: internal docker network + allowlisting
+# CONNECT proxy on the docker-host VM. Agent containers are NOT managed here —
+# dryvist/nix-agent-sandbox's `agent run --host` spawns them ad hoc.
+
+- name: Create agent sandbox directory
+  ansible.builtin.file:
+    path: "{{ agent_sandbox_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Deploy squid configuration
+  ansible.builtin.template:
+    src: squid.conf.j2
+    dest: "{{ agent_sandbox_dir }}/squid.conf"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart agent sandbox proxy
+
+- name: Deploy egress domain allowlist
+  ansible.builtin.template:
+    src: allowed-domains.txt.j2
+    dest: "{{ agent_sandbox_dir }}/allowed-domains.txt"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart agent sandbox proxy
+
+- name: Deploy agent sandbox docker-compose template
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ agent_sandbox_dir }}/docker-compose.yml"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart agent sandbox proxy
+
+- name: Deploy agent sandbox networks and proxy via docker compose
+  community.docker.docker_compose_v2:
+    project_src: "{{ agent_sandbox_dir }}"
+    state: present
+
+- name: Flush handlers so the proxy restarts before validation
+  ansible.builtin.meta: flush_handlers
+
+- name: Validate squid parses the deployed configuration
+  community.docker.docker_container_exec:
+    container: "{{ agent_sandbox_proxy_container }}"
+    command: squid -k parse
+  changed_when: false
+
+# Functional probes from INSIDE the internal network — the same path agent
+# containers use. Allow = an origin HTTP status comes back through the CONNECT
+# tunnel ('000' means no tunnel); deny = curl fails on the proxy's refusal.
+- name: Probe an allowlisted domain through the proxy
+  ansible.builtin.command:
+    cmd: >-
+      docker run --rm --network {{ agent_sandbox_network }}
+      {{ agent_sandbox_probe_image }}
+      -sS -o /dev/null -w '%{http_code}' --max-time 20
+      -x http://{{ agent_sandbox_proxy_alias }}:{{ agent_sandbox_proxy_port }}
+      https://api.anthropic.com
+  register: agent_sandbox_allow_probe
+  changed_when: false
+  failed_when: agent_sandbox_allow_probe.rc != 0 or agent_sandbox_allow_probe.stdout == '000'
+
+- name: Probe a non-allowlisted domain through the proxy (expect denial)
+  ansible.builtin.command:
+    cmd: >-
+      docker run --rm --network {{ agent_sandbox_network }}
+      {{ agent_sandbox_probe_image }}
+      -sS -o /dev/null --max-time 20
+      -x http://{{ agent_sandbox_proxy_alias }}:{{ agent_sandbox_proxy_port }}
+      https://example.com
+  register: agent_sandbox_deny_probe
+  changed_when: false
+  failed_when: agent_sandbox_deny_probe.rc == 0

--- a/roles/agent_sandbox/templates/allowed-domains.txt.j2
+++ b/roles/agent_sandbox/templates/allowed-domains.txt.j2
@@ -1,0 +1,11 @@
+{{ ansible_managed | comment }}
+{% for group, domains in agent_sandbox_egress_domains.items() %}
+# {{ group }}
+{% for domain in domains %}
+{{ domain }}
+{% endfor %}
+{% endfor %}
+# internal (converge-time)
+{% for domain in agent_sandbox_internal_domains %}
+{{ domain }}
+{% endfor %}

--- a/roles/agent_sandbox/templates/docker-compose.yml.j2
+++ b/roles/agent_sandbox/templates/docker-compose.yml.j2
@@ -1,0 +1,26 @@
+---
+# {{ ansible_managed }}
+# The `{{ agent_sandbox_network }}` network is internal-only: Docker gives its
+# members no route out. The squid container is the sole dual-homed member, so
+# the allowlist in squid.conf IS the network policy for every agent container
+# launched with `--network {{ agent_sandbox_network }}`.
+networks:
+  {{ agent_sandbox_network }}:
+    name: {{ agent_sandbox_network }}
+    internal: true
+  {{ agent_sandbox_egress_network }}:
+    name: {{ agent_sandbox_egress_network }}
+
+services:
+  squid:
+    image: {{ agent_sandbox_squid_image }}
+    container_name: {{ agent_sandbox_proxy_container }}
+    restart: unless-stopped
+    networks:
+      {{ agent_sandbox_network }}:
+        aliases:
+          - {{ agent_sandbox_proxy_alias }}
+      {{ agent_sandbox_egress_network }}: {}
+    volumes:
+      - {{ agent_sandbox_dir }}/squid.conf:/etc/squid/squid.conf:ro
+      - {{ agent_sandbox_dir }}/allowed-domains.txt:/etc/squid/allowed-domains.txt:ro

--- a/roles/agent_sandbox/templates/squid.conf.j2
+++ b/roles/agent_sandbox/templates/squid.conf.j2
@@ -1,0 +1,20 @@
+{{ ansible_managed | comment }}
+# Egress gate for agent containers: default-deny CONNECT proxy. Not a cache.
+# The allowlist is rendered from nix-agent-sandbox lib.egressDomains (mirrored
+# in this role's defaults) + the converge-time internal FQDNs.
+
+http_port {{ agent_sandbox_proxy_port }}
+
+acl allowed_dst dstdomain "/etc/squid/allowed-domains.txt"
+acl SSL_ports port 443
+acl CONNECT method CONNECT
+
+# CONNECT only to 443; plain http only to the allowlist (nix substituters
+# and package indexes are https, but redirects may bounce through http).
+http_access deny CONNECT !SSL_ports
+http_access allow allowed_dst
+http_access deny all
+
+cache deny all
+access_log stdio:/dev/stdout
+cache_log /dev/stderr


### PR DESCRIPTION
## What

New `agent_sandbox` role + site.yml play (hosts: `docker_vms`, tag `agent_sandbox`) implementing the egress enforcement half of nix-agent-sandbox's phase 2 (companion PR: dryvist/nix-agent-sandbox#3):

- `agents` docker network with `internal: true` — agent containers get **no route out**; Docker enforces the default-deny.
- squid CONNECT proxy (`agent-squid`, alias `proxy:3128`) as the sole dual-homed member; its domain allowlist is the only egress policy. Mirrors `lib.egressDomains` (regeneration documented in the role README) plus converge-time internal FQDNs (OpenBao ingress) from ambient env — no committed domain literals.
- Converge ends with `squid -k parse` plus live allow/deny probes from inside the network (allowlisted domain tunnels; example.com is refused).
- Agent containers are launched ad hoc by `agent run --host <docker-host>` with plain `docker run --network agents` — no IaC run per container.

Host nftables belt-and-braces is documented as later hardening in the role README (Docker's `internal: true` is the v1 enforcement point).

## Verification

- `ansible-lint roles/agent_sandbox playbooks/site.yml`: **Passed — 0 failures, 0 warnings, production profile** (via nix-devenv ansible-apps shell).
- Live converge + end-to-end probes follow post-merge: `ansible-playbook playbooks/site.yml --tags agent_sandbox --diff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVWSuDfonpSGjXAXw7gqni