### PR TITLE
docs(nautobot): Phase-2 authority-flip design + Phase-1 absorption boundary (#977)

### DIFF
--- a/docs/nautobot/phase1-absorption-status.md
+++ b/docs/nautobot/phase1-absorption-status.md
@@ -1,0 +1,66 @@
+# Phase 1 — Absorption Status & Native-Coverage Roadmap
+
+Status of the read-only absorption effort (#977 gates 1-4). Nautobot is the
+system of record for everything it can natively model; this page records what is
+absorbed today and the roadmap to model **everything Nautobot is natively
+capable of**.
+
+## Absorbed today (verified live, read-only)
+
+The converge-owned seed pipeline (`roles/nautobot`, gated by `nautobot_build_seed`
++ `nautobot_run_seed_jobs`) imports from the sibling-repo sources via additive
+SSoT DiffSync jobs. Current modeled coverage, all verified against source:
+
+| Domain | Nautobot model | Source | State |
+| --- | --- | --- | --- |
+| VLANs | VLAN | network defs (`NAUTOBOT_SEED_NETWORKS`) | ✅ complete |
+| Prefixes/subnets | Prefix | network defs | ✅ complete |
+| Fixed-IP reservations | IPAddress | UniFi fixed-ips | ✅ complete |
+| Guests (containers/VMs) | VirtualMachine (+ cluster, eth0, primary IP) | tofu inventory | ✅ complete |
+| Guest tags → groups | Tag | tofu inventory | ✅ complete |
+| Proxmox nodes | Device (role pve-node) | Ansible hosts | ✅ complete |
+| Rack servers | Device / Rack | SOPS (optional) | ⚠️ retained; source file absent |
+
+**Drift = 0** on all modeled domains (guests 1:1, tags 1:1). The GraphQL dynamic
+inventory answers with **1:1 group parity** against the tofu inventory
+(verified at the data layer: identical host set, identical tag→group membership).
+
+## Consumption contracts (verified ready, not cut over)
+
+- **GraphQL dynamic inventory** (`inventory/nautobot.yml`): 1:1 parity confirmed.
+  Local `ansible-inventory` needs `pynautobot` in the dev shell to run the plugin
+  (nix-devenv gap — tracked); the converged controller has it.
+- **Export artifact** (`nautobot-export-v1`): validates against its schema.
+- Read-only token is role-managed (`nautobot_token_publish_openbao`, fail-closed
+  non-superuser + view-only ObjectPermission + `write_enabled=False`).
+
+## Roadmap — everything Nautobot can natively model
+
+"Everything it is native for" is bounded by what Nautobot core + mature apps can
+represent. Per-domain plan (no source-system changes — read-only ingestion only):
+
+| Source domain | Native target | Mechanism | Status |
+| --- | --- | --- | --- |
+| DNS names | `IPAddress.dns_name` | extend the reservation/guest seed | tractable next |
+| Physical devices/interfaces | DCIM Device/Interface | `nautobot-device-onboarding` (live discovery) | dry-run next |
+| Cabling | DCIM Cable | onboarding / manual as-known | after onboarding |
+| Firewall groups/rules, NAT/port-forwards | firewall models | `nautobot-firewall-models` app + SSoT job | needs app install |
+| WLANs | Wireless models | Nautobot 2.x Wireless (Controller/RadioProfile/SSID) + SSoT | needs eval + SSoT |
+| WAN circuits | Circuit / Provider | SSoT job | new SSoT job |
+| Static/traffic routes | config-context / custom | design decision | design |
+| VPN | L2VPN/tunnel or custom | design decision | design |
+| RADIUS | Secrets / custom | design decision | design |
+| Node storage / ingress | custom fields / config-context | design decision | design |
+
+**Rule for every addition:** a new SSoT DataSource job per domain, run
+`dryrun=True` first with the DiffSync diff reviewed before any committing run
+(see the Phase-2 design §9). Add a mature app only where it demonstrably
+increases read-only coverage; model with core first.
+
+## What is NOT yet modeled (honest coverage gap)
+
+Firewall, DNS records, WLANs, port profiles/forwards, static/traffic routes,
+RADIUS, VPN, WAN, physical interfaces, and cables are **not yet in Nautobot** —
+several require an app (firewall-models, wireless) or a modeling decision. The
+repeatable drift report (`scripts/nautobot_drift.py`) lists this gap on every run
+so it is never silently hidden.

--- a/docs/nautobot/phase1-absorption-status.md
+++ b/docs/nautobot/phase1-absorption-status.md
@@ -18,6 +18,8 @@ SSoT DiffSync jobs. Current modeled coverage, all verified against source:
 | Fixed-IP reservations | IPAddress | UniFi fixed-ips | ✅ complete |
 | Guests (containers/VMs) | VirtualMachine (+ cluster, eth0, primary IP) | tofu inventory | ✅ complete |
 | Guest tags → groups | Tag | tofu inventory | ✅ complete |
+| DNS names | `IPAddress.dns_name` | reservation/guest hostnames | ✅ complete (77/77) |
+| VM interfaces | VMInterface (eth0) + primary IP | tofu inventory | ✅ complete (65) |
 | Proxmox nodes | Device (role pve-node) | Ansible hosts | ✅ complete |
 | Rack servers | Device / Rack | SOPS (optional) | ⚠️ retained; source file absent |
 
@@ -41,7 +43,6 @@ represent. Per-domain plan (no source-system changes — read-only ingestion onl
 
 | Source domain | Native target | Mechanism | Status |
 | --- | --- | --- | --- |
-| DNS names | `IPAddress.dns_name` | extend the reservation/guest seed | tractable next |
 | Physical devices/interfaces | DCIM Device/Interface | `nautobot-device-onboarding` (live discovery) | dry-run next |
 | Cabling | DCIM Cable | onboarding / manual as-known | after onboarding |
 | Firewall groups/rules, NAT/port-forwards | firewall models | `nautobot-firewall-models` app + SSoT job | needs app install |

--- a/docs/nautobot/phase2-authority-flip-design.md
+++ b/docs/nautobot/phase2-authority-flip-design.md
@@ -1,0 +1,181 @@
+# Phase 2 — Nautobot Authority-Flip Design
+
+Status: **DESIGN ONLY — do not execute.** This document is Phase 1 exit
+criterion 5 (the written authority-flip design) for the Nautobot
+source-of-truth effort tracked in
+[dryvist/ansible-proxmox-apps#977](https://github.com/dryvist/ansible-proxmox-apps/issues/977).
+Phase 2 is a separate, separately-gated engagement; nothing here is a licence to
+begin the flip.
+
+## 1. Phase boundary
+
+- **Phase 1 (absorb):** Nautobot learns everything, writing to nothing but its
+  own DB and reviewed PRs. Its consumption contracts (GraphQL dynamic inventory,
+  `nautobot-export-v1` artifact) are proven *ready* but not cut over.
+- **Phase 2 (own — this doc's subject):** authority for each network-intent
+  field moves to Nautobot; the execution planes (DNS, DHCP, the network
+  controller) reconcile *from* Nautobot instead of being hand-fed; OpenTofu
+  keeps guest lifecycle only.
+
+The invariant that separates them: **Phase 1 never becomes the writer.** The
+first write of authority is the first act of Phase 2.
+
+## 2. Current state (verified, Phase-1 recon)
+
+Who writes each fact today:
+
+| Fact | Today's writer | Today's consumers |
+| --- | --- | --- |
+| Guest lifecycle (vmid, node, cpu, mem, disk, template, features, pool, tags) | `tofu-proxmox` `deployment.json` | `ansible_inventory.json` → Ansible repos |
+| Guest IP / MAC / gateway / reserved-IP | `tofu-proxmox` (derived from VLAN+vmid; deterministic MAC) | inventory artifact; controller reads back MAC+IP |
+| VLAN → subnet table (`network_cidrs`) | `tofu-proxmox` `deployment.json` | IP derivation above |
+| Network defs, reservations, firewall, DNS, WLAN, routes, VPN, WAN, device | network-controller (UniFi) IaC | controller; reservations feed inventory |
+| DNS A records | `technitium_dns` role, pointed at reserved IP | clients |
+| Ansible host/group membership | `ansible_inventory.json` + `load_tofu.yml` tags | every playbook |
+
+What Nautobot already models (Phase-1 seed pipeline, **gated off by default**,
+activated only at cutover via `nautobot_build_seed` + `nautobot_run_seed_jobs`):
+VLANs, Prefixes, IPAddresses (from the reservation feed), Racks + rack Devices +
+BMC interfaces, Proxmox nodes as Devices, guests as VirtualMachines with a
+primary IP. It does **not** yet model: guest Tags (so tag→group inventory is
+inert — see #1008), Cables, physical interface↔IP bindings, or live-discovered
+network devices.
+
+**Model-coverage reality:** only four source domains map to Nautobot *core*
+models — networks→VLAN+Prefix, reservations→IPAddress, adopted device→Device,
+DNS-name→`IPAddress.dns_name`. Firewall groups/rules and NAT need a plugin
+(e.g. nautobot-firewall-models); WLANs, port-profiles, static/traffic routes,
+VPN, WAN, and RADIUS have no core model and require custom models or
+config-contexts. This bounds what "Nautobot owns network intent" can mean at
+flip time and is the largest open prerequisite (§7).
+
+## 3. One-writer-per-field ownership map (Phase 2 target)
+
+The rule: exactly one system is the **writer** of each field; every other system
+is a **reader** that reconciles from it. No field has two writers; no
+bidirectional sync.
+
+| Field / domain | Phase-2 writer | Readers (reconcile FROM writer) |
+| --- | --- | --- |
+| VLAN id/name, subnet/prefix, VLAN→CIDR map | **Nautobot** (VLAN, Prefix) | tofu-proxmox (IP math), controller, Ansible |
+| Host IP address, prefix, gateway | **Nautobot** (IPAddress, Prefix) | Ansible inventory, DNS, DHCP |
+| Fixed-IP / DHCP reservation (MAC↔IP) | **Nautobot** (IPAddress + iface/MAC) | controller IaC (DHCP), tofu-proxmox (reads assigned IP) |
+| DNS name (A/PTR intent) | **Nautobot** (`IPAddress.dns_name`) | `technitium_dns` role reconciles records |
+| Firewall groups/rules, NAT/port-forwards | **Nautobot** (firewall plugin) — *pending model* | controller IaC renders rules |
+| WLAN, port-profile, routes, VPN, WAN, RADIUS | **Nautobot** (custom/config-context) — *pending model* | controller IaC |
+| Ansible host/group membership | **Nautobot** (tags + GraphQL inventory) | every playbook |
+| Guest lifecycle (cpu, mem, disk, template, features, pool…; full list §4) | **OpenTofu** (`deployment.json`) | Proxmox, inventory |
+| Physical: rack, device, interface, cable | **Nautobot** (DCIM; onboarding-discovered) | as-built docs, export |
+| Deterministic MAC | **OpenTofu** at create → published to Nautobot as the iface MAC (then authoritative) | controller IaC DHCP |
+
+Boundary line: **Nautobot owns "where it lives on the network" (IPAM / DNS /
+VLAN / firewall intent); OpenTofu owns "what the guest is" (lifecycle).** The MAC
+is the one hand-off: OpenTofu still mints the deterministic MAC when it creates
+the guest NIC, but writes it *into* Nautobot, which becomes the single reader
+surface for the controller's DHCP reservations.
+
+## 4. `deployment.json` shrink plan
+
+`deployment.json` (schema `deployment.schema.json`) shrinks to guest-lifecycle
+only. The publish boundary is `tofu apply` writing `ansible_inventory.json`
+(single S3 object; the `lifecycle.precondition` blocks are the schema gate).
+
+**Stays (guest lifecycle):** `vm_id`, `hostname`, `node_name`, `cpu_cores`,
+`memory_dedicated`/`memory_swap`, `root_disk`, `mount_points[]`,
+`device_passthrough[]`, `template`/`os_type`, `unprivileged`, `protection`,
+`features`, `tags`, `pool_id`, `start_on_boot`, `user_account`, and the
+top-level `nodes`, `node_storage`, `pools`, `datastores`, `host_services`,
+`proxmox_node`, `vm_ssh_public_key`.
+
+**Leaves (moves to Nautobot authority):** `vlan`, `network_cidrs`, `ip_config`
+(`ipv4_address`/`ipv4_gateway`), `dhcp`, `reserved_host`, `network_interfaces[]`,
+`domain`; and the `modules/proxmox-stack/locals.tf` derivation block
+(`container_address`, `container_mac`, `container_gateway`,
+`container_reserved_ip`, and the VM equivalents) is deleted or repointed to read
+Nautobot.
+
+Migration order matters: **Nautobot must be authoritative and populated for the
+guest's IP/VLAN before the field is removed from `deployment.json`**, or the
+`cidrhost` derivation loses its input and DHCP reservations go stale. Populate
+Nautobot (Phase 1) → repoint the derivation to read Nautobot (Phase 2 step) →
+only then delete the source fields (schema bump).
+
+## 5. `ansible_inventory.json` retirement path
+
+The artifact is `schema_version 2.0.0`, keys `containers`/`vms`/`docker_vms`/
+`splunk_vm`/`constants`/`ingress`/`ingress_vip`/`ingress_hosts`/`host_services`/
+`nodes`/`node_storage`/`domain`, written to the RustFS `iac-inventory` bucket.
+Five consumers: `ansible-proxmox`, `ansible-proxmox-apps` (`load_tofu.yml`),
+`ansible-splunk`, the controller IaC (reads MAC + reserved IP), and the
+`technitium_dns` role.
+
+Retirement is a **`schema_version 3.0.0` breaking bump**, done in two options
+(prefer **A** first, then **B** once all readers are proven on Nautobot):
+
+- **Option A — strip network fields, keep the shim.** Remove per-guest `ip`,
+  `mac`, `reserved_ip` (and `ingress*`, `domain`) from the published artifact;
+  consumers pull addressing from Nautobot's dynamic inventory. Guest-lifecycle
+  keys (`vmid`, `node`, `ansible_connection`, `ansible_pct_vmid`, `tags`,
+  `pool_id`, `constants`) stay OpenTofu-sourced — those never live in Nautobot.
+- **Option B — full retire.** Delete `aws_s3_object.ansible_inventory` and the
+  `iac-inventory/ansible_inventory.json` key; repoint all five consumers at
+  Nautobot. Only reachable after every consumer runs green on Option A.
+
+The artifact ends Phase 2 as a legacy shim (Option A) or gone (Option B),
+matching the #977 "done when" state.
+
+## 6. Per-repo change lists
+
+- **tofu-proxmox** — shrink `deployment.schema.json` + `variables-containers.tf`
+  to the lifecycle field set; delete/repoint the `locals.tf` network-derivation
+  block; bump the published artifact to `3.0.0` (Option A: strip network fields).
+- **ansible-proxmox-apps (this repo)** — flip `ansible.cfg` inventory to
+  `inventory/nautobot.yml`; close the parity gap first (add `postgres_ai`,
+  `ai_orchestration`, `authelia` groups or confirm they moved to
+  `ansible-proxmox-ai`); land #1006 (role-managed read-only token) and #1008
+  (tag sync) so the GraphQL inventory is trustworthy; retire the `load_tofu.yml`
+  network-field dependence.
+- **ansible-proxmox** — repoint host sourcing from the artifact to Nautobot.
+- **ansible-splunk** — `splunk_vm` + `constants` still come from the artifact
+  (lifecycle/constants), so it is affected only by Option B; verify no network
+  field is read.
+- **the network-controller (UniFi) IaC** — flip DHCP-reservation rendering,
+  firewall/DNS/WLAN/route intent to read from Nautobot instead of its own JSON;
+  this is the largest reader change and is gated on the Nautobot model coverage
+  in §7.
+- **technitium_dns role** — source A/PTR records from `IPAddress.dns_name`
+  instead of the artifact's reserved IP.
+
+## 7. Prerequisites & open questions (must close before flip)
+
+1. **Model gap.** Firewall/NAT need a plugin; WLAN/routes/VPN/WAN/RADIUS/
+   port-profiles need custom models or config-contexts. Until modeled, those
+   domains cannot flip and the controller IaC stays their writer. Decide
+   per-domain: model it, or explicitly keep it OpenTofu-owned and out of scope.
+2. **#1006 / #1008** must be merged and converged — a role-managed read-only
+   token and guest-tag sync — or the GraphQL inventory cannot answer with 1:1
+   group parity.
+3. **Export contract asymmetry.** VirtualMachines are seeded in but absent from
+   `nautobot-export-v1`; decide whether the export must round-trip guests before
+   it is a retirement-grade artifact.
+4. **Reservation circular dependency.** Today tofu-proxmox computes the IP and
+   the controller reads it back. Post-flip both read Nautobot; sequence the
+   repoint so neither is briefly the writer of a field the other also writes.
+
+## 8. Rollback
+
+Each step is independently reversible because Phase 1 leaves the artifact intact:
+
+- **Inventory cutover** (`ansible.cfg` → `nautobot.yml`): revert the one-line
+  config change; `load_tofu.yml` + the still-published artifact resume sourcing.
+- **`deployment.json` shrink**: the removed fields live in git history and the
+  `2.0.0` artifact; restore the schema + `locals.tf` block and re-apply to
+  republish network fields. Do **not** delete the `2.0.0` publish path until
+  every consumer is proven on `3.0.0`.
+- **Controller reader flip**: revert to reading its own desired-state JSON; the
+  JSON is unchanged in Phase 2 (Nautobot became authoritative *of the same
+  values*, not a new source of truth), so a revert is loss-free.
+
+Rollback invariant: **keep the old writer's data intact and the old artifact
+published until the new reader path is proven green**, so any step reverts to a
+known-good source with no data reconstruction.

--- a/docs/nautobot/phase2-authority-flip-design.md
+++ b/docs/nautobot/phase2-authority-flip-design.md
@@ -179,3 +179,33 @@ Each step is independently reversible because Phase 1 leaves the artifact intact
 Rollback invariant: **keep the old writer's data intact and the old artifact
 published until the new reader path is proven green**, so any step reverts to a
 known-good source with no data reconstruction.
+
+## 9. Phase-2 safety gates (from adversarial review)
+
+These gates were surfaced by an independent review and must be satisfied before
+authority flips — schema validity and additive absorption are necessary but not
+sufficient.
+
+- **Semantic validation, not just schema.** A schema-valid export can still
+  carry duplicate IP allocations, overlapping subnets, duplicate MACs, or
+  unresolvable FQDNs. Before Phase 2 applies Nautobot data, run pre-flight checks
+  for IP collisions, subnet overlap, duplicate MAC, and FQDN resolvability. A
+  schema pass alone must not gate the flip.
+- **Drift triage before absorption.** Classify every drift item before it enters
+  Nautobot: IaC-managed (stale seed — safe to absorb), ephemeral/test, or
+  genuinely out-of-band (created outside IaC). Absorbing an out-of-band object
+  makes it authoritative with no OpenTofu state behind it — a Phase-2 trap where
+  the controller has no HCL/state and may conflict or re-create. Only IaC-sourced
+  facts absorb silently; others are classified or fixed upstream first.
+- **Explicit DiffSync diff, reviewed before commit.** The seed runner commits
+  directly (`dryrun=False`). Phase-2-grade absorption should first run the SSoT
+  jobs in `dryrun=True`, capture the create/update/delete DiffSync diff, and
+  review it before the committing run — the drift report is a proxy, not the
+  native diff.
+- **Deletion-safety cap.** Additive models make delete a no-op today; if any
+  future sync enables deletion, gate it on a threshold (e.g. abort if >5% of a
+  model's objects would be deleted) so a bad source never mass-deletes.
+- **No boot-loop dependency.** Nautobot must never become a boot prerequisite for
+  the execution planes: if it is down or state-lost, DNS/DHCP/controllers and
+  OpenTofu must still boot and be able to reconstruct Nautobot — not deadlock
+  waiting on it. Audit the recovery order before the flip.

--- a/docs/nautobot/phase2-authority-flip-design.md
+++ b/docs/nautobot/phase2-authority-flip-design.md
@@ -113,10 +113,16 @@ Retirement is a **`schema_version 3.0.0` breaking bump**, done in two options
 (prefer **A** first, then **B** once all readers are proven on Nautobot):
 
 - **Option A — strip network fields, keep the shim.** Remove per-guest `ip`,
-  `mac`, `reserved_ip` (and `ingress*`, `domain`) from the published artifact;
+  `mac`, `reserved_ip` (and `ingress*`) from the published artifact;
   consumers pull addressing from Nautobot's dynamic inventory. Guest-lifecycle
   keys (`vmid`, `node`, `ansible_connection`, `ansible_pct_vmid`, `tags`,
   `pool_id`, `constants`) stay OpenTofu-sourced — those never live in Nautobot.
+  **`domain` also stays in the shim.** `inventory/load_tofu.yml` asserts
+  `tofu_data.domain` is defined and non-empty (the "carries the node-FQDN
+  derivation inputs" gate) and derives every LXC `ansible_host` as
+  `{node-role}.{domain}`; stripping `domain` breaks the loader before any reader
+  reaches Nautobot. It leaves only once `load_tofu.yml` itself is retired
+  (Option B).
 - **Option B — full retire.** Delete `aws_s3_object.ansible_inventory` and the
   `iac-inventory/ansible_inventory.json` key; repoint all five consumers at
   Nautobot. Only reachable after every consumer runs green on Option A.
@@ -130,8 +136,9 @@ matching the #977 "done when" state.
   to the lifecycle field set; delete/repoint the `locals.tf` network-derivation
   block; bump the published artifact to `3.0.0` (Option A: strip network fields).
 - **ansible-proxmox-apps (this repo)** — flip `ansible.cfg` inventory to
-  `inventory/nautobot.yml`; close the parity gap first (add `postgres_ai`,
-  `ai_orchestration`, `authelia` groups or confirm they moved to
+  `inventory/nautobot.yml`; close the parity gap first (add `postgres_ai_group`,
+  `ai_orchestration_group`, `authelia_group` — the exact `_group`-suffixed names
+  `load_tofu.yml` emits — or confirm they moved to
   `ansible-proxmox-ai`); land #1006 (role-managed read-only token) and #1008
   (tag sync) so the GraphQL inventory is trustworthy; retire the `load_tofu.yml`
   network-field dependence.
@@ -144,7 +151,11 @@ matching the #977 "done when" state.
   this is the largest reader change and is gated on the Nautobot model coverage
   in §7.
 - **technitium_dns role** — source A/PTR records from `IPAddress.dns_name`
-  instead of the artifact's reserved IP.
+  instead of the artifact's reserved IP. **Gap:** the GraphQL dynamic-inventory
+  query in `inventory/nautobot.yml` fetches only `name`, `primary_ip4.host`, and
+  `tags` — not `dns_name` — and the role today keys on
+  `hostvars[item].hostname`. The query must add `dns_name` and the role repoint
+  to it before this reader can flip.
 
 ## 7. Prerequisites & open questions (must close before flip)
 


### PR DESCRIPTION
## What

Adds `docs/nautobot/phase2-authority-flip-design.md` — the written Phase-2
authority-flip design, which is **exit criterion 5** of the Nautobot
source-of-truth Phase 1 (#977, gate 5 design).

Contents: the one-writer-per-field ownership map (Nautobot = network
intent/IPAM/DNS/VLANs; OpenTofu = guest lifecycle only; controllers = execution
planes), the `deployment.json` shrink-to-lifecycle plan, the
`ansible_inventory.json` `3.0.0` retirement path, per-repo change lists,
prerequisites, and rollback.

## Boundary (why this is safe to merge now)

**Design only.** Phase 2 is a separate, separately-gated engagement. This doc
does not flip any authority and does not authorize doing so. Phase 1 stays
read-only absorption: Nautobot writes to nothing but its own DB and reviewed
PRs, and never becomes the writer.

## Ground truth

Written from live recon of the Nautobot seed/SSoT pipeline (this repo), the
tofu-proxmox inventory publish flow, and the network-controller IaC domains.
No IP/host/MAC literals; cross-system references kept at this repo's existing
public-docs abstraction level.

Refs #977, #1006, #1008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)