### PR TITLE
fix(download_vpn): self-heal killswitch, indexer/CF-solver restarts, FlareSolverr deps

### DIFF
--- a/molecule/download_vpn/verify.yml
+++ b/molecule/download_vpn/verify.yml
@@ -153,6 +153,38 @@
           - "'policy drop' in live_chain.stdout"
         fail_msg: "Loaded killswitch output policy is not drop."
 
+    # --- 1b. self-healing /etc/nftables.conf survives an unattended flush --
+    # Reproduces exactly what Debian's nftables postinst does on every package
+    # upgrade (`nft flush ruleset` then `nft -f /etc/nftables.conf` — the
+    # ExecStop/ExecStart pair of nftables.service): proves the killswitch table
+    # is reconstructed by that reload, not merely present because we loaded it
+    # by hand two tasks ago.
+    - name: Simulate the exact flush an unattended nftables restart triggers
+      ansible.builtin.command:
+        cmd: nft flush ruleset
+      changed_when: true
+
+    - name: Simulate nftables.service's own reload of /etc/nftables.conf
+      ansible.builtin.command:
+        cmd: nft -f /etc/nftables.conf
+      changed_when: true
+
+    - name: Read the killswitch output chain after the simulated flush+reload
+      ansible.builtin.command:
+        cmd: nft list chain inet killswitch output
+      register: post_flush_chain
+      changed_when: false
+
+    - name: Assert the killswitch survives the simulated flush+reload
+      ansible.builtin.assert:
+        that:
+          - "'policy drop' in post_flush_chain.stdout"
+        fail_msg: >-
+          The killswitch table did NOT survive a simulated `nft flush ruleset`
+          + `nft -f /etc/nftables.conf` (exactly what an unattended nftables
+          package restart does). /etc/nftables.conf must `include` the
+          killswitch ruleset so that reload is atomic and self-healing.
+
     # --- 2. qBittorrent bound to wg0 ---------------------------------------
     - name: Read qBittorrent config
       ansible.builtin.slurp:
@@ -296,6 +328,26 @@
           - "'peer \"${BACKUP_PEER}\" endpoint' in (validator.content | b64decode)"
           - "'peer \"${PRIMARY_PEER}\" remove' in (validator.content | b64decode)"
         fail_msg: "Runtime validator does not cover both address families, fail closed, or sticky failover."
+
+    - name: Assert the self-heal loop restarts ALL FOUR tunnel-bound services
+      # All four units carry BindsTo=download-vpn-wg.service, so all four stop
+      # whenever the tunnel unit restarts (e.g. a real Proton failover) — not
+      # just qBittorrent/NAT-PMP. Prowlarr and FlareSolverr previously stayed
+      # down until the next converge; regressing this silently breaks indexer
+      # sync again.
+      vars:
+        _validator_content: "{{ validator.content | b64decode }}"
+      ansible.builtin.assert:
+        that:
+          - "'for svc in ' in _validator_content"
+          - "'qbittorrent-nox.service' in _validator_content"
+          - "'download-vpn-natpmp.service' in _validator_content"
+          - "'prowlarr.service' in _validator_content"
+          - "'flaresolverr.service' in _validator_content"
+        fail_msg: >-
+          The runtime validator's self-heal loop must restart all four
+          BindsTo=download-vpn-wg.service units, not just qbittorrent-nox and
+          download-vpn-natpmp.
 
     - name: Clean up the loaded killswitch table
       ansible.builtin.command:

--- a/roles/download_vpn/README.md
+++ b/roles/download_vpn/README.md
@@ -37,6 +37,13 @@ outside the VPN:
    intact so the tunnel is never recursively routed. The role re-asserts this
    table immediately before the deploy-time gate, atomically rebuilding it only
    when it has drifted to a clearnet `default via`, so every converge is clean.
+7. **Self-healing `/etc/nftables.conf`** — Debian's nftables package restarts
+   `nftables.service` (a global `flush ruleset` + reload) on every package
+   upgrade, including unattended ones; without this, that restart would erase
+   the killswitch with no systemd-visible signal. `/etc/nftables.conf` is
+   role-managed to `include` the killswitch and LAN-reply rulesets, so the same
+   restart's reload is one atomic transaction that reconstructs them instead of
+   leaving the box open. See `templates/nftables.conf.j2`.
 
 ## Persistent state
 
@@ -103,7 +110,11 @@ If/when IPv6 is enabled, do **all** of these or it can leak:
   violation.**
 - **Runtime** — `download-vpn-validate.timer` (every ~2 min). Re-checks the
   above; on ANY breach it stops qBittorrent, alerts ntfy, and pings the
-  healthchecks deadman. A stalled validator also pages (deadman semantics).
+  healthchecks deadman. A stalled validator also pages (deadman semantics). On
+  a clean cycle it also self-heals: qBittorrent, NAT-PMP, Prowlarr, and
+  FlareSolverr all carry `BindsTo=download-vpn-wg.service`, so all four stop
+  whenever the tunnel unit restarts (e.g. a real Proton failover); the
+  validator restarts any of the four still down once the VPN is healthy again.
 
 ## Installation
 

--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -344,6 +344,35 @@ download_vpn_flaresolverr_port: 8191
 # Plex; the cap guarantees the kernel OOM-kills FlareSolverr (stateless,
 # auto-restarts) rather than qBittorrent or a Plex-serving sibling.
 download_vpn_flaresolverr_memory_max: "2G"
+# FlareSolverr bundles its own headless-Chromium BINARY but not the shared
+# libraries it links against — those come from Debian's own packages (derived
+# from `apt-cache depends chromium`, the authoritative source, not a guess).
+# Package names for the subset affected by the 64-bit time_t ABI transition
+# differ starting with Debian 13/trixie (a "t64" suffix); everything else is
+# unaffected and identical across releases. Both bookworm and trixie are
+# declared-supported (meta/main.yml), so pick the right suffix instead of
+# hardcoding one release.
+download_vpn_flaresolverr_chromium_libs_t64_suffix: >-
+  {{ 't64' if (ansible_facts['distribution_major_version'] | default('13') | int) >= 13 else '' }}
+download_vpn_flaresolverr_chromium_libs:
+  - "libasound2{{ download_vpn_flaresolverr_chromium_libs_t64_suffix }}"
+  - "libatk-bridge2.0-0{{ download_vpn_flaresolverr_chromium_libs_t64_suffix }}"
+  - "libatk1.0-0{{ download_vpn_flaresolverr_chromium_libs_t64_suffix }}"
+  - "libatspi2.0-0{{ download_vpn_flaresolverr_chromium_libs_t64_suffix }}"
+  - "libcups2{{ download_vpn_flaresolverr_chromium_libs_t64_suffix }}"
+  - libcairo2
+  - libgbm1
+  - libnspr4
+  - libnss3
+  - libpango-1.0-0
+  - libx11-6
+  - libxcb1
+  - libxcomposite1
+  - libxdamage1
+  - libxext6
+  - libxfixes3
+  - libxkbcommon0
+  - libxrandr2
 
 # --- NAT-PMP port forwarding -------------------------------------------------
 # Proton supports NAT-PMP. A systemd service loops natpmpc to keep a forwarded

--- a/roles/download_vpn/tasks/main.yml
+++ b/roles/download_vpn/tasks/main.yml
@@ -542,6 +542,25 @@
     daemon_reload: true
   when: download_vpn_manage_services
 
+# --- Phase 5c: self-healing /etc/nftables.conf (survives an unattended flush) -
+# Debian's nftables package restarts nftables.service (`nft flush ruleset` then
+# `nft -f /etc/nftables.conf`) on every package upgrade, including unattended
+# ones. Making that file `include` our own rulesets means the restart's own
+# atomic reload reconstructs the killswitch + LAN-reply tables instead of
+# leaving them flushed. See templates/nftables.conf.j2 for the full rationale.
+# Not notified to any handler: writing the file must never itself trigger an
+# nftables.service reload, which would also flush WireGuard's own fwmark table
+# and disrupt a live tunnel. It takes effect the next time something else
+# restarts nftables.service — precisely the event this guards against.
+- name: Deploy self-healing /etc/nftables.conf (includes our rulesets)
+  ansible.builtin.template:
+    src: nftables.conf.j2
+    dest: /etc/nftables.conf
+    owner: root
+    group: root
+    mode: "0755"
+    validate: "/usr/sbin/nft -c -f %s"
+
 # --- Phase 6: qBittorrent ----------------------------------------------------
 # Pre-create every level of the --profile tree (see defaults/main.yml) with the
 # correct owner BEFORE the daemon starts, so it never has to mkdir its own tree
@@ -782,6 +801,17 @@
 # A native binary + bundled headless Chromium, co-located here so its solve
 # traffic shares Prowlarr's wg0 egress (CloudFlare binds the clearance to the
 # solving IP). Loopback-bound; the killswitch already covers its egress.
+# FlareSolverr's bundled Chromium was crash-looping (`error while loading
+# shared libraries`) because these runtime libs were never installed — the
+# role installed FlareSolverr but not the browser's own dependencies. See
+# defaults/main.yml for how the package list is derived and kept portable
+# across Debian releases.
+- name: Install FlareSolverr's headless-Chromium runtime dependencies
+  ansible.builtin.apt:
+    name: "{{ download_vpn_flaresolverr_chromium_libs }}"
+    state: present
+  when: download_vpn_flaresolverr_enabled
+
 - name: Create the FlareSolverr system user
   ansible.builtin.user:
     name: "{{ download_vpn_flaresolverr_user }}"

--- a/roles/download_vpn/templates/killswitch-validate.sh.j2
+++ b/roles/download_vpn/templates/killswitch-validate.sh.j2
@@ -181,7 +181,12 @@ echo 0 > "{{ download_vpn_failover_counter_file }}" 2>/dev/null || true
 # maintenance. --no-block queues the start asynchronously so a slow or hung
 # service start can never stall this validator — it must stay responsive so the
 # next cycle can still catch a leak.
-for svc in qbittorrent-nox.service download-vpn-natpmp.service; do
+#
+# Covers all four units carrying BindsTo=download-vpn-wg.service (they all stop
+# together whenever the tunnel unit restarts, e.g. a real Proton failover): not
+# just qBittorrent/NAT-PMP but also Prowlarr and FlareSolverr, which previously
+# stayed down after every tunnel restart until the next converge.
+for svc in qbittorrent-nox.service download-vpn-natpmp.service prowlarr.service flaresolverr.service; do
   if [[ "$(systemctl is-enabled "${svc}" 2>/dev/null)" == "enabled" \
      && "$(systemctl is-active "${svc}" 2>/dev/null)" != "active" ]]; then
     logger -t killswitch-validate \

--- a/roles/download_vpn/templates/nftables.conf.j2
+++ b/roles/download_vpn/templates/nftables.conf.j2
@@ -1,0 +1,42 @@
+#!/usr/sbin/nft -f
+{#
+  Self-healing replacement for Debian's stock /etc/nftables.conf.
+
+  WHY this file is now role-managed: nftables.service's own ExecStart/
+  ExecReload is `nft -f /etc/nftables.conf`, and its ExecStop is `nft flush
+  ruleset` (a GLOBAL flush — every table, every family, not just this
+  package's own). The nftables package's postinst runs
+  `deb-systemd-invoke try-restart nftables.service` on every upgrade,
+  including one unattended-upgrades applies with nobody watching. Before this
+  file included our rulesets, that restart flushed the killswitch (and the
+  LAN-reply mangle table) and reloaded only the stock empty stub below —
+  leaving the box wide open (no rule at all, not even fail-closed) until the
+  next converge, with no systemd-level signal (the killswitch unit reports
+  "active" throughout; only the kernel ruleset was ever gone).
+
+  `nft -f` loads an entire file as ONE atomic kernel transaction: a flush
+  followed by these `include`s can never be observed half-applied, so a
+  restart of nftables.service (however triggered) reconstructs killswitch +
+  lanroute in the same breath it tears them down — no open window, unlike
+  stopping and separately restarting the killswitch service's own unit would.
+  Deliberately NOT wired to notify a reload here (see tasks/main.yml) so
+  deploying this file is inert on a live host until nftables.service is next
+  triggered on its own.
+-#}
+
+flush ruleset
+
+include "{{ download_vpn_nft_ruleset_path }}"
+include "{{ download_vpn_mangle_ruleset_path }}"
+
+table inet filter {
+	chain input {
+		type filter hook input priority filter;
+	}
+	chain forward {
+		type filter hook forward priority filter;
+	}
+	chain output {
+		type filter hook output priority filter;
+	}
+}


### PR DESCRIPTION
## Summary

- Manage `/etc/nftables.conf` to `include` the killswitch and LAN-reply rulesets, so a restart of the OS firewall service (e.g. triggered by an unattended package upgrade) atomically reconstructs both instead of leaving egress unfiltered until the next converge.
- Add the indexer manager and CloudFlare-challenge solver to the runtime validator's self-heal restart loop, alongside the existing two services — all four are bound to the tunnel unit and previously only two were revived after it restarts.
- Install the CloudFlare solver's missing headless-Chromium shared-library dependencies (package names mapped per Debian release) so its bundled browser can start instead of crash-looping.
- Adds Molecule coverage: a simulated firewall flush+reload proving the killswitch survives, and an assertion that the self-heal loop covers all four services.

## Test plan

- [x] `ansible-lint` (production profile): 0 failures across 28 files.
- [x] `molecule test -s download_vpn`: full sequence (syntax/create/prepare/converge/idempotence/verify/destroy) green, including the new simulated-flush and self-heal-loop assertions.
- [x] Package names for the browser dependency fix verified via `apt-get install --dry-run` against a live host's real package index (not applied — read-only).
- [ ] Live deploy/converge — sequenced separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)