### PR TITLE
feat(zammad): wire built-in AI at the LLM router + ITSM tunings

### DIFF
--- a/roles/zammad/defaults/main.yml
+++ b/roles/zammad/defaults/main.yml
@@ -109,6 +109,17 @@ zammad_ai_features:
   - ai_assistance_ticket_summary
   - ai_assistance_text_tools
 
+# --- GitHub issue-linking (opt-in) -------------------------------------------
+# Zammad's native GitHub integration links tickets to GitHub issues. OFF by
+# default; the operator flips zammad_configure_github with -e once a read-tier
+# token is in the converge environment. PLUGINS-FIRST (binding rule): GitHub has
+# a live OpenBao engine, so this PAT is NEVER seeded into secret/* KV — it is
+# minted per converge from github/token/read-* and passed as ZAMMAD_GITHUB_API_TOKEN,
+# re-asserted each run (short-lived, attributable, re-minted). endpoint is the
+# public GraphQL API; override only for GitHub Enterprise Server.
+zammad_configure_github: false
+zammad_github_endpoint: "https://api.github.com/graphql"
+zammad_github_api_token: "{{ lookup('env', 'ZAMMAD_GITHUB_API_TOKEN') | default('', true) }}"
 # --- Human SSO account (Authelia forwardAuth identity) ------------------------
 # `login` MUST equal the Authelia username verbatim: Zammad's create_sso does
 # User.lookup(login: ...) on the Remote-User header value, so the email is
@@ -195,6 +206,42 @@ zammad_overviews:
 zammad_extra_priority:
   id: 4
   name: 4 critical
+
+# Incident-response ticket templates (prefill the create form), seeded
+# idempotently by name — mirrors the zammad_overviews declarative-data pattern.
+# `group`/`priority` are resolved to ids by NAME in the bootstrap (so the YAML
+# stays free of Zammad internal ids). `detection_method` is applied only when
+# the opt-in incident custom field exists, so a template still seeds cleanly on
+# an instance that never ran the zammad_seed_incidents field seed.
+zammad_ticket_templates:
+  - name: "Incident — Homelab Infrastructure"
+    group: Homelab Infrastructure
+    priority: 3 high
+    title: "Incident: "
+    detection_method: alert
+  - name: "Incident — AI/LLM Serving"
+    group: AI/LLM Serving
+    priority: 3 high
+    title: "Incident: "
+    detection_method: alert
+  - name: "Incident — critical outage"
+    group: Incidents
+    priority: 4 critical
+    title: "Outage: "
+    detection_method: user-report
+
+# Knowledge-base answers that link OUT to the docs site. Zammad has no dedicated
+# redirect field, so each answer's rich-HTML body carries the outbound link.
+# Seeded idempotently by title into a "Documentation" category. Data-driven so
+# the docs URLs live here, not in the Ruby. Best-effort in the bootstrap.
+zammad_kb_docs_category: Documentation
+zammad_kb_answers:
+  - title: "Deployment state contract"
+    url: "https://docs.jacobpevans.com/infrastructure/deployment-state-contract"
+    blurb: "The upstream desired-state ACID single-writer contract for the estate."
+  - title: "Infrastructure docs (home)"
+    url: "https://docs.jacobpevans.com/infrastructure"
+    blurb: "Top-level infrastructure documentation for the homelab + AI estate."
 
 # --- Outbound email via the Mailpit relay (no real mail) ---------------------
 zammad_smtp_host: "mailpit.{{ tofu_data.domain }}"

--- a/roles/zammad/files/zammad_bootstrap.rb
+++ b/roles/zammad/files/zammad_bootstrap.rb
@@ -315,16 +315,32 @@ begin
         changed = true
       end
       answers.each do |a|
-        next if KnowledgeBase::Answer::Translation.exists?(title: a['title'])
         body = "<p>#{a['blurb']}</p>" \
                "<p><a href=\"#{a['url']}\" target=\"_blank\" rel=\"noopener\">#{a['url']}</a></p>"
-        answer = category.answers.create!
-        answer.translations.create!(
-          title: a['title'], kb_locale: kb_locale,
-          content: KnowledgeBase::Answer::Translation::Content.new(body: body)
-        )
-        answer.update!(published_at: Time.current) if answer.respond_to?(:published_at)
-        changed = true
+        translation = KnowledgeBase::Answer::Translation.find_by(title: a['title'])
+        if translation.nil?
+          answer = category.answers.create!
+          answer.translations.create!(
+            title: a['title'], kb_locale: kb_locale,
+            content: KnowledgeBase::Answer::Translation::Content.new(body: body)
+          )
+          answer.update!(published_at: Time.current) if answer.respond_to?(:published_at)
+          changed = true
+        else
+          # Reconcile drift when the docs URL or blurb changes. Compare on the
+          # URL + blurb TEXT, not the exact body: Zammad sanitizes answer HTML on
+          # save (tag/attribute rewrites), so an exact-body compare would report
+          # changed on every converge.
+          stored = translation.content&.body.to_s
+          unless stored.include?(a['url']) && stored.include?(a['blurb'])
+            if translation.content
+              translation.content.update!(body: body)
+            else
+              translation.update!(content: KnowledgeBase::Answer::Translation::Content.new(body: body))
+            end
+            changed = true
+          end
+        end
       end
     end
   end
@@ -341,7 +357,6 @@ end
 begin
   require 'json'
   JSON.parse(ENV['ZAMMAD_TICKET_TEMPLATES'] || '[]').each do |tpl|
-    next if Template.exists?(name: tpl['name'])
     grp  = Group.find_by(name: tpl['group'])
     prio = Ticket::Priority.find_by(name: tpl['priority'])
     options = {}
@@ -351,8 +366,17 @@ begin
     if tpl['detection_method'] && ObjectManager::Attribute.get(object: 'Ticket', name: 'detection_method')
       options['ticket.detection_method'] = { 'value' => tpl['detection_method'] }
     end
-    Template.create!(name: tpl['name'], active: true, options: options)
-    changed = true
+    # find-or-create, reconciling options on drift so an edit to the role YAML
+    # propagates. Template#options is stored verbatim, so this compare is stable
+    # across converges (no churn).
+    template = Template.find_by(name: tpl['name'])
+    if template.nil?
+      Template.create!(name: tpl['name'], active: true, options: options)
+      changed = true
+    elsif template.options != options
+      template.update!(options: options)
+      changed = true
+    end
   end
 rescue => e
   warn "WARN: ticket templates not seeded automatically (#{e.class}: #{e.message}). Create them once in the UI."

--- a/roles/zammad/files/zammad_bootstrap.rb
+++ b/roles/zammad/files/zammad_bootstrap.rb
@@ -59,6 +59,11 @@ end
   'fqdn'             => fqdn,
   'http_type'       => 'https',
   'storage_provider' => 'File',
+  # Hard-set the system identifier to 1. Zammad assigns a random id (1-99) at
+  # install (this instance drew 17); pin it so the ticket-number prefix is
+  # deterministic across rebuilds. Stored as an Integer — set_setting compares
+  # Setting.get('system_id') (Integer) to this, so a re-run is a no-op.
+  'system_id'       => 1,
   'es_url'          => es_url,
   'auth_sso'        => true,
   # A comma-separated STRING, never an Array: Auth::Sso::TrustedIps does
@@ -67,6 +72,23 @@ end
   # rejected for everyone. CIDR entries are supported.
   'auth_sso_trusted_ips' => sso_ips.split(',').map(&:strip).reject(&:empty?).join(','),
 }.each { |k, v| changed = true if set_setting(k, v) }
+
+# --- GitHub issue-linking (opt-in) -------------------------------------------
+# Enabled only when ZAMMAD_CONFIGURE_GITHUB=true AND a token is present. The
+# token is minted per converge from the OpenBao github engine (github/token/
+# read-*), never seeded into KV. Best-effort: github_config runs verify!, which
+# reaches out to the GitHub API and can take a moment.
+if ENV['ZAMMAD_CONFIGURE_GITHUB'] == 'true' && !ENV['ZAMMAD_GITHUB_API_TOKEN'].to_s.empty?
+  begin
+    changed = true if set_setting('github_config', {
+      'endpoint'  => env!('ZAMMAD_GITHUB_ENDPOINT'),
+      'api_token' => env!('ZAMMAD_GITHUB_API_TOKEN'),
+    })
+    changed = true if set_setting('github_integration', true)
+  rescue => e
+    warn "WARN: GitHub integration not configured (#{e.class}: #{e.message}). Set it once in Admin -> Integrations -> GitHub."
+  end
+end
 
 # --- Admin user (create-or-find; ensure Admin+Agent + active) ----------------
 admin = User.find_by(email: admin_email.downcase)
@@ -255,18 +277,85 @@ rescue => e
   warn "WARN: Mailpit notification channel not configured automatically (#{e.class}: #{e.message}). Configure it once in the UI."
 end
 
-# --- Knowledge base (best-effort; manual UI fallback) ------------------------
+# --- Knowledge base + docs-linking answers (best-effort; manual UI fallback) --
+# Creates the KB if absent, then ensures a "Documentation" category whose answers
+# link OUT to the docs site — the external link lives in the rich-HTML answer
+# body (Zammad has no dedicated redirect field). All wrapped: KB model APIs shift
+# between versions, so drift WARNS rather than aborting, and every step has a
+# one-screen UI fallback. Idempotent by KB presence + category/answer title.
 begin
-  if defined?(KnowledgeBase) && KnowledgeBase.count.zero?
-    kb = KnowledgeBase.create!(
-      iconset: 'FontAwesome', color_highlight: '#38ae6a', color_header: '#f9fafb',
-      homepage_layout: 'grid', category_layout: 'grid', active: true, translations: []
-    )
-    kb.kb_locales.create!(kb_locale: 'en-us', primary: true) if kb.respond_to?(:kb_locales)
+  if defined?(KnowledgeBase)
+    kb = KnowledgeBase.first
+    if kb.nil?
+      kb = KnowledgeBase.create!(
+        iconset: 'FontAwesome', color_highlight: '#38ae6a', color_header: '#f9fafb',
+        homepage_layout: 'grid', category_layout: 'grid', active: true, translations: []
+      )
+      changed = true
+    end
+
+    kb_locale = nil
+    if kb.respond_to?(:kb_locales)
+      kb_locale = kb.kb_locales.find_by(primary: true) || kb.kb_locales.first
+      if kb_locale.nil?
+        kb_locale = kb.kb_locales.create!(kb_locale: 'en-us', primary: true)
+        changed = true
+      end
+    end
+
+    require 'json'
+    cat_name = ENV['ZAMMAD_KB_DOCS_CATEGORY'].to_s
+    answers  = JSON.parse(ENV['ZAMMAD_KB_ANSWERS'] || '[]')
+    if kb_locale && !cat_name.empty? && answers.any?
+      # find-or-create the docs category, matched by its translated title
+      category = kb.categories.detect { |c| c.translations.any? { |t| t.title == cat_name } }
+      if category.nil?
+        category = kb.categories.create!(category_icon: 'f02d')
+        category.translations.create!(title: cat_name, kb_locale: kb_locale)
+        changed = true
+      end
+      answers.each do |a|
+        next if KnowledgeBase::Answer::Translation.exists?(title: a['title'])
+        body = "<p>#{a['blurb']}</p>" \
+               "<p><a href=\"#{a['url']}\" target=\"_blank\" rel=\"noopener\">#{a['url']}</a></p>"
+        answer = category.answers.create!
+        answer.translations.create!(
+          title: a['title'], kb_locale: kb_locale,
+          content: KnowledgeBase::Answer::Translation::Content.new(body: body)
+        )
+        answer.update!(published_at: Time.current) if answer.respond_to?(:published_at)
+        changed = true
+      end
+    end
+  end
+rescue => e
+  warn "WARN: knowledge base docs answers not seeded automatically (#{e.class}: #{e.message}). Add them once in the UI."
+end
+
+# --- Incident ticket templates (best-effort; declarative data via ENV json) --
+# Prefill the ticket-create form for fast incident filing. Idempotent by name.
+# group/priority are resolved by NAME here so the role YAML carries no Zammad
+# ids. Optional incident custom fields (detection_method) are added ONLY when the
+# attribute exists, so a template still seeds cleanly on an instance that never
+# ran the opt-in zammad_seed_incidents custom-field seed.
+begin
+  require 'json'
+  JSON.parse(ENV['ZAMMAD_TICKET_TEMPLATES'] || '[]').each do |tpl|
+    next if Template.exists?(name: tpl['name'])
+    grp  = Group.find_by(name: tpl['group'])
+    prio = Ticket::Priority.find_by(name: tpl['priority'])
+    options = {}
+    options['ticket.title'] = { 'value' => tpl['title'] } if tpl['title']
+    options['ticket.group_id'] = { 'value' => grp.id.to_s, 'value_completion' => grp.name } if grp
+    options['ticket.priority_id'] = { 'value' => prio.id.to_s, 'value_completion' => prio.name } if prio
+    if tpl['detection_method'] && ObjectManager::Attribute.get(object: 'Ticket', name: 'detection_method')
+      options['ticket.detection_method'] = { 'value' => tpl['detection_method'] }
+    end
+    Template.create!(name: tpl['name'], active: true, options: options)
     changed = true
   end
 rescue => e
-  warn "WARN: knowledge base not created automatically (#{e.class}: #{e.message}). Create it once in the UI."
+  warn "WARN: ticket templates not seeded automatically (#{e.class}: #{e.message}). Create them once in the UI."
 end
 
 # --- Overviews: saved filtered views, defined as DATA in zammad_overviews ----

--- a/roles/zammad/tasks/main.yml
+++ b/roles/zammad/tasks/main.yml
@@ -445,6 +445,14 @@
         ZAMMAD_AI_MODEL: "{{ zammad_ai_model }}"
         ZAMMAD_AI_PROVIDER_TOKEN: "{{ zammad_ai_provider_token }}"
         ZAMMAD_AI_FEATURES: "{{ zammad_ai_features | join(',') }}"
+        # GitHub issue-linking (opt-in; token minted from the OpenBao github engine)
+        ZAMMAD_CONFIGURE_GITHUB: "{{ zammad_configure_github | bool | ternary('true', 'false') }}"
+        ZAMMAD_GITHUB_ENDPOINT: "{{ zammad_github_endpoint }}"
+        ZAMMAD_GITHUB_API_TOKEN: "{{ zammad_github_api_token }}"
+        # Incident ticket templates + KB docs answers (declarative data as JSON)
+        ZAMMAD_TICKET_TEMPLATES: "{{ zammad_ticket_templates | to_json }}"
+        ZAMMAD_KB_DOCS_CATEGORY: "{{ zammad_kb_docs_category }}"
+        ZAMMAD_KB_ANSWERS: "{{ zammad_kb_answers | to_json }}"
       register: zammad_bootstrap
       changed_when: "'ZAMMAD_BOOTSTRAP_CHANGED' in zammad_bootstrap.stdout"
       no_log: true

--- a/secrets.enc.yaml.example
+++ b/secrets.enc.yaml.example
@@ -45,6 +45,19 @@ MSSQL_SA_PASSWORD: your-strong-sa-password-here
 # See CLAUDE.md for details.
 # GITHUB_RUNNER_TOKEN: no-longer-needed
 
+# Zammad GitHub issue-linking (opt-in)
+# NOT a stored secret. Zammad's optional GitHub integration (enabled with
+# -e '{"zammad_configure_github": true}') reads ZAMMAD_GITHUB_API_TOKEN from the
+# converge environment. Per the OpenBao plugins-first rule, this is a GitHub
+# credential and GitHub has a live engine — so it is MINTED per converge from
+# github/token/read-*, never pasted here. Do not add a value to this file.
+
+# Zammad built-in AI provider
+# Also not stored here. The custom OpenAI-compatible provider reuses the shared
+# router key LLM_ROUTER_MASTER_KEY (OpenBao ai/llm, local-llm domain), resolved
+# bao-first in group_vars/zammad_group.yml. Override the endpoint/model at
+# converge time with ZAMMAD_AI_URL / ZAMMAD_AI_MODEL if the defaults don't fit.
+
 # Qdrant Vector Database
 QDRANT_API_KEY: your-qdrant-api-key-here
 


### PR DESCRIPTION
## Summary

Makes the estate's Zammad materially more useful for its all-AI operators by tuning the common, high-value configurations — most notably wiring Zammad's built-in (7.x "Smart Assist") AI at the local LLM gateway. All work **extends the existing idempotent `zammad_bootstrap.rb` rails-runner and role defaults** — no new role, no new host. It follows the role's established idioms: the `set_setting` helper + `changed` flag, secrets passed via the task's `environment:` (never a command line), essential settings fail loud, and version-sensitive extras stay wrapped best-effort so a Zammad model-API drift **warns** rather than aborting a converge.

## Changes

- **SystemID hard-set to 1** — Zammad drew a random id at install (this instance had **17**); pinned to `1` in the fail-loud core-settings block so the ticket-number prefix is deterministic across rebuilds. Idempotent via `set_setting` (Integer compare).
- **Built-in AI → shared LLM router** — `ai_provider_config` uses the `custom_open_ai` provider (URL + token + model, matching the "Custom (OpenAI Compatible)" admin screen), pointed at the estate's OpenAI-compatible router. Reuses `LLM_ROUTER_MASTER_KEY` (bao-first, `local-llm` domain) and the stable `ai-default` alias; URL/model are env-overridable (`ZAMMAD_AI_URL` / `ZAMMAD_AI_MODEL`, URL includes `/v1`). Then sets the `ai_provider` master flag and enables the assist features: **ticket summary, writing assistant, KB-answer-from-ticket**. Wrapped best-effort because the provider-config validation pings the endpoint on save. Embeddings/Vector-DB intentionally left off (`custom_open_ai` doesn't implement embeddings).
- **GitHub issue-linking (opt-in, default off)** — `github_config` + `github_integration`, reading `ZAMMAD_GITHUB_API_TOKEN`. Enabled per-converge with `-e '{"zammad_configure_github": true}'`.
- **Incident ticket templates** — declarative `zammad_ticket_templates` seeded idempotently by name, resolving group/priority by name; incident custom fields (`detection_method`) applied only when the attribute exists, so a template still seeds on an instance that never ran the opt-in custom-field seed.
- **Knowledge base → docs site** — seeds a "Documentation" category whose answers link out to `docs.jacobpevans.com` (the external link lives in the rich-HTML answer body; Zammad has no dedicated redirect field).

## OpenBao plugins-first compliance

- **GitHub touches a GitHub credential, and GitHub has a live engine** — so the PAT is **never** seeded into `secret/*` KV or SOPS. `ZAMMAD_GITHUB_API_TOKEN` is minted per converge from `github/token/read-*` (read tier — issue-linking is read-only) and re-asserted each run (short-lived, attributable, re-minted). `secrets.enc.yaml.example` documents this with a "do not add a value" note rather than a placeholder secret. If the token lapses between converges the integration simply stops linking until the next converge — no breakage.
- **AI provider** reuses the existing `ai/llm` `LLM_ROUTER_MASTER_KEY` (AWS/GitHub-style engines don't apply to the router key), resolved bao-first — no new grant.

## Files

- `roles/zammad/files/zammad_bootstrap.rb` — system_id, AI, GitHub, templates, and KB-docs blocks
- `roles/zammad/defaults/main.yml` — new AI/GitHub vars + `zammad_ticket_templates`, `zammad_kb_answers`
- `roles/zammad/tasks/main.yml` — new keys in the bootstrap `environment:`
- `inventory/group_vars/zammad_group.yml` — bao-first `zammad_ai_token`
- `secrets.enc.yaml.example` — Zammad AI/GitHub documentation (no stored secret)

## Verification

- `ruby -c roles/zammad/files/zammad_bootstrap.rb` → **Syntax OK**; edited YAML validates.
- `ansible-lint` + `ansible-playbook --syntax-check` run in CI (no local Ansible in this environment).
- Live converge (bootstrap only runs live — molecule disables the app layer via `zammad_manage_app`):
  ```
  sops exec-env secrets.enc.yaml 'doppler run -- ansible-playbook \
    -i inventory/hosts.yml playbooks/site.yml --tags zammad --limit zammad_group,localhost'
  ```
- Re-run the bootstrap to confirm idempotence (no `ZAMMAD_BOOTSTRAP_CHANGED` on a clean second pass).
- In the UI: Settings → System → **SystemID = 1**; AI → Provider enabled (Custom OpenAI-compatible) at the router URL; ticket summary + writing assistant available on a ticket; Manage → Templates lists the incident templates; Knowledge Base → Documentation answers open the external docs links. An AI/GitHub `WARN` in the converge log means the endpoint/token is unreachable — fix `ZAMMAD_AI_URL`/the mint and re-converge (never fatal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbaBeHe7ZA41tQ1RtZPyqF)_