### PR TITLE
feat(openbao): add ai-donna AppRole and isolated KV policy

### DIFF
--- a/roles/openbao/defaults/main.yml
+++ b/roles/openbao/defaults/main.yml
@@ -716,6 +716,10 @@ openbao_hermes_policy_name: hermes
 openbao_hermes_approle_name: hermes
 openbao_hermes_write_policy_name: hermes-write
 openbao_hermes_write_approle_name: hermes-write
+# ai-donna: a second Hermes agent's dedicated, least-privilege reader — its own
+# isolated credential domain (secret/ai/donna), sharing nothing with hermes.
+openbao_ai_donna_policy_name: ai-donna
+openbao_ai_donna_approle_name: ai-donna
 openbao_public_policy_name: public
 openbao_public_approle_name: public
 # config-read: THE DEFAULT identity on the non-secret `config` mount — read +
@@ -952,6 +956,8 @@ openbao_base_approles:
     policy: "{{ openbao_hermes_policy_name }}"
   - name: "{{ openbao_hermes_write_approle_name }}"
     policy: "{{ openbao_hermes_write_policy_name }}"
+  - name: "{{ openbao_ai_donna_approle_name }}"
+    policy: "{{ openbao_ai_donna_policy_name }}"
   # config-read: sole consumer identity on the non-secret `config` mount.
   # Read + list everywhere in that mount, nothing outside it. Like `public`,
   # leaking it costs nothing — the mount holds no exploitable value by
@@ -1121,6 +1127,8 @@ openbao_base_policies:
     template: hermes-policy.hcl.j2
   - name: "{{ openbao_hermes_write_policy_name }}"
     template: hermes-write-policy.hcl.j2
+  - name: "{{ openbao_ai_donna_policy_name }}"
+    template: ai-donna-policy.hcl.j2
   - name: "{{ openbao_public_policy_name }}"
     template: public-policy.hcl.j2
   - name: "{{ openbao_config_read_policy_name }}"

--- a/roles/openbao/templates/ai-donna-policy.hcl.j2
+++ b/roles/openbao/templates/ai-donna-policy.hcl.j2
@@ -1,0 +1,11 @@
+{{ ansible_managed | comment }}
+# OpenBao policy for the ai-donna AppRole — the Donna AI agent's dedicated,
+# least-privilege reader. Read-only on EXACTLY its own secret; nothing else
+# in the ai subtree or any other domain. Mirrors the hermes AppRole's
+# isolation (see hermes-policy.hcl.j2) so the two agents share no credential.
+path "{{ openbao_kv_mount }}/data/ai/donna" {
+  capabilities = ["read"]
+}
+path "{{ openbao_kv_mount }}/metadata/ai/donna" {
+  capabilities = ["read", "list"]
+}


### PR DESCRIPTION
## Summary
- Adds `roles/openbao/templates/ai-donna-policy.hcl.j2`, a read-only KV policy scoped to exactly one path (no wildcard).
- Registers the policy and a matching AppRole in `roles/openbao/defaults/main.yml`, following the existing per-identity pattern (see `hermes`/`hermes-write`).

## Test plan
- [x] `ansible-lint roles/openbao/` — 0 failures, 0 warnings (production profile)
- [x] `ansible-playbook --syntax-check playbooks/site.yml` — passed