### PR TITLE
feat(openbao): add read-only ai-public AppRole for the fabric-brain runtime domain

### DIFF
--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -551,6 +551,13 @@ openbao_hermes_write_policy_name: hermes-write
 openbao_hermes_write_approle_name: hermes-write
 openbao_public_policy_name: public
 openbao_public_approle_name: public
+# ai-public: the fabric-brain runtime domain (secret/ai/public/*, field
+# active_model). Its OWN narrow read-only credential — NOT local-llm's broader
+# ai/* read — held by the hermes_agent / open_webui brain-sync timers to
+# re-point the brain from OpenBao without a converge. See ansible-proxmox-ai
+# roles/openbao_secrets (ai-public domain) + roles/hermes_agent brain-sync.
+openbao_ai_public_policy_name: ai-public
+openbao_ai_public_approle_name: ai-public
 openbao_ai_orchestrator_policy_name: ai-orchestrator
 openbao_ai_orchestrator_approle_name: ai-orchestrator
 # ai-readonly / ai-elevated are now ACTOR ROLES that ATTACH base capability
@@ -704,6 +711,10 @@ openbao_base_approles:
     policy: "{{ openbao_hermes_write_policy_name }}"
   - name: "{{ openbao_public_approle_name }}"
     policy: "{{ openbao_public_policy_name }}"
+  # ai-public: read-only fabric-brain domain, its own narrow credential (see
+  # the name vars above) — held by the hermes / open_webui brain-sync timers.
+  - name: "{{ openbao_ai_public_approle_name }}"
+    policy: "{{ openbao_ai_public_policy_name }}"
   # GitHub token tiers: engine mints, tokens never stored. github-read and
   # github-write are standing ambient identities consumed by nix-darwin's
   # `openbao-github-creds` (role_id/secret_id operator-held in Doppler,
@@ -844,6 +855,8 @@ openbao_base_policies:
     template: hermes-write-policy.hcl.j2
   - name: "{{ openbao_public_policy_name }}"
     template: public-policy.hcl.j2
+  - name: "{{ openbao_ai_public_policy_name }}"
+    template: ai-public-policy.hcl.j2
   # GitHub token tiers (workstation git/gh). Engine mints only — each template
   # names its own boundary: read-* sets, the parameter-pinned raw token path,
   # or the human-gated *-full-automation sets.

--- a/roles/openbao/templates/ai-public-policy.hcl.j2
+++ b/roles/openbao/templates/ai-public-policy.hcl.j2
@@ -1,0 +1,18 @@
+{{ ansible_managed | comment }}
+# OpenBao policy for the ai-public AppRole — the fabric-brain coordination
+# domain. Read-only on secret/ai/public/*: non-secret operational values that
+# no engine can mint (e.g. active_model, the fabric-brain id an operator picks).
+# Consumed by the hermes_agent / open_webui brain-sync timers in
+# ansible-proxmox-ai to re-point the brain from OpenBao alone, no converge —
+# see that repo's roles/openbao_secrets (ai-public domain) and
+# roles/hermes_agent brain-sync. Deliberately its OWN narrow credential, never
+# local-llm's broader ai/* read: a guest holding this reads only ai/public/*,
+# not the rest of ai/*.
+
+path "{{ openbao_kv_mount }}/data/ai/public/*" {
+  capabilities = ["read"]
+}
+
+path "{{ openbao_kv_mount }}/metadata/ai/public/*" {
+  capabilities = ["read", "list"]
+}

--- a/roles/openbao/templates/ai-public-policy.hcl.j2
+++ b/roles/openbao/templates/ai-public-policy.hcl.j2
@@ -13,6 +13,10 @@ path "{{ openbao_kv_mount }}/data/ai/public/*" {
   capabilities = ["read"]
 }
 
+# read only, no list: the brain-sync consumer reads one known key
+# (data/ai/public/brain) and never enumerates the subtree, so LIST is unused.
+# Dropping it also sidesteps the KV-v2 gotcha that a `metadata/ai/public/*`
+# glob does not match the bare `metadata/ai/public` a LIST actually targets.
 path "{{ openbao_kv_mount }}/metadata/ai/public/*" {
-  capabilities = ["read", "list"]
+  capabilities = ["read"]
 }


### PR DESCRIPTION
## What

Companion to [ansible-proxmox-ai#49](https://github.com/dryvist/ansible-proxmox-ai/pull/49) (merged), which made the fabric brain an OpenBao **runtime** var — `secret/ai/public/brain`, field `active_model` — that the `hermes_agent` and `open_webui` brain-sync timers poll to re-point the brain with **no converge**. Those consumers authenticate with a dedicated `ai-public` AppRole. Until this server-side role/policy exists, the domain resolves to its literal fallback only (`ai_default_model`), so #49 is inert without this.

This mirrors the existing **`public`** domain exactly (a standalone read-only AppRole):

- new `roles/openbao/templates/ai-public-policy.hcl.j2` — `read` on `secret/data/ai/public/*`, `read`+`list` on the `metadata` subtree; nothing wider.
- `ai-public` name vars + one row each in `openbao_base_policies` / `openbao_base_approles`.

Deliberately its **own narrow** credential rather than `local-llm`'s broader `ai/*` read: a guest holding this can read only `ai/public/*`, never the rest of `ai/*` — the whole point of Option A.

## `openbao-plugins-first` gate

1. **Resource:** the fabric-brain coordination value (`active_model`) — a non-secret model id an operator picks.
2. **Engine exists?** No. The GitHub/AWS engines are irrelevant; no engine can mint a *chosen model id*.
3. **Mint path:** N/A — no engine produces this value.
4. **Why KV read is justified:** app-config coordination material with no backing engine — exactly KV's stated job ("values nothing can mint").

## Validation

- `yamllint roles/openbao/defaults/main.yml` — clean.
- `ansible-lint roles/openbao/{defaults/main.yml,tasks/init.yml}` — **0 failures, 0 warnings** (production profile).
- No task-logic changes: `init.yml` already loops `openbao_base_policies` / `openbao_base_approles`, so it renders the template, `bao policy write`s it, and `bao write auth/approle/role/ai-public` with no edits. Runtime effect (policy scope + approle binding) is only exercised at a live converge — molecule's `openbao` scenario doesn't start OpenBao under Docker.

## Go-live after merge (separate, operator-run)

1. Converge the openbao role (supply `BAO_TOKEN`) → mints `ai-public` role_id/secret_id (add-if-missing), emits the break-glass file on the controller.
2. Publish those to Doppler tier-0 as `AI_PUBLIC_VAULT_ROLE_ID` / `AI_PUBLIC_VAULT_SECRET_ID` (NOT ambient — unlike `public`).
3. Seed the value: `bao kv patch secret/ai/public/brain active_model=mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit`.
4. Converge `hermes_agent` (under `doppler run`) → `/etc/hermes-brain-sync.env` lands on the guest; the 5-min timer picks up the brain live.

## Not in scope

No `secret/ai/public/brain` value is seeded by this role (that's step 3, an operator action). No CIDR binding (matches every other AppRole here today; tracked separately).