### PR TITLE
fix(nautobot): pin the Python packages so the venv tracks upstream

### DIFF
--- a/roles/nautobot/defaults/main.yml
+++ b/roles/nautobot/defaults/main.yml
@@ -21,14 +21,35 @@ nautobot_system_packages:
   - openssl
   - sudo
 
-# Python packages installed into the venv (latest stable). The pip
-# distribution names differ from the Django app/plugin names used in PLUGINS:
+# Python packages installed into the venv. The pip distribution names differ
+# from the Django app/plugin names used in PLUGINS:
 #   nautobot-ssot              -> nautobot_ssot
 #   nautobot-device-onboarding -> nautobot_device_onboarding
+#
+# These are PINNED, and the pin is what keeps the instance current. Unpinned,
+# the install task (state: present) is satisfied by any installed version and
+# never upgrades, so the venv freezes at whatever "latest" meant on the day of
+# the first converge — silently, and invisibly to Renovate, which cannot track a
+# dependency that carries no version. Naming an exact version makes pip
+# reconcile to it and gives Renovate something to bump.
+#
+# Upgrading Nautobot across a MAJOR runs database migrations. Treat a major bump
+# here as a deliberate, scheduled change with a backup taken first, not as an
+# ordinary converge.
+# renovate: datasource=pypi depName=nautobot
+nautobot_version: "3.2.2"
+# renovate: datasource=pypi depName=nautobot-ssot
+nautobot_ssot_version: "4.6.1"
+# renovate: datasource=pypi depName=nautobot-device-onboarding
+nautobot_device_onboarding_version: "5.4.1"
+
+# boto3 and jsonschema are deliberately unpinned: both are used for
+# version-insensitive work (an S3 PUT, a schema validation), neither gates a
+# migration, and pip resolves them against whatever Nautobot itself requires.
 nautobot_pip_packages:
-  - nautobot
-  - nautobot-ssot
-  - nautobot-device-onboarding
+  - "nautobot=={{ nautobot_version }}"
+  - "nautobot-ssot=={{ nautobot_ssot_version }}"
+  - "nautobot-device-onboarding=={{ nautobot_device_onboarding_version }}"
   - boto3
   - jsonschema
 nautobot_plugins:


### PR DESCRIPTION
The Nautobot venv could not move and nothing reported that it had not.

## What was wrong

The three Nautobot packages were installed by bare name, and the install task uses `state: present` — a condition any installed version satisfies. pip was therefore never asked to upgrade, so the venv held whatever "latest stable" resolved to on the day of the first converge, indefinitely.

Renovate could not correct it either. A dependency carrying no version gives it nothing to compare or bump, so no update was ever proposed. The role looked like it tracked upstream precisely because it named no version, when the absence of a version is what prevented tracking.

## What changes

Each package gets an explicit pinned version with a `# renovate:` annotation. One change fixes both halves: pip reconciles to the named version instead of accepting any installed one, and Renovate now has something to track.

`boto3` and `jsonschema` stay unpinned deliberately — both do version-insensitive work (an S3 PUT, a schema validation), neither gates a migration, and pip resolves them against Nautobot's own requirements.

## Verification

**The annotation is not inert.** Every existing `# renovate:` annotation in this repo uses `github-releases` or `docker`; none uses `pypi`, so I checked the shared preset rather than assuming the pattern generalised. `dryvist/.github` `renovate-presets.json` custom manager 2 targets `roles/.+/defaults/main\.ya?ml$` and matches an annotation comment followed by `<word>: "<value>"`, taking the datasource from the comment itself. The added lines match that shape, and `pypi` is a native Renovate datasource.

Current PyPI versions were read from the PyPI API at time of writing rather than guessed. `ansible-lint` passes under the production profile; the file parses and the pins resolve.

## Operational note

A **major** bump of these pins runs Nautobot database migrations. It should be applied as a scheduled change with a backup taken first, not folded into a routine converge. That is recorded where the pins are declared.

Because the venv has been frozen since its first converge, the first converge after this merges may cross one or more majors. Check the running version (`nautobot-server --version`) against the pin before converging, and sequence the upgrade deliberately if it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)