### PR TITLE
fix(apps): self-healing restart policy + bao-first vikunja jwt/admin

### DIFF
--- a/inventory/group_vars/vikunja_group.yml
+++ b/inventory/group_vars/vikunja_group.yml
@@ -2,8 +2,10 @@
 # Vikunja task management (issue #141) — bao-first secrets (apps domain) with an
 # env fallback, mirroring nautobot_group.yml / zammad_group.yml. Only the fields
 # with a home in secret/apps/vikunja (the openbao_vikunja_secrets promotion map)
-# are wired bao-first here; VIKUNJA_JWT_SECRET and VIKUNJA_ADMIN_PASSWORD have no
-# bao home yet, so they stay pure env lookups on the role default.
+# are wired bao-first here. As of the apps-tier cutover (#17039) all three of the
+# role's required secrets — vikunja_db_password, vikunja_jwt_secret,
+# vikunja_admin_password — have a bao home and are wired bao-first below; the env
+# fallback stays for hosts where the apps domain was not fetched.
 #
 # The database password is app-namespaced (vikunja_db_password) so the flat merge
 # into bao_apps_secrets never collides with Nautobot's bare db_password. It MUST
@@ -14,6 +16,21 @@
 vikunja_db_password: >-
   {{ bao_apps_secrets.vikunja_db_password
      | default(lookup('env', 'VIKUNJA_DB_PASSWORD'), true) }}
+
+# JWT signing secret + initial admin password bao-first (secret/apps/vikunja
+# fields vikunja_jwt_secret / vikunja_admin_password, promoted via
+# openbao_vikunja_secrets). App-namespaced so the flat merge into
+# bao_apps_secrets never collides with a sibling app's bare field name. The
+# role's secrets-assert requires all three; seeding these two closes the
+# half-migrated gap that blocked converge (#17039). The JWT secret is a stable
+# value promoted from the live guest, NOT regenerated — rotating it would
+# invalidate every issued session/API token.
+vikunja_jwt_secret: >-
+  {{ bao_apps_secrets.vikunja_jwt_secret
+     | default(lookup('env', 'VIKUNJA_JWT_SECRET'), true) }}
+vikunja_admin_password: >-
+  {{ bao_apps_secrets.vikunja_admin_password
+     | default(lookup('env', 'VIKUNJA_ADMIN_PASSWORD'), true) }}
 
 # Postgres has no ingress; reach it by the primary guest's FQDN. Tracks the
 # shared postgres_primary_host switch (group_vars/all): unset -> the stable
@@ -40,3 +57,12 @@ vikunja_service_users:
     password: >-
       {{ bao_apps_secrets.svc_mcp_rw_password
          | default(lookup('env', 'VIKUNJA_SVC_MCP_RW_PASSWORD'), true) }}
+
+# Robust auto-restart (#17046). The vikunja.service unit already carries
+# Restart=on-failure inline, but with systemd's default start-rate limiter it
+# gave up during the apps-tier backend outage and stayed dead after Postgres
+# recovered. Wiring the service into systemd_restart_policy adds the widened
+# StartLimitIntervalSec/Burst drop-in so it keeps retrying until the backend
+# returns and self-heals after a blip.
+systemd_restart_policy_services:
+  - vikunja

--- a/inventory/group_vars/zammad_group.yml
+++ b/inventory/group_vars/zammad_group.yml
@@ -60,3 +60,12 @@ zammad_smtp_host: "mailpit.{{ hostvars['localhost']['tofu_data']['domain'] }}"
 zammad_smtp_port: >-
   {{ (hostvars['localhost']['tofu_data']['constants']['notification_ports']['mailpit_smtp'])
      | default(1025) }}
+
+# Robust auto-restart (#17046). Zammad returned 502 through the apps-tier outage
+# (nginx up, backend down) and did not self-recover after Postgres came back.
+# `zammad` is the packager.io control unit the role starts/restarts; wiring it
+# into systemd_restart_policy applies the widened StartLimitIntervalSec/Burst +
+# Restart=on-failure drop-in so a backend blip no longer exhausts the restart
+# budget and leaves the app dead.
+systemd_restart_policy_services:
+  - zammad

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -132,6 +132,14 @@ openbao_vikunja_secrets:
   # App-namespaced DB password (matches the postgres_managed_databases +
   # vikunja_group.yml consumers reading bao_apps_secrets.vikunja_db_password).
   vikunja_db_password: VIKUNJA_DB_PASSWORD
+  # JWT signing secret + initial admin password (#17039). App-namespaced to
+  # match the vikunja_group.yml consumers reading bao_apps_secrets.
+  # vikunja_jwt_secret / .vikunja_admin_password. These are promoted from the
+  # live guest, not generated here — the JWT secret must stay stable (rotating
+  # it invalidates every issued session/API token), so they belong in this
+  # promotion map, never in openbao_generated_app_secrets.
+  vikunja_jwt_secret: VIKUNJA_JWT_SECRET
+  vikunja_admin_password: VIKUNJA_ADMIN_PASSWORD
 
 # App service secrets GENERATED (random, generate-if-absent) in OpenBao itself,
 # replacing the retired terraform-proxmox vault-secrets root. Each app maps to

--- a/roles/systemd_restart_policy/defaults/main.yml
+++ b/roles/systemd_restart_policy/defaults/main.yml
@@ -7,3 +7,15 @@ systemd_restart_policy_restart: "on-failure"
 
 # Delay between restart attempts
 systemd_restart_policy_restart_sec: "5s"
+
+# Start-rate limiter (systemd [Unit] StartLimitIntervalSec/StartLimitBurst).
+# WHY these exist: systemd's DEFAULT limiter (5 starts / 10s) makes a service
+# GIVE UP and stay `failed` when a backend outage outlasts the budget — the
+# service then never comes back on its own after the backend recovers (the
+# apps-tier outage, #17046). A wide window plus a high burst keeps the service
+# retrying every restart_sec for the whole realistic length of a backend blip:
+# at one start per restart_sec (5s), a 300s window yields ~60 starts, well under
+# the 100 burst, so the limiter never trips and the service self-heals. The
+# burst still backstops a genuinely pathological instant crash-loop.
+systemd_restart_policy_start_limit_interval_sec: "300s"
+systemd_restart_policy_start_limit_burst: "100"

--- a/roles/systemd_restart_policy/templates/restart-override.conf.j2
+++ b/roles/systemd_restart_policy/templates/restart-override.conf.j2
@@ -1,3 +1,7 @@
+[Unit]
+StartLimitIntervalSec={{ systemd_restart_policy_start_limit_interval_sec }}
+StartLimitBurst={{ systemd_restart_policy_start_limit_burst }}
+
 [Service]
 Restart={{ systemd_restart_policy_restart }}
 RestartSec={{ systemd_restart_policy_restart_sec }}


### PR DESCRIPTION
## Why

Two apps-tier resilience fixes from the 2026-07-17 outage cluster.

**Restart policy.** After a shared-backend blip, the apps-tier services did not
recover on their own — the backend came back but the app services stayed dead,
so the outage outlived its cause. Root cause: systemd's **default** start-rate
limiter (5 starts / 10s) makes a unit give up and stay `failed` when a backend
outage outlasts the budget. It then never restarts after the backend recovers.
The host RAM/disk root cause is tracked separately in
dryvist/nix-mac-performance#38 (not chased here).

**Bao-first secrets.** The vikunja JWT secret and admin password had no OpenBao
home, so a half-migrated secret set left the role's secrets-assert correctly
blocking converge while vikunja ran on its pre-cutover config.

## What

- `systemd_restart_policy`: emit a `[Unit]` `StartLimitIntervalSec` /
  `StartLimitBurst` drop-in (defaults 300s / 100, paired with `RestartSec=5s` so
  the limiter never trips for a realistic outage). This is a fleet-wide fix — it
  hardens every service already wired into the role, not just the apps tier.
- Wire `vikunja` and `zammad` into `systemd_restart_policy_services` so they
  retry until the backend returns and self-heal after a blip.
- Add `vikunja_jwt_secret` + `vikunja_admin_password` to the `apps/vikunja`
  promotion map and wire them bao-first (env fallback) in group_vars. Both are
  **promoted from the live guest, not regenerated** — the JWT secret must stay
  stable or every issued session/API token is invalidated.

OpenProject already carries `restart: unless-stopped` (Docker never gives up),
so no change there.

## OpenBao (per openbao-plugins-first)

These are app config / bootstrap material with no upstream engine, so KV
(`secret/apps/vikunja`) is the correct home; no engine can mint a JWT signing
secret. No new KV-read policy — the apps read grant already covers the whole
`apps/vikunja` path.

## Validation

- `ansible-lint` (production profile): passed, 0 failures on changed files.
- Drop-in template render checked → valid systemd unit override.
- Live seed + converge + probe verification: **not yet run** — blocked on
  authoritative inventory access and the secrets-write gate. Tracked in the
  incident thread; PR stays draft until a live idempotent converge is green.

Session: claude-jevans-mbp-ed70b6dd