### PR TITLE
docs(openbao): correct engine-live claim; github-mint is read-tier only

### DIFF
--- a/.claude/rules/openbao-plugins-first.md
+++ b/.claude/rules/openbao-plugins-first.md
@@ -35,22 +35,30 @@ The engines are already paid for — installed, version-pinned, checksum- and
 signature-verified, and mounted. Reaching past a working engine for KV
 re-introduces every property the engine was adopted to eliminate.
 
-## What is already enabled — check before you build
+## What is live — check before you build
 
 | Resource | Engine | Mount | Mint from |
 | --- | --- | --- | --- |
-| GitHub | `vault-plugin-secrets-github` | `github` | `github/token/<permission_set>` |
+| GitHub | `vault-plugin-secrets-github` | `github` | `github/token/<permission_set>` or the tiered AppRoles below |
 | AWS | `openbao-plugins` secrets-aws | `aws` | `aws/sts/<role>` |
 
 Both default to enabled (`openbao_github_engine_enabled`,
-`openbao_aws_engine_enabled` in `roles/openbao/defaults/main.yml`).
+`openbao_aws_engine_enabled` in `roles/openbao/defaults/main.yml`). AWS has been
+converged and live for some time; the **GitHub engine was configured and
+converged on 2026-07-17** (App `openbao-service-broker`, both installations,
+read + per-repo-write + admin tiers). Engine-not-ready is never a licence to
+seed a PAT: if the GitHub engine is ever found unconfigured on a cluster, the
+fix is to converge it (supply the App credentials), not to reach for KV.
 
-**GitHub — do not build a new grant.** The `github-mint` base-capability policy
-(`templates/github-mint-policy.hcl.j2`) already grants
-`github/token/<permission_set>` for every administrator-defined permission set,
-and already composes with the KV leaves. An identity that needs a GitHub token
-attaches `github-mint`. It does not get a new policy template, and it does not
-get a KV path.
+**GitHub — do not build a new grant.** Estate/AI identities that need a GitHub
+token attach the `github-mint` base-capability policy
+(`templates/github-mint-policy.hcl.j2`), which grants the **read-tier**
+permission sets (`github/token/read-*`) only. The workstation git/gh path uses
+the dedicated AppRoles instead: `github-read` (ambient all-repo read),
+`github-write` (per-repo write via the parameter-pinned raw `github/token`
+endpoint plus a claim lease), and the inert, human-gated `github-admin`. There
+is no `secret/github/*` KV path and never was — do not add one, and do not
+widen `github-mint` to reach the write or admin sets.
 
 **AWS — same shape.** Consumers read `aws/sts/<role>` for short-lived STS
 credentials. Never plumb `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,14 +222,20 @@ suggestion, and it is short.
 The one-line version: if a resource has an OpenBao **secrets engine**, that
 engine is the only way its credentials may be produced. A credential a human
 minted, typed, pasted, or stored in KV is manual control and is banned wherever
-an engine exists. **GitHub and AWS both have engines here and are already
-enabled** — so a static PAT or a static AWS access key is never the answer,
-never a starting point, and never a "temporary" step.
+an engine exists. **GitHub and AWS both have engines here and both are live**
+(AWS long-standing; GitHub configured + converged 2026-07-17) — so a static PAT
+or a static AWS access key is never the answer, never a starting point, and
+never a "temporary" step. Engine-not-ready is never a licence to seed a PAT.
 
-| Resource | Engine (enabled by default) | Mint from | Never |
+| Resource | Engine (live) | Mint from | Never |
 | --- | --- | --- | --- |
-| GitHub | `vault-plugin-secrets-github` @ `github` | `github/token/<permission_set>` (attach the existing `github-mint` policy) | a PAT in `secret/github/*` |
+| GitHub | `vault-plugin-secrets-github` @ `github` | `github/token/<set>` — read / per-repo-write / admin tiers (see rule) | a PAT in `secret/github/*` |
 | AWS | [`openbao-plugins`](https://github.com/openbao/openbao-plugins) secrets-aws @ `aws` | `aws/sts/<role>` | a static access key |
+
+GitHub token tiers: estate/AI identities attach `github-mint` (read sets only);
+the workstation git/gh path uses the `github-read` / `github-write` (per-repo,
+lease-gated) / `github-admin` (human-gated) AppRoles. No `secret/github/*` path
+exists — see the rule.
 
 Adding a **new** resource? Check
 [openbao/openbao-plugins](https://github.com/openbao/openbao-plugins) for an


### PR DESCRIPTION
Corrects three now-inaccurate statements in the merged plugins-first rule and AGENTS.md (follow-up to #1018 / #1089):

1. **Engine status** — the rule said GitHub was generically "enabled"; it was actually configured + converged **2026-07-17** (App `openbao-service-broker`, both installations, read/write/admin tiers). AWS was already live. Now stated with the date, plus the explicit line **"engine-not-ready is never a licence to seed a PAT."**
2. **github-mint scope** — it no longer grants "every permission set." Per #1089 it grants the **read-tier sets only** (`github/token/read-*`); full-ceiling `*-full-automation` is human-gated (`github-admin`) and per-repo write rides the raw `github/token` endpoint (`github-write`). The three workstation tiers are now described.
3. **KV framing** — dropped the stale "composes with the KV leaves" / `secret/github/*` language; that path was removed in #1089 and never existed on the live cluster.

Docs-only. markdownlint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuqhVhA3t3Uyyh1FtMHMdA