### PR TITLE
feat(windows): baseline role for RDP-enabled Windows VDI guests

### DIFF
--- a/inventory/load_tofu.yml
+++ b/inventory/load_tofu.yml
@@ -321,19 +321,65 @@
         - tofu_data.containers is defined
         - tofu_data.containers | length > 0
 
-    - name: Add VMs to inventory (SSH connection)
+    # Windows VMs (ansible_connection: winrm, published from deployment.json)
+    # need a WinRM password instead of an SSH key. Fetched once here rather
+    # than per-role, mirroring how openbao_secrets fetches other domains.
+    # Skips cleanly (host stays SSH-shaped but unreachable, same as any other
+    # missing credential) when the AppRole envs aren't set — never a hard fail.
+    - name: Resolve Windows local Administrator password from OpenBao
+      when:
+        - tofu_data.vms is defined
+        - tofu_data.vms | selectattr('ansible_connection', 'equalto', 'winrm') | list | length > 0
+      no_log: true
+      block:
+        - name: Log in with the ansible AppRole
+          community.hashi_vault.vault_login:
+            url: "{{ lookup('env', 'BAO_ADDR') }}"
+            auth_method: approle
+            role_id: "{{ lookup('env', 'OPENBAO_APPROLE_ANSIBLE_ROLE_ID') }}"
+            secret_id: "{{ lookup('env', 'OPENBAO_APPROLE_ANSIBLE_SECRET_ID') }}"
+          register: windows_vdi_openbao_login
+          failed_when: false
+
+        - name: Read the win11-vdi local Administrator credential
+          community.hashi_vault.vault_kv2_get:
+            url: "{{ lookup('env', 'BAO_ADDR') }}"
+            auth_method: token
+            token: "{{ windows_vdi_openbao_login.login.auth.client_token }}"
+            engine_mount_point: secret
+            path: platform/windows-vdi/win11-admin
+          register: windows_vdi_admin_secret
+          failed_when: false
+          when: windows_vdi_openbao_login.login is defined
+
+        - name: Store the resolved Windows admin credential
+          ansible.builtin.set_fact:
+            windows_vdi_admin_password: "{{ windows_vdi_admin_secret.secret.password | default('') }}"
+
+    - name: Add VMs to inventory (SSH or WinRM connection)
       ansible.builtin.add_host:
         name: "{{ item.key }}"
-        groups:
-          - vms
-          - all
+        groups: >-
+          {{
+            ['vms', 'all'] +
+            (['windows_group'] if 'windows' in (item.value.tags | default([])) else [])
+          }}
         ansible_host: "{{ item.value.ip }}"
         ansible_connection: "{{ item.value.ansible_connection }}"
-        ansible_user: debian
-        ansible_ssh_private_key_file: "{{ lookup('env', 'PROXMOX_SSH_KEY_PATH') }}"
+        ansible_user: "{{ 'Administrator' if item.value.ansible_connection == 'winrm' else 'debian' }}"
+        ansible_ssh_private_key_file: >-
+          {{ lookup('env', 'PROXMOX_SSH_KEY_PATH')
+             if item.value.ansible_connection == 'ssh' else omit }}
+        ansible_password: >-
+          {{ windows_vdi_admin_password | default(omit)
+             if item.value.ansible_connection == 'winrm' else omit }}
+        ansible_winrm_transport: "{{ 'basic' if item.value.ansible_connection == 'winrm' else omit }}"
+        ansible_winrm_scheme: "{{ 'http' if item.value.ansible_connection == 'winrm' else omit }}"
+        ansible_port: "{{ 5985 if item.value.ansible_connection == 'winrm' else omit }}"
         host_tags: "{{ item.value.tags | default([]) }}"
       loop: "{{ tofu_data.vms | dict2items }}"
       changed_when: false
+      no_log: true
       when:
         - tofu_data.vms is defined
         - tofu_data.vms | length > 0

--- a/inventory/load_tofu.yml
+++ b/inventory/load_tofu.yml
@@ -356,6 +356,22 @@
           ansible.builtin.set_fact:
             windows_vdi_admin_password: "{{ windows_vdi_admin_secret.secret.password | default('') }}"
 
+        # An empty password here is never benign: it produces a WinRM auth
+        # failure at converge time that reads like a broken guest rather than a
+        # missing grant. Fail where the cause is visible, but only once the
+        # AppRole envs were actually supplied — with no envs at all this is an
+        # offline run and staying soft is the documented behaviour above.
+        - name: Fail when a WinRM host exists but no password could be resolved
+          ansible.builtin.fail:
+            msg: >-
+              Windows guests are published with ansible_connection=winrm but the
+              local Administrator password at
+              secret/platform/windows-vdi/win11-admin could not be read. Check
+              that the ansible AppRole's policy grants read on that exact path.
+          when:
+            - lookup('env', 'OPENBAO_APPROLE_ANSIBLE_ROLE_ID') | length > 0
+            - windows_vdi_admin_password | length == 0
+
     - name: Add VMs to inventory (SSH or WinRM connection)
       ansible.builtin.add_host:
         name: "{{ item.key }}"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -1424,6 +1424,19 @@
       when: systemd_restart_policy_services | default([]) | length > 0
 
 # =============================================================================
+# Phase 9b: Windows VDI baseline (RDP enablement)
+# =============================================================================
+- name: Configure Windows VDI baseline (RDP)
+  hosts: windows_group
+  become: false
+  gather_facts: false
+  tags:
+    - windows
+    - vdi
+  roles:
+    - role: windows_baseline
+
+# =============================================================================
 # Phase 10: End-of-run failure gate (issue #672)
 # Every independent app play above records its own failures into
 # site_isolated_failures (see tasks/record_isolated_failure.yml) instead of

--- a/requirements.yml
+++ b/requirements.yml
@@ -39,6 +39,9 @@ collections:
   - name: community.hashi_vault
     version: ">=6.0.0"  # openbao_secrets role: vault_login (approle) + vault_kv2_get (needs python hvac)
 
+  - name: ansible.windows
+    version: ">=2.0.0"  # windows_baseline role: win_regedit, win_shell (WinRM targets)
+
   - name: community.postgresql
     version: ">=3.4.0"  # postgres role: postgresql_user/_db/_privs idempotent role+db creation
 

--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -525,6 +525,10 @@ openbao_terraform_apply_policy_name: terraform-apply
 openbao_terraform_apply_approle_name: terraform-apply
 openbao_flow_lock_policy_name: flow-lock
 openbao_flow_lock_approle_name: flow-lock
+# packer — Windows VDI template builds. Reads the Proxmox API credential and the
+# Windows local Administrator credential; writes nothing anywhere.
+openbao_packer_policy_name: packer
+openbao_packer_approle_name: packer
 # GitHub token tiers for the workstation git/gh path — engine-minted App
 # installation tokens, NEVER stored PATs (there is no secret/github/* KV path;
 # see .claude/rules/openbao-plugins-first.md). nix-darwin's
@@ -909,6 +913,8 @@ openbao_base_approles:
       - "{{ openbao_config_write_policy_name }}"
   - name: "{{ openbao_flow_lock_approle_name }}"
     policy: "{{ openbao_flow_lock_policy_name }}"
+  - name: "{{ openbao_packer_approle_name }}"
+    policy: "{{ openbao_packer_policy_name }}"
   # ansible-converge additionally signs automation-ansible SSH certs: the
   # pre-play mint in each repo's run-ansible.sh replaces the shared static key.
   # It is also the Ansible config author, so it composes config-write too.
@@ -1079,6 +1085,8 @@ openbao_base_policies:
     template: terraform-apply-policy.hcl.j2
   - name: "{{ openbao_flow_lock_policy_name }}"
     template: flow-lock-policy.hcl.j2
+  - name: "{{ openbao_packer_policy_name }}"
+    template: packer-policy.hcl.j2
   - name: "{{ openbao_ansible_converge_policy_name }}"
     template: ansible-converge-policy.hcl.j2
   - name: "{{ openbao_observability_policy_name }}"

--- a/roles/openbao/templates/ansible-converge-policy.hcl.j2
+++ b/roles/openbao/templates/ansible-converge-policy.hcl.j2
@@ -22,13 +22,19 @@
 #       ansible-proxmox-ai     inventory/load_tofu.yml
 #       ansible-splunk         inventory/load_tofu.yml
 #
+#   platform/windows-vdi/win11-admin
+#     inventory/load_tofu.yml resolves the local Administrator password for the
+#     Windows guests, which are published with ansible_connection=winrm and are
+#     unreachable without it. The same credential is what roles/windows_baseline
+#     authenticates with. READ ONLY: the credential is minted elsewhere and a
+#     converge must never rewrite it.
 #
 #   apps/nautobot is NOT listed here. It is granted once, below, by the
 #   credential-publication loop — which is a superset of the read it used to
 #   carry. Two stanzas for one path is ambiguous at policy-parse time, so the
 #   path must appear exactly once in this file.
 
-{% for kv_path in ['platform/object-storage'] %}
+{% for kv_path in ['platform/object-storage', 'platform/windows-vdi/win11-admin'] %}
 path "{{ openbao_kv_mount }}/data/{{ kv_path }}" {
   capabilities = ["read"]
 }

--- a/roles/openbao/templates/packer-policy.hcl.j2
+++ b/roles/openbao/templates/packer-policy.hcl.j2
@@ -1,0 +1,27 @@
+{{ ansible_managed | comment }}
+# OpenBao policy for the packer AppRole — Windows VDI template builds.
+#
+# Two reads, both exact paths, nothing else. Packer needs the Proxmox API
+# credential to create and capture the build VM, and the Windows local
+# Administrator credential because it is baked into both answer files and is
+# what Packer authenticates with over WinRM during the build.
+#
+# Deliberately NOT granted: any write anywhere, the SSH key fields' siblings by
+# wildcard, or platform/* generally. A template build creates infrastructure but
+# owns no secret, so it never needs to mint or rotate one.
+
+path "{{ openbao_kv_mount }}/data/infrastructure/proxmox" {
+  capabilities = ["read"]
+}
+
+path "{{ openbao_kv_mount }}/metadata/infrastructure/proxmox" {
+  capabilities = ["read", "list"]
+}
+
+path "{{ openbao_kv_mount }}/data/platform/windows-vdi/win11-admin" {
+  capabilities = ["read"]
+}
+
+path "{{ openbao_kv_mount }}/metadata/platform/windows-vdi/win11-admin" {
+  capabilities = ["read", "list"]
+}

--- a/roles/windows_baseline/defaults/main.yml
+++ b/roles/windows_baseline/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# Windows baseline defaults
+
+windows_baseline_winrm_port: 5985
+windows_baseline_winrm_wait_timeout: 1800

--- a/roles/windows_baseline/tasks/main.yml
+++ b/roles/windows_baseline/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+# Windows baseline: wait for the unattended install's WinRM listener, then
+# enable RDP. autounattend.xml already enables WinRM itself
+# (FirstLogonCommands) — this role only needs to wait for it and layer on
+# what the answer file didn't already do.
+
+- name: Wait for WinRM to come up (unattended install can take ~20-30 min)
+  ansible.builtin.wait_for:
+    host: "{{ ansible_host }}"
+    port: "{{ windows_baseline_winrm_port }}"
+    timeout: "{{ windows_baseline_winrm_wait_timeout }}"
+  delegate_to: localhost
+
+- name: Allow incoming RDP connections
+  ansible.windows.win_regedit:
+    path: HKLM:\System\CurrentControlSet\Control\Terminal Server
+    name: fDenyTSConnections
+    data: 0
+    type: dword
+
+- name: Enable the Remote Desktop firewall rule group
+  ansible.windows.win_shell: >
+    netsh advfirewall firewall set rule group="remote desktop" new enable=yes
+  changed_when: true


### PR DESCRIPTION
## Summary
- Adds `windows_baseline` role: waits for WinRM, enables RDP (registry + firewall rule group)
- Wires WinRM connection vars (user/password/transport/port) into `inventory/load_tofu.yml` for VMs tagged `windows`, resolving the local Administrator credential from OpenBao once per run
- Adds `windows_group` (tag-derived) and wires the role into `site.yml`
- Adds `ansible.windows` to requirements.yml

Companion to dryvist/tofu-proxmox#884 (autounattend answer-file ISO for win11-vdi).

## Test plan
- [x] `ansible-lint` (production profile) — clean
- [ ] Runs against win11-vdi once the Terrakube apply lands and the unattended install completes

Assisted-by: Claude:claude-sonnet-5

https://claude.ai/code/session_01EJrXtKvXSpNF8rrzUHTYS7