### PR TITLE
fix(nautobot): role-managed read-only inventory token via OpenBao (#1006)

### DIFF
--- a/roles/nautobot/defaults/main.yml
+++ b/roles/nautobot/defaults/main.yml
@@ -74,6 +74,23 @@ nautobot_superuser_name: admin
 nautobot_superuser_email: "admin@{{ nautobot_ui_fqdn }}"
 nautobot_superuser_password: ""
 
+# Read-only inventory token (issue #1006). Opt-in: the converge enables it with
+# -e '{"nautobot_token_publish_openbao": true}' and BAO_ADDR/BAO_TOKEN in the
+# controller env. Mints a write-disabled, non-privileged token and publishes it
+# (with the API URL) to OpenBao apps KV so the GraphQL dynamic inventory reads it
+# bao-first instead of the superuser creds. The KV write preserves siblings, so
+# the superuser fields at the same path are untouched. Consumers map
+# nautobot_token_openbao_token_key -> NAUTOBOT_TOKEN, url_key -> NAUTOBOT_URL.
+nautobot_token_publish_openbao: false
+nautobot_ro_username: svc-inventory-ro
+nautobot_ro_url: "https://{{ nautobot_ui_fqdn }}"
+nautobot_token_openbao_addr: "{{ lookup('env', 'BAO_ADDR') | default('', true) }}"
+nautobot_token_openbao_token: "{{ lookup('env', 'BAO_TOKEN') | default('', true) }}"
+nautobot_token_openbao_mount: secret
+nautobot_token_openbao_path: apps/nautobot
+nautobot_token_openbao_url_key: inventory_url
+nautobot_token_openbao_token_key: inventory_ro_token
+
 # Jobs. The SSoT seed jobs, export job, and onboarding setup ship in
 # files/jobs and are copied into JOBS_ROOT.
 nautobot_jobs_root: "{{ nautobot_root }}/jobs"

--- a/roles/nautobot/files/readonly_token_bootstrap.py
+++ b/roles/nautobot/files/readonly_token_bootstrap.py
@@ -1,0 +1,77 @@
+"""Idempotently ensure a read-only Nautobot API token for the dynamic inventory.
+
+Run via ``nautobot-server shell --interface python`` (mirrors
+``superuser_bootstrap.py``). Ensures a non-privileged service account, grants it
+a view-only ObjectPermission on the object types the GraphQL dynamic inventory
+reads (Device, VirtualMachine, Tag), and mints one write-disabled Token for it.
+Prints ``RO_TOKEN=<key>`` (always, so the caller can publish it) and
+``RO_TOKEN_CHANGED`` only when a database row changed.
+
+Fail-closed by construction: the user is never superuser/staff and the token has
+``write_enabled = False``, so a mistaken or missing permission grant yields *no*
+access (caught by the inventory parity check), never excess access — the token
+cannot write regardless of permissions. Issue #1006.
+
+Live-validation note (verify at cutover): Nautobot 2.x ``users.Token`` /
+``users.ObjectPermission`` field names (``write_enabled``, ``actions``,
+``object_types``) target current 2.x and can shift across minor versions.
+"""
+import os
+
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from nautobot.users.models import ObjectPermission, Token
+
+User = get_user_model()
+
+username = os.environ.get("NAUTOBOT_RO_USERNAME", "svc-inventory-ro")
+PERM_NAME = "ansible-readonly-inventory"
+TOKEN_DESC = "ansible-readonly-inventory"
+
+# Object types the GraphQL dynamic inventory reads (inventory/nautobot.yml).
+RO_TYPES = [
+    ("dcim", "device"),
+    ("virtualization", "virtualmachine"),
+    ("extras", "tag"),
+]
+
+changed = False
+
+user, created = User.objects.get_or_create(
+    username=username, defaults={"is_active": True}
+)
+changed = changed or created
+# Never privileged — re-enforce every run in case it was changed by hand.
+if user.is_superuser or user.is_staff:
+    user.is_superuser = False
+    user.is_staff = False
+    user.save()
+    changed = True
+
+perm, perm_created = ObjectPermission.objects.get_or_create(
+    name=PERM_NAME, defaults={"actions": ["view"]}
+)
+changed = changed or perm_created
+if perm.actions != ["view"]:
+    perm.actions = ["view"]
+    perm.save()
+    changed = True
+perm.object_types.set(
+    ContentType.objects.get(app_label=app, model=model) for app, model in RO_TYPES
+)
+if not perm.users.filter(pk=user.pk).exists():
+    perm.users.add(user)
+    changed = True
+
+token = Token.objects.filter(user=user, description=TOKEN_DESC).first()
+if token is None:
+    token = Token(user=user, description=TOKEN_DESC, write_enabled=False)
+    token.save()
+    changed = True
+elif token.write_enabled:  # re-enforce read-only on an existing token
+    token.write_enabled = False
+    token.save()
+    changed = True
+
+print("RO_TOKEN=" + token.key)
+print("RO_TOKEN_CHANGED" if changed else "RO_TOKEN_UNCHANGED")

--- a/roles/nautobot/tasks/main.yml
+++ b/roles/nautobot/tasks/main.yml
@@ -287,6 +287,10 @@
       become_user: "{{ nautobot_user }}"
       no_log: true
 
+    - name: Publish a role-managed read-only inventory token to OpenBao
+      ansible.builtin.include_tasks: readonly_token.yml
+      when: nautobot_token_publish_openbao | bool
+
     - name: Apply pending systemd reload before starting services
       ansible.builtin.meta: flush_handlers
 

--- a/roles/nautobot/tasks/readonly_token.yml
+++ b/roles/nautobot/tasks/readonly_token.yml
@@ -1,0 +1,88 @@
+---
+# Mint a role-managed, read-only Nautobot API token for the GraphQL dynamic
+# inventory (issue #1006) and publish it (with the API URL) to OpenBao so the
+# inventory plugin reads it bao-first — instead of the superuser creds that
+# secret/apps/nautobot holds today. Included from tasks/main.yml only when
+# nautobot_token_publish_openbao is true; BAO_ADDR/BAO_TOKEN must be in the
+# CONTROLLER environment. Mirrors roles/vikunja/tasks/mcp_tokens.yml (KV v2
+# read-modify-write that preserves sibling keys — the superuser creds stay put).
+
+- name: Assert OpenBao write credentials are present
+  ansible.builtin.assert:
+    that:
+      - nautobot_token_openbao_addr | length > 0
+      - nautobot_token_openbao_token | length > 0
+    fail_msg: >-
+      nautobot_token_publish_openbao is on but BAO_ADDR/BAO_TOKEN are unset.
+      Provide a write-capable OpenBao AppRole in the converge environment.
+    quiet: true
+
+- name: Resolve the OpenBao KV v2 data URL
+  ansible.builtin.set_fact:
+    nautobot_bao_kv_url: >-
+      {{ nautobot_token_openbao_addr }}/v1/{{
+      nautobot_token_openbao_mount }}/data/{{ nautobot_token_openbao_path }}
+
+- name: Ensure the read-only inventory token exists
+  ansible.builtin.command:
+    cmd: "{{ nautobot_root }}/bin/nautobot-server shell --interface python"
+    stdin: "{{ lookup('ansible.builtin.file', 'readonly_token_bootstrap.py') }}"
+  environment: "{{ nautobot_env | combine({'NAUTOBOT_RO_USERNAME': nautobot_ro_username}) }}"
+  register: nautobot_ro_token_run
+  changed_when: "'RO_TOKEN_CHANGED' in nautobot_ro_token_run.stdout"
+  become: true
+  become_user: "{{ nautobot_user }}"
+  no_log: true
+
+- name: Extract the read-only token from the bootstrap output
+  ansible.builtin.set_fact:
+    nautobot_ro_token: "{{ nautobot_ro_token_run.stdout | regex_search('RO_TOKEN=(\\S+)', '\\1') }}"
+  no_log: true
+
+- name: Read current OpenBao secret at {{ nautobot_token_openbao_path }}
+  ansible.builtin.uri:
+    url: "{{ nautobot_bao_kv_url }}"
+    method: GET
+    headers:
+      X-Vault-Token: "{{ nautobot_token_openbao_token }}"
+    validate_certs: false
+    status_code: [200, 404]
+  register: nautobot_bao_current
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  no_log: true
+
+- name: Capture the current secret data (preserve siblings on write)
+  ansible.builtin.set_fact:
+    nautobot_bao_data: "{{ (nautobot_bao_current.json | default({}, true)).get('data', {}).get('data', {}) }}"
+  no_log: true
+
+# KV v2 replaces the whole secret, so merge the read-only URL + token over the
+# current data to preserve the superuser siblings. Guarded on an actual delta so
+# repeat converges no-op once URL + token are present and current.
+- name: Publish the read-only inventory connection to OpenBao
+  ansible.builtin.uri:
+    url: "{{ nautobot_bao_kv_url }}"
+    method: POST
+    headers:
+      X-Vault-Token: "{{ nautobot_token_openbao_token }}"
+    body_format: json
+    body:
+      data: >-
+        {{ nautobot_bao_data
+           | combine({nautobot_token_openbao_url_key: nautobot_ro_url})
+           | combine({nautobot_token_openbao_token_key: nautobot_ro_token}) }}
+    validate_certs: false
+    status_code: [200, 204]
+  delegate_to: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_become: false
+  when: >-
+    nautobot_bao_data.get(nautobot_token_openbao_token_key) != nautobot_ro_token
+    or nautobot_bao_data.get(nautobot_token_openbao_url_key) != nautobot_ro_url
+  no_log: true

--- a/roles/nautobot/tasks/readonly_token.yml
+++ b/roles/nautobot/tasks/readonly_token.yml
@@ -36,7 +36,7 @@
 
 - name: Extract the read-only token from the bootstrap output
   ansible.builtin.set_fact:
-    nautobot_ro_token: "{{ nautobot_ro_token_run.stdout | regex_search('RO_TOKEN=(\\S+)', '\\1') }}"
+    nautobot_ro_token: "{{ (nautobot_ro_token_run.stdout | regex_search('RO_TOKEN=(\\S+)', '\\1')) | first }}"
   no_log: true
 
 - name: Read current OpenBao secret at {{ nautobot_token_openbao_path }}


### PR DESCRIPTION
> **Draft — needs a live converge to verify.** Opened as draft because two
> aspects cannot be checked offline (this env has no live Nautobot): the exact
> Nautobot 2.x `users.Token` / `users.ObjectPermission` field names, and the KV
> field → `NAUTOBOT_TOKEN` consumer mapping. Please review the security-sensitive
> bootstrap before merge.

## What

Closes the #1006 gap. `inventory/nautobot.yml` authenticates with the **superuser**
creds in OpenBao `secret/apps/nautobot`, which is wrong for read-only inventory
use. This makes a read-only token **converge-owned**, behind an opt-in flag.

## Changes

- `files/readonly_token_bootstrap.py` — idempotent, non-privileged service
  account + a view-only `ObjectPermission` (Device / VirtualMachine / Tag) + one
  `write_enabled=False` Token. Mirrors `superuser_bootstrap.py`.
- `tasks/readonly_token.yml` — mint via the bootstrap, then a KV v2
  read-modify-write publish of `{inventory_url, inventory_ro_token}` to the apps
  path that **preserves the superuser siblings**. Mirrors the vikunja
  `mcp_tokens.yml` pattern. `no_log` throughout.
- `defaults` — `nautobot_token_publish_openbao` (opt-in, default `false`) + KV
  path/field vars; `main.yml` includes it in the `manage_app` block after the
  superuser task.

## Fail-closed by design

The service user is **never** superuser/staff and the token is
`write_enabled=False`, so a mistaken or missing permission grant yields **no**
access (caught by the inventory parity check), never excess — the token cannot
write regardless of permissions.

## OpenBao rule check (per `.claude/rules/openbao-plugins-first.md`)

Nautobot app tokens have no OpenBao secrets engine (not GitHub/AWS). The token is
**generated at source** (by Nautobot's own ORM) and only the resulting value is
stored in KV as the shared connection — this is the sanctioned pattern for
engine-less app credentials, identical to the vikunja MCP tokens. No static
credential is seeded; nothing an engine could mint is placed in KV.

## Verification

Offline: `py_compile` + `ansible-lint` (production, 0 failures) + yaml parse — all
pass. Seed/token tasks are gated off by default, so this cannot regress a default
converge. **Un-drafting requires** a converge with `nautobot_token_publish_openbao=true`
+ `BAO_ADDR`/`BAO_TOKEN`, then confirming `ansible -i inventory/nautobot.yml <group> -m ping`
resolves using the minted read-only token.

Refs #977, #992, #1008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)