### PR TITLE
feat(zammad): configure AI provider on Hermes' brain (LiteLLM router)

### DIFF
--- a/docs/ai-prompt-format.md
+++ b/docs/ai-prompt-format.md
@@ -1,0 +1,105 @@
+# AI Prompt / Agent-Definition Format
+
+Prompts and agent-definitions in this homelab are fragmented across Claude Code
+plugins & skills, imported skills, Claude Code routines, GitHub AW (agentic
+workflows), `ai-workflows`, the Hermes `nix-hermes` bundle (skills + SOUL), and
+n8n seed workflows. This document defines **one canonical, version-controlled
+format** so a single source of truth can feed all of them.
+
+> **Canonical home:** the [`dryvist/ai-llm-prompts`](https://github.com/dryvist/ai-llm-prompts)
+> repository (owned/created elsewhere). This document is this repository's adopted
+> reference and the mapping for its own consumers (Zammad, n8n). **Migration of the
+> existing scattered sources is on hold** until after the first main push — the
+> format is agreed now so nothing new is authored against a moving target.
+
+## Design goal
+
+Keep it simple yet valuable: **no bespoke schema**. The canonical unit is the file
+the AI-agent open-source community already standardized on — an **Agent Skill**
+(`SKILL.md`, supported by 16+ tools incl. Claude Code, Cursor, Gemini CLI, GitHub
+Copilot, Letta) — extended so the *same file* is simultaneously:
+
+- a valid **Agent Skill** — `name` + `description` + Markdown body;
+- a valid **OKF concept** (Google's [Open Knowledge Format](https://cloud.google.com/blog):
+  a directory of Markdown files whose one required field is `type`, with explicit
+  Markdown links between concepts);
+- **versioned** — an explicit `version` (semver), which neither base format mandates.
+
+Skill-aware and OKF-aware consumers read the file directly. Behavior consumers
+(Zammad, n8n, GitHub AW) render it through a thin adapter.
+
+## The unit
+
+One directory per unit; the file is named `SKILL.md` (drop-in for Agent Skills):
+
+```text
+ai-llm-prompts/
+  splunk-triage/
+    SKILL.md
+  incident-severity/
+    SKILL.md
+```
+
+```markdown
+---
+# Agent Skills — required
+name: splunk-triage
+description: Triage Splunk alerts into prioritized homelab incidents.
+# OKF — required (single mandatory field)
+type: agent            # agent | skill | knowledge | routine | workflow
+# Explicit version — required here (semver)
+version: 1.0.0
+# Registry metadata — simple, optional
+consumers: [zammad, hermes, claude, n8n, github-aw]
+tags: [splunk, incident, triage]
+# Per-consumer hints — optional; kept in frontmatter so the body stays portable
+zammad:
+  agent_type: ticket_tagger
+---
+
+The Markdown body is the actual prompt / instructions. Reference related
+concepts with ordinary links so both humans and agents can navigate:
+see [incident severity](../incident-severity/SKILL.md).
+```
+
+### Fields
+
+| Field | Source | Required | Notes |
+| --- | --- | --- | --- |
+| `name` | Agent Skills | yes | Unique slug; matches the directory name. |
+| `description` | Agent Skills | yes | One line; what the unit does / when to use it. |
+| `type` | OKF | yes | Controlled vocabulary below. |
+| `version` | this spec | yes | Semver. Bump on any body/behavior change. |
+| `consumers` | registry | no | Which systems render this unit. Omit = all. |
+| `tags` | registry | no | Free-form; reuse existing taxonomies where they exist. |
+| `<consumer>` | registry | no | Per-consumer hint block (e.g. `zammad.agent_type`). |
+
+### `type` vocabulary
+
+| `type` | Meaning |
+| --- | --- |
+| `agent` | An autonomous/triggered agent definition (maps to Zammad `AI::Agent`, Hermes agent, GitHub AW). |
+| `skill` | A reusable capability injected into a larger agent/session. |
+| `knowledge` | Curated context / runbook (pure OKF concept, no action). |
+| `routine` | A scheduled prompt (Claude Code routine, cron-driven). |
+| `workflow` | A multi-step orchestration (n8n workflow, GitHub AW pipeline). |
+
+## Consumer model
+
+Each consumer either reads `SKILL.md` natively or renders it via a thin adapter
+(adapters live in the canonical repo; built when migration resumes):
+
+| Consumer | Consumption |
+| --- | --- |
+| Claude Code (plugins / skills / routines) | native — the file **is** an Agent Skill |
+| Hermes | `nix-hermes` bundle ingests the skill directories (skills + SOUL) — existing precedent |
+| Zammad AI Agents | adapter → `AI::Agent { name, agent_type, definition, action_definition }` |
+| n8n | adapter → workflow JSON |
+| GitHub AW | adapter → agentic-workflow file |
+
+## Status
+
+- **Now:** format agreed; this document adopted; Zammad's AI **provider** ("same
+  brain" — the LiteLLM router) wired independently of the registry.
+- **After the first main push:** stand up adapters, source Zammad `AI::Agent`
+  seeds from `dryvist/ai-llm-prompts`, and migrate the scattered sources in.

--- a/inventory/group_vars/zammad_group.yml
+++ b/inventory/group_vars/zammad_group.yml
@@ -45,6 +45,15 @@ zammad_hermes_api_token: >-
   {{ bao_local_llm_secrets.ZAMMAD_API_TOKEN
      | default(lookup('env', 'ZAMMAD_API_TOKEN'), true) }}
 
+# Bearer token for the LiteLLM router (Hermes' brain front door) that Zammad's
+# AI provider authenticates with. Canonical home is ai/llm's LLM_ROUTER_MASTER_KEY
+# (local-llm domain) — the SAME key Hermes/n8n use — so bao-first with env
+# fallback, mirroring zammad_hermes_api_token. On hosts where the local-llm domain
+# is not fetched, bao_local_llm_secrets is {} and the env fallback resolves it.
+zammad_ai_provider_token: >-
+  {{ bao_local_llm_secrets.LLM_ROUTER_MASTER_KEY
+     | default(lookup('env', 'LLM_ROUTER_MASTER_KEY'), true) }}
+
 # API token for the interactive-AI service account (Claude Code / Codex
 # sessions — a separate Zammad user from both hermes and the human admin, so
 # the activity stream attributes writes to the real actor). Canonical home is

--- a/roles/zammad/defaults/main.yml
+++ b/roles/zammad/defaults/main.yml
@@ -77,6 +77,38 @@ zammad_ai_email: "ai@{{ tofu_data.domain }}"
 zammad_hermes_api_token: "{{ lookup('env', 'ZAMMAD_API_TOKEN') }}"
 zammad_ai_api_token: "{{ lookup('env', 'ZAMMAD_AI_API_TOKEN') }}"
 
+# --- AI provider: Zammad AI on Hermes' brain (the LiteLLM router) -------------
+# Zammad's built-in AI features (ticket summaries, writing assistant) run against
+# the SAME LLM front door Hermes and n8n use — the LiteLLM router at
+# https://llm.<subdomain>/v1 — NOT through the Hermes agent. Provider type is
+# `custom_open_ai` (Zammad's "Custom (OpenAI-compatible)" option); the URL MUST
+# include `/v1` because that provider appends `/chat/completions` and `/models`
+# itself. Seeded idempotently by zammad_bootstrap.rb with validate:false so an
+# unreachable brain at converge time cannot abort essential seeding (the
+# validated path pings the endpoint). Turn the whole block off with
+# zammad_ai_enabled: false (molecule/dry runs never reach it — bootstrap is
+# gated on zammad_manage_app).
+#
+# AI *Agents* (AI::Agent records) are intentionally NOT seeded here yet: their
+# prompts belong in the canonical dryvist/ai-llm-prompts registry (see
+# docs/ai-prompt-format.md), consumed once migration resumes after the main push.
+zammad_ai_enabled: true
+zammad_ai_provider_name: custom_open_ai
+zammad_ai_provider_url: "https://llm.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}/v1"
+# Model to request. Defaults to the router alias n8n already uses; override via
+# ZAMMAD_AI_MODEL to match Hermes' ai_default_model (the "OptiQ brain") when they
+# differ. Zammad needs a model that reliably emits strict JSON.
+zammad_ai_model: "{{ lookup('env', 'ZAMMAD_AI_MODEL') | default('gpt-oss-120b', true) }}"
+# Bearer for the router. custom_open_ai treats the token as optional, but our
+# router requires it — group_vars supplies it bao-first (ai/llm's
+# LLM_ROUTER_MASTER_KEY); this env-only default is the fallback.
+zammad_ai_provider_token: "{{ lookup('env', 'LLM_ROUTER_MASTER_KEY') }}"
+# Per-feature toggles enabled once the provider is configured. Names match
+# zammad/zammad (Setting area AI::Assistance).
+zammad_ai_features:
+  - ai_assistance_ticket_summary
+  - ai_assistance_text_tools
+
 # --- Human SSO account (Authelia forwardAuth identity) ------------------------
 # `login` MUST equal the Authelia username verbatim: Zammad's create_sso does
 # User.lookup(login: ...) on the Remote-User header value, so the email is

--- a/roles/zammad/files/zammad_bootstrap.rb
+++ b/roles/zammad/files/zammad_bootstrap.rb
@@ -320,4 +320,43 @@ rescue => e
   warn "WARN: overviews not seeded automatically (#{e.class}: #{e.message}). Create them once in the UI."
 end
 
+# --- AI provider: Zammad AI on Hermes' brain (best-effort; UI fallback) -------
+# Point Zammad's AI at the SAME LiteLLM router Hermes/n8n use (provider
+# custom_open_ai). Seeded with validate:false so an unreachable brain at converge
+# time never aborts the essential seeding above — the validated path pings
+# <url>/models AND makes a live chat request (and mutates the config to add
+# model_temperature_support). Order matters: ai_provider_config must be present
+# BEFORE ai_provider is flipped true (Setting::Validation::AIProvider rejects
+# ai_provider=true with a blank config). Gated on ZAMMAD_AI_ENABLED; a version/
+# schema drift warns rather than aborting (like the KB + overviews blocks).
+if ENV['ZAMMAD_AI_ENABLED'] == 'true'
+  begin
+    desired_ai = {
+      provider: ENV['ZAMMAD_AI_PROVIDER'].to_s.empty? ? 'custom_open_ai' : ENV['ZAMMAD_AI_PROVIDER'],
+      url:      env!('ZAMMAD_AI_PROVIDER_URL'),
+      model:    env!('ZAMMAD_AI_MODEL'),
+      token:    ENV['ZAMMAD_AI_PROVIDER_TOKEN'].to_s, # optional for custom_open_ai
+    }
+    # Idempotency: compare ONLY the keys we manage against the stored config, so a
+    # validation-added key (e.g. model_temperature_support) can't force a
+    # perpetual "changed". Stored config round-trips with string keys.
+    current_ai = Setting.get('ai_provider_config') || {}
+    if desired_ai.any? { |k, v| current_ai[k.to_s] != v }
+      Setting.set('ai_provider_config', desired_ai, validate: false)
+      changed = true
+    end
+    unless Setting.get('ai_provider') == true
+      Setting.set('ai_provider', true, validate: false)
+      changed = true
+    end
+    # Per-feature toggles (comma-separated list from ZAMMAD_AI_FEATURES).
+    (ENV['ZAMMAD_AI_FEATURES'] || '').split(',').map(&:strip).reject(&:empty?).each do |feature|
+      changed = true if set_setting(feature, true)
+    end
+  rescue => e
+    warn "WARN: Zammad AI provider not configured automatically (#{e.class}: #{e.message}). " \
+         'Configure it once in Admin > System > AI.'
+  end
+end
+
 puts 'ZAMMAD_BOOTSTRAP_CHANGED' if changed

--- a/roles/zammad/tasks/main.yml
+++ b/roles/zammad/tasks/main.yml
@@ -388,11 +388,18 @@
           # verify_sso_trusted_ip! treats blank as "skip the check", so an empty
           # value here silently accepts an SSO assertion from any source.
           - zammad_sso_trusted_ips | length > 0
+          # When AI is enabled, the router model + bearer must be present: a blank
+          # token would silently 401 against the LiteLLM router (custom_open_ai
+          # treats it as optional, but OUR router requires it).
+          - not (zammad_ai_enabled | bool) or (zammad_ai_model | length > 0)
+          - not (zammad_ai_enabled | bool) or (zammad_ai_provider_token | length > 0)
         fail_msg: >-
           ZAMMAD_ADMIN_PASSWORD, ZAMMAD_API_TOKEN and ZAMMAD_AI_API_TOKEN must
           be set before the first converge (Doppler/SOPS or OpenBao
           apps/zammad + ai/hermes), and zammad_sso_trusted_ips must be non-empty
-          (a blank value disables Zammad's SSO source check entirely).
+          (a blank value disables Zammad's SSO source check entirely). With
+          zammad_ai_enabled, LLM_ROUTER_MASTER_KEY (OpenBao ai/llm) and a model
+          must also be set for the Zammad AI provider.
         quiet: true
       no_log: true
 
@@ -430,6 +437,14 @@
         ZAMMAD_ORGANIZATION: "{{ zammad_organization }}"
         ZAMMAD_HERMES_ORGANIZATION: "{{ zammad_hermes_organization }}"
         ZAMMAD_OVERVIEWS: "{{ zammad_overviews | to_json }}"
+        # AI provider ("same brain" — the LiteLLM router). Booleanized to the
+        # literal string the bootstrap checks (`== 'true'`).
+        ZAMMAD_AI_ENABLED: "{{ zammad_ai_enabled | bool | string | lower }}"
+        ZAMMAD_AI_PROVIDER: "{{ zammad_ai_provider_name }}"
+        ZAMMAD_AI_PROVIDER_URL: "{{ zammad_ai_provider_url }}"
+        ZAMMAD_AI_MODEL: "{{ zammad_ai_model }}"
+        ZAMMAD_AI_PROVIDER_TOKEN: "{{ zammad_ai_provider_token }}"
+        ZAMMAD_AI_FEATURES: "{{ zammad_ai_features | join(',') }}"
       register: zammad_bootstrap
       changed_when: "'ZAMMAD_BOOTSTRAP_CHANGED' in zammad_bootstrap.stdout"
       no_log: true


### PR DESCRIPTION
## What & why

The ask started as "set up Zammad AI Agents on the same brain as Hermes" and broadened to "centralize and version-control the prompts scattered across Claude Code plugins/skills, imported skills, routines, GitHub AW, ai-workflows, and more." This PR delivers the two pieces that are **unblocked today**:

1. **Zammad AI *provider* on Hermes' brain** — point Zammad's built-in AI features at the **same LiteLLM router** Hermes and n8n already use (`https://llm.<subdomain>/v1`), **not** through the Hermes agent. This is registry-independent, so it ships now.
2. **A canonical prompt/agent-definition format spec** (`docs/ai-prompt-format.md`) so every consumer draws from one versioned source.

**Deliberately deferred** (until after the first main push): seeding Zammad `AI::Agent` records, adapters, and migrating the existing scattered sources. Those prompts belong in the canonical `dryvist/ai-llm-prompts` registry (created elsewhere), consumed once migration resumes.

## Changes

**Zammad AI provider (the "same brain")**
- `roles/zammad/defaults/main.yml` — `zammad_ai_*` vars: provider `custom_open_ai` (Zammad's OpenAI-compatible option), router URL with `/v1` (that provider appends `/chat/completions` + `/models` itself), model default overridable via `ZAMMAD_AI_MODEL` to match Hermes' `ai_default_model`, and the AI feature toggles.
- `inventory/group_vars/zammad_group.yml` — `zammad_ai_provider_token` bao-first from `ai/llm`'s `LLM_ROUTER_MASTER_KEY` (the key Hermes/n8n already use), env fallback — mirrors the existing `zammad_hermes_api_token` pattern.
- `roles/zammad/files/zammad_bootstrap.rb` — seed `ai_provider_config` **first**, then flip `ai_provider = true` (a validation guard rejects the flag with a blank config), both with `validate: false` so an unreachable brain at converge time cannot abort essential seeding (the validated path pings the endpoint). Enable AI features. Idempotent via a managed-keys-only drift check; wrapped in `begin/rescue` (non-fatal, UI fallback) like the KB/overviews blocks. Whole block gated on `ZAMMAD_AI_ENABLED`.
- `roles/zammad/tasks/main.yml` — pass the `ZAMMAD_AI_*` env into the bootstrap; extend the secrets assert to require the model + router token when AI is enabled.

**Format spec**
- `docs/ai-prompt-format.md` — the canonical unit is an **Agent Skill** (`SKILL.md`) whose frontmatter is a superset making the same file simultaneously a valid Agent Skill (`name`, `description`), a valid **OKF** concept (`type`), and **versioned** (`version`, semver). Includes the `type` vocabulary and the per-consumer mapping (Claude, Hermes, Zammad, n8n, GitHub AW). Canonical home is `dryvist/ai-llm-prompts`; this doc is the repo's adopted reference.

## Verification

- `ansible-lint --offline roles/zammad/` and the changed inventory var file — **pass** (production profile, 0 failures).
- `yamllint` on the changed YAML — clean.
- `ruby -c roles/zammad/files/zammad_bootstrap.rb` — Syntax OK.
- Molecule is unaffected: the bootstrap (and thus the AI block + new assert) is gated on `zammad_manage_app`, which molecule disables.

Suggested live check on a real converge:
```
sops exec-env secrets.enc.yaml 'doppler run -- ansible-playbook -i inventory/hosts.yml \
  playbooks/site.yml --tags zammad --limit zammad_group,localhost --forks 25'
# on the guest:
zammad run rails r 'p Setting.get("ai_provider_config"); p Setting.get("ai_provider")'
# brain-link sanity:
curl -H "Authorization: Bearer $LLM_ROUTER_MASTER_KEY" https://llm.<subdomain>/v1/models
```
A second converge should report **ok** (no `ZAMMAD_BOOTSTRAP_CHANGED`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBqXkYuy629U1nNMuUqrL6

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBqXkYuy629U1nNMuUqrL6)_