### PR TITLE
fix(openbao): string-form github-write params — OpenBao ACL cannot element-match lists

### DIFF
--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -414,34 +414,78 @@ openbao_github_write_approle_name: github-write
 openbao_github_admin_policy_name: github-admin
 openbao_github_admin_approle_name: github-admin
 # Repositories a github-write identity may name (exactly one per request; the
-# wrapper always sends a single-element list). Values are repository NAMES
-# resolved within whichever installation the request names — a name existing
-# in both accounts is therefore allowlisted in both (accepted, documented).
-# Prefix/suffix value globs are honored by the policy layer. Editing this
-# list + converging IS the write-grant process; anything off-list needs the
-# human-gated github-admin tier.
+# wrapper sends `repositories` as a plain STRING, `installation_id` as a
+# STRING). Values are repository NAMES resolved within whichever installation
+# the request names — a name existing in both accounts is therefore
+# allowlisted in both (accepted, documented). Editing this list + converging
+# IS the write-grant process; anything off-list needs the human-gated
+# github-admin tier.
+#
+# EXPLICIT LITERALS ONLY — never add a glob (verified live 2026-07-18):
+#   * OpenBao's ACL does not element-match LIST-valued request parameters, so
+#     the wrapper sends `repositories` as a comma-capable STRING the ACL can
+#     compare. Exact literals make comma smuggling impossible
+#     ("docs,evil" != "docs"), but a prefix glob like "nix-*" would match
+#     "nix-a,evil-repo" and hand the caller an off-list repo.
+#   * `installation_id` must be allowlisted (and sent) in STRING form — the
+#     JSON-number form matches neither a quoted nor an unquoted policy value.
 openbao_github_write_repo_allowlist:
-  - "nix-*"
-  - "ansible-*"
-  - "tofu-*"
-  - "claude-code-*"
-  - "ai-*"
-  - "mlx-*"
-  - "cc-edge-*"
-  - "homelab*"
-  - int_homelab
+  # dryvist (org installation)
+  - ".github"
+  - ai-assistant-instructions
+  - ai-workflows
+  - ansible-proxmox
+  - ansible-proxmox-ai
+  - ansible-proxmox-apps
+  - ansible-splunk
+  - cc-edge-claude-code-io
+  - cc-edge-pack-template
+  - cc-edge-the-mac-pack-io
+  - claude-code-best-practice
+  - claude-code-plugins
+  - claude-code-routines
+  - cribl-migration
   - docs
   - docs-starlight
-  - nixos-ai
-  - unifi-config
+  - homelab
+  - homelab-contracts
   - iac-platform
-  - python-template
+  - int_homelab
+  - mlx-benchmarks
+  - nix-agent-sandbox
+  - nix-ai
+  - nix-ai-open-harness
+  - nix-ai-server
+  - nix-claude-code
+  - nix-darwin
+  - nix-darwin-host
+  - nix-devenv
+  - nix-hermes
+  - nix-home
+  - nix-mac-performance
+  - nix-pxe-bootstrap
+  - nixos-ai
   - orbstack-kubernetes
-  - cribl-migration
+  - python-template
+  - raycast-smart-issue
   - routine-state
   - splunk-ui-dev
-  - raycast-smart-issue
-  - ".github"
+  - tofu-aws
+  - tofu-aws-templates
+  - tofu-github
+  - tofu-proxmox
+  - tofu-runs-on
+  - tofu-splunk-aws
+  - tofu-unifi
+  - unifi-config
+  # JacobPEvans-personal (user installation) — names not already above
+  - cc-edge-claude-code-otel
+  - cc-edge-copilot-otel
+  - cc-edge-gemini-antigravity-io
+  - cc-edge-vscode-io
+  - tofu-aws-bedrock
+  - tofu-aws-static-website
+  - tofu-static-website
 # Deadman TTL on the per-repo write lease (KV lock under
 # secret/locks/github-write/): a crashed holder's claim self-expires via KV-v2
 # delete_version_after — no janitor process.

--- a/roles/openbao/templates/github-write-policy.hcl.j2
+++ b/roles/openbao/templates/github-write-policy.hcl.j2
@@ -4,14 +4,19 @@
 # and the parameter pinning is the entire privilege boundary:
 #
 #   * required_parameters forces every request to name an installation AND a
-#     repositories list — an unconstrained request (= full installation
+#     repositories value — an unconstrained request (= full installation
 #     ceiling) is impossible.
 #   * allowed_parameters restricts installation_id to the two known
-#     installations and every repositories element to the administrator
-#     allowlist (openbao_github_write_repo_allowlist; prefix/suffix value
-#     globs honored). Listing any key denies all unlisted parameters, so
-#     org_name and repository_ids — both alternate selectors that would
-#     bypass the name allowlist — are denied by construction.
+#     installations and repositories to the administrator allowlist
+#     (openbao_github_write_repo_allowlist). STRING-FORM CONTRACT (verified
+#     live 2026-07-18): the ACL does not element-match LIST-valued request
+#     parameters, so callers MUST send `repositories` as a plain string (the
+#     plugin's TypeCommaStringSlice accepts it) and `installation_id` as a
+#     string. The allowlist is exact literals only — a glob would let
+#     "nix-a,evil" ride a "nix-*" prefix through the plugin's comma split.
+#     Listing any key denies all unlisted parameters, so org_name and
+#     repository_ids — both alternate selectors that would bypass the name
+#     allowlist — are denied by construction.
 #   * denied_parameters bans `permissions` outright (belt-and-suspenders on
 #     top of the allowlist gating): an omitted permissions map yields the App
 #     ceiling scoped to the ONE named repo, and map-valued parameter matching
@@ -30,11 +35,12 @@ path "{{ openbao_github_mount }}/token" {
   capabilities = ["create", "update"]
   required_parameters = ["installation_id", "repositories"]
   allowed_parameters = {
+    # String forms only: the JSON-number form matches neither a quoted nor an
+    # unquoted policy value, so listing numbers is dead weight that reads as
+    # a live grant.
     "installation_id" = [
       "{{ openbao_github_dryvist_installation_id }}",
-      {{ openbao_github_dryvist_installation_id | int }},
-      "{{ openbao_github_personal_installation_id }}",
-      {{ openbao_github_personal_installation_id | int }}
+      "{{ openbao_github_personal_installation_id }}"
     ]
     "repositories" = [
 {% for repo in openbao_github_write_repo_allowlist %}


### PR DESCRIPTION
## What

Live bisect with throwaway policies proved two ACL semantics that break the raw-mint parameter pinning as shipped:

- `allowed_parameters` never matches a **list-valued** request parameter — even a single exact-literal element (`["docs"]` vs allowed `"docs"` → denied).
- `installation_id` only matches in **string** form; the JSON-number form matches neither a quoted nor an unquoted policy value.

New contract: callers send `repositories` as a plain STRING (the plugin's `TypeCommaStringSlice` accepts it) and `installation_id` as a STRING. The allowlist becomes **exact literals only**, enumerated per installation — a prefix glob like `nix-*` would let `nix-a,evil` ride through the plugin's comma split, while exact literals make comma smuggling impossible.

Companion wrapper change: nix-darwin `fix/openbao-github-string-params`.

## Verification (live, 2026-07-18)

- String `docs` vs literal allowlist → **passed ACL** (S1); comma smuggle `docs,nix-darwin` → 403 (S2); off-list → 403 (S3); list form → 403 (S4).
- `ansible-lint roles/openbao/` — 0 failures, 0 warnings (production profile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuqhVhA3t3Uyyh1FtMHMdA