### PR TITLE
fix(postgres): reconcile orphaned physical replication slots on the primary

### DIFF
--- a/molecule/postgres/converge.yml
+++ b/molecule/postgres/converge.yml
@@ -11,6 +11,14 @@
 
   vars:
     postgres_listen_addresses: localhost
+    # Make this single container its own primary so the replication/slot block
+    # runs. No second container exists, so pin the expected-standby slot list
+    # rather than deriving it from group membership. This is what lets the
+    # verify play assert the slot create + orphan reconcile behaviour.
+    postgres_primary_host: postgres-test
+    postgres_replication_password: molecule-replication-pw
+    postgres_expected_replication_slots:
+      - standby_fake_standby
     postgres_managed_databases:
       - name: nautobot
         user: nautobot

--- a/molecule/postgres/verify.yml
+++ b/molecule/postgres/verify.yml
@@ -82,3 +82,57 @@
         that:
           - pg_backup_timer.stat.exists
         fail_msg: "pg-backup.timer was not installed"
+
+    # --- Replication-slot orphan reconcile (Zammad #17050) ---
+    # converge created standby_fake_standby (the one expected standby). Seed a
+    # stale slot with no matching standby, re-run the role, and prove the
+    # reconcile drops the orphan while keeping the expected (also inactive) slot.
+    - name: Gather facts before re-running the role
+      ansible.builtin.setup:
+
+    - name: Seed a stale orphan physical slot with no matching standby
+      become: true
+      become_user: postgres
+      community.postgresql.postgresql_slot:
+        name: standby_stale_orphan
+        slot_type: physical
+        state: present
+
+    - name: Re-run the role so the primary reconcile drops the orphan
+      ansible.builtin.include_role:
+        name: postgres
+      vars:
+        postgres_listen_addresses: localhost
+        postgres_primary_host: postgres-test
+        postgres_replication_password: molecule-replication-pw
+        postgres_expected_replication_slots:
+          - standby_fake_standby
+        postgres_managed_databases:
+          - name: nautobot
+            user: nautobot
+            password: molecule-nautobot-pw
+            client_cidr: 127.0.0.1/32
+
+    - name: Query physical replication slots after reconcile
+      become: true
+      become_user: postgres
+      community.postgresql.postgresql_query:
+        db: postgres
+        query: "SELECT slot_name FROM pg_replication_slots WHERE slot_type = 'physical'"
+      register: postgres_slots_after
+      changed_when: false
+
+    # A genuinely active=true slot needs a streaming standby, impossible
+    # single-node. The expected-but-inactive standby_fake_standby covers the same
+    # keep-guard (active=false slots that ARE expected must survive) that protects
+    # a live standby briefly down; add a two-container scenario only if it regresses.
+    - name: Assert the orphan was dropped and the expected slot kept
+      ansible.builtin.assert:
+        that:
+          - "'standby_stale_orphan' not in slot_names"
+          - "'standby_fake_standby' in slot_names"
+        fail_msg: >-
+          reconcile did not drop the orphan or dropped an expected slot;
+          slots present: {{ slot_names }}
+      vars:
+        slot_names: "{{ postgres_slots_after.query_result | map(attribute='slot_name') | list }}"

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -126,6 +126,15 @@ postgres_replication_password: >-
 # One physical slot per standby, so the primary retains WAL while a standby is
 # down instead of relying on wal_keep_size guesswork.
 postgres_replication_slot: "standby_{{ inventory_hostname | regex_replace('[^A-Za-z0-9]', '_') }}"
+# Final physical-slot names the primary must have — one per standby in this
+# cluster. Single source of truth for the create loop and the orphan reconcile,
+# so the name transform can never drift between them. Lazily evaluated, so
+# groups[...] resolves per-host at runtime and stays overridable (molecule).
+postgres_expected_replication_slots: >-
+  {{ groups.get(postgres_cluster_group, [])
+     | difference([postgres_primary_host])
+     | map('regex_replace', '[^A-Za-z0-9]', '_')
+     | map('regex_replace', '^', 'standby_') | list }}
 # CIDR the primary accepts replication connections from (the standby's subnet).
 # Same env-derived pg_hba pattern as the app client_cidrs — pg_hba needs a CIDR,
 # not an FQDN, so this is the one legitimate place for one, and even here it is

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -346,12 +346,34 @@
 
     - name: Ensure a physical replication slot exists for each standby
       community.postgresql.postgresql_slot:
-        name: "standby_{{ item | regex_replace('[^A-Za-z0-9]', '_') }}"
+        name: "{{ item }}"
         slot_type: physical
         state: present
+      loop: "{{ postgres_expected_replication_slots }}"
+      loop_control:
+        label: "{{ item }}"
+
+    # Reconcile: a standby removed from the cluster leaves its slot behind, and
+    # an inactive slot retains WAL forever. Drop any inactive physical slot with
+    # no matching converged standby. The active = false filter means a live
+    # standby's slot (even one briefly down but still expected) is never a drop
+    # candidate; postgresql_slot state=absent also refuses an active slot.
+    - name: Enumerate inactive physical replication slots
+      community.postgresql.postgresql_query:
+        db: postgres
+        query: >-
+          SELECT slot_name FROM pg_replication_slots
+          WHERE slot_type = 'physical' AND active = false
+      register: postgres_inactive_slots
+      changed_when: false
+
+    - name: Drop inactive slots with no converged standby (orphan reconcile)
+      community.postgresql.postgresql_slot:
+        name: "{{ item }}"
+        state: absent
       loop: >-
-        {{ groups[postgres_cluster_group] | default([])
-           | difference([postgres_primary_host]) }}
+        {{ postgres_inactive_slots.query_result | map(attribute='slot_name') | list
+           | difference(postgres_expected_replication_slots) }}
       loop_control:
         label: "{{ item }}"
 


### PR DESCRIPTION
## What

The primary creates one physical replication slot per standby but never dropped slots for standbys that no longer exist, so an inactive slot retained WAL forever. On the ai primary two such orphans exist (pre-#1081 artifacts: a renamed standby and a wrong-cluster name).

Adds an idempotent, **primary-only** reconcile step in the postgres role:

- Enumerate inactive physical slots (`active = false`), then drop any whose name is not in the expected-standby set for that cluster.
- Two safety layers keep a live standby's slot: the `active = false` query filter (a slot that is streaming, or expected but briefly down, is never a drop candidate) and `postgresql_slot state=absent` refusing an active slot.
- New `postgres_expected_replication_slots` default is the single source of truth for the slot-name transform, consumed by both the create loop and the reconcile diff so they can never drift.

Because the reconcile is gated inside the existing `postgres_role == 'primary'` + `postgres_replication_enabled` block, it cleans whichever cluster is converged (each cluster names its own `postgres_cluster_group`). The shared-apps cluster runs replication-disabled, so it has no slots and the block is skipped there.

## Design note

Uses the dedicated `community.postgresql.postgresql_slot` module for the drop (idempotent, already used for creation) rather than a raw `pg_drop_replication_slot` query; `postgresql_query` is used only to enumerate.

## Test

`molecule test -s postgres` — green end to end:

- **Idempotence play `changed=0`** — clean converge is a no-op; the drop loop is empty when there is no orphan.
- **Verify play** seeds a stale inactive slot, re-runs the role, and asserts the orphan was dropped (`changed: item=standby_stale_orphan`) while the expected (also inactive) slot survives — the exact guard that protects a live standby that is briefly down.

`ansible-lint roles/postgres molecule/postgres` passes clean.

Follow-up (verified post-merge, not in this PR): converge the ai cluster (`--tags postgres`) to clear the two live orphans, then confirm only the active standby slot remains.