### PR TITLE
fix: pin sortarr and configarr images for Renovate tracking

### DIFF
--- a/roles/configarr/README.md
+++ b/roles/configarr/README.md
@@ -43,7 +43,7 @@ without tying that policy to a particular playback client.
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `configarr_manage` | `true` | master on/off |
-| `configarr_image_tag` | `latest` | pin for a frozen version |
+| `configarr_image` | `ghcr.io/raydak-labs/configarr:<tag>` | image + pinned tag |
 | `configarr_sonarr_templates` | quality definition | Recyclarr/TRaSH includes |
 | `configarr_radarr_templates` | quality definition | Recyclarr/TRaSH includes |
 

--- a/roles/configarr/defaults/main.yml
+++ b/roles/configarr/defaults/main.yml
@@ -14,10 +14,8 @@
 configarr_manage: true
 
 # --- Container ---------------------------------------------------------------
-# Tag left at the moving `latest` per the repo's "don't hardcode versions"
-# rule; pin in inventory if a frozen version is wanted.
-configarr_image: "ghcr.io/raydak-labs/configarr"
-configarr_image_tag: "latest"
+# Pinned to a tag so it's reproducible AND Renovate can bump it.
+configarr_image: "ghcr.io/raydak-labs/configarr:1.30.1"
 configarr_container_name: "configarr"
 # Host dir holding the rendered config.yml + secrets.yml + the template cache.
 configarr_config_dir: "/opt/configarr"

--- a/roles/configarr/tasks/main.yml
+++ b/roles/configarr/tasks/main.yml
@@ -45,7 +45,7 @@
     - name: Run Configarr (one-shot — enforces TRaSH quality config)
       community.docker.docker_container:
         name: "{{ configarr_container_name }}"
-        image: "{{ configarr_image }}:{{ configarr_image_tag }}"
+        image: "{{ configarr_image }}"
         pull: true
         detach: false
         cleanup: true

--- a/roles/sortarr/defaults/main.yml
+++ b/roles/sortarr/defaults/main.yml
@@ -6,7 +6,7 @@
 # it never moves, renames, or deletes media. It reaches Sonarr/Radarr/Plex over
 # the LAN using their existing API keys; no new *arr-side wiring is required.
 # Pinned to a tag so it's reproducible AND Renovate can bump it.
-sortarr_image: "ghcr.io/jaredharper1/sortarr:latest"
+sortarr_image: "ghcr.io/jaredharper1/sortarr:v0.9.0"
 sortarr_container_name: sortarr
 sortarr_data_dir: /opt/sortarr
 # Host dir bind-mounted to the container's /data (Sortarr's persistent config +


### PR DESCRIPTION
## Summary
- Pins `sortarr_image` to a release tag instead of `latest`
- Consolidates `configarr_image` + `configarr_image_tag` into a single quoted `repo:tag` string so the existing customManager regex can track it, and updates every reference

## Test plan
- [x] `ansible-lint --profile production` on changed files — passed
- [x] `yamllint` on changed files — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHs9wANPB35K994ag7QpN7