### PR TITLE
fix(cribl_stream): classify *_docker AI sources as syslog inputs by suffix

### DIFF
--- a/roles/cribl_stream/defaults/main.yml
+++ b/roles/cribl_stream/defaults/main.yml
@@ -82,7 +82,11 @@ cribl_stream_ai_log_routing: >-
 
 # Input type per AI source. Default is tcpjson (agent CLIs / serving hosts ship
 # newline-delimited JSON over TCP). rsyslog senders (omfwd) speak RFC3164/5424,
-# so their inputs must be syslog-type instead — override per name here.
+# so their inputs must be syslog-type instead. Names here are the pre-`_docker`
+# rsyslog senders that need an explicit override; every `*_docker` name (the
+# journald-driver-tagged Docker-in-LXC AI services, syslog_forwarder role)
+# classifies as syslog by suffix in inputs.yml.j2 — no per-service entry
+# needed here as tofu-proxmox adds more of them.
 cribl_stream_ai_input_types:
   homelab_llm: syslog
   openbao_audit: syslog

--- a/roles/cribl_stream/templates/inputs.yml.j2
+++ b/roles/cribl_stream/templates/inputs.yml.j2
@@ -44,7 +44,7 @@ inputs:
         pipeline: force_splunk_meta
     pqEnabled: {{ cribl_stream_pq_enabled | lower }}
 {% for name, entry in cribl_stream_ai_log_routing | default({}) | dictsort %}
-{% set ai_type = cribl_stream_ai_input_types.get(name, 'tcpjson') %}
+{% set ai_type = cribl_stream_ai_input_types.get(name, 'syslog' if name.endswith('_docker') else 'tcpjson') %}
   # AI/LLM ingest '{{ name }}' (HAProxy-fronted). The ai_stamp connection
   # pipeline stamps index={{ entry.index }} / sourcetype={{ entry.sourcetype }}
   # by __inputId (conditional evals — pre-stamped events pass untouched).

--- a/tests/template_render/verify_templates.yml
+++ b/tests/template_render/verify_templates.yml
@@ -1580,11 +1580,14 @@
     cribl_stream_pq_enabled: true
     cribl_stream_prometheus_rw_port: 9201
     cribl_stream_prometheus_rw_api_path: /api/v1/write
-    # Mirror the ai_log_routing-derived defaults (representative subset:
-    # one tcpjson CLI source + one rsyslog-fed syslog-type source).
+    # Mirror the ai_log_routing-derived defaults (representative subset: one
+    # tcpjson CLI source, one rsyslog-fed syslog-type source with an explicit
+    # override, and one *_docker source that must classify as syslog by
+    # suffix alone — no cribl_stream_ai_input_types entry for it below).
     cribl_stream_ai_log_routing:
       claude_code: { port: 10311, index: claude, sourcetype: "claude:code" }
       homelab_llm: { port: 10323, index: llm, sourcetype: llamaswap }
+      qdrant_docker: { port: 10347, index: qdrant, sourcetype: "qdrant:app" }
     cribl_stream_ai_input_types:
       homelab_llm: syslog
       openbao_audit: syslog
@@ -1738,7 +1741,11 @@
           - "'in_ai_homelab_llm' in _cribl_stream_inputs"
           - "'type: syslog' in _cribl_stream_inputs"
           - "'tcpPort: 10323' in _cribl_stream_inputs"
-          # Both connect through the ai_stamp pipeline.
+          # *_docker source classifies as syslog by name suffix alone — no
+          # cribl_stream_ai_input_types entry exists for qdrant_docker.
+          - "'in_ai_qdrant_docker' in _cribl_stream_inputs"
+          - "'tcpPort: 10347' in _cribl_stream_inputs"
+          # All three connect through the ai_stamp pipeline.
           - "'pipeline: ai_stamp' in _cribl_stream_inputs"
         fail_msg: >-
           inputs.yml.j2 must render one in_ai_<name> input per ai_log_routing


### PR DESCRIPTION
## Summary

`cribl_stream_ai_input_types` only overrode `homelab_llm`, `openbao_audit`,
and `hermes_agent` to `syslog`; every other `ai_log_routing` entry defaulted
to `tcpjson` in `roles/cribl_stream/templates/inputs.yml.j2`. Sources that
forward via rsyslog (RFC3164/5424 over TCP) but aren't in that override list
would render as `tcpjson` listeners, which expect newline-delimited JSON.

`inputs.yml.j2` now derives `syslog` for any `ai_log_routing` name ending in
`_docker` before falling back to `tcpjson`, so new `*_docker` entries
classify correctly with zero edits to this role's per-name override list.

## Changes

- `roles/cribl_stream/templates/inputs.yml.j2`: derive input type by
  `_docker` suffix, falling back to the existing per-name override dict and
  then `tcpjson`.
- `roles/cribl_stream/defaults/main.yml`: document the suffix convention
  next to `cribl_stream_ai_input_types`.
- `tests/template_render/verify_templates.yml`: add a `qdrant_docker`
  case to the cribl_stream representative-subset fixture, asserting it
  renders as a `syslog`/`tcpPort` input with no explicit override entry.

## Test plan

- [x] `ansible-playbook tests/template_render/verify_templates.yml -c local`
      — all plays pass, including the new assertion.
- [x] `pre-commit run` on the changed files — yamllint, ansible-lint pass.