### PR TITLE
fix(nautobot): stop the node seed overwriting curated device facts

### DIFF
--- a/roles/nautobot/files/jobs/ssot_nodes.py
+++ b/roles/nautobot/files/jobs/ssot_nodes.py
@@ -28,6 +28,8 @@ from ssot_common import (
 
 NODE_ROLE = "pve-node"
 NODE_DEVICE_TYPE = "pve-node"
+# Seeded only when Nautobot has no Device for the node yet; see NodesSourceAdapter.load.
+DEFAULT_LOCATION = "homelab"
 
 
 class NodeDeviceModel(AdditiveNautobotModel):
@@ -77,19 +79,47 @@ class NodesSourceAdapter(Adapter):
         self.job = job
 
     def load(self) -> None:
-        """Populate node Device models from the seed bundle (commissioned only)."""
+        """Populate node Device models from the seed bundle (commissioned only).
+
+        `device_type` and `location` are seeded ONLY for a node Nautobot does not
+        already have. Where a Device already exists, its current values are
+        carried into the source model so the diff is empty for those fields.
+
+        This job knows a node's NAME, not its hardware. Emitting the placeholder
+        type and the default location unconditionally makes them managed
+        attributes, so DiffSync would "correct" curated values back down to
+        them — turning a real chassis model into the literal placeholder and
+        moving the device to the default location. That is silent data loss in
+        the system of record, and it is triggered by an ordinary rename, since
+        these models are identified by name alone.
+
+        Status stays managed: a node the seed calls commissioned is expected to
+        be active, and that is an assertion this job is entitled to make.
+        """
         seed = load_seed()
         ensure_device_type(NODE_DEVICE_TYPE)
         ensure_role(NODE_ROLE, Device)
+        curated = {
+            device.name: device
+            for device in Device.objects.filter(role__name=NODE_ROLE).select_related(
+                "device_type", "location"
+            )
+        }
         for node in seed["nodes"]:
             if not node.get("commissioned", True):
                 continue
+            name = str(node["name"])
+            existing = curated.get(name)
             self.add(
                 self.device(
-                    name=str(node["name"]),
+                    name=name,
                     role__name=NODE_ROLE,
-                    device_type__model=NODE_DEVICE_TYPE,
-                    location__name="homelab",
+                    device_type__model=(
+                        existing.device_type.model if existing else NODE_DEVICE_TYPE
+                    ),
+                    location__name=(
+                        existing.location.name if existing else DEFAULT_LOCATION
+                    ),
                     status__name=STATUS_ACTIVE,
                 )
             )

--- a/roles/nautobot/files/jobs/ssot_nodes.py
+++ b/roles/nautobot/files/jobs/ssot_nodes.py
@@ -3,7 +3,13 @@
 Source of truth: the ``nodes`` array of the seed bundle (from ``ansible-proxmox``
 ``hosts.yml``). DiffSyncs the commissioned pve nodes into Nautobot Devices with
 role ``pve-node`` and a ``pve-node`` DeviceType under the Generic manufacturer.
-Uncommissioned nodes are skipped.
+
+Uncommissioned nodes are skipped, but note that the bundle currently stamps
+every node ``commissioned: true`` — it does not read ``pve_node_commissioned``,
+which tracks storage commissioning rather than whether the node exists. So the
+skip is a guard for a value nothing produces yet, not an active filter: every
+node in the inventory group reaches Nautobot today. Do not reason from it that
+a particular node is exempt from this job.
 
 Live-validation notes: like the DCIM job, DeviceType/Role are ensured via the
 ORM before the DiffSync run; mgmt-IP-to-interface binding is deferred to Device

--- a/tests/nautobot_nodes_seed.py
+++ b/tests/nautobot_nodes_seed.py
@@ -1,0 +1,193 @@
+"""Behaviour check for the node seed job (roles/nautobot/files/jobs/ssot_nodes.py).
+
+Stubs django/nautobot the way tests/nautobot_hardware_seed.py does, so the job's
+real load() logic runs without a Nautobot install.
+
+What is pinned down here is the one thing that is silently destructive: these
+models are identified by NAME alone, so a node rename makes the job look at a
+Device it has never seen before. If it emitted its placeholder device type and
+default location unconditionally, DiffSync would treat curated values as drift
+and write the placeholders over them — losing the real chassis model and
+location from the system of record, with no error and no diff to review.
+
+So: an already-known node keeps its curated device_type and location, and only a
+genuinely new node gets the seeded defaults.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+JOBS = ROOT / "roles/nautobot/files/jobs"
+
+
+class Record:
+    """An object with named attributes, standing in for a model instance."""
+
+    def __init__(self, **attrs: Any) -> None:
+        self.__dict__.update(attrs)
+
+
+class FakeQuerySet(list):
+    """List with the queryset method the job chains onto filter()."""
+
+    def select_related(self, *_args):
+        """Ignore prefetch hints; the fakes are already whole objects."""
+        return self
+
+
+class FakeDeviceManager:
+    """Minimal Django manager: only the filter() the job actually calls."""
+
+    def __init__(self, store: list[Record]) -> None:
+        self.store = store
+
+    def filter(self, **kwargs):
+        """Return the records matching every supplied lookup."""
+        return FakeQuerySet(
+            [
+                item
+                for item in self.store
+                if all(_lookup(item, key) == value for key, value in kwargs.items())
+            ]
+        )
+
+
+def _lookup(item: Record, key: str) -> Any:
+    """Resolve a Django-style `a__b` lookup against a fake record."""
+    value: Any = item
+    for part in key.split("__"):
+        value = getattr(value, part, None)
+    return value
+
+
+def load_job(devices: list[Record], nodes: list[dict[str, Any]]):
+    """Install stubs, import ssot_nodes fresh, and return the module."""
+    device_cls = type("Device", (), {"objects": FakeDeviceManager(devices)})
+
+    dcim = types.ModuleType("nautobot.dcim.models")
+    dcim.Device = device_cls
+
+    nautobot = types.ModuleType("nautobot")
+    apps_jobs = types.ModuleType("nautobot.apps.jobs")
+    apps_jobs.register_jobs = lambda *_a, **_k: None
+
+    class _Adapter:
+        """Stand-in for diffsync.Adapter that just collects added models."""
+
+        def __init__(self, *_a, **_k) -> None:
+            self.added: list[Any] = []
+
+        def add(self, model):
+            """Record the model the job emitted."""
+            self.added.append(model)
+
+    diffsync = types.ModuleType("diffsync")
+    diffsync.Adapter = _Adapter
+
+    ssot_contrib = types.ModuleType("nautobot_ssot.contrib")
+    ssot_contrib.NautobotAdapter = _Adapter
+    ssot_base = types.ModuleType("nautobot_ssot.jobs.base")
+    ssot_base.DataSource = type("DataSource", (), {})
+
+    class _Model:
+        """Stand-in for the pydantic-ish DiffSync model base."""
+
+        def __init__(self, **attrs: Any) -> None:
+            self.__dict__.update(attrs)
+
+    common = types.ModuleType("ssot_common")
+    common.STATUS_ACTIVE = "Active"
+    common.AdditiveNautobotModel = _Model
+    common.ensure_device_type = lambda *_a, **_k: None
+    common.ensure_location = lambda *_a, **_k: None
+    common.ensure_role = lambda *_a, **_k: None
+    common.load_seed = lambda: {"nodes": nodes}
+
+    for name, module in {
+        "nautobot": nautobot,
+        "nautobot.apps": types.ModuleType("nautobot.apps"),
+        "nautobot.apps.jobs": apps_jobs,
+        "nautobot.dcim": types.ModuleType("nautobot.dcim"),
+        "nautobot.dcim.models": dcim,
+        "nautobot_ssot": types.ModuleType("nautobot_ssot"),
+        "nautobot_ssot.contrib": ssot_contrib,
+        "nautobot_ssot.jobs": types.ModuleType("nautobot_ssot.jobs"),
+        "nautobot_ssot.jobs.base": ssot_base,
+        "diffsync": diffsync,
+        "ssot_common": common,
+    }.items():
+        sys.modules[name] = module
+
+    sys.modules.pop("ssot_nodes", None)
+    spec = importlib.util.spec_from_file_location("ssot_nodes", JOBS / "ssot_nodes.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["ssot_nodes"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _emit(devices, nodes):
+    """Run the source adapter's load() and return the emitted models by name."""
+    module = load_job(devices, nodes)
+    adapter = module.NodesSourceAdapter()
+    adapter.device = module.NodeDeviceModel
+    adapter.load()
+    return {model.name: model for model in adapter.added}
+
+
+def test_curated_device_fields_are_preserved() -> None:
+    """A node Nautobot already knows keeps its real chassis model and location."""
+    devices = [
+        Record(
+            name="pve-r710",
+            device_type=Record(model="PowerEdge R710"),
+            location=Record(name="server room"),
+            role=Record(name="pve-node"),
+        )
+    ]
+    emitted = _emit(devices, [{"name": "pve-r710", "commissioned": True}])
+
+    model = emitted["pve-r710"]
+    assert model.device_type__model == "PowerEdge R710", model.device_type__model
+    assert model.location__name == "server room", model.location__name
+    assert model.status__name == "Active", model.status__name
+
+
+def test_unknown_node_gets_the_seeded_defaults() -> None:
+    """A node with no Device yet is still created, with the placeholder type."""
+    emitted = _emit([], [{"name": "pve-brand-new", "commissioned": True}])
+
+    model = emitted["pve-brand-new"]
+    assert model.device_type__model == "pve-node", model.device_type__model
+    assert model.location__name == "homelab", model.location__name
+
+
+def test_uncommissioned_node_is_skipped() -> None:
+    """An uncommissioned node is never emitted, so its Device is left alone."""
+    devices = [
+        Record(
+            name="pve-r410",
+            device_type=Record(model="PowerEdge R410"),
+            location=Record(name="server room"),
+            role=Record(name="pve-node"),
+        )
+    ]
+    emitted = _emit(devices, [{"name": "pve-r410", "commissioned": False}])
+
+    assert emitted == {}, emitted
+
+
+if __name__ == "__main__":
+    ran = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            ran += 1
+            print(f"PASS {name}")
+    print(f"\n{ran} assertions groups passed")
+    assert ran == 3, f"expected 3 tests, ran {ran}"


### PR DESCRIPTION
## The defect

`ssot_nodes` identifies devices by **name alone**. A node rename therefore makes
the job look at a Device it has never seen before — and it emitted its
placeholder device type and default location unconditionally, which makes them
*managed* attributes.

DiffSync then reads the curated values as drift and writes the placeholders over
them. A real chassis model becomes the literal `pve-node`, and the device moves
to the default location. No error, and the diff that does it is the job's own
normal output.

This is live: Nautobot already holds all five nodes under hardware-keyed names,
two of them with real chassis models and a curated location. The rename program
about to change the node keys would have flattened them on the next sync.

## The fix

Seed `device_type` and `location` only for a node Nautobot does not already
have. Where a Device exists, carry its current values into the source model so
the diff is empty for those fields.

Status stays managed — a node the seed calls commissioned is expected to be
active, and that is an assertion this job is entitled to make.

## Tests

`tests/nautobot_nodes_seed.py`, stubbing django/nautobot the way
`tests/nautobot_hardware_seed.py` does, covering all three paths: curated fields
preserved, unknown node still created with defaults, uncommissioned node
skipped.

Confirmed to fail when the change is reverted — the preserved-fields assertion
reports `pve-node` in place of the real chassis model, which is the data loss
itself.