### PR TITLE
chore: promote develop to main

### DIFF
--- a/inventory/group_vars/postgres_ai_group.yml
+++ b/inventory/group_vars/postgres_ai_group.yml
@@ -9,6 +9,11 @@
 # HA: postgres-ai-1 is the primary; every other postgres_ai-tagged guest
 # reinitializes as a hot streaming standby (the role's replication path).
 postgres_primary_host: postgres-ai-1
+# This cluster's members live in postgres_ai_group, not the role's default
+# postgres_group — the primary needs it to create a replication slot per
+# standby. Without it the standby's pg_basebackup fails with
+# `replication slot "standby_postgres_ai_2" does not exist`.
+postgres_cluster_group: postgres_ai_group
 
 # Replication credential — bao-first (apps/hindsight, generated at source),
 # same env-fallback shape as the shared cluster's replication_password.

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -616,6 +616,22 @@
       when: github_runner_admin_token is defined or github_runner_token is defined
 
 # =============================================================================
+# Phase 7a: Agent Sandbox Egress Boundary
+# Internal `agents` docker network + allowlisting CONNECT proxy on the
+# docker-host VM. Agent containers themselves are launched ad hoc by
+# dryvist/nix-agent-sandbox (`agent run --host`), never by Ansible.
+# =============================================================================
+
+- name: Deploy agent sandbox egress boundary
+  hosts: docker_vms
+  become: true
+  gather_facts: false
+  tags:
+    - agent_sandbox
+  roles:
+    - role: agent_sandbox
+
+# =============================================================================
 # Phase 7b: iDRAC KVM HTML5 Viewer
 # domistyle/idrac6-based viewers (R410 + R710) on dedicated LXC 251.
 # Credentials come from Doppler IDRAC_R*_HOST/USER/PASSWORD env vars.

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -630,6 +630,7 @@
     - agent_sandbox
   roles:
     - role: agent_sandbox
+      when: inventory_hostname == agent_sandbox_host | default('docker-host')
 
 # =============================================================================
 # Phase 7b: iDRAC KVM HTML5 Viewer

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -736,8 +736,12 @@
   roles:
     - role: plex
     # Playback visibility: a session probe that alerts on forced transcode
-    # (incident history: Zammad ticket #17040, Media).
+    # (incident history: Zammad ticket #17040, Media). Carries its own
+    # `media_monitor` tag so `--tags media_monitor` converges just this role
+    # (e.g. to run its absent-cleanup) without re-converging the Plex role.
     - role: media_monitor
+      tags:
+        - media_monitor
 
 # Seerr request UI (Docker in LXC). Registers Sonarr/Radarr/Plex via its settings
 # API — depends only on those apps being up (from the plays above), not on the

--- a/roles/agent_sandbox/README.md
+++ b/roles/agent_sandbox/README.md
@@ -1,0 +1,58 @@
+# agent_sandbox
+
+Egress boundary for autonomous agent containers
+([dryvist/nix-agent-sandbox](https://github.com/dryvist/nix-agent-sandbox))
+on the docker-host VM:
+
+- `agents` docker network with `internal: true` — members have **no route
+  out**; Docker itself enforces the default-deny.
+- A squid CONNECT proxy (`agent-squid`, alias `proxy:3128` on that network)
+  is the sole dual-homed member; its domain allowlist is the only egress
+  policy. Converge ends with live allow/deny probes from inside the network.
+
+Agent containers are **not** managed by Ansible: the nix-agent-sandbox
+`agent run --host <docker-host>` launcher spawns them ad hoc with plain
+`docker run --network agents` — no IaC run per container.
+
+## Installation
+
+Included via the `Deploy agent sandbox egress boundary` play in
+`playbooks/site.yml` (hosts: `docker_vms`). Converge just this role:
+
+```sh
+ansible-playbook playbooks/site.yml --tags agent_sandbox --diff
+```
+
+## Usage
+
+From a workstation with the nix-agent-sandbox CLI:
+
+```sh
+BAO_ADDR=https://openbao.<domain> \
+  agent run --host <docker-host-fqdn> --profile dev \
+  --repo dryvist/some-repo "task prompt"
+```
+
+The launcher attaches the container to `agents` and points
+`HTTP(S)_PROXY` at `http://proxy:3128`; everything not on the allowlist is
+denied by squid, and everything else has no route at all.
+
+## Allowlist maintenance
+
+`agent_sandbox_egress_domains` mirrors nix-agent-sandbox `lib.egressDomains`
+(the source of truth). Regenerate after upstream changes:
+
+```sh
+nix eval github:dryvist/nix-agent-sandbox#lib.egressDomains --json
+```
+
+`agent_sandbox_internal_domains` appends in-network FQDNs (the OpenBao
+ingress route) at converge time from ambient `PROXMOX_SUBDOMAIN` — the
+sensitive domain is never committed.
+
+## Later hardening
+
+Docker's `internal: true` is the enforcement point. If containers ever get
+host networking or the compose definition drifts, host nftables rules
+dropping forwarded traffic from the `agents` subnet (except to the proxy)
+are the belt-and-braces follow-up; not implemented in v1.

--- a/roles/agent_sandbox/defaults/main.yml
+++ b/roles/agent_sandbox/defaults/main.yml
@@ -1,0 +1,46 @@
+---
+# Egress boundary for autonomous agent containers (dryvist/nix-agent-sandbox)
+# on the docker-host VM. Creates an internal-only docker network whose sole
+# route out is an allowlisting CONNECT proxy; `agent run --host` attaches
+# fresh containers to it with plain `docker run` — no IaC in the loop.
+
+agent_sandbox_dir: /opt/agent-sandbox
+agent_sandbox_squid_image: "ubuntu/squid:6.10-24.04_beta"
+agent_sandbox_probe_image: "curlimages/curl:8.15.0"
+agent_sandbox_proxy_container: agent-squid
+# Network + alias names are the contract with the nix-agent-sandbox launcher
+# (its AGENT_NETWORK / AGENT_PROXY_URL defaults: agents / http://proxy:3128).
+agent_sandbox_network: agents
+agent_sandbox_egress_network: agents-egress
+agent_sandbox_proxy_alias: proxy
+agent_sandbox_proxy_port: 3128
+
+# Committed mirror of dryvist/nix-agent-sandbox `lib.egressDomains` — that
+# repo is the source of truth. Regenerate with:
+#   nix eval github:dryvist/nix-agent-sandbox#lib.egressDomains --json
+agent_sandbox_egress_domains:
+  modelApis:
+    - api.anthropic.com
+    - api.openai.com
+    - chatgpt.com
+    - generativelanguage.googleapis.com
+    - cloudcode-pa.googleapis.com
+  github:
+    - github.com
+    - api.github.com
+    - objects.githubusercontent.com
+    - raw.githubusercontent.com
+    - ghcr.io
+    - pkg-containers.githubusercontent.com
+  nix:
+    - cache.nixos.org
+    - channels.nixos.org
+    - install.determinate.systems
+  internal: []
+
+# In-network FQDNs appended at converge time (the OpenBao ingress route for
+# task-profile secret fetch + GitHub token minting). The sensitive domain is
+# ambient env, never a committed literal — same pattern as the openbao role's
+# Terrakube issuer.
+agent_sandbox_internal_domains:
+  - "openbao.{{ lookup('env', 'PROXMOX_SUBDOMAIN') | default('local', true) }}"

--- a/roles/agent_sandbox/defaults/main.yml
+++ b/roles/agent_sandbox/defaults/main.yml
@@ -4,8 +4,11 @@
 # route out is an allowlisting CONNECT proxy; `agent run --host` attaches
 # fresh containers to it with plain `docker run` — no IaC in the loop.
 
+# The one docker_vms member that hosts agent sandboxes (iac-platform is the
+# IaC platform, not an agent host — the site play gates the role on this).
+agent_sandbox_host: docker-host
 agent_sandbox_dir: /opt/agent-sandbox
-agent_sandbox_squid_image: "ubuntu/squid:6.10-24.04_beta"
+agent_sandbox_squid_image: "ubuntu/squid:6.6-24.04_beta"
 agent_sandbox_probe_image: "curlimages/curl:8.15.0"
 agent_sandbox_proxy_container: agent-squid
 # Network + alias names are the contract with the nix-agent-sandbox launcher

--- a/roles/agent_sandbox/defaults/main.yml
+++ b/roles/agent_sandbox/defaults/main.yml
@@ -7,6 +7,9 @@
 # The one docker_vms member that hosts agent sandboxes (iac-platform is the
 # IaC platform, not an agent host — the site play gates the role on this).
 agent_sandbox_host: docker-host
+# SSH user the nix-agent-sandbox launcher connects as (DOCKER_HOST=ssh://);
+# granted docker group membership so remote `docker run` works without sudo.
+agent_sandbox_operator_user: "{{ ansible_user | default('debian') }}"
 agent_sandbox_dir: /opt/agent-sandbox
 agent_sandbox_squid_image: "ubuntu/squid:6.6-24.04_beta"
 agent_sandbox_probe_image: "curlimages/curl:8.15.0"

--- a/roles/agent_sandbox/handlers/main.yml
+++ b/roles/agent_sandbox/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart agent sandbox proxy
+  community.docker.docker_compose_v2:
+    project_src: "{{ agent_sandbox_dir }}"
+    state: present
+    recreate: always

--- a/roles/agent_sandbox/tasks/main.yml
+++ b/roles/agent_sandbox/tasks/main.yml
@@ -1,0 +1,80 @@
+---
+# Agent sandbox egress boundary: internal docker network + allowlisting
+# CONNECT proxy on the docker-host VM. Agent containers are NOT managed here —
+# dryvist/nix-agent-sandbox's `agent run --host` spawns them ad hoc.
+
+- name: Create agent sandbox directory
+  ansible.builtin.file:
+    path: "{{ agent_sandbox_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Deploy squid configuration
+  ansible.builtin.template:
+    src: squid.conf.j2
+    dest: "{{ agent_sandbox_dir }}/squid.conf"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart agent sandbox proxy
+
+- name: Deploy egress domain allowlist
+  ansible.builtin.template:
+    src: allowed-domains.txt.j2
+    dest: "{{ agent_sandbox_dir }}/allowed-domains.txt"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart agent sandbox proxy
+
+- name: Deploy agent sandbox docker-compose template
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ agent_sandbox_dir }}/docker-compose.yml"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart agent sandbox proxy
+
+- name: Deploy agent sandbox networks and proxy via docker compose
+  community.docker.docker_compose_v2:
+    project_src: "{{ agent_sandbox_dir }}"
+    state: present
+
+- name: Flush handlers so the proxy restarts before validation
+  ansible.builtin.meta: flush_handlers
+
+- name: Validate squid parses the deployed configuration
+  community.docker.docker_container_exec:
+    container: "{{ agent_sandbox_proxy_container }}"
+    command: squid -k parse
+  changed_when: false
+
+# Functional probes from INSIDE the internal network — the same path agent
+# containers use. Allow = an origin HTTP status comes back through the CONNECT
+# tunnel ('000' means no tunnel); deny = curl fails on the proxy's refusal.
+- name: Probe an allowlisted domain through the proxy
+  ansible.builtin.command:
+    cmd: >-
+      docker run --rm --network {{ agent_sandbox_network }}
+      {{ agent_sandbox_probe_image }}
+      -sS -o /dev/null -w '%{http_code}' --max-time 20
+      -x http://{{ agent_sandbox_proxy_alias }}:{{ agent_sandbox_proxy_port }}
+      https://api.anthropic.com
+  register: agent_sandbox_allow_probe
+  changed_when: false
+  failed_when: agent_sandbox_allow_probe.rc != 0 or agent_sandbox_allow_probe.stdout == '000'
+
+- name: Probe a non-allowlisted domain through the proxy (expect denial)
+  ansible.builtin.command:
+    cmd: >-
+      docker run --rm --network {{ agent_sandbox_network }}
+      {{ agent_sandbox_probe_image }}
+      -sS -o /dev/null --max-time 20
+      -x http://{{ agent_sandbox_proxy_alias }}:{{ agent_sandbox_proxy_port }}
+      https://example.com
+  register: agent_sandbox_deny_probe
+  changed_when: false
+  failed_when: agent_sandbox_deny_probe.rc == 0

--- a/roles/agent_sandbox/tasks/main.yml
+++ b/roles/agent_sandbox/tasks/main.yml
@@ -3,6 +3,14 @@
 # CONNECT proxy on the docker-host VM. Agent containers are NOT managed here —
 # dryvist/nix-agent-sandbox's `agent run --host` spawns them ad hoc.
 
+# The nix-agent-sandbox launcher spawns containers over DOCKER_HOST=ssh://
+# as this user, which needs direct daemon access (no sudo in that path).
+- name: Grant the launcher SSH user docker daemon access
+  ansible.builtin.user:
+    name: "{{ agent_sandbox_operator_user }}"
+    groups: docker
+    append: true
+
 - name: Create agent sandbox directory
   ansible.builtin.file:
     path: "{{ agent_sandbox_dir }}"

--- a/roles/agent_sandbox/templates/allowed-domains.txt.j2
+++ b/roles/agent_sandbox/templates/allowed-domains.txt.j2
@@ -1,0 +1,11 @@
+{{ ansible_managed | comment }}
+{% for group, domains in agent_sandbox_egress_domains.items() %}
+# {{ group }}
+{% for domain in domains %}
+{{ domain }}
+{% endfor %}
+{% endfor %}
+# internal (converge-time)
+{% for domain in agent_sandbox_internal_domains %}
+{{ domain }}
+{% endfor %}

--- a/roles/agent_sandbox/templates/docker-compose.yml.j2
+++ b/roles/agent_sandbox/templates/docker-compose.yml.j2
@@ -1,0 +1,26 @@
+---
+# {{ ansible_managed }}
+# The `{{ agent_sandbox_network }}` network is internal-only: Docker gives its
+# members no route out. The squid container is the sole dual-homed member, so
+# the allowlist in squid.conf IS the network policy for every agent container
+# launched with `--network {{ agent_sandbox_network }}`.
+networks:
+  {{ agent_sandbox_network }}:
+    name: {{ agent_sandbox_network }}
+    internal: true
+  {{ agent_sandbox_egress_network }}:
+    name: {{ agent_sandbox_egress_network }}
+
+services:
+  squid:
+    image: {{ agent_sandbox_squid_image }}
+    container_name: {{ agent_sandbox_proxy_container }}
+    restart: unless-stopped
+    networks:
+      {{ agent_sandbox_network }}:
+        aliases:
+          - {{ agent_sandbox_proxy_alias }}
+      {{ agent_sandbox_egress_network }}: {}
+    volumes:
+      - {{ agent_sandbox_dir }}/squid.conf:/etc/squid/squid.conf:ro
+      - {{ agent_sandbox_dir }}/allowed-domains.txt:/etc/squid/allowed-domains.txt:ro

--- a/roles/agent_sandbox/templates/squid.conf.j2
+++ b/roles/agent_sandbox/templates/squid.conf.j2
@@ -1,0 +1,20 @@
+{{ ansible_managed | comment }}
+# Egress gate for agent containers: default-deny CONNECT proxy. Not a cache.
+# The allowlist is rendered from nix-agent-sandbox lib.egressDomains (mirrored
+# in this role's defaults) + the converge-time internal FQDNs.
+
+http_port {{ agent_sandbox_proxy_port }}
+
+acl allowed_dst dstdomain "/etc/squid/allowed-domains.txt"
+acl SSL_ports port 443
+acl CONNECT method CONNECT
+
+# CONNECT only to 443; plain http only to the allowlist (nix substituters
+# and package indexes are https, but redirects may bounce through http).
+http_access deny CONNECT !SSL_ports
+http_access allow allowed_dst
+http_access deny all
+
+cache deny all
+access_log stdio:/dev/stdout
+cache_log /dev/stderr

--- a/roles/agent_sandbox/templates/squid.conf.j2
+++ b/roles/agent_sandbox/templates/squid.conf.j2
@@ -16,5 +16,6 @@ http_access allow allowed_dst
 http_access deny all
 
 cache deny all
-access_log stdio:/dev/stdout
-cache_log /dev/stderr
+# Logging stays on the image defaults (/var/log/squid, writable by the
+# squid `proxy` user). stdio:/dev/stdout is fatal here: squid drops
+# privileges and the proxy user cannot open the container's stdout.

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -108,6 +108,14 @@ postgres_role: >-
      if (postgres_primary_host | length > 0 and inventory_hostname != postgres_primary_host)
      else 'primary' }}
 postgres_replication_enabled: "{{ (postgres_primary_host | length > 0) | bool }}"
+# Inventory group holding THIS cluster's members. The primary creates one
+# replication slot per standby in this group, so it must name the cluster
+# being converged — the role backs more than one (postgres_group,
+# postgres_ai_group), and a cluster whose standbys live elsewhere would get
+# no slots while its siblings' names were created against the wrong primary.
+# Not derived from the play hosts: `--limit primary` would then resolve to an
+# empty standby list and silently skip slot creation.
+postgres_cluster_group: postgres_group
 
 # The standby authenticates to the primary as this LOGIN + REPLICATION role. The
 # password is bao-first with an env fallback — never a literal.

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -349,7 +349,9 @@
         name: "standby_{{ item | regex_replace('[^A-Za-z0-9]', '_') }}"
         slot_type: physical
         state: present
-      loop: "{{ groups['postgres_group'] | default([]) | difference([postgres_primary_host]) }}"
+      loop: >-
+        {{ groups[postgres_cluster_group] | default([])
+           | difference([postgres_primary_host]) }}
       loop_control:
         label: "{{ item }}"
 

--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -110,6 +110,7 @@
           'insecure_tls': item.insecure_tls | default(false),
           'sticky': item.sticky | default(false),
           'health_check': item.health_check | default(false),
+          'health_check_path': item.health_check_path | default('/'),
           'sso': item.sso | default(false)
         }]
       }}

--- a/roles/traefik/templates/dynamic.yml.j2
+++ b/roles/traefik/templates/dynamic.yml.j2
@@ -70,9 +70,15 @@ http:
           - url: "{{ url }}"
 {% endfor %}
 {% if route.health_check | default(false) %}
+{# health_check_path comes from the tofu ingress contract. A hardcoded "/"
+   ejects every server of any backend whose root is not 200 - an API that only
+   answers on /health looks entirely down. Default "/" keeps legacy routes
+   byte-identical. Keep comments at column 0, never indented inside the emitted
+   block: the stripped comment leaves its leading whitespace behind and
+   corrupts the YAML. #}
         healthCheck:
           scheme: "{{ route.scheme | default('http') }}"
-          path: "/"
+          path: "{{ route.health_check_path | default('/') }}"
           interval: "10s"
           timeout: "5s"
 {% endif %}


### PR DESCRIPTION
## Summary
Promotes the current state of `develop` to `main`.

Carries recent fixes incl. agent_sandbox egress boundary (#1082/#1084/#1085), postgres replication-slot fix (#1081), and traefik `health_check_path` support (#1080 — fixes the hindsight health-check 404, issue #1072).

## Notes
- Merge commit only — `main`'s ruleset bans squash and rebase.
- Merging triggers release-please on `main` (version bump + CHANGELOG). This PR does not touch versioning.