### PR TITLE
fix(openbao): declare the file audit device in server config, drop the impossible API enable

### DIFF
--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -903,10 +903,10 @@ openbao_audit_enabled: true
 openbao_audit_device_name: file
 openbao_audit_log_dir: /var/log/openbao
 openbao_audit_log_path: "{{ openbao_audit_log_dir }}/audit.log"
-# `bao audit enable` needs a privileged token (BAO_TOKEN via Doppler tier-0 /
-# break-glass, same as openbao_admin_token). When empty the enable step is
-# skipped cleanly — dir/logrotate/rsyslog still converge so the device starts
-# shipping the moment it is enabled.
+# The device is DECLARATIVE — an `audit` stanza in openbao.hcl (this OpenBao
+# build rejects `sys/audit` API writes). No token needed: the active node
+# materializes the stanza on start/SIGHUP; dir/logrotate/rsyslog converge
+# alongside so shipping starts the moment the device is live.
 openbao_audit_rsyslog_config_path: /etc/rsyslog.d/20-openbao-audit.conf
 openbao_audit_syslog_host: "syslog.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
 # openbao_audit AI ingest port from tofu constants; guarded default = the

--- a/roles/openbao/tasks/audit.yml
+++ b/roles/openbao/tasks/audit.yml
@@ -1,9 +1,10 @@
 ---
-# Audit device enable + shipping. Runs on EVERY node (each node writes its own
-# local audit file once the device is enabled cluster-wide); the actual
-# `bao audit enable` API write is idempotent (guarded by `bao audit list`) and
-# needs a privileged token — skipped cleanly when BAO_TOKEN is absent so a
-# pre-provisioning converge stays green.
+# Audit-log shipping plumbing. Runs on EVERY node (each node writes its own
+# local audit file once the device is live cluster-wide). The device itself is
+# DECLARATIVE: an `audit` stanza in openbao.hcl (this OpenBao build rejects
+# `sys/audit` API writes outright — "cannot enable audit device via API",
+# verified live 2026-07-18). The active node materializes the stanza on
+# start/SIGHUP, so no privileged token and no API call are needed here.
 
 - name: Create the OpenBao audit log directory
   ansible.builtin.file:
@@ -20,64 +21,6 @@
     owner: root
     group: root
     mode: "0644"
-
-# --- Enable the file audit device (idempotent, token-gated) ------------------
-- name: List enabled audit devices
-  ansible.builtin.command:
-    cmd: bao audit list -format=json
-  environment:
-    BAO_ADDR: "{{ openbao_api_addr }}"
-    BAO_TOKEN: "{{ openbao_admin_token }}"
-  register: openbao_audit_list
-  changed_when: false
-  # rc=0 with a JSON object when devices exist; OpenBao exits non-zero with
-  # "No audit devices are enabled" on a cluster that has none — treat that as
-  # an empty list, fail on anything else (bad token, sealed node, ...).
-  failed_when:
-    - openbao_audit_list.rc != 0
-    - "'No audit devices are enabled' not in (openbao_audit_list.stderr | default(''))"
-  when: openbao_admin_token | length > 0
-  no_log: true
-
-- name: Enable the file audit device
-  ansible.builtin.command:
-    # mode=0640: the device default is 0600, which the syslog group (rsyslog
-    # imfile reader) cannot open — shipping would fail silently.
-    cmd: >-
-      bao audit enable {{ openbao_audit_device_name }}
-      file_path={{ openbao_audit_log_path }}
-      mode=0640
-  environment:
-    BAO_ADDR: "{{ openbao_api_addr }}"
-    BAO_TOKEN: "{{ openbao_admin_token }}"
-  register: openbao_audit_enable
-  changed_when: openbao_audit_enable.rc == 0
-  # The `bao audit list` guard above should already skip an enabled device, but
-  # tolerate the one benign race it cannot cover: a device enabled between the
-  # list and this task (or a list output the guard parsed as empty) makes
-  # `bao audit enable` exit non-zero with "path already in use". That is the
-  # desired end state, not a failure. Any OTHER non-zero exit (bad token,
-  # unwritable file_path, sealed node) still fails loudly.
-  failed_when:
-    - openbao_audit_enable.rc is defined
-    - openbao_audit_enable.rc != 0
-    - "'already in use' not in (openbao_audit_enable.stderr | default(''))"
-  when:
-    - openbao_admin_token | length > 0
-    - inventory_hostname == openbao_bootstrap_host
-    - >-
-      (openbao_audit_device_name ~ '/') not in
-      ((openbao_audit_list.stdout | default('{}', true) | from_json)
-       if openbao_audit_list.rc | default(1) == 0 else {})
-  no_log: true
-
-- name: Note when the audit enable step was skipped for a missing token
-  ansible.builtin.debug:
-    msg: >-
-      BAO_TOKEN is not set — skipped `bao audit list/enable`. The audit
-      shipping plumbing (dir, logrotate, rsyslog ruleset) is converged; enable
-      the device with a privileged token to start emitting.
-  when: openbao_admin_token | length == 0
 
 # --- Ship the audit file via a dedicated rsyslog ruleset ----------------------
 # rsyslog is already present on these guests (site.yml applies syslog_forwarder

--- a/roles/openbao/templates/openbao.hcl.j2
+++ b/roles/openbao/templates/openbao.hcl.j2
@@ -60,4 +60,19 @@ plugin_directory = "{{ openbao_plugin_dir }}"
 # deployment.json, so secrets cannot page to disk.
 # https://openbao.org/docs/install/#post-installation-hardening
 
+# Declarative audit device. This OpenBao build REJECTS `bao audit enable` /
+# `sys/audit` API writes ("cannot enable audit device via API; use
+# declarative, config-based audit device management instead" — verified live
+# 2026-07-18), so the config stanza is the ONLY way to enable auditing. The
+# active node materializes it on start/SIGHUP; the stanza must be identical on
+# every server. mode=0640: the device default 0600 would lock out the syslog
+# group that the rsyslog imfile shipper reads with (see tasks/audit.yml).
+audit "file" "{{ openbao_audit_device_name }}" {
+  description = "Local file audit log, shipped via rsyslog imfile"
+  options {
+    file_path = "{{ openbao_audit_log_path }}"
+    mode      = "0640"
+  }
+}
+
 ui = {{ openbao_enable_ui | ternary('true', 'false') }}


### PR DESCRIPTION
## What

The `Enable the file audit device` task has failed on every converge of the active node, `no_log`-censored. Reproducing the call directly revealed the real error: **this OpenBao build rejects `sys/audit` API writes entirely** — `cannot enable audit device via API; use declarative, config-based audit device management instead` (verified live 2026-07-18). `sys/audit` lists no devices: **auditing has never actually been on**.

- `openbao.hcl.j2`: add the declarative `audit "file"` stanza (identical on all servers; the active node materializes it on start/SIGHUP via the existing `Restart openbao` handler). `mode = "0640"` preserved so the rsyslog imfile shipper's syslog-group read keeps working.
- `tasks/audit.yml`: drop the `bao audit list`/`enable` tasks and their token gate — no API path exists. Dir/logrotate/rsyslog plumbing unchanged.
- `defaults/main.yml`: comment now describes the declarative model.

Supersedes the #1092 idempotency approach, which tolerated the wrong error (`already in use`) — the real failure was the API write being categorically rejected.

## Verification

- `ansible-lint roles/openbao/` — 0 failures, 0 warnings (production profile).
- Live enable-path error captured via direct `PUT sys/audit/file` with an admin token.
- Post-merge: converge `--tags openbao` rolls the config; `GET sys/audit` must then list the `file/` device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuqhVhA3t3Uyyh1FtMHMdA