### PR TITLE
fix(openbao): grant create on the github mint paths — POST routes as CreateOperation

### DIFF
--- a/roles/openbao/templates/github-admin-policy.hcl.j2
+++ b/roles/openbao/templates/github-admin-policy.hcl.j2
@@ -10,7 +10,7 @@
 # converge's job, not a tier's.
 {% for permission_set in openbao_github_permission_sets | selectattr('tier', 'equalto', 'admin') %}
 path "{{ openbao_github_mount }}/token/{{ permission_set.name }}" {
-  capabilities = ["update"]
+  capabilities = ["create", "update"]
 }
 
 {% endfor %}

--- a/roles/openbao/templates/github-mint-policy.hcl.j2
+++ b/roles/openbao/templates/github-mint-policy.hcl.j2
@@ -12,7 +12,7 @@
 # roles; carries no self-escalation path, so composing it with KV leaves is safe.
 {% for permission_set in openbao_github_permission_sets | rejectattr('tier', 'equalto', 'admin') %}
 path "{{ openbao_github_mount }}/token/{{ permission_set.name }}" {
-  capabilities = ["update"]
+  capabilities = ["create", "update"]
 }
 
 {% endfor %}

--- a/roles/openbao/templates/github-read-policy.hcl.j2
+++ b/roles/openbao/templates/github-read-policy.hcl.j2
@@ -8,7 +8,7 @@
 # absent — a leaked github-read secret-zero can read, never change.
 {% for permission_set in openbao_github_permission_sets | selectattr('tier', 'equalto', 'read') %}
 path "{{ openbao_github_mount }}/token/{{ permission_set.name }}" {
-  capabilities = ["update"]
+  capabilities = ["create", "update"]
 }
 
 {% endfor %}

--- a/roles/openbao/templates/github-write-policy.hcl.j2
+++ b/roles/openbao/templates/github-write-policy.hcl.j2
@@ -22,7 +22,12 @@
 # secret/locks/github-write/<installation_id>/<repo> before minting, so two
 # agents cannot hold the same repo. KV-v2 delete_version_after is the deadman.
 path "{{ openbao_github_mount }}/token" {
-  capabilities = ["update"]
+  # "create" is required, not belt-and-suspenders: the plugin's token paths
+  # have no existence check, so POST routes as CreateOperation — an
+  # update-only grant returns "permission denied" on every mint (verified
+  # live 2026-07-18; sys/capabilities-self still reports the path as usable,
+  # which makes the omission invisible until a real mint is attempted).
+  capabilities = ["create", "update"]
   required_parameters = ["installation_id", "repositories"]
   allowed_parameters = {
     "installation_id" = [


### PR DESCRIPTION
## What

Every GitHub-engine mint from every tier returned `permission denied` even though `sys/capabilities-self` reported the paths as granted. Root cause (bisected live with throwaway test policies): the plugin's token paths have **no existence check**, so a mint POST routes as **CreateOperation** — and all four tier policies granted only `update`.

Adds `create` to the mint-path grants in `github-write`, `github-read`, `github-mint`, and `github-admin` policy templates, with a comment on the write policy explaining why it's load-bearing.

## Verification

- Live bisect: bare `update`-only grant on the raw mint path → 403 `permission denied`; `create`+`update` → **token minted end-to-end** for an allowlisted repo (also proving GitHub egress works; an earlier `context deadline exceeded` was transient).
- `ansible-lint roles/openbao/` — 0 failures, 0 warnings (production profile).
- Post-merge converge reconciles the same content into the live policies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuqhVhA3t3Uyyh1FtMHMdA