### PR TITLE
feat(zammad): make the incident seed independently taggable

### DIFF
--- a/roles/zammad/tasks/main.yml
+++ b/roles/zammad/tasks/main.yml
@@ -443,6 +443,12 @@
     # =========================================================================
     - name: Seed incident custom fields and backdated incident history
       when: zammad_seed_incidents | bool
+      # `zammad_seed`: lets the seed run on its own (`--tags zammad_seed`)
+      # against an already-installed Zammad, skipping the apt/package tasks a
+      # full `--tags zammad` converge would drag in. The scripts self-heal
+      # (find-or-create groups/org/admin), so they need no prior role task.
+      tags:
+        - zammad_seed
       block:
         - name: Stage the ObjectManager attribute seed on the target
           ansible.builtin.copy:


### PR DESCRIPTION
Tags the incident-seed block `zammad_seed` so it can run on its own (`--tags zammad_seed`) against an already-installed guest, skipping the apt/package tasks a full `--tags zammad` converge drags in (which fail on any apt-cache hiccup even though the guest is installed). The seed scripts self-heal (find-or-create groups/org/admin), so they need no prior role task; a full `--tags zammad` converge still includes the block.

Verified live: ran the seed via this tag against the zammad guest — 6 custom Ticket fields created, backdated incident tickets seeded (confirmed a ticket at 2026-05-09, i.e. update_column backdating works), zammad ok=49 changed=10 failed=0.

Assisted-by: Claude