### PR TITLE
chore(media_monitor): add role tag for isolated convergence

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -736,8 +736,12 @@
   roles:
     - role: plex
     # Playback visibility: a session probe that alerts on forced transcode
-    # (incident history: Zammad ticket #17040, Media).
+    # (incident history: Zammad ticket #17040, Media). Carries its own
+    # `media_monitor` tag so `--tags media_monitor` converges just this role
+    # (e.g. to run its absent-cleanup) without re-converging the Plex role.
     - role: media_monitor
+      tags:
+        - media_monitor
 
 # Seerr request UI (Docker in LXC). Registers Sonarr/Radarr/Plex via its settings
 # API — depends only on those apps being up (from the plays above), not on the


### PR DESCRIPTION
## Why

`media_monitor` shares the `plex_group` play with the `plex` role, tagged only
`plex`/`media` at the play level. So running just `media_monitor`'s tasks —
e.g. its absent-cleanup for the retired AC3 codec-audit units (#1068) — required
`--tags plex`, which re-converges Plex and drags in the production-safety
session-check. This left 3 inert codec-audit units lingering on the plex host
with no clean, isolated way to remove them.

## What

Give the `media_monitor` role include its own `media_monitor` tag, so
`--tags media_monitor` converges exactly this role. It has `dependencies: []`
and uses no plex-role facts, so it runs standalone.

## Verify

`ansible-lint` passes (production profile). After merge, the codec-audit units
clear with `--tags media_monitor` (no Plex re-converge, no session-check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)