### PR TITLE
fix(agent_sandbox): image-default squid logging; docker group for launcher user

### DIFF
--- a/roles/agent_sandbox/defaults/main.yml
+++ b/roles/agent_sandbox/defaults/main.yml
@@ -7,6 +7,9 @@
 # The one docker_vms member that hosts agent sandboxes (iac-platform is the
 # IaC platform, not an agent host — the site play gates the role on this).
 agent_sandbox_host: docker-host
+# SSH user the nix-agent-sandbox launcher connects as (DOCKER_HOST=ssh://);
+# granted docker group membership so remote `docker run` works without sudo.
+agent_sandbox_operator_user: "{{ ansible_user | default('debian') }}"
 agent_sandbox_dir: /opt/agent-sandbox
 agent_sandbox_squid_image: "ubuntu/squid:6.6-24.04_beta"
 agent_sandbox_probe_image: "curlimages/curl:8.15.0"

--- a/roles/agent_sandbox/tasks/main.yml
+++ b/roles/agent_sandbox/tasks/main.yml
@@ -3,6 +3,14 @@
 # CONNECT proxy on the docker-host VM. Agent containers are NOT managed here —
 # dryvist/nix-agent-sandbox's `agent run --host` spawns them ad hoc.
 
+# The nix-agent-sandbox launcher spawns containers over DOCKER_HOST=ssh://
+# as this user, which needs direct daemon access (no sudo in that path).
+- name: Grant the launcher SSH user docker daemon access
+  ansible.builtin.user:
+    name: "{{ agent_sandbox_operator_user }}"
+    groups: docker
+    append: true
+
 - name: Create agent sandbox directory
   ansible.builtin.file:
     path: "{{ agent_sandbox_dir }}"

--- a/roles/agent_sandbox/templates/squid.conf.j2
+++ b/roles/agent_sandbox/templates/squid.conf.j2
@@ -16,5 +16,6 @@ http_access allow allowed_dst
 http_access deny all
 
 cache deny all
-access_log stdio:/dev/stdout
-cache_log /dev/stderr
+# Logging stays on the image defaults (/var/log/squid, writable by the
+# squid `proxy` user). stdio:/dev/stdout is fatal here: squid drops
+# privileges and the proxy user cannot open the container's stdout.


### PR DESCRIPTION
## What

Second live-converge follow-up:

- squid crash-looped with `FATAL: Cannot open '/dev/stdout' for writing` — it drops privileges to `proxy`, which cannot open the container's stdout. Logging now stays on the image defaults (`/var/log/squid`, owned by `proxy`); the fatal `stdio:`/`cache_log` overrides are removed with a comment explaining why.
- The launcher's remote path (`DOCKER_HOST=ssh://<user>@docker-host`) needs direct daemon access; the role now adds the operator SSH user (`agent_sandbox_operator_user`, default `ansible_user`) to the `docker` group.

## Verification

- `ansible-lint roles/agent_sandbox`: Passed, production profile.
- Live re-converge with in-network allow/deny probes follows post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVWSuDfonpSGjXAXw7gqni