### PR TITLE
docs(traefik): drop decommissioned pi-hole from Tier 2 infra UI list

### DIFF
--- a/roles/traefik/README.md
+++ b/roles/traefik/README.md
@@ -90,7 +90,7 @@ fronted service is added/removed in exactly one place. Add it in tofu-proxmox.
   (→ `seerr` backend), `sonarr`, `radarr`, `qbittorrent`, `prowlarr`. Reachable
   at layer 2 — no UniFi rule, and **no killswitch change** (the qBittorrent/Prowlarr
   WebUIs are LAN-reachable; the killswitch governs egress only).
-- **Tier 2 — infra UIs on other VLANs** (`technitium`, `pihole`, `phpipam`,
+- **Tier 2 — infra UIs on other VLANs** (`technitium`, `phpipam`,
   `mailpit`, `ntfy`, `homeassistant`, `openproject`, `prometheus`,
   `qdrant`, `haproxy-stats`): each needs a **UniFi inter-VLAN allow** (Traefik
   `media_svc` → target VLAN), enforced in `terraform-unifi`. Some apps also need


### PR DESCRIPTION
## Summary
- Removes a decommissioned service from the Traefik role's Tier 2 infra-UI backend list.

## Test plan
- Docs-only change; no roles or playbooks touched.