### PR TITLE
fix(openbao): make the file audit-device enable idempotent

### DIFF
--- a/roles/openbao/tasks/audit.yml
+++ b/roles/openbao/tasks/audit.yml
@@ -52,6 +52,16 @@
     BAO_TOKEN: "{{ openbao_admin_token }}"
   register: openbao_audit_enable
   changed_when: openbao_audit_enable.rc == 0
+  # The `bao audit list` guard above should already skip an enabled device, but
+  # tolerate the one benign race it cannot cover: a device enabled between the
+  # list and this task (or a list output the guard parsed as empty) makes
+  # `bao audit enable` exit non-zero with "path already in use". That is the
+  # desired end state, not a failure. Any OTHER non-zero exit (bad token,
+  # unwritable file_path, sealed node) still fails loudly.
+  failed_when:
+    - openbao_audit_enable.rc is defined
+    - openbao_audit_enable.rc != 0
+    - "'already in use' not in (openbao_audit_enable.stderr | default(''))"
   when:
     - openbao_admin_token | length > 0
     - inventory_hostname == openbao_bootstrap_host


### PR DESCRIPTION
## Symptom

Once #1089 let the converge get past the GitHub-engine drift assert, the bootstrap node (`openbao-01`) failed on `TASK [openbao : Enable the file audit device]` (`failed=1`, output `no_log`-censored).

## Cause

The enable task has a `bao audit list` guard meant to skip an already-enabled `file/` device, but **no `failed_when`**. If the device is already present but the guard evaluated the list as empty (e.g. a list output shape the `from_json`/`in` check didn't match, or a device enabled between the list and the enable), `bao audit enable` exits non-zero with `path already in use` and hard-fails the play.

## Fix

Add a `failed_when` that tolerates only the `already in use` string. That is the desired end state (the device is enabled), not a failure. **Any other non-zero exit still fails loudly** — a bad token, an unwritable `file_path`, or a sealed node are not masked.

## Caveat

The failing stderr was `no_log`-censored and the cluster is not reachable from CI, so I could not confirm the exact live error string. If this recurs after the fix, the failure is a *real* enable error (perms/path), not the idempotency race — capture `openbao_audit_enable.stderr` with a privileged token to diagnose. Tracked in the linked issue.

Molecule's `openbao` scenario exercises this role in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuqhVhA3t3Uyyh1FtMHMdA