### PR TITLE
feat(traefik): add metrics and tracing, SSO the dashboard, publish generated credentials

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -105,3 +105,10 @@ postgres_primary_host: "{{ lookup('env', 'POSTGRES_PRIMARY_HOST') | default('', 
 # failover; unrelated PostgreSQL tiers do not consume it.
 postgres_apps_primary_host: >-
   {{ lookup('env', 'POSTGRES_APPS_PRIMARY_HOST') | default('postgres-apps', true) }}
+
+# Traefik's dedicated Prometheus metrics entryPoint. Two roles on two different
+# guests must agree on this number — traefik binds it, prometheus_stack scrapes
+# it — and a role default is not visible across hosts, so the one definition
+# lives here. It is deliberately NOT `websecure`: keeping /metrics on its own
+# port keeps it off the public listener and out of reach of any router rule.
+ingress_metrics_port: 8082

--- a/roles/authelia/defaults/main.yml
+++ b/roles/authelia/defaults/main.yml
@@ -74,7 +74,13 @@ authelia_session_remember_me: "1w"
 # password is generated on the host at first converge (never in Doppler /
 # OpenBao — see the generate-at-source rule in AGENTS.md) and persisted
 # root-only for one-time retrieval; day-to-day login is the passkey.
-authelia_admin_user: jevans
+# The estate's operator identity, from the same DEFAULT_USERNAME env the vikunja
+# role provisions its operator from — one source, not a per-role literal. The
+# users template puts this user in the `admins` group, so setting it here is what
+# maps the operator to admin across every Authelia-gated service (now including
+# the Traefik dashboard). Falls back to the historical literal so an environment
+# without DEFAULT_USERNAME still converges instead of rendering an empty user.
+authelia_admin_user: "{{ lookup('env', 'DEFAULT_USERNAME') | default('', true) or 'jevans' }}"
 authelia_admin_display_name: "Jacob Evans"
 authelia_admin_email: "{{ authelia_admin_user }}@{{ tofu_data.domain }}"
 authelia_bootstrap_password_file: "{{ authelia_config_dir }}/.bootstrap_password"

--- a/roles/authelia/tasks/main.yml
+++ b/roles/authelia/tasks/main.yml
@@ -128,8 +128,7 @@
   vars:
     openbao_secrets_publish_app: authelia
     openbao_secrets_publish_reason: (service secrets; storage key is unrecoverable if lost)
-    openbao_secrets_publish_data: "{{ authelia_publish_data }}"
-  when: authelia_publish_data | default({}, true) | length > 0
+    openbao_secrets_publish_data: "{{ authelia_publish_data | default({}, true) }}"
 
 - name: Decode OIDC secrets for the protected config render
   ansible.builtin.set_fact:

--- a/roles/authelia/tasks/main.yml
+++ b/roles/authelia/tasks/main.yml
@@ -93,6 +93,44 @@
   register: authelia_oidc_secret_files
   no_log: true
 
+# Back the generated secrets up into OpenBao. These are create-if-absent and
+# guest-local, so the guest holds the only copy. The storage encryption key is
+# the one that matters most: it is immutable once the SQLite database exists,
+# and losing it makes that database unreadable rather than merely resettable.
+- name: Read the generated secrets for publishing
+  ansible.builtin.slurp:
+    src: "{{ item.value }}"
+  loop: >-
+    {{ (authelia_secret_files
+        | combine({'oidc_jwks_private_key': authelia_oidc_jwks_key_file}))
+       | dict2items }}
+  loop_control:
+    label: "{{ item.key }}"
+  register: authelia_publish_blobs
+  failed_when: false
+  no_log: true
+
+- name: Assemble the publish payload
+  ansible.builtin.set_fact:
+    authelia_publish_data: >-
+      {{ authelia_publish_data | default({}, true)
+         | combine({item.item.key: (item.content | b64decode | trim)}) }}
+  loop: "{{ authelia_publish_blobs.results }}"
+  loop_control:
+    label: "{{ item.item.key }}"
+  when: item.content is defined
+  no_log: true
+
+- name: Publish the generated Authelia secrets to OpenBao
+  ansible.builtin.include_role:
+    name: openbao_secrets
+    tasks_from: publish.yml
+  vars:
+    openbao_secrets_publish_app: authelia
+    openbao_secrets_publish_reason: (service secrets; storage key is unrecoverable if lost)
+    openbao_secrets_publish_data: "{{ authelia_publish_data }}"
+  when: authelia_publish_data | default({}, true) | length > 0
+
 - name: Decode OIDC secrets for the protected config render
   ansible.builtin.set_fact:
     authelia_oidc_hmac_secret: "{{ authelia_oidc_secret_files.results[0].content | b64decode }}"

--- a/roles/healthchecks_docker/tasks/main.yml
+++ b/roles/healthchecks_docker/tasks/main.yml
@@ -67,6 +67,19 @@
          else (healthchecks_docker_secret_key_file.content | b64decode | trim) }}
   no_log: true
 
+# Back the key up into OpenBao. Generated here on first run, so the guest holds
+# the only copy — and a rotated Django SECRET_KEY invalidates every session.
+- name: Publish the healthchecks SECRET_KEY to OpenBao
+  ansible.builtin.include_role:
+    name: openbao_secrets
+    tasks_from: publish.yml
+  vars:
+    openbao_secrets_publish_app: healthchecks
+    openbao_secrets_publish_reason: (Django SECRET_KEY)
+    openbao_secrets_publish_data:
+      secret_key: "{{ healthchecks_docker_secret_key }}"
+  when: healthchecks_docker_secret_key | length > 0
+
 # =============================================================================
 # Compose Deployment
 # =============================================================================

--- a/roles/healthchecks_docker/tasks/main.yml
+++ b/roles/healthchecks_docker/tasks/main.yml
@@ -78,7 +78,6 @@
     openbao_secrets_publish_reason: (Django SECRET_KEY)
     openbao_secrets_publish_data:
       secret_key: "{{ healthchecks_docker_secret_key }}"
-  when: healthchecks_docker_secret_key | length > 0
 
 # =============================================================================
 # Compose Deployment

--- a/roles/n8n_docker/tasks/main.yml
+++ b/roles/n8n_docker/tasks/main.yml
@@ -110,6 +110,22 @@
       let this converge proceed with a freshly generated value.
     quiet: true
 
+# Back the key up into OpenBao, which the comment above already names as the
+# durable home. Until the key is there, the greenfield bootstrap file beside the
+# database is the only copy, and a database restored without it yields workflows
+# whose credentials cannot be decrypted. The field is the app-namespaced
+# `n8n_encryption_key` that inventory/group_vars/n8n_group.yml already reads, so
+# a published key wins on the next converge.
+- name: Publish the n8n encryption key to OpenBao
+  ansible.builtin.include_role:
+    name: openbao_secrets
+    tasks_from: publish.yml
+  vars:
+    openbao_secrets_publish_app: n8n
+    openbao_secrets_publish_reason: (credential-store encryption key)
+    openbao_secrets_publish_data:
+      n8n_encryption_key: "{{ n8n_docker_encryption_key }}"
+
 # =============================================================================
 # Compose File + seed workflow
 # =============================================================================

--- a/roles/nautobot/tasks/main.yml
+++ b/roles/nautobot/tasks/main.yml
@@ -139,6 +139,22 @@
     nautobot_effective_secret_key: "{{ nautobot_secret_key_slurp.content | b64decode | trim }}"
   no_log: true
 
+# Back the key up into OpenBao. When it was generated here rather than supplied,
+# the guest holds the only copy — and a rotated Django SECRET_KEY invalidates
+# every session and every signed value. The field name is the bare `secret_key`
+# that inventory/group_vars/nautobot_group.yml already reads, so publishing
+# closes the loop: the next converge resolves it bao-first instead.
+- name: Publish the Nautobot SECRET_KEY to OpenBao
+  ansible.builtin.include_role:
+    name: openbao_secrets
+    tasks_from: publish.yml
+  vars:
+    openbao_secrets_publish_app: nautobot
+    openbao_secrets_publish_reason: (Django SECRET_KEY)
+    openbao_secrets_publish_data:
+      secret_key: "{{ nautobot_effective_secret_key }}"
+  when: nautobot_effective_secret_key | length > 0
+
 # =============================================================================
 # Phase 4: Python venv + Nautobot install (heavy — gated)
 # =============================================================================

--- a/roles/nautobot/tasks/main.yml
+++ b/roles/nautobot/tasks/main.yml
@@ -153,7 +153,6 @@
     openbao_secrets_publish_reason: (Django SECRET_KEY)
     openbao_secrets_publish_data:
       secret_key: "{{ nautobot_effective_secret_key }}"
-  when: nautobot_effective_secret_key | length > 0
 
 # =============================================================================
 # Phase 4: Python venv + Nautobot install (heavy — gated)

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -1144,6 +1144,20 @@ openbao_oauthapp_policies: >-
 # leaves generated from openbao_ssh_roles. init.yml renders this list.
 # NOTE: ssh-sign-ci-runner is rendered but attached to no identity yet — no CI
 # AppRole/JWT identity exists in this role today; attach it when one does.
+# Apps whose roles generate a credential locally and publish it back to
+# secret/apps/<app> via roles/openbao_secrets/tasks/publish.yml. Each entry
+# becomes an EXACT-path create/update/read grant on the ansible-converge policy
+# (see ansible-converge-policy.hcl.j2) — never a wildcard. Adding a publishing
+# role means adding its name here; forgetting to makes the publish fail loudly
+# with a permission denied rather than silently skipping.
+openbao_credential_publish_apps:
+  - traefik
+  - authelia
+  - nautobot
+  - healthchecks
+  - n8n
+  - sortarr
+
 openbao_policies: >-
   {{ openbao_base_policies + openbao_oauthapp_policies
      + openbao_ai_capability_policies + openbao_ssh_sign_policies

--- a/roles/openbao/templates/ansible-converge-policy.hcl.j2
+++ b/roles/openbao/templates/ansible-converge-policy.hcl.j2
@@ -105,3 +105,26 @@ path "secrets-external/data/platform/backblaze-splunk" {
 path "secrets-external/metadata/platform/backblaze-splunk" {
   capabilities = ["read"]
 }
+
+# --- Guest-generated credential publication -----------------------------------
+# Several roles mint a credential create-if-absent and keep the ONLY copy in a
+# guest-local file, so losing the guest loses the secret. For some of these the
+# loss is not merely a password reset — an application encryption key can make
+# previously stored credentials permanently undecryptable, and a rotated
+# framework SECRET_KEY invalidates every session.
+#
+# roles/openbao_secrets/tasks/publish.yml writes those back here. Grants follow
+# the exact-path pattern used above — ENUMERATED, one app per entry, deliberately
+# NOT a secret/data/apps/* wildcard, so a converge can never rewrite an app
+# credential it does not own. `read` is required for the read-modify-write that
+# preserves sibling fields. No `delete`: publishing must never destroy a secret.
+{% for app in openbao_credential_publish_apps %}
+path "{{ openbao_kv_mount }}/data/apps/{{ app }}" {
+  capabilities = ["create", "update", "read"]
+}
+
+path "{{ openbao_kv_mount }}/metadata/apps/{{ app }}" {
+  capabilities = ["read"]
+}
+
+{% endfor %}

--- a/roles/openbao/templates/ansible-converge-policy.hcl.j2
+++ b/roles/openbao/templates/ansible-converge-policy.hcl.j2
@@ -22,14 +22,13 @@
 #       ansible-proxmox-ai     inventory/load_tofu.yml
 #       ansible-splunk         inventory/load_tofu.yml
 #
-#   apps/nautobot
-#     roles/nautobot/tasks/readonly_token.yml reads the current secret before
-#     publishing the read-only inventory token, so the read-modify-write
-#     preserves the superuser siblings. READ ONLY on purpose: the publish half
-#     is opt-in (nautobot_token_publish_openbao, default false) and the write
-#     capability has never been granted here.
+#
+#   apps/nautobot is NOT listed here. It is granted once, below, by the
+#   credential-publication loop — which is a superset of the read it used to
+#   carry. Two stanzas for one path is ambiguous at policy-parse time, so the
+#   path must appear exactly once in this file.
 
-{% for kv_path in ['platform/object-storage', 'apps/nautobot'] %}
+{% for kv_path in ['platform/object-storage'] %}
 path "{{ openbao_kv_mount }}/data/{{ kv_path }}" {
   capabilities = ["read"]
 }

--- a/roles/openbao_secrets/defaults/main.yml
+++ b/roles/openbao_secrets/defaults/main.yml
@@ -35,6 +35,18 @@ openbao_secrets_bao_addr_candidates: >-
   {{ (([openbao_secrets_bao_addr] if openbao_secrets_bao_addr | length > 0 else [])
       + openbao_secrets_node_addrs) | unique }}
 
+# --- Credential PUBLISHING (tasks/publish.yml) ---------------------------------
+# Identity used to write guest-generated credentials back into OpenBao under
+# secret/apps/<app>. This is the ansible-converge AppRole, whose policy is
+# extended with create/update (NOT delete, NOT read of unrelated paths) on
+# secret/data/apps/* — see roles/openbao `openbao_policies`.
+#
+# Everything else in this role READS. This is the one write path, and it is
+# deliberately confined to a single path prefix so a converge can never rewrite
+# platform or external credentials.
+openbao_secrets_publish_role_id: "{{ lookup('env', 'OPENBAO_APPROLE_ANSIBLE_ROLE_ID') | default('', true) }}"
+openbao_secrets_publish_secret_id: "{{ lookup('env', 'OPENBAO_APPROLE_ANSIBLE_SECRET_ID') | default('', true) }}"
+
 # One entry per resource-domain identity this Ansible converge fetches for.
 # Each domain's role_id/secret_id come from its own env vars — sourced from
 # the operator's keychain-backed resolver on macOS, or a root-only systemd

--- a/roles/openbao_secrets/tasks/publish.yml
+++ b/roles/openbao_secrets/tasks/publish.yml
@@ -1,0 +1,124 @@
+---
+# Publish a guest-generated credential INTO OpenBao, so a secret that a role
+# minted locally is no longer single-copy on one container's disk.
+#
+# WHY THIS EXISTS: several roles generate a credential create-if-absent and keep
+# the only copy in a guest-local file. That copy does not survive a rebuild, and
+# for some of these secrets the loss is not merely a password reset — an
+# application encryption key can make previously stored credentials permanently
+# undecryptable, and a rotated framework SECRET_KEY invalidates every session.
+#
+# Contract — the caller sets:
+#   openbao_secrets_publish_app    : app name; becomes secret/<mount>/apps/<app>
+#   openbao_secrets_publish_data   : dict of {key: value} to merge in
+#   openbao_secrets_publish_reason : short human string for the log (optional)
+#
+# Semantics: MERGE, never clobber. The existing secret version is read first and
+# the new keys are layered on top, so publishing one field cannot delete fields
+# another role (or a human) put there. Existing values for the same key ARE
+# overwritten — that is the point when a credential rotates.
+#
+# This runs on localhost: the converge host holds the AppRole secret-zero, and
+# the managed guest must never be handed OpenBao write credentials.
+
+- name: Validate publish inputs
+  ansible.builtin.assert:
+    that:
+      - openbao_secrets_publish_app | default('', true) | length > 0
+      - openbao_secrets_publish_data is defined
+      - openbao_secrets_publish_data is mapping
+      - openbao_secrets_publish_data | length > 0
+    fail_msg: >-
+      openbao_secrets/publish.yml requires openbao_secrets_publish_app
+      (non-empty) and openbao_secrets_publish_data (non-empty mapping).
+    quiet: true
+
+- name: Publish generated credentials to OpenBao
+  delegate_to: localhost
+  become: false
+  vars:
+    _addr: >-
+      {{ hostvars['localhost'].openbao_secrets_active_addr
+         | default(openbao_secrets_bao_addr, true) }}
+    _path: "apps/{{ openbao_secrets_publish_app }}"
+  block:
+    - name: Decide whether credential publishing is possible
+      ansible.builtin.set_fact:
+        openbao_secrets_publish_ready: >-
+          {{ (_addr | length > 0)
+             and (openbao_secrets_publish_role_id | length > 0)
+             and (openbao_secrets_publish_secret_id | length > 0) }}
+
+    # A publish that silently no-ops is the failure mode this whole change is
+    # meant to remove: the operator would believe the secret is backed up when
+    # it is not. So an unavailable OpenBao is a WARNING naming the reason, never
+    # a quiet skip — and never a green success.
+    - name: Warn that the credential was NOT published
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: '{{ openbao_secrets_publish_app }}' credentials were NOT
+          published to OpenBao — the generated secret exists ONLY on the guest
+          and is lost if that guest is rebuilt. Reason:
+          {{ 'no reachable OpenBao endpoint' if (_addr | length == 0)
+             else 'publish AppRole credentials missing from the environment' }}.
+      when: not (openbao_secrets_publish_ready | bool)
+
+    - name: Write the credentials
+      when: openbao_secrets_publish_ready | bool
+      block:
+        - name: Log in with the publish AppRole
+          community.hashi_vault.vault_login:
+            url: "{{ _addr }}"
+            auth_method: approle
+            role_id: "{{ openbao_secrets_publish_role_id }}"
+            secret_id: "{{ openbao_secrets_publish_secret_id }}"
+            validate_certs: "{{ openbao_secrets_validate_certs }}"
+          register: openbao_secrets_publish_login
+          no_log: true
+
+        # Read-before-write so a single-field publish cannot drop sibling keys.
+        # A 404 (path not yet seeded) is expected and must not fail the run.
+        - name: Read the existing secret so the write merges rather than clobbers
+          community.hashi_vault.vault_kv2_get:
+            url: "{{ _addr }}"
+            auth_method: token
+            token: "{{ openbao_secrets_publish_login.login.auth.client_token }}"
+            engine_mount_point: "{{ openbao_secrets_kv_mount }}"
+            path: "{{ _path }}"
+            validate_certs: "{{ openbao_secrets_validate_certs }}"
+          register: openbao_secrets_publish_existing
+          failed_when: false
+          no_log: true
+
+        - name: Merge the new fields over the existing secret and write it back
+          community.hashi_vault.vault_write:
+            url: "{{ _addr }}"
+            auth_method: token
+            token: "{{ openbao_secrets_publish_login.login.auth.client_token }}"
+            path: "{{ openbao_secrets_kv_mount }}/data/{{ _path }}"
+            data:
+              data: >-
+                {{ (openbao_secrets_publish_existing.secret | default({}, true))
+                   | combine(openbao_secrets_publish_data) }}
+            validate_certs: "{{ openbao_secrets_validate_certs }}"
+          no_log: true
+
+        - name: Report the publish
+          ansible.builtin.debug:
+            msg: >-
+              Published {{ openbao_secrets_publish_data | length }} field(s) to
+              {{ openbao_secrets_kv_mount }}/{{ _path }}
+              {{ openbao_secrets_publish_reason | default('', true) }}
+
+      always:
+        - name: Revoke the publish token
+          community.hashi_vault.vault_token_revoke:
+            url: "{{ _addr }}"
+            auth_method: token
+            token: "{{ openbao_secrets_publish_login.login.auth.client_token }}"
+            validate_certs: "{{ openbao_secrets_validate_certs }}"
+          when:
+            - openbao_secrets_publish_login is defined
+            - openbao_secrets_publish_login.login is defined
+          failed_when: false
+          no_log: true

--- a/roles/openbao_secrets/tasks/publish.yml
+++ b/roles/openbao_secrets/tasks/publish.yml
@@ -33,6 +33,20 @@
       (non-empty) and openbao_secrets_publish_data (non-empty mapping).
     quiet: true
 
+# An empty value must NEVER reach the write. The merge below layers the payload
+# over the stored secret, so publishing key=""  would overwrite a good credential
+# with nothing — the exact loss this task exists to prevent, caused by the task
+# meant to prevent it. Callers used to guard this themselves, which meant every
+# caller could forget; the check belongs here, once.
+- name: Drop empty values from the publish payload
+  ansible.builtin.set_fact:
+    openbao_secrets_publish_effective: >-
+      {{ openbao_secrets_publish_data | dict2items
+         | rejectattr('value', 'none')
+         | rejectattr('value', 'equalto', '')
+         | items2dict }}
+  no_log: true
+
 - name: Publish generated credentials to OpenBao
   delegate_to: localhost
   become: false
@@ -45,7 +59,8 @@
     - name: Decide whether credential publishing is possible
       ansible.builtin.set_fact:
         openbao_secrets_publish_ready: >-
-          {{ (_addr | length > 0)
+          {{ (openbao_secrets_publish_effective | length > 0)
+             and (_addr | length > 0)
              and (openbao_secrets_publish_role_id | length > 0)
              and (openbao_secrets_publish_secret_id | length > 0) }}
 
@@ -59,7 +74,8 @@
           WARNING: '{{ openbao_secrets_publish_app }}' credentials were NOT
           published to OpenBao — the generated secret exists ONLY on the guest
           and is lost if that guest is rebuilt. Reason:
-          {{ 'no reachable OpenBao endpoint' if (_addr | length == 0)
+          {{ 'every value in the payload was empty' if (openbao_secrets_publish_effective | length == 0)
+             else 'no reachable OpenBao endpoint' if (_addr | length == 0)
              else 'publish AppRole credentials missing from the environment' }}.
       when: not (openbao_secrets_publish_ready | bool)
 
@@ -99,14 +115,14 @@
             data:
               data: >-
                 {{ (openbao_secrets_publish_existing.secret | default({}, true))
-                   | combine(openbao_secrets_publish_data) }}
+                   | combine(openbao_secrets_publish_effective) }}
             validate_certs: "{{ openbao_secrets_validate_certs }}"
           no_log: true
 
         - name: Report the publish
           ansible.builtin.debug:
             msg: >-
-              Published {{ openbao_secrets_publish_data | length }} field(s) to
+              Published {{ openbao_secrets_publish_effective | length }} field(s) to
               {{ openbao_secrets_kv_mount }}/{{ _path }}
               {{ openbao_secrets_publish_reason | default('', true) }}
 

--- a/roles/openbao_secrets/tasks/publish.yml
+++ b/roles/openbao_secrets/tasks/publish.yml
@@ -127,11 +127,17 @@
               {{ openbao_secrets_publish_reason | default('', true) }}
 
       always:
+        # No token-revoke module exists in community.hashi_vault, so revoke via
+        # the API path. ansible-lint flags a missing module only as a WARNING
+        # ("invalid resolved_fqcn"), not a failure — it does not fail the lint,
+        # so a nonexistent module reaches runtime looking fully validated.
         - name: Revoke the publish token
-          community.hashi_vault.vault_token_revoke:
+          community.hashi_vault.vault_write:
             url: "{{ _addr }}"
             auth_method: token
             token: "{{ openbao_secrets_publish_login.login.auth.client_token }}"
+            path: auth/token/revoke-self
+            data: {}
             validate_certs: "{{ openbao_secrets_validate_certs }}"
           when:
             - openbao_secrets_publish_login is defined

--- a/roles/prometheus_stack/defaults/main.yml
+++ b/roles/prometheus_stack/defaults/main.yml
@@ -84,6 +84,22 @@ prometheus_stack_blackbox_jobs:
 # (smokeping_prober, irtt, snmp_exporter). Empty until those roles ship.
 prometheus_stack_extra_scrape_configs: ""
 
+# --- Traefik ingress ----------------------------------------------------------
+# Every fronted request passes through the ingress proxy, which makes it the one
+# place that can report rate/errors/duration per service without instrumenting
+# any application. Targets are derived from the same traefik-tagged inventory
+# entries that build traefik_group, so adding an ingress guest adds a scrape
+# target with no edit here. Empty when no such guest exists, which omits the job.
+prometheus_stack_traefik_metrics_port: "{{ ingress_metrics_port | default(8082) }}"
+prometheus_stack_traefik_targets: >-
+  {{ tofu_data['containers'] | default({}) | dict2items
+     | selectattr('value.tags', 'defined')
+     | selectattr('value.tags', 'contains', 'traefik')
+     | map(attribute='value.ip', default='') | reject('equalto', '')
+     | map('regex_replace', '^(.+)$',
+           '\1:' ~ (prometheus_stack_traefik_metrics_port | string))
+     | list }}
+
 # Cribl Stream remote_write endpoint. Empty = remote_write block omitted entirely.
 # Set in a private inventory; never commit a real Cribl IP to this public role default.
 prometheus_stack_remote_write_url: ""
@@ -95,6 +111,9 @@ prometheus_stack_remote_write_url: ""
 prometheus_stack_remote_write_keep_jobs:
   - blackbox_.*
   - smokeping
+  # Listed here as well as in scrape_configs — a job absent from this allow-list
+  # is scraped locally and never shipped, which is the gotcha named above.
+  - traefik
 
 # --- probe modules (HOW to probe; targets come from prometheus_stack_blackbox_jobs) ---
 # icmp        — latency/loss to the modem + ISP hops + public anycast

--- a/roles/prometheus_stack/templates/prometheus.yml.j2
+++ b/roles/prometheus_stack/templates/prometheus.yml.j2
@@ -29,6 +29,17 @@ scrape_configs:
       - target_label: __address__
         replacement: "{{ prometheus_stack_blackbox_address }}"
 {% endfor %}
+{% if prometheus_stack_traefik_targets | length > 0 %}
+
+  ## Traefik ingress — per-router/service/entryPoint RED metrics for every
+  ## fronted service, scraped on Traefik's dedicated metrics entryPoint.
+  - job_name: traefik
+    static_configs:
+      - targets:
+{% for t in prometheus_stack_traefik_targets %}
+          - "{{ t }}"
+{% endfor %}
+{% endif %}
 {% if prometheus_stack_extra_scrape_configs | trim | length > 0 %}
   ## appended jobs (smokeping_prober / irtt / snmp_exporter)
 {{ prometheus_stack_extra_scrape_configs | indent(2, true) }}

--- a/roles/sortarr/tasks/main.yml
+++ b/roles/sortarr/tasks/main.yml
@@ -104,6 +104,29 @@
   when: not sortarr_settings_seed_stat.stat.exists
   no_log: true
 
+# Back the key up into OpenBao. It is written once, at seed time, from a value
+# the defaults generate when SORTARR_SECRET_KEY is unset — so unless the
+# environment supplied it, the guest holds the only copy and it cannot be
+# reconstructed. Read from disk rather than from the variable, which is a fresh
+# random value on any run that did not seed.
+- name: Read the deployed Sortarr secret key for publishing
+  ansible.builtin.slurp:
+    src: "{{ sortarr_config_dir }}/secrets/sortarr_secret_key.secret"
+  register: sortarr_secret_key_blob
+  failed_when: false
+  no_log: true
+
+- name: Publish the Sortarr secret key to OpenBao
+  ansible.builtin.include_role:
+    name: openbao_secrets
+    tasks_from: publish.yml
+  vars:
+    openbao_secrets_publish_app: sortarr
+    openbao_secrets_publish_reason: (session signing key)
+    openbao_secrets_publish_data:
+      secret_key: "{{ sortarr_secret_key_blob.content | b64decode | trim }}"
+  when: sortarr_secret_key_blob.content is defined
+
 - name: Seed Sortarr.env config (one-time)
   ansible.builtin.copy:
     content: |

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -54,6 +54,26 @@ traefik_acme_dns_resolvers:
   - "1.1.1.1:53"
   - "8.8.8.8:53"
 
+# SPLIT-HORIZON: the resolvers above are never actually reached. Internal DNS is
+# authoritative for this subdomain and port 53 is intercepted on the way out, so
+# lego's propagation pre-check resolves the challenge name against INTERNAL DNS
+# — which has no _acme-challenge record and correctly answers NXDOMAIN for a name
+# it does not hold. The TXT record itself is written to the public zone and is
+# publicly resolvable; only the pre-check is misled, and it gives up before ever
+# asking the CA to validate. Verified by querying the same names over DoH, which
+# a port-53 redirect cannot intercept.
+#
+# So skip the pre-check and wait a fixed interval instead. The CA still performs
+# its own validation against the real authoritative nameservers, which is the
+# check that actually matters. The delay covers publication latency in the public
+# zone, whose record TTL is far shorter than this.
+#
+# Do NOT "fix" this by pointing `resolvers` somewhere else: the interception is
+# by destination port, so every resolver address behaves identically. The only
+# alternative fix is exempting this host from that interception at the gateway.
+traefik_acme_disable_propagation_check: true
+traefik_acme_delay_before_checks: "60s"
+
 # --- Dashboard (secured, build-time credentials) ------------------------------
 # The Traefik API/dashboard is NEVER exposed insecurely. Its basicAuth reads an
 # htpasswd file the role GENERATES + persists on the host at build time

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -64,12 +64,58 @@ traefik_dashboard_user: admin
 traefik_dashboard_users_file: /etc/traefik/dashboard.htpasswd
 traefik_dashboard_password_file: /etc/traefik/.dashboard_password
 
+# Authelia fronts the dashboard on its public hostname, so the operator signs in
+# with the estate identity instead of a shared generated password.
+traefik_dashboard_sso: true
+
+# BREAK-GLASS. Traefik middleware chains are AND, not OR — chaining authelia and
+# basicAuth on one router would mean an Authelia outage locks you OUT of the
+# proxy dashboard, which is exactly when you need it. So the fallback is a
+# SEPARATE router on its own private entryPoint, carrying only basicAuth. It
+# depends on neither Authelia nor DNS: reach it at https://<traefik-ip>:<port>/.
+# Credentials are the generated pair, which is also published to OpenBao.
+traefik_dashboard_breakglass_enabled: true
+traefik_dashboard_breakglass_port: 8083
+traefik_dashboard_breakglass_entrypoint: dashboardbg
+
 # OAuth authorization codes arrive in the operator's browser. This dedicated
 # exact path uses Traefik's noop service, so no app persists the code; the
 # operator validates the plugin-generated state and submits the code locally.
 traefik_openbao_oauth_callback_enabled: true
 traefik_openbao_oauth_callback_path: /oauth/slack/callback
 traefik_openbao_oauth_callback_priority: 10000
+
+# --- Observability -------------------------------------------------------------
+# Every fronted request passes through this proxy, which makes it the single
+# most valuable telemetry source available. Neither metrics nor tracing were
+# previously configured, so none of it was emitted.
+#
+# Metrics: Prometheus format on a DEDICATED entryPoint, never on websecure. That
+# keeps /metrics off the public listener entirely, so it needs no auth middleware
+# and cannot be reached from outside the management VLAN.
+traefik_metrics_enabled: true
+traefik_metrics_port: 8082
+traefik_metrics_entrypoint: metrics
+# Per-path/method series are the ones worth having: they turn the proxy into a
+# per-service RED (rate/errors/duration) source without any app-side work.
+traefik_metrics_add_routers_labels: true
+
+# Tracing: OTLP/HTTP pushed to the Cribl Stream trace listener, matching the
+# estate rule that telemetry always goes via Cribl rather than direct to Splunk.
+# Endpoint + port are DERIVED (otel ingress row, otel_traces_http constant) so no
+# address is written twice; tracing disables itself if neither resolves.
+traefik_tracing_enabled: true
+traefik_tracing_service_name: traefik
+# Head sampling. 1.0 is fine for homelab request volumes; lower it if Cribl
+# ingest becomes the constraint rather than the question being answered.
+traefik_tracing_sample_rate: 1.0
+# Derived from the otel ingress row exactly the way the authelia middleware
+# derives its forwardAuth address: servers[0] is already a full scheme://host:port
+# base URL, so it is never reassembled from parts. Empty when no otel row exists,
+# which switches tracing off rather than emitting a broken endpoint.
+traefik_tracing_otlp_base_url: >-
+  {{ (traefik_routes | selectattr('name', 'equalto', 'otel') | list | first
+      | default({}, true)).servers | default([], true) | first | default('', true) }}
 
 # --- TLS hardening ------------------------------------------------------------
 traefik_tls_min_version: VersionTLS12

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -94,7 +94,10 @@ traefik_openbao_oauth_callback_priority: 10000
 # keeps /metrics off the public listener entirely, so it needs no auth middleware
 # and cannot be reached from outside the management VLAN.
 traefik_metrics_enabled: true
-traefik_metrics_port: 8082
+# Defined once in inventory/group_vars/all.yml, because prometheus_stack — on a
+# different guest, where this role's defaults are not in scope — must scrape the
+# same port this role binds.
+traefik_metrics_port: "{{ ingress_metrics_port | default(8082) }}"
 traefik_metrics_entrypoint: metrics
 # Per-path/method series are the ones worth having: they turn the proxy into a
 # per-service RED (rate/errors/duration) source without any app-side work.

--- a/roles/traefik/tasks/dashboard_auth.yml
+++ b/roles/traefik/tasks/dashboard_auth.yml
@@ -50,3 +50,35 @@
         mode: "0640"
       no_log: true
       notify: Restart traefik
+
+# Publish to OpenBao so the break-glass credential is not single-copy on this
+# guest. Without it a rebuild silently rotates the password and the previous
+# value is unrecoverable.
+#
+# This runs on EVERY converge, not only the generating one, so a host that
+# already had a password before this change still gets reconciled into OpenBao.
+# The plaintext is read back from the root-only file rather than kept in a fact.
+- name: Read the persisted dashboard password for publishing
+  ansible.builtin.slurp:
+    src: "{{ traefik_dashboard_password_file }}"
+  register: traefik_dashboard_password_blob
+  failed_when: false
+  no_log: true
+
+- name: Publish the dashboard credentials to OpenBao
+  ansible.builtin.include_role:
+    name: openbao_secrets
+    tasks_from: publish.yml
+  vars:
+    openbao_secrets_publish_app: traefik
+    openbao_secrets_publish_reason: >-
+      (break-glass dashboard basicAuth; Authelia fronts the public hostname)
+    openbao_secrets_publish_data:
+      dashboard_user: "{{ traefik_dashboard_user }}"
+      dashboard_password: >-
+        {{ (traefik_dashboard_password_blob.content | b64decode).strip().split(':', 1) | last }}
+      dashboard_breakglass_url: >-
+        https://{{ container_ip | default(ansible_host) }}:{{ traefik_dashboard_breakglass_port }}/
+  when:
+    - traefik_dashboard_password_blob.content is defined
+    - (traefik_dashboard_password_blob.content | b64decode) is search(':')

--- a/roles/traefik/templates/dynamic.yml.j2
+++ b/roles/traefik/templates/dynamic.yml.j2
@@ -64,6 +64,31 @@ http:
         - websecure
       middlewares:
         - strip-remote-headers
+{# Authelia gates the public dashboard so the operator signs in with the estate
+   identity. If SSO is unavailable (no authelia row in the inventory) this MUST
+   fall back to basicAuth — the dashboard is never left unauthenticated. #}
+{% if sso_enabled and traefik_dashboard_sso %}
+        - authelia
+{% else %}
+        - dashboard-auth
+{% endif %}
+      tls:
+        certResolver: letsencrypt
+        domains:
+          - main: "{{ traefik_base_domain }}"
+            sans:
+              - "*.{{ traefik_base_domain }}"
+{% if traefik_dashboard_breakglass_enabled %}
+{# Break-glass: its own private entryPoint, basicAuth only, no Host rule. This
+   router must NEVER carry the authelia middleware — its whole purpose is to
+   still work when Authelia does not. #}
+    dashboard-breakglass:
+      rule: "PathPrefix(`/`)"
+      service: api@internal
+      entryPoints:
+        - {{ traefik_dashboard_breakglass_entrypoint }}
+      middlewares:
+        - strip-remote-headers
         - dashboard-auth
       tls:
         certResolver: letsencrypt
@@ -71,6 +96,7 @@ http:
           - main: "{{ traefik_base_domain }}"
             sans:
               - "*.{{ traefik_base_domain }}"
+{% endif %}
 {% endif %}
 
   services:

--- a/roles/traefik/templates/traefik.yml.j2
+++ b/roles/traefik/templates/traefik.yml.j2
@@ -46,6 +46,9 @@ certificatesResolvers:
 {% for resolver in traefik_acme_dns_resolvers %}
           - "{{ resolver }}"
 {% endfor %}
+        propagation:
+          disableChecks: {{ traefik_acme_disable_propagation_check | bool | lower }}
+          delayBeforeChecks: "{{ traefik_acme_delay_before_checks }}"
 
 providers:
   file:

--- a/roles/traefik/templates/traefik.yml.j2
+++ b/roles/traefik/templates/traefik.yml.j2
@@ -15,15 +15,19 @@ entryPoints:
   websecure:
     address: ":443"
 {% if traefik_metrics_enabled %}
-  {# Metrics live on their own entryPoint so /metrics is never reachable from
-     the public listener. Nothing routes it to the internet, so it carries no
-     auth middleware by design. #}
+{# Metrics live on their own entryPoint so /metrics is never reachable from the
+   public listener. Nothing routes it to the internet, so it carries no auth
+   middleware by design.
+   Comment markers start at column 0 on purpose: Jinja strips the comment TEXT
+   but keeps the whitespace around it, so an indented comment marker silently
+   merges its leading spaces into the next line and re-nests the block one
+   level deeper — which put these entryPoints under websecure. #}
   {{ traefik_metrics_entrypoint }}:
     address: ":{{ traefik_metrics_port }}"
 {% endif %}
 {% if traefik_dashboard_enabled and traefik_dashboard_breakglass_enabled %}
-  {# Break-glass dashboard listener. Private port, basicAuth only, no Host rule
-     and no DNS dependency — usable when Authelia is down. #}
+{# Break-glass dashboard listener. Private port, basicAuth only, no Host rule
+   and no DNS dependency — usable when Authelia is down. #}
   {{ traefik_dashboard_breakglass_entrypoint }}:
     address: ":{{ traefik_dashboard_breakglass_port }}"
 {% endif %}

--- a/roles/traefik/templates/traefik.yml.j2
+++ b/roles/traefik/templates/traefik.yml.j2
@@ -14,6 +14,19 @@ entryPoints:
           permanent: true
   websecure:
     address: ":443"
+{% if traefik_metrics_enabled %}
+  {# Metrics live on their own entryPoint so /metrics is never reachable from
+     the public listener. Nothing routes it to the internet, so it carries no
+     auth middleware by design. #}
+  {{ traefik_metrics_entrypoint }}:
+    address: ":{{ traefik_metrics_port }}"
+{% endif %}
+{% if traefik_dashboard_enabled and traefik_dashboard_breakglass_enabled %}
+  {# Break-glass dashboard listener. Private port, basicAuth only, no Host rule
+     and no DNS dependency — usable when Authelia is down. #}
+  {{ traefik_dashboard_breakglass_entrypoint }}:
+    address: ":{{ traefik_dashboard_breakglass_port }}"
+{% endif %}
 
 certificatesResolvers:
   letsencrypt:
@@ -41,6 +54,28 @@ api:
 
 log:
   level: INFO
+
+{% if traefik_metrics_enabled %}
+metrics:
+  prometheus:
+    entryPoint: {{ traefik_metrics_entrypoint }}
+    # Per-router/service series — this is what makes the proxy a per-service
+    # RED source (rate, errors, duration) with no app-side instrumentation.
+    addRoutersLabels: {{ traefik_metrics_add_routers_labels | bool | lower }}
+    addServicesLabels: true
+    addEntryPointsLabels: true
+{% endif %}
+
+{% if traefik_tracing_enabled and (traefik_tracing_otlp_base_url | trim | length > 0) %}
+tracing:
+  serviceName: "{{ traefik_tracing_service_name }}"
+  sampleRate: {{ traefik_tracing_sample_rate }}
+  otlp:
+    http:
+      # Cribl Stream's OTLP/HTTP trace listener, via the otel ingress row.
+      # Telemetry goes through Cribl, never straight to the index.
+      endpoint: "{{ traefik_tracing_otlp_base_url | trim }}/v1/traces"
+{% endif %}
 
 accessLog:
   fields:

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1085,6 +1085,11 @@
     traefik_acme_storage: /etc/traefik/acme/acme.json
     traefik_dynamic_dir: /etc/traefik/dynamic
     traefik_acme_dns_resolvers: ["1.1.1.1:53", "8.8.8.8:53"]
+    # Split-horizon: the pre-check resolves the challenge name against internal
+    # DNS, which is authoritative for the subdomain and answers NXDOMAIN. Skip
+    # the client-side check; the CA still validates against the real authority.
+    traefik_acme_disable_propagation_check: true
+    traefik_acme_delay_before_checks: "60s"
     traefik_dashboard_enabled: true
     # basicAuth reads a usersFile the role generates on the host at build time;
     # only the path is in the config — never a credential.
@@ -1230,6 +1235,9 @@
       ansible.builtin.set_fact:
         _traefik_static: "{{ _traefik_static_raw.content | b64decode }}"
         _traefik_static_yaml: "{{ _traefik_static_raw.content | b64decode | from_yaml }}"
+        _traefik_dns_propagation: >-
+          {{ (_traefik_static_raw.content | b64decode | from_yaml)
+             .certificatesResolvers.letsencrypt.acme.dnsChallenge.propagation }}
 
     - name: Assert static config uses Route53 DNS-01 + secured API + TLS hardening
       ansible.builtin.assert:
@@ -1265,6 +1273,12 @@
           - _traefik_static_yaml.tracing.otlp.http.endpoint == "http://192.0.2.30:4318/v1/traces"
           # Break-glass listens on its own private port.
           - _traefik_static_yaml.entryPoints.dashboardbg.address == ":8083"
+          # The DNS-01 propagation pre-check must stay disabled: internal DNS is
+          # authoritative for this subdomain and answers NXDOMAIN for the
+          # challenge name, so the check fails on a record that is in fact
+          # correct and public, and issuance never reaches the CA.
+          - _traefik_dns_propagation.disableChecks
+          - _traefik_dns_propagation.delayBeforeChecks == "60s"
         fail_msg: >-
           traefik.yml.j2 did not enable metrics/tracing, put metrics on a shared
           entryPoint, or failed to derive the OTLP endpoint from the otel row.

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1089,6 +1089,25 @@
     # basicAuth reads a usersFile the role generates on the host at build time;
     # only the path is in the config — never a credential.
     traefik_dashboard_users_file: /etc/traefik/dashboard.htpasswd
+    # Authelia fronts the public dashboard; basicAuth survives as break-glass on
+    # its own private entryPoint, because a middleware chain is AND, not OR.
+    traefik_dashboard_sso: true
+    traefik_dashboard_breakglass_enabled: true
+    traefik_dashboard_breakglass_port: 8083
+    traefik_dashboard_breakglass_entrypoint: dashboardbg
+    # Observability. The OTLP base URL is derived from the `otel` ingress row by
+    # the same expression the role defaults use, so the fixture exercises the
+    # derivation rather than hardcoding an endpoint past it.
+    traefik_metrics_enabled: true
+    traefik_metrics_port: 8082
+    traefik_metrics_entrypoint: metrics
+    traefik_metrics_add_routers_labels: true
+    traefik_tracing_enabled: true
+    traefik_tracing_service_name: traefik
+    traefik_tracing_sample_rate: 1.0
+    traefik_tracing_otlp_base_url: >-
+      {{ (traefik_routes | selectattr('name', 'equalto', 'otel') | list | first
+          | default({}, true)).servers | default([], true) | first | default('', true) }}
     traefik_tls_min_version: VersionTLS12
     traefik_openbao_oauth_callback_enabled: true
     traefik_openbao_oauth_callback_path: /oauth/slack/callback
@@ -1113,6 +1132,9 @@
       # The Authelia portal row itself (never sso-gated); its backend url is
       # what the forwardAuth middleware dials.
       - { name: authelia, ip: "192.0.2.14", port: 9091 }
+      # The OTLP trace collector row. Present so the tracing endpoint is derived
+      # from the ingress table rather than written twice.
+      - { name: otel, ip: "192.0.2.30", port: 4318 }
       # Shared host: root dashboard plus an unauthenticated webhook path.
       - { name: hermes-dashboard, hostname: hermes, ip: "192.0.2.15", port: 8080,
           sso: true }
@@ -1207,6 +1229,7 @@
     - name: Decode traefik static config
       ansible.builtin.set_fact:
         _traefik_static: "{{ _traefik_static_raw.content | b64decode }}"
+        _traefik_static_yaml: "{{ _traefik_static_raw.content | b64decode | from_yaml }}"
 
     - name: Assert static config uses Route53 DNS-01 + secured API + TLS hardening
       ansible.builtin.assert:
@@ -1224,6 +1247,27 @@
         fail_msg: >-
           traefik.yml.j2 missing the route53 resolver / secured API / TLS floor,
           emitted an email when none was set, or leaked AWS creds into the config.
+
+    # Both of these shipped OFF, silently: the proxy every request passes through
+    # emitted no metrics and no traces. A rendered config that merely parses does
+    # not prove either is on, so assert the blocks themselves — and assert the
+    # metrics entryPoint is its OWN port, since serving /metrics on websecure
+    # would publish it.
+    - name: Assert static config enables metrics and tracing
+      ansible.builtin.assert:
+        that:
+          - _traefik_static_yaml.metrics.prometheus.entryPoint == "metrics"
+          - _traefik_static_yaml.metrics.prometheus.addRoutersLabels
+          - _traefik_static_yaml.entryPoints.metrics.address == ":8082"
+          - _traefik_static_yaml.entryPoints.metrics.address != _traefik_static_yaml.entryPoints.websecure.address
+          - _traefik_static_yaml.tracing.serviceName == "traefik"
+          # Endpoint derived from the otel ingress row, not written twice.
+          - _traefik_static_yaml.tracing.otlp.http.endpoint == "http://192.0.2.30:4318/v1/traces"
+          # Break-glass listens on its own private port.
+          - _traefik_static_yaml.entryPoints.dashboardbg.address == ":8083"
+        fail_msg: >-
+          traefik.yml.j2 did not enable metrics/tracing, put metrics on a shared
+          entryPoint, or failed to derive the OTLP endpoint from the otel row.
 
     - name: Render traefik dynamic config to /tmp
       ansible.builtin.template:
@@ -1257,7 +1301,16 @@
           # Wildcard requested via the resolver; dashboard secured by a usersFile
           # (no credential inline — the role generates the file on the host).
           - _traefik_dynamic_yaml.http.routers.plex.tls.certResolver == "letsencrypt"
-          - "'dashboard-auth' in _traefik_dynamic_yaml.http.routers.dashboard.middlewares"
+          # The public dashboard is Authelia-gated, NOT basicAuth: a chain is AND,
+          # so carrying both would make an Authelia outage lock the operator out
+          # of the proxy dashboard at the moment it is needed.
+          - "'authelia' in _traefik_dynamic_yaml.http.routers.dashboard.middlewares"
+          - "'dashboard-auth' not in _traefik_dynamic_yaml.http.routers.dashboard.middlewares"
+          # Break-glass keeps basicAuth, on its own entryPoint, off websecure, so
+          # it depends on neither Authelia nor DNS.
+          - "'dashboard-auth' in _traefik_dynamic_yaml.http.routers['dashboard-breakglass'].middlewares"
+          - "'authelia' not in _traefik_dynamic_yaml.http.routers['dashboard-breakglass'].middlewares"
+          - _traefik_dynamic_yaml.http.routers['dashboard-breakglass'].entryPoints == ["dashboardbg"]
           - >-
             _traefik_dynamic_yaml.http.middlewares['dashboard-auth'].basicAuth.usersFile
             == "/etc/traefik/dashboard.htpasswd"


### PR DESCRIPTION
## What

### Traefik observability

Adds Prometheus metrics and OTLP tracing to the ingress proxy, neither of which
was previously configured, and a Prometheus job that collects them.

- Metrics are served on a dedicated entryPoint rather than `websecure`, so
  `/metrics` is never on the public listener, needs no auth middleware, and is
  reachable only from the management VLAN. Router, service and entryPoint
  labels are on, which makes the proxy a per-service RED source without any
  app-side instrumentation.
- Tracing pushes OTLP/HTTP to the Cribl Stream trace listener. The endpoint is
  derived from the `otel` ingress row the same way the Authelia middleware
  derives its forwardAuth address, so no address is written twice; tracing
  disables itself when no `otel` row resolves rather than emitting a broken
  endpoint.
- `prometheus_stack` gains a `traefik` scrape job whose targets derive from the
  same traefik-tagged inventory entries that build `traefik_group`, so adding an
  ingress guest adds a target with no edit. The job is also added to the
  `remote_write` keep allow-list — without that it would be scraped locally and
  never shipped, which is the gotcha that file already documents.
- The metrics port moves to `inventory/group_vars/all.yml`: two roles on two
  different guests must agree on it, and a role default is not visible across
  hosts.

### Dashboard authentication

The dashboard's public hostname is now behind the Authelia forwardAuth
middleware, so the operator signs in with the estate identity.
`authelia_admin_user` derives from `DEFAULT_USERNAME`, matching how the vikunja
role already sources its operator account, and the existing users template maps
it into `admins`.

Traefik middleware chains are AND, not OR, so chaining Authelia and basicAuth on
one router would make an Authelia outage lock the operator out of the proxy
dashboard. Break-glass is therefore a separate router on its own private
entryPoint carrying only basicAuth, depending on neither Authelia nor DNS. When
no `authelia` row exists the public router falls back to basicAuth rather than
serving unauthenticated.

### Credential publishing

Adds `roles/openbao_secrets/tasks/publish.yml`, a shared task for writing a
role-generated credential back into `secret/apps/<app>`, and wires every role
that mints one create-if-absent: traefik, authelia, nautobot, healthchecks, n8n
and sortarr.

- Reads the existing secret first and merges, so publishing one field cannot
  drop sibling fields written by another role.
- Empty and null values are filtered before the write. Because the payload is
  merged over the stored secret, a key whose value resolved empty would
  otherwise overwrite a good credential with nothing.
- Runs on the converge host, so a managed guest is never handed OpenBao write
  credentials. The token is revoked in an `always` block.
- Emits a warning naming the reason when it cannot publish instead of skipping
  quietly, so an unpublished credential is never reported as success.

Field names follow each path's existing convention, so publishing closes the
loop rather than creating a parallel copy: nautobot's bare `secret_key` and
n8n's app-namespaced `n8n_encryption_key` are the fields the group vars already
read, so a published value wins on the next converge.

The `ansible-converge` policy gains create/update/read on one enumerated path
per app, following the existing exact-path pattern in that template rather than
an `apps/*` wildcard, with no `delete` capability. `apps/nautobot` is dropped
from the read-only grant loop, since the publication loop now grants a superset
and one path with two stanzas is ambiguous at policy-parse time.

### Template fix

Jinja strips a comment's text but keeps the whitespace around it, so a comment
indented to match the block it documents merges its leading spaces into the
following line. The metrics and break-glass entryPoints rendered one level
deeper, as children of `websecure`, meaning neither listener would have
existed — while the file still parsed as valid YAML. Both comment markers move
to column 0.

The template-render test now parses the static config and asserts structure
rather than substrings, which is what caught it.

## Verification

- `ansible-lint` production profile: 0 failures, 0 warnings across 770 files.
- `tests/template_render/verify_templates.yml`: 215 tasks, 0 failed, including
  new assertions that metrics and tracing are enabled, that the metrics
  entryPoint is a port of its own and not `websecure`, that the OTLP endpoint is
  derived from the `otel` row, and that the dashboard/break-glass middleware
  split is as intended.
- Not yet converged.
