### PR TITLE
feat(technitium_dns): publish idrac-<node> A records from env single source

### DIFF
--- a/inventory/group_vars/technitium_dns_group.yml
+++ b/inventory/group_vars/technitium_dns_group.yml
@@ -52,14 +52,33 @@ technitium_dns_extra_cname_records:
 # Studio above. IP comes from the live tofu reservation, not a literal, so it
 # tracks any future re-IP automatically. The underlying domain-naming mismatch
 # (every guest using bare-apex FQDNs is exposed to the same gap) is tracked
-# separately — see ansible-proxmox-apps issue (INC-17123 follow-up).
-technitium_dns_extra_a_records:
-  - name: "{{ llm_large_serving_host }}"
-    ip: "{{ llm_large_serving_ip }}"
-  - name: cribl-stream-01
-    # Cribl Stream is critical-tier, so container_ip is its declared static
-    # address. default('') so an incomplete inventory during a rebuild
-    # (cribl-stream-01 not yet loaded) yields a blank IP that the writer's truthy
-    # filter skips, instead of an undefined-var error that aborts the play (#17136).
-    ip: "{{ hostvars['cribl-stream-01'].container_ip | default('', true) }}"
-    zone: "{{ technitium_dns_apex_domain }}"
+# separately — see ansible-proxmox-apps issue (INC-17123 follow-up). Its IP keeps
+# default('') so an incomplete inventory during a rebuild (cribl-stream-01 not yet
+# loaded) yields a blank IP the writer's truthy filter skips, instead of an
+# undefined-var error that aborts the play (#17136).
+# Out-of-band management (BMC) addresses, as `<node>=<address>` pairs from the
+# PROXMOX_BMC_ADDRESSES single source. A BMC vends its own default hostname from
+# the CHASSIS MODEL or the vendor service tag, so the only names that resolve to
+# one identify the metal, not the node running on it — aiming a power or console
+# action by node name is then pure inference, and inferring it wrongly power-cycled
+# a live node (Zammad #17188). Publishing `idrac-<node>` gives that name.
+#
+# Env-sourced, never literals: this repo is public and a BMC address is the
+# privileged out-of-band interface. Unset env yields an empty map, hence no
+# records — the writer's truthy filter skips a blank IP, so a node whose BMC is
+# absent (consumer boards have none) simply contributes nothing.
+technitium_dns_bmc_addresses: >-
+  {{ dict(lookup('env', 'PROXMOX_BMC_ADDRESSES') | default('', true)
+     | split(',') | map('trim') | reject('equalto', '')
+     | map('split', '=') | list) }}
+
+technitium_dns_extra_a_records: >-
+  {{ [
+       {'name': llm_large_serving_host, 'ip': llm_large_serving_ip},
+       {'name': 'cribl-stream-01',
+        'ip': hostvars['cribl-stream-01'].container_ip | default('', true),
+        'zone': technitium_dns_apex_domain},
+     ]
+     + (dict(technitium_dns_bmc_addresses.keys() | map('regex_replace', '^', 'idrac-')
+             | zip(technitium_dns_bmc_addresses.values()))
+        | dict2items(key_name='name', value_name='ip')) }}

--- a/inventory/group_vars/technitium_dns_group.yml
+++ b/inventory/group_vars/technitium_dns_group.yml
@@ -67,10 +67,14 @@ technitium_dns_extra_cname_records:
 # privileged out-of-band interface. Unset env yields an empty map, hence no
 # records — the writer's truthy filter skips a blank IP, so a node whose BMC is
 # absent (consumer boards have none) simply contributes nothing.
+#
+# regex_replace collapses whitespace around `=` before the split, so the
+# natural operator spelling `<node> = <address>` yields a clean key/value
+# instead of a record name with an embedded space the API would reject.
 technitium_dns_bmc_addresses: >-
   {{ dict(lookup('env', 'PROXMOX_BMC_ADDRESSES') | default('', true)
      | split(',') | map('trim') | reject('equalto', '')
-     | map('split', '=') | list) }}
+     | map('regex_replace', '\s*=\s*', '=') | map('split', '=') | list) }}
 
 technitium_dns_extra_a_records: >-
   {{ [

--- a/molecule/technitium_dns/verify.yml
+++ b/molecule/technitium_dns/verify.yml
@@ -177,7 +177,7 @@
         parse_bmc: >-
           {{ dict(bmc_source | default('', true)
              | split(',') | map('trim') | reject('equalto', '')
-             | map('split', '=') | list) }}
+             | map('regex_replace', '\s*=\s*', '=') | map('split', '=') | list) }}
         bmc_records: >-
           {{ dict(parse_bmc.keys() | map('regex_replace', '^', 'idrac-')
                   | zip(parse_bmc.values()))
@@ -186,14 +186,18 @@
         that:
           - >-
             (bmc_records | map(attribute='name') | list)
-            == (bmc_source | length > 0) | ternary(['idrac-node-a', 'idrac-node-b'], [])
+            == (bmc_source | trim | length > 0) | ternary(['idrac-node-a', 'idrac-node-b'], [])
           - >-
             (bmc_records | map(attribute='ip') | list)
-            == (bmc_source | length > 0) | ternary(['192.0.2.11', '192.0.2.12'], [])
+            == (bmc_source | trim | length > 0) | ternary(['192.0.2.11', '192.0.2.12'], [])
         fail_msg: >-
           BMC parsing produced {{ bmc_records }} for source '{{ bmc_source }}'.
+      # Third case is the operator-spaced spelling; fourth is whitespace-only,
+      # which trims to empty and must contribute no records at all.
       loop:
         - "node-a=192.0.2.11, node-b=192.0.2.12"
         - ""
+        - "node-a = 192.0.2.11 , node-b = 192.0.2.12"
+        - "   "
       loop_control:
         loop_var: bmc_source

--- a/molecule/technitium_dns/verify.yml
+++ b/molecule/technitium_dns/verify.yml
@@ -168,3 +168,32 @@
         fail_msg: >-
           Extra-A truthy filter did not drop the empty-ip entry:
           {{ technitium_dns_extra_a_records }}.
+
+    # BMC records: the `<node>=<address>` env single source must parse into
+    # idrac-<node> entries, and an unset/empty source must yield an empty map
+    # rather than a malformed entry — a node with no BMC contributes nothing.
+    - name: Assert BMC address parsing yields idrac-<node> entries
+      vars:
+        parse_bmc: >-
+          {{ dict(bmc_source | default('', true)
+             | split(',') | map('trim') | reject('equalto', '')
+             | map('split', '=') | list) }}
+        bmc_records: >-
+          {{ dict(parse_bmc.keys() | map('regex_replace', '^', 'idrac-')
+                  | zip(parse_bmc.values()))
+             | dict2items(key_name='name', value_name='ip') }}
+      ansible.builtin.assert:
+        that:
+          - >-
+            (bmc_records | map(attribute='name') | list)
+            == (bmc_source | length > 0) | ternary(['idrac-node-a', 'idrac-node-b'], [])
+          - >-
+            (bmc_records | map(attribute='ip') | list)
+            == (bmc_source | length > 0) | ternary(['192.0.2.11', '192.0.2.12'], [])
+        fail_msg: >-
+          BMC parsing produced {{ bmc_records }} for source '{{ bmc_source }}'.
+      loop:
+        - "node-a=192.0.2.11, node-b=192.0.2.12"
+        - ""
+      loop_control:
+        loop_var: bmc_source


### PR DESCRIPTION
Adds per-node out-of-band management A records to the local DNS zone.

- New `technitium_dns_bmc_addresses`: parses a `<node>=<address>` environment single source into a map. No address literal is added to this repository; an unset or empty source yields an empty map.
- `technitium_dns_extra_a_records` now appends one `idrac-<node>` entry per parsed node. The existing writer's truthy-IP filter skips a blank address, so a node with no BMC contributes nothing.
- Molecule verify asserts the parse for both a populated and an empty source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCcZBzRrPxHtAQYbk3skVH