### PR TITLE
fix(download_vpn): derive LAN interface/IP from interface facts, never the tunnel

### DIFF
--- a/molecule/download_vpn/prepare.yml
+++ b/molecule/download_vpn/prepare.yml
@@ -55,6 +55,23 @@
         group: media
         mode: "2775"
 
+    # Reproduce the exact live failure mode the LAN-IP derivation must
+    # tolerate: a dummy interface named like the WireGuard tunnel, carrying a
+    # documentation-range address (RFC 5737 TEST-NET-2 — not a real tunnel or
+    # LAN value), present alongside the real LAN NIC (default route untouched,
+    # so the rest of this scenario's networking is unaffected). A regression
+    # that ever falls back to "any interface with an IPv4 address" instead of
+    # excluding the tunnel by name fails verify.yml's assertion.
+    - name: Add a dummy wg0 interface carrying a fake tunnel address (no route change)
+      ansible.builtin.command:
+        cmd: "{{ item }}"
+      loop:
+        - ip link add wg0 type dummy
+        - ip addr add 198.51.100.5/32 dev wg0
+        - ip link set wg0 up
+      changed_when: true
+      failed_when: false  # tolerate re-prepare where wg0 already exists
+
     # The role consumes tofu_data.constants.media_ports and the host's
     # container_ip (normally injected by load_tofu.yml). Provide a minimal
     # stand-in so the role renders without the full tofu inventory.

--- a/molecule/download_vpn/verify.yml
+++ b/molecule/download_vpn/verify.yml
@@ -56,6 +56,23 @@
           - "'policy drop' in ks"
         fail_msg: "Killswitch output chain is not default-DROP."
 
+    - name: Assert the LAN-derived rules use the real LAN NIC, never the dummy tunnel iface
+      # prepare.yml adds a dummy wg0 carrying a fake (RFC 5737) tunnel address
+      # alongside the real LAN NIC, without touching the default route — so
+      # ansible_default_ipv4 here is still the real NIC. A regression that
+      # derives lan_ip from "any interface with an address" instead of
+      # excluding the tunnel by name would pick up the dummy's address instead.
+      vars:
+        _real_lan_net: "{{ (ansible_default_ipv4.address ~ '/24') | ansible.utils.ipaddr('network/prefix') }}"
+      ansible.builtin.assert:
+        that:
+          - "'198.51.100.5' not in ks"
+          - _real_lan_net.split('/')[0] in ks
+        fail_msg: >-
+          The killswitch ruleset references the dummy tunnel interface's
+          address instead of the real LAN NIC's — the lan_ip derivation
+          regressed.
+
     - name: Assert reload is replace-not-merge (declare < flush < definition)
       vars:
         # The bare declaration line and the definition open share a prefix, so
@@ -143,6 +160,22 @@
           handler re-runs nft -f on every mangle change, and without the
           preamble that merge appends a duplicate connmark rule for the old
           web-UI port instead of replacing the ruleset.
+
+    - name: Read the rendered lanroute systemd unit
+      ansible.builtin.slurp:
+        src: /etc/systemd/system/download-vpn-lanroute.service
+      register: lanroute_unit
+
+    - name: Assert the lanroute unit's onlink routes use the real LAN gateway, never the dummy tunnel iface
+      vars:
+        lru: "{{ lanroute_unit.content | b64decode }}"
+      ansible.builtin.assert:
+        that:
+          - "'198.51.100.5' not in lru"
+        fail_msg: >-
+          download-vpn-lanroute.service routes via the dummy tunnel interface's
+          address instead of the real LAN gateway — the exact failure mode an
+          `onlink` route silently blackholes instead of refusing to start.
 
     - name: Assert ONLY the allowed egress rules are present
       ansible.builtin.assert:

--- a/roles/download_vpn/defaults/main.yml
+++ b/roles/download_vpn/defaults/main.yml
@@ -94,15 +94,20 @@ download_vpn_wg_backup_key_path: /etc/wireguard/wg0-backup.key
 # the guest itself is the only truthful source. This also has to be a real
 # address, not a name: an FQDN fed to ipaddr() yields `False`, which renders an
 # invalid nftables rule (`ip daddr False accept`) and fails the killswitch deploy.
-download_vpn_lan_ip: "{{ ansible_default_ipv4.address }}"
+# Empty default => tasks/main.yml (Phase 0) MUST set it from the LAN interface's
+# own facts, never ansible_default_ipv4.address (that's the tunnel once wg0 is
+# up). To pin a value, override download_vpn_lan_interface, not this directly —
+# an override here would be silently clobbered by that derivation.
+download_vpn_lan_ip: ""
 
 download_vpn_lan_subnet: >-
   {{ (download_vpn_lan_ip ~ '/24')
      | ansible.utils.ipaddr('network/prefix') }}
 
 # Primary LAN interface — the NIC that actually holds the container's LAN IP.
-# Used by the leak tests as the "force non-VPN egress" interface. Derived in
-# tasks/main.yml (Phase 0) by matching container_ip against the interface facts,
+# Used by the leak tests as the "force non-VPN egress" interface, and to derive
+# download_vpn_lan_ip above. Derived in tasks/main.yml (Phase 0) from the
+# gathered interface facts themselves (excluding loopback and the wg interface),
 # NOT assumed to be eth0 and NOT ansible_default_ipv4.interface (which is wg0
 # once the tunnel is up). Empty default => the derivation must set it; override
 # only to pin a specific NIC.

--- a/roles/download_vpn/tasks/main.yml
+++ b/roles/download_vpn/tasks/main.yml
@@ -118,27 +118,47 @@
          | select('ansible.utils.ipv4') | list | first
          | default(download_vpn_wg_address.split(',')[0] | trim) }}
 
-# Derive the primary LAN interface — the NIC that actually holds the container's
-# LAN IP — so the leak tests force non-VPN egress out the RIGHT interface even
-# when the NIC is not named eth0. We must NOT use ansible_default_ipv4.interface
-# (that is wg0 once the tunnel is up). Match container_ip against the gathered
-# interface facts; honour an explicit override; fall back to eth0 last so
-# behaviour is identical when the NIC IS eth0.
-- name: Derive the primary LAN interface (the NIC holding the LAN IP)
+# The NIC that actually holds the container's LAN IP — first gathered interface
+# that is neither loopback nor the wg interface and carries an IPv4 address.
+# Feeds both the leak tests and the LAN IP derivation just below.
+- name: Derive the primary LAN interface (the NIC holding the LAN IP, never the tunnel)
   ansible.builtin.set_fact:
     download_vpn_lan_interface: >-
       {{ download_vpn_lan_interface
          if (download_vpn_lan_interface | length > 0)
          else (
            ansible_facts.interfaces
+           | reject('equalto', 'lo')
+           | reject('equalto', download_vpn_wg_interface)
            | map('extract', ansible_facts)
            | selectattr('ipv4', 'defined')
            | selectattr('ipv4.address', 'defined')
-           | selectattr('ipv4.address', 'equalto',
-                        (download_vpn_lan_ip | default(ansible_default_ipv4.address | default(''))))
            | map(attribute='device') | list | first
            | default('eth0', true)
          ) }}
+
+# LAN IP comes from that interface's OWN facts, never ansible_default_ipv4
+# (that's the tunnel once wg0 is up). Everything below — subnet, gateway,
+# killswitch, lanroute — flows from this one value.
+- name: Derive the LAN IP from the LAN interface's own facts (never the tunnel's)
+  ansible.builtin.set_fact:
+    download_vpn_lan_ip: >-
+      {{ ansible_facts[download_vpn_lan_interface].ipv4.address
+         | default(ansible_default_ipv4.address, true) }}
+
+# Fail-fast: everything downstream trusts lan_ip/subnet/gateway blindly. A
+# wrong value here must fail loudly, before the killswitch or lanroute unit
+# ever render, never deploy quietly.
+- name: Guard — the derived LAN IP must belong to the LAN NIC, never the tunnel
+  ansible.builtin.assert:
+    that:
+      - download_vpn_lan_interface != download_vpn_wg_interface
+      - download_vpn_lan_ip == (ansible_facts[download_vpn_lan_interface].ipv4.address | default(''))
+    fail_msg: >-
+      download_vpn_lan_ip ('{{ download_vpn_lan_ip }}') did not come from
+      '{{ download_vpn_lan_interface }}' as expected — refusing to render the
+      killswitch/lanroute with a possibly-tunnel address.
+    quiet: true
 
 - name: Show the derived LAN interface used by the leak tests
   ansible.builtin.debug:

--- a/roles/download_vpn/templates/download-vpn-lanroute.service.j2
+++ b/roles/download_vpn/templates/download-vpn-lanroute.service.j2
@@ -64,7 +64,10 @@ ExecStart=/usr/bin/env ip rule add fwmark {{ download_vpn_lanroute_mark }} table
    yet and returns "Nexthop has invalid gateway"; the unit is Type=oneshot, so
    that failure is permanent until something restarts it — observed live, the
    reply routing stayed uninstalled for over 14 hours with nothing noticing.
-   onlink asserts the nexthop is directly attached and removes the race. #}
+   onlink asserts the nexthop is directly attached and removes the race. Safe
+   only because Phase 0 asserts the gateway derives from the LAN NIC before
+   this renders — onlink on a wrong gateway would blackhole silently instead
+   of failing loud. #}
 {% for net in download_vpn_lanroute_reply_networks %}
 ExecStart=/usr/bin/env ip route replace {{ net }} via {{ download_vpn_lan_gateway }} dev {{ download_vpn_lan_interface }} onlink table {{ download_vpn_lanroute_table }}
 {% endfor %}


### PR DESCRIPTION
## Summary

- `download_vpn_lan_interface` is now derived directly from the gathered interface facts, explicitly excluding loopback and the WireGuard interface by name, instead of matching against `download_vpn_lan_ip`.
- `download_vpn_lan_ip` is now derived from that already-resolved LAN interface's own facts, instead of `ansible_default_ipv4.address` (which is the tunnel interface once it is up).
- Added a converge-time guard that fails the play before any killswitch/lanroute template renders if either value ever resolves to the tunnel interface.
- Updated the `download-vpn-lanroute.service.j2` comment documenting why `onlink` is safe given the new guard.
- Extended the `download_vpn` Molecule scenario with a dummy tunnel-named interface (RFC 5737 documentation address) so a regression back to matching "any interface with an address" fails CI, and added assertions on the rendered killswitch ruleset and lanroute unit.

## Test plan

- [x] `ansible-lint --profile production` clean on all changed files
- [x] `yamllint` clean on all changed files
- [x] `molecule test -s download_vpn` — full sequence green, including the new dummy-tunnel-interface regression assertions
- [ ] Reviewer: confirm the guard's fail message reads clearly in isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHs9wANPB35K994ag7QpN7