### PR TITLE
fix(download_vpn): remove qBittorrent seeding capacity caps

### DIFF
--- a/molecule/download_vpn/verify.yml
+++ b/molecule/download_vpn/verify.yml
@@ -495,3 +495,21 @@
         fail_msg: >-
           The download_vpn role no longer has a fatal mountpoint guard (with an
           ntfy alert) for both /data and the Prowlarr data dir.
+
+    # download_vpn_manage_services is false in this scenario, so the API call
+    # that applies these never runs against the container — assert the
+    # defaults directly instead. Namespaced so it cannot clobber this play's
+    # own vars (an un-namespaced include_vars outranks play vars).
+    - name: Load the role defaults for the seeding-capacity assertion
+      ansible.builtin.include_vars:
+        file: "{{ playbook_dir }}/../../roles/download_vpn/defaults/main.yml"
+        name: dv_defaults
+
+    - name: Assert seeding is not capacity-limited by default
+      ansible.builtin.assert:
+        that:
+          - dv_defaults.download_vpn_qbittorrent_max_active_torrents == -1
+          - dv_defaults.download_vpn_qbittorrent_max_active_uploads == -1
+        fail_msg: >-
+          max_active_torrents/max_active_uploads must default to -1
+          (unlimited) so a seeding obligation can never be silently capped.

--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -282,7 +282,7 @@ download_vpn_qbittorrent_categories:
 # 0 = unlimited.
 download_vpn_qbittorrent_up_limit: 3750000      # 30 Mbps — 24/7 global upload cap
 download_vpn_qbittorrent_dl_limit: 31250000     # 250 Mbps — 24/7 global download cap
-download_vpn_qbittorrent_alt_up_limit: 2500000  # work-hours 20 Mbps upload
+download_vpn_qbittorrent_alt_up_limit: 3750000  # matches 24/7 cap: keep upload unthrottled during work hours
 download_vpn_qbittorrent_alt_dl_limit: 12500000 # work-hours 100 Mbps download
 download_vpn_qbittorrent_scheduler_enabled: true
 # scheduler_days: 0=every day, 1=weekdays (Mon–Fri), 2=weekends, 3–9=Mon..Sun.
@@ -297,10 +297,16 @@ download_vpn_qbittorrent_schedule_to_min: 0
 # --- Concurrency + connection limits -----------------------------------------
 # Concurrency caps (applied via setPreferences). dont_count_slow_torrents keeps
 # idle transfers from consuming active slots so completed items do not block new
-# ones. Raised above the client defaults (5/3/5) for more parallelism.
+# ones.
+#
+# max_active_uploads and max_active_torrents are unlimited: a seeding
+# obligation on a private tracker keeps a torrent active for as long as it
+# takes to satisfy, so a fixed cap eventually stops seeding on the overflow
+# with no visible error. max_active_downloads is the real WAN-protecting
+# knob and stays capped.
 download_vpn_qbittorrent_max_active_downloads: 10
-download_vpn_qbittorrent_max_active_uploads: 20
-download_vpn_qbittorrent_max_active_torrents: 100
+download_vpn_qbittorrent_max_active_uploads: -1
+download_vpn_qbittorrent_max_active_torrents: -1
 download_vpn_qbittorrent_dont_count_slow_torrents: true
 # Connection caps. More global connections improve throughput; per-item kept
 # moderate so a single item cannot monopolize them.

--- a/roles/download_vpn/tasks/validate.yml
+++ b/roles/download_vpn/tasks/validate.yml
@@ -128,6 +128,17 @@
           '{{ download_vpn_qbt_prefs.json.current_network_interface | default("(unset)") }}',
           expected '{{ download_vpn_wg_interface }}'.
 
+    - name: Assert seeding is not capacity-limited
+      ansible.builtin.assert:
+        that:
+          - download_vpn_qbt_prefs.json.max_active_torrents | default(0) == -1
+          - download_vpn_qbt_prefs.json.max_active_uploads | default(0) == -1
+        fail_msg: >-
+          max_active_torrents/max_active_uploads must be -1 (unlimited) so a
+          seeding obligation can never be silently capped; got
+          max_active_torrents={{ download_vpn_qbt_prefs.json.max_active_torrents | default('(unset)') }},
+          max_active_uploads={{ download_vpn_qbt_prefs.json.max_active_uploads | default('(unset)') }}.
+
     # --- E. live IPv4 egress via the VPN exit works ------------------------
     # noqa command-instead-of-module: the uri module cannot bind a request to a
     # specific source interface (curl --interface). Interface-scoped egress is


### PR DESCRIPTION
## Summary

- `max_active_torrents` and `max_active_uploads` default to `-1` (unlimited); `max_active_downloads` stays at `10`.
- `alt_up_limit` now equals `up_limit` (3750000 B/s); `alt_dl_limit` is unchanged (still throttled during the work-hours scheduler window).
- Adds assertions for the new defaults in `roles/download_vpn/tasks/validate.yml` and `molecule/download_vpn/verify.yml`.

## Test plan

- [x] `ansible-lint` clean on changed files
- [x] `yamllint` clean on changed files
- [x] `molecule test -s download_vpn` passes (create, prepare, converge, idempotence, verify, destroy)