### PR TITLE
feat(nautobot): repeatable read-only drift report (Nautobot vs sources) (#977)

### DIFF
--- a/scripts/nautobot_drift.py
+++ b/scripts/nautobot_drift.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Read-only Nautobot-vs-source drift report (issue #977 gate 3).
+
+Compares what Nautobot currently holds against the source-of-truth facts and
+prints a repeatable drift report: modeled-object counts, guest/tag drift (what
+Nautobot has that sources lack and vice versa), and the coverage gap for source
+domains Nautobot has no model for yet. Read-only — queries the Nautobot REST +
+GraphQL API and reads the published inventory artifact; writes nothing.
+
+Environment (same fallbacks as the GraphQL dynamic inventory):
+  NAUTOBOT_URL    Nautobot API base URL
+  NAUTOBOT_TOKEN  read-only API token
+Argument:
+  --tofu-inventory PATH   the published inventory artifact (source guests+tags)
+
+Exit code is non-zero only on an API/IO error, never on drift — this is a
+report, not a gate.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import ssl
+import urllib.request
+
+# Source domains Nautobot core has no model for yet (see the Phase-2 design doc
+# §7). Listed so the report states the coverage gap explicitly rather than
+# silently omitting it.
+UNMODELED_DOMAINS = [
+    "firewall groups/rules",
+    "DNS records",
+    "WLANs",
+    "port profiles / port-forwards",
+    "static + traffic routes",
+    "RADIUS",
+    "VPN",
+    "WAN",
+    "cables",
+    "physical device interfaces",
+]
+
+GUEST_SECTIONS = ("containers", "vms", "docker_vms", "splunk_vm")
+
+
+def _get(path: str, url: str, token: str) -> dict:
+    req = urllib.request.Request(
+        url.rstrip("/") + path,
+        headers={"Authorization": "Token " + token, "Accept": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=30, context=ssl.create_default_context()) as resp:
+        return json.load(resp)
+
+
+def _graphql(query: str, url: str, token: str) -> dict:
+    req = urllib.request.Request(
+        url.rstrip("/") + "/api/graphql/",
+        data=json.dumps({"query": query}).encode(),
+        headers={"Authorization": "Token " + token, "Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=45, context=ssl.create_default_context()) as resp:
+        return json.load(resp)["data"]
+
+
+def source_guests(tofu: dict) -> dict[str, set]:
+    """Map each source guest hostname -> set of its tags."""
+    guests: dict[str, set] = {}
+    for section in GUEST_SECTIONS:
+        for key, val in (tofu.get(section) or {}).items():
+            name = val.get("hostname") or key
+            guests[name] = set(val.get("tags") or [])
+    return guests
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--tofu-inventory", required=True, help="published inventory artifact JSON")
+    args = ap.parse_args()
+    url = os.environ["NAUTOBOT_URL"]
+    token = os.environ["NAUTOBOT_TOKEN"]
+
+    with open(args.tofu_inventory, encoding="utf-8") as handle:
+        src = source_guests(json.load(handle))
+
+    data = _graphql("{ virtual_machines { name tags { name } } }", url, token)
+    nb = {
+        vm["name"]: {t["name"] for t in (vm.get("tags") or [])}
+        for vm in data["virtual_machines"]
+    }
+
+    counts = {
+        model: _get("/api/%s/?limit=1" % model, url, token).get("count")
+        for model in (
+            "ipam/vlans",
+            "ipam/prefixes",
+            "ipam/ip-addresses",
+            "dcim/devices",
+            "virtualization/virtual-machines",
+            "extras/tags",
+        )
+    }
+
+    missing_guests = sorted(set(src) - set(nb))
+    extra_guests = sorted(set(nb) - set(src))
+    tag_drift = {
+        name: sorted(src[name] - nb.get(name, set()))
+        for name in src
+        if src[name] - nb.get(name, set())
+    }
+    missing_tag_assignments = sum(len(v) for v in tag_drift.values())
+
+    print("=== Nautobot drift report (read-only) ===")
+    print("modeled object counts:")
+    for model, count in counts.items():
+        print("  %-34s %s" % (model, count))
+    print("source guests: %d   nautobot VMs: %d" % (len(src), len(nb)))
+    print("guests in sources but MISSING from Nautobot: %d %s"
+          % (len(missing_guests), missing_guests[:10]))
+    print("VMs in Nautobot NOT in sources: %d %s"
+          % (len(extra_guests), extra_guests[:10]))
+    print("guests with MISSING tags: %d  (total %d tag assignments to import)"
+          % (len(tag_drift), missing_tag_assignments))
+    print("coverage gap — source domains with NO Nautobot model yet:")
+    for domain in UNMODELED_DOMAINS:
+        print("  - %s" % domain)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/nautobot_drift.py
+++ b/scripts/nautobot_drift.py
@@ -22,6 +22,7 @@ import argparse
 import json
 import os
 import ssl
+import sys
 import urllib.request
 
 # Source domains Nautobot core has no model for yet (see the Phase-2 design doc
@@ -59,7 +60,12 @@ def _graphql(query: str, url: str, token: str) -> dict:
         headers={"Authorization": "Token " + token, "Content-Type": "application/json"},
     )
     with urllib.request.urlopen(req, timeout=45, context=ssl.create_default_context()) as resp:
-        return json.load(resp)["data"]
+        payload = json.load(resp)
+    # A GraphQL 200 can still carry an ``errors`` array with ``data: null`` — treat
+    # that as a hard failure instead of dereferencing None downstream.
+    if payload.get("errors"):
+        raise RuntimeError("Nautobot GraphQL error: %s" % json.dumps(payload["errors"]))
+    return payload["data"]
 
 
 def source_guests(tofu: dict) -> dict[str, set]:
@@ -76,8 +82,11 @@ def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--tofu-inventory", required=True, help="published inventory artifact JSON")
     args = ap.parse_args()
-    url = os.environ["NAUTOBOT_URL"]
-    token = os.environ["NAUTOBOT_TOKEN"]
+    url = os.environ.get("NAUTOBOT_URL")
+    token = os.environ.get("NAUTOBOT_TOKEN")
+    if not url or not token:
+        print("NAUTOBOT_URL and NAUTOBOT_TOKEN must both be set", file=sys.stderr)
+        return 2
 
     with open(args.tofu_inventory, encoding="utf-8") as handle:
         src = source_guests(json.load(handle))
@@ -102,10 +111,13 @@ def main() -> int:
 
     missing_guests = sorted(set(src) - set(nb))
     extra_guests = sorted(set(nb) - set(src))
+    # Only guests present in BOTH sources have meaningful tag drift; guests
+    # missing from Nautobot are already reported as missing_guests, so counting
+    # their tags here would double-count and inflate the drift.
     tag_drift = {
-        name: sorted(src[name] - nb.get(name, set()))
+        name: sorted(src[name] - nb[name])
         for name in src
-        if src[name] - nb.get(name, set())
+        if name in nb and src[name] - nb[name]
     }
     missing_tag_assignments = sum(len(v) for v in tag_drift.values())
 


### PR DESCRIPTION
## What

Phase-1 **gate 3** (#977): a repeatable job/report showing Nautobot-vs-reality
drift. `scripts/nautobot_drift.py` queries the Nautobot REST + GraphQL API
(read-only, env-driven) and diffs against the published inventory artifact.

Reports: modeled object counts; guests in sources but missing from Nautobot
(stale-seed drift); orphan VMs; guests with missing tags + total tag assignments
to import (#1008); and the coverage gap (source domains with no Nautobot model).

## Verification (live, read-only)

Ran against the homelab — writes nothing. Real findings surfaced:
- **7 source guests missing from Nautobot** → the seed is stale, not just incomplete
- **64 guests missing tags / 365 tag assignments to import** → quantifies #1008
- 0 orphan VMs; VLAN/Prefix counts matched (13/13)

`py_compile` clean; exit code reflects API/IO errors only, never drift.

## Notes

Env-driven (no hardcoded topology). Repeatable:
`NAUTOBOT_URL=… NAUTOBOT_TOKEN=… python3 scripts/nautobot_drift.py --tofu-inventory <artifact>`.
Full domain-level drift (firewall/DNS/WLAN/etc) is bounded by Nautobot model
coverage — tracked in the Phase-2 design §7.

Refs #977, #1008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)