### PR TITLE
fix(ci): isolate per-job ANSIBLE_HOME on the shared fleet runners

### DIFF
--- a/.github/workflows/_data-contract.yml
+++ b/.github/workflows/_data-contract.yml
@@ -62,6 +62,14 @@ jobs:
     # Self-hosted (pre-baked ansible + collections); fork PRs fall back to a
     # hosted runner so fork-author code never runs on the fleet.
     runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'proxmox' }}
+    env:
+      # Per-job Ansible state. The fleet runners share ~/.ansible, and
+      # concurrent `ansible-galaxy collection install` runs race in it — the
+      # git-sourced collection is tar-built under ANSIBLE_HOME/tmp, so two jobs
+      # on one host corrupt each other's build and every later job on that
+      # runner dies with "Collection tar file member MANIFEST.json does not
+      # contain a valid json string". runner.temp is unique per job.
+      ANSIBLE_HOME: ${{ runner.temp }}/ansible-home
 
     steps:
       - name: Checkout code
@@ -130,6 +138,9 @@ jobs:
   verify-inventory-load:
     name: Verify Inventory Load
     runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'proxmox' }}
+    env:
+      # Per-job Ansible state — see syntax-check above for why.
+      ANSIBLE_HOME: ${{ runner.temp }}/ansible-home
 
     steps:
       - name: Checkout code

--- a/.github/workflows/_data-contract.yml
+++ b/.github/workflows/_data-contract.yml
@@ -62,18 +62,21 @@ jobs:
     # Self-hosted (pre-baked ansible + collections); fork PRs fall back to a
     # hosted runner so fork-author code never runs on the fleet.
     runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'proxmox' }}
-    env:
-      # Per-job Ansible state. The fleet runners share ~/.ansible, and
-      # concurrent `ansible-galaxy collection install` runs race in it — the
-      # git-sourced collection is tar-built under ANSIBLE_HOME/tmp, so two jobs
-      # on one host corrupt each other's build and every later job on that
-      # runner dies with "Collection tar file member MANIFEST.json does not
-      # contain a valid json string". runner.temp is unique per job.
-      ANSIBLE_HOME: ${{ runner.temp }}/ansible-home
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # Per-job Ansible state. The fleet runners share ~/.ansible, and
+      # concurrent `ansible-galaxy collection install` runs race in it — the
+      # git-sourced collection is tar-built under ANSIBLE_HOME/tmp, so two
+      # jobs on one host corrupt each other's build and every later job on
+      # that runner dies with "Collection tar file member MANIFEST.json does
+      # not contain a valid json string". RUNNER_TEMP is unique per job. A
+      # $GITHUB_ENV step, not job-level env: the runner context is not
+      # available to jobs.<id>.env.
+      - name: Isolate per-job ANSIBLE_HOME
+        run: echo "ANSIBLE_HOME=$RUNNER_TEMP/ansible-home" >> "$GITHUB_ENV"
 
       # Hosted-only provisioning: fleet runners use the image's pre-baked
       # toolchain — setup-python's standalone build needs a newer CPU ISA
@@ -138,13 +141,14 @@ jobs:
   verify-inventory-load:
     name: Verify Inventory Load
     runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'proxmox' }}
-    env:
-      # Per-job Ansible state — see syntax-check above for why.
-      ANSIBLE_HOME: ${{ runner.temp }}/ansible-home
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # Per-job Ansible state — see syntax-check above for why.
+      - name: Isolate per-job ANSIBLE_HOME
+        run: echo "ANSIBLE_HOME=$RUNNER_TEMP/ansible-home" >> "$GITHUB_ENV"
 
       # Hosted-only provisioning — same constraint as syntax-check above.
       - name: Set up Python

--- a/.github/workflows/_molecule.yml
+++ b/.github/workflows/_molecule.yml
@@ -17,14 +17,6 @@ jobs:
     # Self-hosted (pre-baked toolchain); fork PRs fall back to a hosted runner
     # so fork-author code never runs on the fleet.
     runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'proxmox' }}
-    env:
-      # Per-job Ansible state. The fleet runners share ~/.ansible, and
-      # concurrent `ansible-galaxy collection install` runs race in it — the
-      # git-sourced collection is tar-built under ANSIBLE_HOME/tmp, so two jobs
-      # on one host corrupt each other's build and every later job on that
-      # runner dies with "Collection tar file member MANIFEST.json does not
-      # contain a valid json string". runner.temp is unique per job.
-      ANSIBLE_HOME: ${{ runner.temp }}/ansible-home
     strategy:
       fail-fast: false
       matrix:
@@ -50,6 +42,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # Per-job Ansible state. The fleet runners share ~/.ansible, and
+      # concurrent `ansible-galaxy collection install` runs race in it — the
+      # git-sourced collection is tar-built under ANSIBLE_HOME/tmp, so two
+      # jobs on one host corrupt each other's build and every later job on
+      # that runner dies with "Collection tar file member MANIFEST.json does
+      # not contain a valid json string". RUNNER_TEMP is unique per job. A
+      # $GITHUB_ENV step, not job-level env: the runner context is not
+      # available to jobs.<id>.env.
+      - name: Isolate per-job ANSIBLE_HOME
+        run: echo "ANSIBLE_HOME=$RUNNER_TEMP/ansible-home" >> "$GITHUB_ENV"
 
       # Hosted-only provisioning: fleet runners use the image's pre-baked
       # toolchain — setup-python's standalone build needs a newer CPU ISA
@@ -134,13 +137,14 @@ jobs:
   template-render:
     name: Template Rendering Tests
     runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'proxmox' }}
-    env:
-      # Per-job Ansible state — see the `test` job above for why.
-      ANSIBLE_HOME: ${{ runner.temp }}/ansible-home
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # Per-job Ansible state — see the `test` job above for why.
+      - name: Isolate per-job ANSIBLE_HOME
+        run: echo "ANSIBLE_HOME=$RUNNER_TEMP/ansible-home" >> "$GITHUB_ENV"
 
       # Hosted-only provisioning — same constraint as the test job above.
       - name: Set up Python

--- a/.github/workflows/_molecule.yml
+++ b/.github/workflows/_molecule.yml
@@ -17,6 +17,14 @@ jobs:
     # Self-hosted (pre-baked toolchain); fork PRs fall back to a hosted runner
     # so fork-author code never runs on the fleet.
     runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'proxmox' }}
+    env:
+      # Per-job Ansible state. The fleet runners share ~/.ansible, and
+      # concurrent `ansible-galaxy collection install` runs race in it — the
+      # git-sourced collection is tar-built under ANSIBLE_HOME/tmp, so two jobs
+      # on one host corrupt each other's build and every later job on that
+      # runner dies with "Collection tar file member MANIFEST.json does not
+      # contain a valid json string". runner.temp is unique per job.
+      ANSIBLE_HOME: ${{ runner.temp }}/ansible-home
     strategy:
       fail-fast: false
       matrix:
@@ -126,6 +134,9 @@ jobs:
   template-render:
     name: Template Rendering Tests
     runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'proxmox' }}
+    env:
+      # Per-job Ansible state — see the `test` job above for why.
+      ANSIBLE_HOME: ${{ runner.temp }}/ansible-home
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Problem

Every CI wave today hit the same failure across unrelated Molecule/Data-Contract jobs: `ansible-galaxy collection install` dying in ~1s with `Collection tar file member MANIFEST.json does not contain a valid json string`. Job→runner correlation for one run shows it exactly tracks runner containers, not scenarios: every job on two runner containers failed with this, every job on the other containers passed.

Cause: the fleet runner containers share `~/.ansible`. Concurrent galaxy installs race in it — the git-sourced homelab-contracts collection is tar-built under `ANSIBLE_HOME/tmp` — and a corrupted artifact then fails every subsequent install on that runner. This is also the long-standing source of the 'molecule is flaky, rerun it' pattern.

## Fix

Job-level `ANSIBLE_HOME: ${{ runner.temp }}/ansible-home` on the four jobs that run galaxy installs on fleet runners (Molecule test matrix, Template Rendering, Syntax Check, Verify Inventory Load). `runner.temp` is unique per job, so shared mutable state is gone.

- Each of these jobs already installs its own collections from `requirements.yml` — nothing relied on the shared dir except as a cache.
- `roles_path` is repo-relative (`ansible.cfg`), unaffected.
- Hosted-runner jobs are single-use VMs and need nothing.

## Verification

This PR's own CI runs the patched reusable workflows (local `uses:` resolves to the PR merge ref), so a green run here is the fix proving itself on the fleet runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJfqTnsdLekPNt9SVYfKYN