### PR TITLE
fix(agent_sandbox): real squid image tag; gate role to the agent host only

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -630,6 +630,7 @@
     - agent_sandbox
   roles:
     - role: agent_sandbox
+      when: inventory_hostname == agent_sandbox_host | default('docker-host')
 
 # =============================================================================
 # Phase 7b: iDRAC KVM HTML5 Viewer

--- a/roles/agent_sandbox/defaults/main.yml
+++ b/roles/agent_sandbox/defaults/main.yml
@@ -4,8 +4,11 @@
 # route out is an allowlisting CONNECT proxy; `agent run --host` attaches
 # fresh containers to it with plain `docker run` — no IaC in the loop.
 
+# The one docker_vms member that hosts agent sandboxes (iac-platform is the
+# IaC platform, not an agent host — the site play gates the role on this).
+agent_sandbox_host: docker-host
 agent_sandbox_dir: /opt/agent-sandbox
-agent_sandbox_squid_image: "ubuntu/squid:6.10-24.04_beta"
+agent_sandbox_squid_image: "ubuntu/squid:6.6-24.04_beta"
 agent_sandbox_probe_image: "curlimages/curl:8.15.0"
 agent_sandbox_proxy_container: agent-squid
 # Network + alias names are the contract with the nix-agent-sandbox launcher


### PR DESCRIPTION
## What

Follow-up to #1082 after the first live converge:

- `ubuntu/squid:6.10-24.04_beta` is not a published tag — the converge failed at image pull on both docker_vms members. Pinned the real `6.6-24.04_beta` (24.04 LTS line, verified against the Docker Hub tags API).
- The `docker_vms` inventory group also contains iac-platform (the IaC platform VM), which must not host agent sandboxes. The role is now gated on `agent_sandbox_host` (default `docker-host`).

## Verification

- `ansible-lint roles/agent_sandbox playbooks/site.yml`: Passed — 0 failures, production profile.
- Live re-converge + in-network allow/deny probes follow post-merge; stray `/opt/agent-sandbox` config files on iac-platform from the failed run are removed as part of the same pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVWSuDfonpSGjXAXw7gqni