### PR TITLE
feat(openbao): time-boxed unlock windows + complete full ai-admin

### DIFF
--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -581,16 +581,22 @@ openbao_ai_elevated_approle_name: ai-elevated
 #        allowed, plus actor mechanics (TTLs, inert human-gated secret_id):
 #        ai-readonly    -> [read-all]                       (standing, ambient)
 #        ai-elevated    -> [read-all + read-<extra>]        (standing, ambient)
-#        ai-apply-<svc> -> [read-<svc>, write-<svc>, github-mint]  (per-task, <=1h)
-#        ai-apply-all   -> [read-write-all, github-mint]           (per-task, <=1h)
-#        ai-admin       -> [ai-admin]                        (break-glass, <=10m)
-# Authorization is scoped by TASK / BLAST-RADIUS and gated by a HUMAN, never by
-# model capability; the model is an AUDIT claim, never a key. Every apply/admin
-# role is provisioned manage_secret_id:false below, so the converge creates the
-# INERT role but never mints/stores a standing secret_id — a token exists only
-# after a human response-wraps a single-use secret_id on demand
-# (`bao write -wrap-ttl=90s -f auth/approle/role/<role>/secret-id`). See the
-# docs.dryvist.com "AI Agent Access (OpenBao)" runbook for the full grant flow.
+#        ai-apply-<svc> -> [read-<svc>, write-<svc>, github-mint]  (per-window, 6h/12h)
+#        ai-apply-all   -> [read-write-all, github-mint]           (per-window, 1h/6h)
+#        ai-admin       -> [ai-admin]                    (COMPLETE full admin, 1h, alerted)
+# "Unlock window" model: authorization is scoped by TASK / BLAST-RADIUS and
+# gated by ONE human UNLOCK per window, never by model capability (the model is
+# an AUDIT claim, never a key). Every apply/admin role is provisioned
+# manage_secret_id:false below, so the converge creates the INERT role but never
+# mints/stores a standing secret_id — a usable token exists only after a human
+# response-wraps a single-use secret_id on demand
+# (`bao write -wrap-ttl=90s -f auth/approle/role/<role>/secret-id`); that ONE
+# unlock then yields a token that lives the window (above), so the agent runs
+# unattended for the window instead of a human minting per task. ai-admin grants
+# COMPLETE full administrator access (superuser) — its containment is temporal
+# (1h) + procedural (human unlock) + observational (alerted every use), NOT
+# capability scoping. See the docs.dryvist.com "AI Agent Access (OpenBao)"
+# runbook for the full unlock/grant flow.
 #
 # SINGLE SOURCE OF TRUTH: add a writable service = ONE entry here. It renders a
 # new read-<svc>+write-<svc> pair, which auto-joins read-all/read-write-all and
@@ -641,18 +647,35 @@ openbao_ssh_sign_policies: >-
 # read+write leaves plus per-run GitHub attribution and interactive SSH-cert
 # signing (ssh-sign-automation-ai — 1h certs, non-root principals, audited).
 # Inert (no standing secret_id).
+# token_ttl/token_max_ttl are the "unlock window": one human unlock (a wrapped,
+# single-use secret_id) yields ONE login whose token then lives the window, so
+# an agent runs unattended for the whole window instead of re-asking per task.
+# The literals here must stay in sync with openbao_ai_apply_token_ttl /
+# openbao_ai_apply_token_max_ttl below (regex_replace can't interpolate a var
+# inside its replacement string; the standalone vars document the intent).
 openbao_ai_apply_approles: >-
   {{ openbao_ai_domains | map('regex_replace', '^(.+)$',
        '{"name": "ai-apply-\1", "token_policies": ["read-\1", "write-\1", "github-mint", "ssh-sign-automation-ai"],
-         "token_ttl": "1h", "token_max_ttl": "1h",
+         "token_ttl": "6h", "token_max_ttl": "12h",
          "manage_secret_id": false, "secret_id_ttl": "15m", "secret_id_num_uses": 1}')
      | map('from_json') | list }}
 openbao_ai_admin_policy_name: ai-admin
 openbao_ai_admin_approle_name: ai-admin
-# Token/secret_id bounds for the elevated tiers. secret_id_ttl bounds an UNUSED
-# minted grant; num_uses=1 makes the wrapped secret_id single-login.
-openbao_ai_apply_token_ttl: 1h
-openbao_ai_admin_token_ttl: 10m
+# Token/secret_id bounds for the elevated tiers, as the "unlock window" model:
+# one human unlock (a wrapped, single-use secret_id) -> one login -> a token that
+# lives the window, so an agent works unattended for the window instead of a
+# human minting per task. secret_id_ttl bounds an UNUSED minted grant (the redeem
+# window); num_uses=1 makes the wrapped secret_id single-login.
+#   ai-apply-<svc>  6h default / 12h max   (single-domain write — routine workhorse)
+#   ai-apply-all    1h default / 6h max    (cross-domain write — wider, so tighter)
+#   ai-admin        1h                     (COMPLETE full admin — alerted every use)
+# ai-apply-<svc> literals live in the generated openbao_ai_apply_approles above
+# and must match openbao_ai_apply_token_ttl / _max_ttl here.
+openbao_ai_apply_token_ttl: 6h
+openbao_ai_apply_token_max_ttl: 12h
+openbao_ai_apply_all_token_ttl: 1h
+openbao_ai_apply_all_token_max_ttl: 6h
+openbao_ai_admin_token_ttl: 1h
 openbao_ai_elevated_secret_id_ttl: 15m
 openbao_snapshot_policy_name: snapshot
 openbao_snapshot_approle_name: snapshot
@@ -768,14 +791,14 @@ openbao_base_approles:
     token_policies: >-
       {{ openbao_read_write_all_policies + ['github-mint']
          + (['ssh-sign-automation-ai'] if openbao_ssh_engine_enabled else []) }}
-    token_ttl: "{{ openbao_ai_apply_token_ttl }}"
-    token_max_ttl: "{{ openbao_ai_apply_token_ttl }}"
+    token_ttl: "{{ openbao_ai_apply_all_token_ttl }}"
+    token_max_ttl: "{{ openbao_ai_apply_all_token_max_ttl }}"
     manage_secret_id: false
     secret_id_ttl: "{{ openbao_ai_elevated_secret_id_ttl }}"
     secret_id_num_uses: 1
-  # ai-admin: break-glass, the ONE self-modify-capable role (policy/auth/token
-  # admin). NO standing secret_id; a token exists only after a human one-shot grant
-  # and lives <=10m, alerted on every use.
+  # ai-admin: break-glass, COMPLETE full administrator (superuser — every path,
+  # every capability incl. sudo). NO standing secret_id; a token exists only after
+  # a human one-shot unlock and lives the admin window (1h), alerted on every use.
   - name: "{{ openbao_ai_admin_approle_name }}"
     policy: "{{ openbao_ai_admin_policy_name }}"
     token_ttl: "{{ openbao_ai_admin_token_ttl }}"
@@ -872,7 +895,8 @@ openbao_base_policies:
   # they are ACTOR roles that attach the base read-/write- capability leaves
   # (generated below into openbao_ai_capability_policies). ai-admin remains a
   # standalone policy: it is the sole self-modify tier and is NOT composed leaves.
-  # ai-admin: break-glass. Intentionally root-ish; contained by TTL + human grant.
+  # ai-admin: break-glass COMPLETE full admin (superuser). Contained by TTL (1h)
+  # + human unlock + alerting, NOT capability scoping.
   - name: "{{ openbao_ai_admin_policy_name }}"
     template: ai-admin-policy.hcl.j2
   - name: "{{ openbao_snapshot_policy_name }}"

--- a/roles/openbao/templates/ai-admin-policy.hcl.j2
+++ b/roles/openbao/templates/ai-admin-policy.hcl.j2
@@ -1,80 +1,37 @@
 {{ ansible_managed | comment }}
 # OpenBao policy for the ai-admin AppRole — BREAK-GLASS, the top tier of the
-# AI-agent access model. Intentionally root-ish: policy edits, AppRole/token
-# administration, all KV, the broad IaC AWS STS broker, and GitHub token mint.
+# AI-agent access model. COMPLETE FULL ADMINISTRATOR access: every path, every
+# capability, including `sudo` for the sudo-protected control endpoints (seal,
+# step-down, raft, rekey, rotate, audit devices, root-token generation). This is
+# the canonical OpenBao superuser policy — equivalent to root operationally.
 #
 #   ai-readonly   read/plan/scan            (default, ambient, standing)
-#   ai-apply-<d>  scoped WRITE to domain d  (per-task, human-minted, <=1h)
-#   ai-admin      break-glass root-ish      (per-task, human-minted, <=10m)   <-- this
+#   ai-apply-<d>  scoped WRITE to domain d  (per-window, human-unlocked, 6h/12h)
+#   ai-admin      break-glass FULL admin    (per-window, human-unlocked, <=1h)   <-- this
 #
-# NEVER STANDING. There is no stored secret_id (manage_secret_id:false); the
-# converge creates the inert role only. A token exists solely after a human
-# response-wraps a single-use secret_id on demand, and lives <=10 minutes
-# (token_ttl 10m). EVERY use is audited (file audit device -> Cribl ->
-# index=openbao_audit) and MUST fire an alert — this is the tier that can edit
-# the controls themselves, so its use is an incident by construction, not a
-# routine. See docs.dryvist.com AI Agent Access runbook for the grant flow and
-# the alerting contract.
+# This environment is AI-created, -managed, and -monitored: an AI agent must be
+# able to acquire complete administrative control of OpenBao itself. Containment
+# is DELIBERATELY not least-privilege capability scoping — it is:
+#   * TEMPORAL      — the token lives at most the admin window (token_ttl 1h);
+#                     when it expires the agent must be re-unlocked.
+#   * PROCEDURAL    — NEVER STANDING. manage_secret_id:false; the converge creates
+#                     the inert role only. A usable token exists solely after a
+#                     one-shot human "unlock" response-wraps a single-use
+#                     secret_id (`bao write -wrap-ttl=90s -f
+#                     auth/approle/role/ai-admin/secret-id`).
+#   * OBSERVATIONAL — EVERY use is audited (file audit device -> Cribl ->
+#                     index=openbao_audit) and MUST fire an alert. This is the
+#                     tier that can edit the controls themselves, so its use is
+#                     an incident by construction, monitored after the fact — the
+#                     audit trail, not a capability wall, is the control.
 #
-# This is the ONE AI identity permitted to self-modify the auth/policy surface.
-# It is not bounded by an enumerated-exclusion argument like the lower tiers —
-# its containment is entirely temporal (10m), procedural (human one-shot grant),
-# and observational (alerted + audited), NOT least-privilege capability scoping.
+# See docs.dryvist.com "AI Agent Access (OpenBao)" runbook for the unlock/grant
+# flow and the alerting contract.
 
-# --- OpenBao policy + auth administration ------------------------------------
-path "sys/policies/acl/*" {
-  capabilities = ["create", "read", "update", "delete", "list"]
+# --- Complete full administrator access --------------------------------------
+# Every path, every capability, plus sudo for the sudo-protected sys endpoints
+# (sys/seal, sys/step-down, sys/raft/*, sys/rekey, sys/rotate, audit devices,
+# root-token generation). The canonical OpenBao superuser policy.
+path "*" {
+  capabilities = ["create", "read", "update", "delete", "list", "patch", "sudo"]
 }
-
-path "auth/approle/role/*" {
-  capabilities = ["create", "read", "update", "delete", "list"]
-}
-
-# Mint (and response-wrap) single-use secret_ids for the ai-apply-<domain> and
-# other AppRoles — this is the mechanism a human/admin session uses to hand a
-# lower tier its per-task grant.
-path "auth/approle/role/*/secret-id" {
-  capabilities = ["create", "update"]
-}
-
-path "auth/token/create" {
-  capabilities = ["create", "update"]
-}
-
-# Enumerate the secrets engines it may administer/mount. sys/mounts governs KV +
-# the AWS/GitHub secrets engines.
-path "sys/mounts/*" {
-  capabilities = ["create", "read", "update", "delete", "list"]
-}
-
-path "sys/auth/*" {
-  capabilities = ["create", "read", "update", "delete", "list"]
-}
-
-# --- All KV, all domains (incl. the infra kernel) ----------------------------
-path "{{ openbao_kv_mount }}/data/*" {
-  capabilities = ["create", "read", "update", "delete"]
-}
-
-path "{{ openbao_kv_mount }}/metadata/*" {
-  capabilities = ["create", "read", "update", "delete", "list"]
-}
-
-# --- Broad IaC AWS STS broker (identity-fabric writes) -----------------------
-# The openbao-iac-admin assumed_role broker (capped by its own AWS permissions
-# boundary), not the tf-proxmox-scoped role the apply tier would use.
-path "{{ openbao_aws_mount }}/sts/{{ openbao_aws_iac_admin_role_name }}" {
-  capabilities = ["read", "update"]
-}
-
-path "{{ openbao_aws_mount }}/sts/{{ openbao_aws_role_name }}" {
-  capabilities = ["read", "update"]
-}
-
-# --- GitHub App token mint (all administrator-defined permission sets) --------
-{% for permission_set in openbao_github_permission_sets %}
-path "{{ openbao_github_mount }}/token/{{ permission_set.name }}" {
-  capabilities = ["update"]
-}
-
-{% endfor %}


### PR DESCRIPTION
## Summary

Shifts the AI-agent OpenBao access model from **human-per-task** to **human-per-window**: one human *unlock* (a wrapped, single-use `secret_id`) yields one login whose token then lives the window, so an agent runs unattended for the window instead of re-asking each task. Roles stay `manage_secret_id: false` (inert, no standing `secret_id`) — the unlock is still the gate; the token TTL is the window.

| Tier | Window before | Window after |
| --- | --- | --- |
| `ai-apply-<svc>` (single-domain write) | 1h / 1h | **6h / 12h** |
| `ai-apply-all` (cross-domain write) | 1h / 1h | **1h / 6h** (tighter — wider blast radius) |
| `ai-admin` | 10m | **1h** |

## `ai-admin` → complete full administrator

The `ai-admin` policy is expanded from the enumerated root-ish grant to the canonical OpenBao **superuser** policy (`path "*"` with `sudo`). This is deliberate and requested: the environment is AI-created, -managed, and -monitored, so an agent must be able to acquire **complete** administrative control of OpenBao itself (incl. `sys/seal`, `sys/raft/*`, audit devices, root-token generation — the sudo-protected endpoints the old enumeration omitted).

Containment is **temporal** (1h token) + **procedural** (human one-shot unlock, inert role) + **observational** (alerted every use → `index=openbao_audit`), **not** capability scoping. This matches the design's existing statement that ai-admin's containment was never least-privilege.

## Reviewer context

Three independent reviewers flagged that blanket-allowing irreversible `sys`/admin ops trades away an accident-catcher. The operator's decision: the classifier is explicitly **not** the guard; the time-box + inert-unlock + audit/alert is. The window model bounds blast radius temporally rather than by capability, and every admin use is an alerted incident by construction.

## OpenBao plugins-first checklist

1. **Resource credentials touched?** None — this changes AppRole token TTLs and the `ai-admin` ACL scope only.
2. **Engine exists?** N/A — no credential production changes.
3. **Mint path?** N/A — the `github`/`aws` engines remain the sole mint path; no static creds, no new `secret/*` KV path.
4. **New KV-read-for-an-engine grant?** No. `ai-admin` already held all-KV; this broadens it to superuser per the explicit design, not to bypass an engine.

## Side effect

`github-admin` shares `openbao_ai_admin_token_ttl`, so its window also moves 10m → 1h — consistent (admin-tier, human-gated, inert AppRole).

## Verification

- `ansible-lint roles/openbao/`: **passed** (0 failures, profile `production`).
- YAML + generated-AppRole JSON validated.
- **Not yet converged** — applying to the live OpenBao cluster is a separate operator step (this is a fleet SPOF; converge deliberately gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)