### PR TITLE
fix(postgres): align apps with shared primary

### DIFF
--- a/.github/workflows/_data-contract.yml
+++ b/.github/workflows/_data-contract.yml
@@ -182,3 +182,6 @@ jobs:
           PROXMOX_SSH_KEY_PATH: /dev/null
           PROXMOX_DKR_SSH_KEY_PATH: /dev/null
           ANSIBLE_HOST_KEY_CHECKING: 'false'
+
+      - name: Verify apps PostgreSQL primary routing
+        run: ansible-playbook tests/postgres_apps_primary/verify.yml -c local

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -67,15 +67,16 @@ bao_media_secrets: {}
 # secret_key, superuser_password under secret/apps/nautobot).
 bao_apps_secrets: {}
 
-# Shared-Postgres primary host — the switch for the streaming-replication
-# topology (issue #138). Empty = single-primary: every postgres-tagged guest is
-# its own primary and apps reach the DB by the stable `postgres` name. Set to
-# the primary guest's inventory hostname to make that guest primary and every
-# OTHER postgres-tagged guest a hot standby streaming from it.
-#
-# This env lookup is only the fallback for groups WITHOUT a committed
-# declaration: the apps cluster declares its primary in postgres_group.yml
-# (group_vars beats all.yml, so POSTGRES_PRIMARY_HOST cannot reach it). For a
-# deliberate failover there, override with `-e postgres_primary_host=...`.
-# The postgres role and the app *_db_host both read this.
+# Generic PostgreSQL primary override for clusters that do not declare their
+# own primary. Empty preserves the role's single-primary default. The shared
+# apps cluster and AI cluster use scoped declarations, so changing this
+# fallback cannot reroute either tier.
 postgres_primary_host: "{{ lookup('env', 'POSTGRES_PRIMARY_HOST') | default('', true) }}"
+
+# One routing authority for the shared apps PostgreSQL cluster and all of its
+# clients. Keeping this scoped name in all.yml makes it visible to the
+# postgres, Nautobot, Vikunja, and Zammad groups without exposing those hosts
+# to each other's role vars. Override this one value for a deliberate apps-tier
+# failover; unrelated PostgreSQL tiers do not consume it.
+postgres_apps_primary_host: >-
+  {{ lookup('env', 'POSTGRES_APPS_PRIMARY_HOST') | default('postgres-apps', true) }}

--- a/inventory/group_vars/nautobot_group.yml
+++ b/inventory/group_vars/nautobot_group.yml
@@ -9,13 +9,11 @@ nautobot_web_port: >-
   {{ (hostvars['localhost']['tofu_data']['constants']['service_ports']['nautobot_web'])
      | default(8080) }}
 
-# Postgres has no ingress; reach it by the primary guest's FQDN. Tracks the
-# shared postgres_primary_host switch (group_vars/all): unset -> the stable
-# `postgres` name (today); set to the apps-tier primary at cutover -> that name.
-# A guest hostname is a stable service identifier here, not a hard-coded address.
+# Postgres has no ingress; reach it by the shared apps cluster's declared
+# primary FQDN. A guest hostname is a stable service identifier here, not a
+# hard-coded address.
 nautobot_db_host: >-
-  {{ (postgres_primary_host if (postgres_primary_host | default('', true) | length > 0) else 'postgres')
-     }}.{{ hostvars['localhost']['tofu_data']['domain'] }}
+  {{ postgres_apps_primary_host }}.{{ hostvars['localhost']['tofu_data']['domain'] }}
 nautobot_db_password: >-
   {{ bao_apps_secrets.db_password
      | default(lookup('env', 'NAUTOBOT_DB_PASSWORD'), true) }}

--- a/inventory/group_vars/postgres_group.yml
+++ b/inventory/group_vars/postgres_group.yml
@@ -7,18 +7,16 @@
 # default (roles/postgres/defaults/main.yml) for why this cluster listens on
 # the wildcard instead of the guest's discovered address.
 
-# Which member of this cluster is the streaming primary. group_vars/all.yml
-# leaves this to an env lookup that defaults to '', and postgres_role derives
-# 'standby' only when it is non-empty AND != inventory_hostname. So an empty
-# value makes EVERY postgres-tagged guest compute role=primary.
+# Which member of this cluster is the streaming primary. The scoped apps-tier
+# authority in group_vars/all.yml is shared with every client, so a normal
+# converge cannot point the applications at a different member than the
+# replication role declares primary.
 #
 # That was the live state until 2026-07-29: postgres-apps was a streaming
 # primary with an active `standby_postgres` slot feeding the `postgres` guest,
 # and none of it was expressed in IaC. A converge or a rebuild would have
-# produced two primaries. Declaring it here makes the running topology
-# reproducible; group_vars beats all.yml, and `-e` still overrides for a
-# deliberate failover.
-postgres_primary_host: postgres-apps
+# produced two primaries.
+postgres_primary_host: "{{ postgres_apps_primary_host }}"
 
 # Databases on this shared cluster. Each password is bao-first
 # (secret/apps/<app>) with an env fallback; each client_cidr is the app LXC's

--- a/inventory/group_vars/vikunja_group.yml
+++ b/inventory/group_vars/vikunja_group.yml
@@ -32,17 +32,11 @@ vikunja_admin_password: >-
   {{ bao_apps_secrets.vikunja_admin_password
      | default(lookup('env', 'VIKUNJA_ADMIN_PASSWORD'), true) }}
 
-# Postgres has no ingress; reach it by the primary guest's FQDN. Tracks the
-# shared postgres_primary_host switch (group_vars/all): unset -> the stable
-# `postgres` name (today); set to the apps-tier primary at cutover -> that name.
-# A guest hostname is a stable service identifier here, not a hard-coded address.
-#
-# Without this, Vikunja alone keeps the role default (`postgres`) while Nautobot
-# and Zammad follow the switch — and the same cutover reinitializes that guest as
-# a read-only standby, so Vikunja's writes would fail against it.
+# Postgres has no ingress; reach it by the shared apps cluster's declared
+# primary FQDN. A guest hostname is a stable service identifier here, not a
+# hard-coded address.
 vikunja_db_host: >-
-  {{ (postgres_primary_host if (postgres_primary_host | default('', true) | length > 0) else 'postgres')
-     }}.{{ hostvars['localhost']['tofu_data']['domain'] }}
+  {{ postgres_apps_primary_host }}.{{ hostvars['localhost']['tofu_data']['domain'] }}
 
 # MCP service-account passwords bao-first (secret/apps/vikunja fields
 # svc_mcp_ro_password / svc_mcp_rw_password). Redefines the role-default list so

--- a/inventory/group_vars/zammad_group.yml
+++ b/inventory/group_vars/zammad_group.yml
@@ -11,13 +11,11 @@ zammad_web_port: >-
   {{ (hostvars['localhost']['tofu_data']['constants']['service_ports']['zammad_web'])
      | default(8080) }}
 
-# Postgres has no ingress; reach it by the primary guest's FQDN. Tracks the
-# shared postgres_primary_host switch (group_vars/all): unset -> the stable
-# `postgres` name (today); set to the apps-tier primary at cutover -> that name.
-# A guest hostname is a stable service identifier here, not a hard-coded address.
+# Postgres has no ingress; reach it by the shared apps cluster's declared
+# primary FQDN. A guest hostname is a stable service identifier here, not a
+# hard-coded address.
 zammad_db_host: >-
-  {{ (postgres_primary_host if (postgres_primary_host | default('', true) | length > 0) else 'postgres')
-     }}.{{ hostvars['localhost']['tofu_data']['domain'] }}
+  {{ postgres_apps_primary_host }}.{{ hostvars['localhost']['tofu_data']['domain'] }}
 zammad_db_password: >-
   {{ bao_apps_secrets.zammad_db_password
      | default(lookup('env', 'ZAMMAD_DB_PASSWORD'), true) }}

--- a/tests/postgres_apps_primary/verify.yml
+++ b/tests/postgres_apps_primary/verify.yml
@@ -1,0 +1,50 @@
+---
+- name: Verify shared apps PostgreSQL routing authority
+  hosts: localhost
+  gather_facts: false
+  vars_files:
+    - ../../inventory/group_vars/all.yml
+    - ../../inventory/group_vars/postgres_group.yml
+    - ../../inventory/group_vars/nautobot_group.yml
+    - ../../inventory/group_vars/vikunja_group.yml
+    - ../../inventory/group_vars/zammad_group.yml
+  tasks:
+    - name: Set the published inventory domain fixture
+      ansible.builtin.set_fact:
+        tofu_data:
+          domain: example.test
+
+    - name: Assert every apps-tier consumer follows the declared primary
+      ansible.builtin.assert:
+        that:
+          - postgres_apps_primary_host == 'postgres-apps'
+          - postgres_primary_host == postgres_apps_primary_host
+          - nautobot_db_host == 'postgres-apps.example.test'
+          - vikunja_db_host == 'postgres-apps.example.test'
+          - zammad_db_host == 'postgres-apps.example.test'
+
+    - name: Model a deliberate apps-tier failover
+      ansible.builtin.set_fact:
+        postgres_apps_primary_host: postgres
+
+    - name: Assert one override moves the cluster role and every client
+      ansible.builtin.assert:
+        that:
+          - postgres_primary_host == 'postgres'
+          - nautobot_db_host == 'postgres.example.test'
+          - vikunja_db_host == 'postgres.example.test'
+          - zammad_db_host == 'postgres.example.test'
+
+- name: Verify the AI PostgreSQL tier remains independent
+  hosts: localhost
+  gather_facts: false
+  vars_files:
+    - ../../inventory/group_vars/all.yml
+    - ../../inventory/group_vars/postgres_ai_group.yml
+
+  tasks:
+    - name: Assert the AI primary declaration is unchanged
+      ansible.builtin.assert:
+        that:
+          - postgres_primary_host == 'postgres-ai-1'
+          - postgres_cluster_group == 'postgres_ai_group'


### PR DESCRIPTION
## Summary
- define one apps-tier PostgreSQL primary authority shared by the database cluster and all three clients
- keep the AI PostgreSQL tier independent
- add a CI regression proving default routing and deliberate failover behavior

## Validation
- `ansible-playbook tests/postgres_apps_primary/verify.yml -c local`
- `ansible-lint` on all touched Ansible files
- `pre-commit run --files ...` on all changed files

## Live scope
No live converge or guest change is included. This only makes the next declarative converge preserve the current `postgres-apps` routing.